### PR TITLE
docs: Translate functions related to `object` into Korean in docs 

### DIFF
--- a/docs/ko/reference/object/omit.md
+++ b/docs/ko/reference/object/omit.md
@@ -1,29 +1,28 @@
 # omit
 
-Creates a new object with specified keys omitted.
+특정 키를 생략한 새로운 객체를 생성해요.
 
-This function takes an object and an array of keys, and returns a new object that 
-excludes the properties corresponding to the specified keys.
+이 함수는 객체와 키 배열을 받아, 지정된 키에 해당하는 속성을 제외한 새로운 객체를 반환해요.
 
-## Signature
+## 인터페이스
 
 ```typescript
 function omit<T, K extends keyof T>(obj: T, keys: K[]): Omit<T, K>;
 ```
 
-### Parameters 
+### 파라미터 
 
-- `obj` (`T`): The object to omit keys from.
-- `keys` (`K[]`): An array of keys to be omitted from the object.
+- `obj` (`T`): 키를 생략할 객체예요.
+- `keys` (`K[]`): 객체에서 생략할 키들의 배열이에요.
 
-### Returns
+### 반환 값
 
-(`Omit<T, K>`): A new object with the specified keys omitted.
+(`Omit<T, K>`): 지정된 키들이 생략된 새로운 객체예요.
 
-## Examples
+## 예시
 
 ```typescript
 const obj = { a: 1, b: 2, c: 3 };
 const result = omit(obj, ['b', 'c']);
-// result will be { a: 1 }
+// 결과는 다음과 같아요 { a: 1 }
 ```

--- a/docs/ko/reference/object/omitBy.md
+++ b/docs/ko/reference/object/omitBy.md
@@ -1,32 +1,29 @@
 # omitBy
 
-Creates a new object composed of the properties that do not satisfy the predicate function.
+조건 함수에 맞지 않는 속성들로 구성된 새로운 객체를 생성해요.
 
-This function takes an object and a predicate function, and returns a new object that 
-includes only the properties for which the predicate function returns false.
+이 함수는 객체와 조건 함수를 받아, 조건 함수가 false를 반환하는 속성들만 포함하는 새로운 객체를 반환해요.
 
-## Signature
+## 인터페이스
 
 ```typescript
 function omitBy<T extends Record<string, any>>(obj: T, shouldOmit: (value: any, key: string) => boolean): Partial<T>;
 ```
 
-### Parameters 
+### 파라미터
 
-- `obj` (`T`): The object to omit properties from.
-- `shouldOmit` (`(value: any, key: string) => boolean`): A predicate function that determines 
-whether a property should be omitted. It takes the property's key and value as arguments and returns `true` 
-if the property should be omitted, and `false` otherwise.
+- `obj` (`T`): 속성을 생략할 객체예요.
+- `shouldOmit` (`(value: any, key: string) => boolean`): 속성을 생략할지를 결정하는 조건 함수예요. 이 함수는 속성의 키와 값을 인자로 받아, 속성을 생략해야 하면 true, 그렇지 않으면 false를 반환해요.
 
-### Returns
+### 반환 값
 
-(`Partial<T>`): A new object with the properties that do not satisfy the predicate function.
+(`Partial<T>`): 조건 함수에 맞지 않는 속성들로 구성된 새로운 객체예요.
 
-## Examples
+## 예시
 
 ```typescript
 const obj = { a: 1, b: 'omit', c: 3 };
 const shouldOmit = (value, key) => typeof value === 'string';
 const result = omitBy(obj, shouldOmit);
-// result will be { a: 1, c: 3 }
+// 결과는 다음과 같아요 { a: 1, c: 3 }
 ```

--- a/docs/ko/reference/object/pick.md
+++ b/docs/ko/reference/object/pick.md
@@ -1,29 +1,28 @@
 # pick
 
-Creates a new object composed of the picked object properties.
+선택한 객체 속성들로 구성된 새로운 객체를 생성해요.
 
-This function takes an object and an array of keys, and returns a new object that 
-includes only the properties corresponding to the specified keys.
+이 함수는 객체와 키 배열을 받아, 지정된 키에 해당하는 속성들만 포함하는 새로운 객체를 반환해요.
 
-## Signature
+## 인터페이스
 
 ```typescript
 function pick<T, K extends keyof T>(obj: T, keys: K[]): Pick<T, K>;
 ```
 
-### Parameters 
+### 파라미터 
 
-- `obj` (`T`): The object to pick keys from.
-- `keys` (`K[]`): An array of keys to be picked from the object.
+- `obj` (`T`): 키를 선택할 객체예요.
+- `keys` (`K[]`): 객체에서 선택할 키들의 배열이에요.
 
-### Returns
+### 반환 값
 
-(`Pick<T, K>`): A new object with the specified keys picked.
+(`Pick<T, K>`): 지정된 키들이 선택된 새로운 객체예요.
 
-## Examples
+## 예시
 
 ```typescript
 const obj = { a: 1, b: 2, c: 3 };
 const result = pick(obj, ['a', 'c']);
-// result will be { a: 1, c: 3 }
+// 결과는 다음과 같아요 { a: 1, c: 3 }
 ```

--- a/docs/ko/reference/object/pickBy.md
+++ b/docs/ko/reference/object/pickBy.md
@@ -1,30 +1,29 @@
 # pickBy
 
-Creates a new object composed of the properties that satisfy the predicate function.
+조건 함수에 맞는 속성들로 구성된 새로운 객체를 생성해요.
 
-This function takes an object and a predicate function, and returns a new object that 
-includes only the properties for which the predicate function returns true.
+이 함수는 객체와 조건 함수를 받아, 조건 함수가 true를 반환하는 속성들만 포함하는 새로운 객체를 반환해요.
 
-## Signature
+## 인터페이스
 
 ```typescript
 function pickBy<T extends Record<string, any>>(obj: T, shouldPick: (value: T[keyof T], key: string) => boolean): Partial<T>;
 ```
 
-### Parameters 
+### 파라미터 
 
-- `obj` (`T`): The object to pick properties from.
-- `shouldPick` (`(value: T[keyof T], key: string) => boolean`): A predicate function that determines whether a property should be picked. It takes the property's key and value as arguments and returns `true` if the property should be picked, and `false` otherwise.
+- `obj` (`T`): 속성을 선택할 객체예요.
+- `shouldPick` (`(value: T[keyof T], key: string) => boolean`): 속성을 선택할지를 결정하는 조건 함수예요. 이 함수는 속성의 키와 값을 인수로 받아, 속성을 선택해야 하면 true, 그렇지 않으면 false를 반환해요.
 
-### Returns
+### 반환 값
 
-(`Partial<T>`): A new object with the properties that satisfy the predicate function.
+(`Partial<T>`): 조건 함수에 맞는 속성들로 구성된 새로운 객체예요.
 
-## Examples
+## 예시
 
 ```typescript
 const obj = { a: 1, b: 'pick', c: 3 };
 const shouldPick = (value, key) => typeof value === 'string';
 const result = pickBy(obj, shouldPick);
-// result will be { b: 'pick' }
+// 결과는 다음과 같아요 { b: 'pick' }
 ```


### PR DESCRIPTION
fix #3 