### PR TITLE
style(*): Fix missing and incorrect JSDoc types

### DIFF
--- a/src/array/differenceWith.ts
+++ b/src/array/differenceWith.ts
@@ -13,7 +13,7 @@
  * according to the custom equality function.
  *
  * @example
- *  * const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+ * const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
  * const array2 = [{ id: 2 }, { id: 4 }];
  * const areItemsEqual = (a, b) => a.id === b.id;
  * const result = differenceWith(array1, array2, areItemsEqual);

--- a/src/array/drop.ts
+++ b/src/array/drop.ts
@@ -9,7 +9,7 @@
  * @returns {T[]} A new array with the specified number of elements removed from the start.
  *
  * @example
- *  * const array = [1, 2, 3, 4, 5];
+ * const array = [1, 2, 3, 4, 5];
  * const result = drop(array, 2);
  * // result will be [3, 4, 5] since the first two elements are dropped.
  */

--- a/src/array/dropRight.ts
+++ b/src/array/dropRight.ts
@@ -9,7 +9,7 @@
  * @returns {T[]} A new array with the specified number of elements removed from the end.
  *
  * @example
- *  * const array = [1, 2, 3, 4, 5];
+ * const array = [1, 2, 3, 4, 5];
  * const result = dropRight(array, 2);
  * // result will be [1, 2, 3] since the last two elements are dropped.
  */

--- a/src/array/dropRightWhile.ts
+++ b/src/array/dropRightWhile.ts
@@ -7,7 +7,7 @@ import { dropWhile } from './dropWhile';
  * predicate function returns false. It then returns a new array with the remaining elements.
  *
  * @param {T[]} arr - The array from which to drop elements.
- * @param {function(item: T): boolean} canContinueDropping - A predicate function that determines
+ * @param {(item: T) => boolean} canContinueDropping - A predicate function that determines
  * whether to continue dropping elements. The function is called with each element from the end,
  * and dropping continues as long as it returns true.
  * @returns {T[]} A new array with the elements remaining after the predicate returns false.

--- a/src/array/dropRightWhile.ts
+++ b/src/array/dropRightWhile.ts
@@ -17,7 +17,7 @@ import { dropWhile } from './dropWhile';
  * const result = dropRightWhile(array, x => x > 3);
  * // result will be [1, 2, 3] since elements greater than 3 are dropped from the end.
  */
