### PR TITLE
fix(shuffle): Ensure shuffle function does not modify original array

### DIFF
--- a/src/array/shuffle.spec.ts
+++ b/src/array/shuffle.spec.ts
@@ -7,4 +7,12 @@ describe('shuffle', () => {
 
     expect(shuffle(arr).slice().sort()).toEqual(arr.slice().sort());
   });
+
+  it('does not modify the original array', () => {
+    const arr = [1, 2, 3, 4, 5];
+    const copiedArr = arr.slice();
+
+    shuffle(arr);
+    expect(arr).toEqual(copiedArr);
+  });
 });

--- a/src/array/shuffle.ts
+++ b/src/array/shuffle.ts
@@ -12,14 +12,15 @@
  * // shuffledArray will be a new array with elements of array in random order, e.g., [3, 1, 4, 5, 2]
  */
 export function shuffle<T>(arr: T[]): T[] {
+  const copiedArr = arr.slice();
+
   /**
    * https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
    */
-  for (let i = arr.length - 1; i >= 1; i--) {
+  for (let i = copiedArr.length - 1; i >= 1; i--) {
     const j = Math.floor(Math.random() * (i + 1));
-
-    [arr[i], arr[j]] = [arr[j], arr[i]];
+    [copiedArr[i], copiedArr[j]] = [copiedArr[j], copiedArr[i]];
   }
 
-  return arr;
+  return copiedArr;
 }

--- a/src/array/shuffle.ts
+++ b/src/array/shuffle.ts
@@ -12,15 +12,15 @@
  * // shuffledArray will be a new array with elements of array in random order, e.g., [3, 1, 4, 5, 2]
  */
 export function shuffle<T>(arr: T[]): T[] {
-  const copiedArr = arr.slice();
+  const result = arr.slice();
 
   /**
    * https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
    */
-  for (let i = copiedArr.length - 1; i >= 1; i--) {
+  for (let i = result.length - 1; i >= 1; i--) {
     const j = Math.floor(Math.random() * (i + 1));
-    [copiedArr[i], copiedArr[j]] = [copiedArr[j], copiedArr[i]];
+    [result[i], result[j]] = [result[j], result[i]];
   }
 
-  return copiedArr;
+  return result;
 }


### PR DESCRIPTION
### [AS-IS]
The previous implementation of the shuffle function modified the original array, which is unintended behavior.

### [TO-BE]
the function now duplicates the array internally before shuffling. This ensures the original array remains unaffected.

## Changes
- Modify the shuffle function to copy the array before shuffling
- Add a test case to validate the preservation of the original array