### PR TITLE
feat: Support passing arguments to callback function in once function

### DIFF
--- a/docs/ko/reference/function/once.md
+++ b/docs/ko/reference/function/once.md
@@ -5,11 +5,11 @@
 
 ## 인터페이스
 
-function once<F extends () => any>(func: F): F;
+function once<F extends (...args: any[]) => any>(func: F): F;
 
 ### 파라미터
 
-- `func` (`F extends () => any`): 한 번만 호출하도록 제한할 함수예요.
+- `func` (`F extends (...args: any[]) => any`): 한 번만 호출하도록 제한할 함수예요.
 
 ### 결과 값
 

--- a/src/function/once.spec.ts
+++ b/src/function/once.spec.ts
@@ -30,4 +30,13 @@ describe('once', () => {
     onceFunc();
     expect(func).toHaveBeenCalledTimes(1);
   });
+
+  it('should handle functions with arguments', () => {
+    const func = vi.fn((a: number, b: number) => a + b);
+    const onceFunc = once(func);
+
+    expect(onceFunc(1, 2)).toBe(3);
+    expect(onceFunc(1, 2)).toBe(3);
+    expect(func).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/function/once.ts
+++ b/src/function/once.ts
@@ -14,16 +14,16 @@
  * initialize(); // Logs: 'Initialized!' and returns true
  * initialize(); // Returns true without logging
  */
-export function once<F extends () => any>(func: F): F {
+export function once<F extends (...args: any[]) => any>(func: F): F {
   let called = false;
   let cache: ReturnType<F> | undefined;
 
-  return function () {
+  return function (...args: Parameters<F>): ReturnType<F> {
     if (called) {
-      return cache;
+      return cache as ReturnType<F>;
     }
 
-    const result = func();
+    const result = func(...args);
 
     called = true;
     cache = result;


### PR DESCRIPTION
Hi :)
Previously, the `once` function could only handle callback functions without arguments.
With this update, the `once` function now properly handles callback function that require arguments.

### Changes
- Updated once function's type definition to accommodate callbacks that can recieve arguments
  ```ts
  // once.ts
  export function once<F extends (...args: any[]) => any>(func: F): F {
     ...
  }
  ```