-export function dropRightWhile<T>(arr: T[], canContinueDropping: (item: T) => boolean) {
+export function dropRightWhile<T>(arr: T[], canContinueDropping: (item: T) => boolean): T[] {
   const reversed = arr.slice().reverse();
   const dropped = dropWhile(reversed, canContinueDropping);
   return dropped.slice().reverse();

--- a/src/array/intersectionWith.ts
+++ b/src/array/intersectionWith.ts
@@ -13,7 +13,7 @@
  * @returns {T[]} A new array containing the elements from the first array that have corresponding matches in the second array according to the custom equality function.
  *
  * @example
- *  * const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+ * const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
  * const array2 = [{ id: 2 }, { id: 4 }];
  * const areItemsEqual = (a, b) => a.id === b.id;
  * const result = intersectionWith(array1, array2, areItemsEqual);

--- a/src/array/take.ts
+++ b/src/array/take.ts
@@ -20,6 +20,6 @@
  * // Returns [1, 2, 3]
  * take([1, 2, 3], 5);
  */
-export function take<T>(arr: T[], count: number) {
+export function take<T>(arr: T[], count: number): T[] {
   return arr.slice(0, count);
 }

--- a/src/array/unionBy.ts
+++ b/src/array/unionBy.ts
@@ -3,7 +3,7 @@
  *
  * @param {T[]} arr1 - The first array.
  * @param {T[]} arr2 - The second array.
- * @param {function(item: T): U} mapper - The function to map array elements to comparison values.
+ * @param {(item: T) => U} mapper - The function to map array elements to comparison values.
  * @returns {T[]} A new array containing the union of unique elements from `arr1` and `arr2`, based on the values returned by the mapping function.
  *
  * @example

--- a/src/array/uniq.ts
+++ b/src/array/uniq.ts
@@ -8,7 +8,7 @@
  * @returns {T[]} A new array with only unique values from the original array.
  *
  * @example
- *  * const array = [1, 2, 2, 3, 4, 4, 5];
+ * const array = [1, 2, 2, 3, 4, 4, 5];
  * const result = uniq(array);
  * // result will be [1, 2, 3, 4, 5]
  */

--- a/src/array/uniqBy.ts
+++ b/src/array/uniqBy.ts
@@ -5,6 +5,10 @@ import { uniqWith } from './uniqWith';
  *
  * It filters out elements with the same value, meaning it does not check for duplicates in data types like Objects.
  *
+ * @param {T[]} arr - The array to process.
+ * @param {(item: T) => U} converter - The function used to convert the array elements.
+ * @returns {T[]} A new array containing only the unique elements from the original array, based on the values returned by the converter function.
+ * 
  * @example
  * ```ts
  * uniqBy([1.2, 1.5, 2.1, 3.2, 5.7, 5.3, 7.19], Math.floor);

--- a/src/array/uniqWith.ts
+++ b/src/array/uniqWith.ts
@@ -3,6 +3,10 @@
  *
  * It evaluates the elements of the array using the comparator function, and if true is returned, it considers those elements as duplicates and removes them.
  *
+ * @param {T[]} arr - The array to process.
+ * @param {(item1: T, item2: T) => boolean} areItemsEqual - The function used to compare the array elements.
+ * @returns {T[]} A new array containing only the unique elements from the original array, based on the values returned by the comparator function.
+ * 
  * @example
  * ```ts
  * uniqWith([1.2, 1.5, 2.1, 3.2, 5.7, 5.3, 7.19], (a, b) => Math.abs(a - b) < 1);

--- a/src/array/xorBy.ts
+++ b/src/array/xorBy.ts
@@ -12,7 +12,7 @@ import { unionBy } from './unionBy';
  *
  * @param {T[]} arr1 - The first array.
  * @param {T[]} arr2 - The second array.
- * @param {function(item: T): U} mapper - The function to map array elements to comparison values.
+ * @param {(item: T) => U} mapper - The function to map array elements to comparison values.
  * @returns {T[]} An array containing the elements that are present in either `arr1` or `arr2` but not in both, based on the values returned by the mapping function.
  *
  * @example

--- a/src/array/zipWith.ts
+++ b/src/array/zipWith.ts
@@ -8,7 +8,7 @@
  * @param {U[]} [arr2] - The second array to zip (optional).
  * @param {V[]} [arr3] - The third array to zip (optional).
  * @param {W[]} [arr4] - The fourth array to zip (optional).
- * @param {function} combine - The combiner function that takes corresponding elements from each array and returns a single value.
+ * @param {(...items: T[]) => R} combine - The combiner function that takes corresponding elements from each array and returns a single value.
  * @returns {R[]} A new array where each element is the result of applying the combiner function to the corresponding elements of the input arrays.
  *
  * @example

--- a/src/math/clamp.ts
+++ b/src/math/clamp.ts
@@ -10,7 +10,7 @@
  * @returns {number} The clamped number within the specified bounds.
  *
  * @example
- *  * const result1 = clamp(10, 5); // result1 will be 5, as 10 is clamped to the bound 5
+ * const result1 = clamp(10, 5); // result1 will be 5, as 10 is clamped to the bound 5
  * const result2 = clamp(10, 5, 15); // result2 will be 10, as it is within the bounds 5 and 15
  * const result3 = clamp(2, 5, 15); // result3 will be 5, as 2 is clamped to the lower bound 5
  * const result4 = clamp(20, 5, 15); // result4 will be 15, as 20 is clamped to the upper bound 15

--- a/src/math/round.ts
+++ b/src/math/round.ts
@@ -9,7 +9,7 @@
  * @returns {number} The rounded number.
  *
  * @example
- *  * const result1 = round(1.2345); // result1 will be 1
+ * const result1 = round(1.2345); // result1 will be 1
  * const result2 = round(1.2345, 2); // result2 will be 1.23
  * const result3 = round(1.2345, 3); // result3 will be 1.235
  */

--- a/src/math/sum.ts
+++ b/src/math/sum.ts
@@ -7,7 +7,7 @@
  * @returns {number} The sum of all the numbers in the array.
  *
  * @example
- *  * const numbers = [1, 2, 3, 4, 5];
+ * const numbers = [1, 2, 3, 4, 5];
  * const result = sum(numbers);
  * // result will be 15
  */

--- a/src/object/omit.ts
+++ b/src/object/omit.ts
@@ -9,7 +9,7 @@
  * @returns {Omit<T, K>} A new object with the specified keys omitted.
  *
  * @example
- *  * const obj = { a: 1, b: 2, c: 3 };
+ * const obj = { a: 1, b: 2, c: 3 };
  * const result = omit(obj, ['b', 'c']);
  * // result will be { a: 1 }
  */

--- a/src/object/pick.ts
+++ b/src/object/pick.ts
@@ -9,7 +9,7 @@
  * @returns {Pick<T, K>} A new object with the specified keys picked.
  *
  * @example
- *  * const obj = { a: 1, b: 2, c: 3 };
+ * const obj = { a: 1, b: 2, c: 3 };
  * const result = pick(obj, ['a', 'c']);
  * // result will be { a: 1, c: 3 }
  */

--- a/src/predicate/isNil.ts
+++ b/src/predicate/isNil.ts
@@ -10,7 +10,7 @@
  * @returns {boolean} `true` if the value is null or undefined, `false` otherwise.
  *
  * @example
- *  * const value1 = null;
+ * const value1 = null;
  * const value2 = undefined;
  * const value3 = 42;
  * const result1 = isNil(value1); // true

--- a/src/predicate/isNull.ts
+++ b/src/predicate/isNull.ts
@@ -10,7 +10,7 @@
  * @returns {x is null} True if the value is null, false otherwise.
  *
  * @example
- *  * const value1 = null;
+ * const value1 = null;
  * const value2 = undefined;
  * const value3 = 42;
  *

--- a/src/predicate/isUndefined.ts
+++ b/src/predicate/isUndefined.ts
@@ -10,7 +10,7 @@
  * @returns {x is undefined} true if the value is undefined, false otherwise.
  *
  * @example
- *  * const value1 = undefined;
+ * const value1 = undefined;
  * const value2 = null;
  * const value3 = 42;
  *


### PR DESCRIPTION
## Changes
- Add missing JSDoc type annotations and update incorrect JSDoc type annotations https://github.com/toss/es-toolkit/commit/13688b03d10ce7de0df7f387059c48e505d6306f
- Remove duplicate asterisks from JSDoc annotations https://github.com/toss/es-toolkit/commit/b2dfb336366b65da9d98dbdd4421200dfa5ddccf
- Add missing TypeScript return types https://github.com/toss/es-toolkit/commit/a580c2c5002b12966776895e70de6613cc6d9015