### PR TITLE
chore(*): Apply eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     curly: ['error', 'all'],
     eqeqeq: ['error', 'always', { null: 'ignore' }],
 
+    '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "scripts": {
     "prepack": "yarn build",
     "build": "rm -rf dist esm && tsc -p tsconfig.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js && ./.scripts/postbuild.sh",
-    "test": "vitest run --coverage --typecheck"
+    "test": "vitest run --coverage --typecheck",
+    "lint": "eslint ./src --ext .ts"
   }
 }

--- a/src/array/groupBy.spec.ts
+++ b/src/array/groupBy.spec.ts
@@ -27,7 +27,7 @@ describe('groupBy', () => {
   });
 
   it('should handle an empty array', () => {
-    const array: { category: string, name: string }[] = [];
+    const array: Array<{ category: string, name: string }> = [];
     
     const result = groupBy(array, item => item.category);
     

--- a/src/array/sample.spec.ts
+++ b/src/array/sample.spec.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { partition } from './partition';
 import { sample } from './sample';
 
 describe('sample', () => {

--- a/src/array/shuffle.spec.ts
+++ b/src/array/shuffle.spec.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { sample } from './sample';
 import { shuffle } from './shuffle';
 
 describe('shuffle', () => {

--- a/src/array/uniqBy.ts
+++ b/src/array/uniqBy.ts
@@ -1,4 +1,3 @@
-import { uniq } from "./uniq";
 import { uniqWith } from "./uniqWith";
 
 /**

--- a/src/array/uniqWith.ts
+++ b/src/array/uniqWith.ts
@@ -1,5 +1,3 @@
-import { uniq } from "./uniq";
-
 /**
  * The `uniqWith` function takes an array as its first argument and a 'comparator' function as the second.
  *

--- a/src/array/zip.ts
+++ b/src/array/zip.ts
@@ -19,10 +19,10 @@
  * const result2 = zip(arr1, arr2, arr3);
  * // result2 will be [[1, 'a', true], [2, 'b', false], [3, 'c', undefined]]
  */
-export function zip<T>(arr1: T[]): [T][];
-export function zip<T, U>(arr1: T[], arr2: U[]): [T, U][];
-export function zip<T, U, V>(arr1: T[], arr2: U[], arr3: V[]): [T, U, V][];
-export function zip<T, U, V, W>(arr1: T[], arr2: U[], arr3: V[], arr4: W[]): [T, U, V, W][];
+export function zip<T>(arr1: T[]): Array<[T]>;
+export function zip<T, U>(arr1: T[], arr2: U[]): Array<[T, U]>;
+export function zip<T, U, V>(arr1: T[], arr2: U[], arr3: V[]): Array<[T, U, V]>;
+export function zip<T, U, V, W>(arr1: T[], arr2: U[], arr3: V[], arr4: W[]): Array<[T, U, V, W]>;
 export function zip<T>(...arrs: T[][]): T[][] {
   const result: T[][] = [];
 

--- a/src/object/omitBy.spec.ts
+++ b/src/object/omitBy.spec.ts
@@ -4,35 +4,35 @@ import { omitBy } from './omitBy';
 describe('omitBy', () => {
   it('should omit properties based on the predicate function', () => {
     const obj = { a: 1, b: 'omit', c: 3 };
-    const shouldOmit = (value: number | string, key: string) => typeof value === 'string';
+    const shouldOmit = (value: number | string) => typeof value === 'string';
     const result = omitBy(obj, shouldOmit);
     expect(result).toEqual({ a: 1, c: 3 });
   });
 
   it('should return an empty object if all properties are omitted', () => {
     const obj = { a: 'omit', b: 'omit' };
-    const shouldOmit = (value: string, key: string) => typeof value === 'string';
+    const shouldOmit = (value: string) => typeof value === 'string';
     const result = omitBy(obj, shouldOmit);
     expect(result).toEqual({});
   });
 
   it('should return the same object if no properties are omitted', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const shouldOmit = (value: number, key: string) => typeof value === 'string';
+    const shouldOmit = (value: number) => typeof value === 'string';
     const result = omitBy(obj, shouldOmit);
     expect(result).toEqual(obj);
   });
 
   it('should work with an empty object', () => {
     const obj = {};
-    const shouldOmit = (value: never, key: string) => true;
+    const shouldOmit = (value: never) => value;
     const result = omitBy(obj, shouldOmit);
     expect(result).toEqual({});
   });
 
   it('should work with nested objects', () => {
     const obj = { a: 1, b: { nested: 'omit' }, c: 3 };
-    const shouldOmit = (value: any, key: string) => key === 'b';
+    const shouldOmit = (_: number | { nested: string }, key: string) => key === 'b';
     const result = omitBy(obj, shouldOmit);
     expect(result).toEqual({ a: 1, c: 3 });
   });

--- a/src/object/pickBy.spec.ts
+++ b/src/object/pickBy.spec.ts
@@ -1,38 +1,38 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { pickBy } from './pickBy';
 
 describe('pickBy', () => {
   it('should pick properties based on the predicate function', () => {
     const obj = { a: 1, b: 'pick', c: 3 };
-    const shouldPick = (value: any, key: string) => typeof value === 'string';
+    const shouldPick = (value: string | number) => typeof value === 'string';
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({ b: 'pick' });
   });
 
   it('should return an empty object if no properties satisfy the predicate', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const shouldPick = (value: any, key: string) => typeof value === 'string';
+    const shouldPick = (value: number) => typeof value === 'string';
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({});
   });
 
   it('should return the same object if all properties satisfy the predicate', () => {
     const obj = { a: 'pick', b: 'pick', c: 'pick' };
-    const shouldPick = (value: any, key: string) => typeof value === 'string';
+    const shouldPick = (value: string) => typeof value === 'string';
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual(obj);
   });
 
   it('should work with an empty object', () => {
     const obj = {};
-    const shouldPick = (value: any, key: string) => true;
+    const shouldPick = (value: never) => value;
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({});
   });
 
   it('should work with nested objects', () => {
     const obj = { a: 1, b: { nested: 'pick' }, c: 3 };
-    const shouldPick = (value: any, key: string) => key === 'b';
+    const shouldPick = (value: number | { nested: string }, key: string) => key === 'b';
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({ b: { nested: 'pick' } });
   });

--- a/src/predicate/isNil.ts
+++ b/src/predicate/isNil.ts
@@ -18,5 +18,5 @@
  * const result3 = isNil(value3); // false
  */
 export function isNil(x: unknown): x is null | undefined {
-  return x == null || x == undefined;
+  return x == null || x === undefined;
 }

--- a/src/predicate/isNotNil.ts
+++ b/src/predicate/isNotNil.ts
@@ -14,5 +14,5 @@
  * // result will be [1, 3]
  */
 export function isNotNil<T>(x: T | null | undefined): x is T {
-  return x != null && x != undefined;
+  return x != null && x !== undefined;
 }


### PR DESCRIPTION
I saw some code that was throwing eslint errors, so I applied lint.

I also changed it to **warn instead of error** because I think there will be cases in the future where the `any` type will be used intermittently.

Before
![image](https://github.com/toss/es-toolkit/assets/57122180/4379dcbf-e90c-4417-86ec-90cbcabfdaad)

After
![image](https://github.com/toss/es-toolkit/assets/57122180/c3ba63db-5d87-44eb-888c-cfc0b1958c6b)
