### PR TITLE
test(uniqWith): Add test cases for uniqWith

### DIFF
--- a/src/array/uniqWith.spec.ts
+++ b/src/array/uniqWith.spec.ts
@@ -12,7 +12,6 @@ describe('uniqWith', () => {
         (a, b) => a.x === b.x
       )
     ).toEqual([{ x: 1, y: 2 }]);
-  });
     expect(uniqWith([1.2, 1.5, 2.1, 3.2, 5.7, 5.3, 7.19], (a, b) => Math.abs(a - b) < 1)).toEqual([
       1.2, 3.2, 5.7, 7.19,
     ]);

--- a/src/array/uniqWith.spec.ts
+++ b/src/array/uniqWith.spec.ts
@@ -13,8 +13,6 @@ describe('uniqWith', () => {
       )
     ).toEqual([{ x: 1, y: 2 }]);
   });
-
-  it('should remove numbers that are within 1 unit of each other', () => {
     expect(uniqWith([1.2, 1.5, 2.1, 3.2, 5.7, 5.3, 7.19], (a, b) => Math.abs(a - b) < 1)).toEqual([
       1.2, 3.2, 5.7, 7.19,
     ]);

--- a/src/array/uniqWith.spec.ts
+++ b/src/array/uniqWith.spec.ts
@@ -13,4 +13,10 @@ describe('uniqWith', () => {
       )
     ).toEqual([{ x: 1, y: 2 }]);
   });
+
+  it('should remove numbers that are within 1 unit of each other', () => {
+    expect(uniqWith([1.2, 1.5, 2.1, 3.2, 5.7, 5.3, 7.19], (a, b) => Math.abs(a - b) < 1)).toEqual([
+      1.2, 3.2, 5.7, 7.19,
+    ]);
+  });
 });

--- a/src/array/uniqWith.ts
+++ b/src/array/uniqWith.ts
@@ -10,7 +10,7 @@
  * @example
  * ```ts
  * uniqWith([1.2, 1.5, 2.1, 3.2, 5.7, 5.3, 7.19], (a, b) => Math.abs(a - b) < 1);
- * // [1, 2, 3, 5, 7]
+ * // [1.2, 3.2, 5.7, 7.19]
  * ```
  */
 export function uniqWith<T>(arr: T[], areItemsEqual: (item1: T, item2: T) => boolean): T[] {


### PR DESCRIPTION
The `@example` was incorrect and fixed it.

comparator function, if false is returned then add element.

**first iter**
- a: X
- b: 1.2
-> 1.2 < 1 = false, added 1.2

**second iter**
- a: 1.2
- b: 1.5
-> 0.3 < 1 = true, not added 

**third iter**
- a: 1.2
- b: 2.1
-> 0.9 < 1 = true, not added

**fourth iter**
- a: 1.2
- b: 3.2
-> 2.0 < 1 = false, added 3.2

**fifth iter**
- a: 3.2
- b: 5.7
-> 2.5 < 1 = false, added 5.7

**sixth iter**
- a: 5.7
- b: 5.3
-> 0.4 < 1 = true, not added

**seventh iter**
- a: 5.7
- b: 7.19
-> 1.49 < 1 = false, added 7.19

answer: [1.2, 3.2, 5.7, 7.19]