### PR TITLE
docs: Fix broken link from README.md and README-ko_kr.md

### DIFF
--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -2,7 +2,7 @@
 
 # es-toolkit &middot; [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/toss/slash/blob/main/LICENSE)
 
-[English](./README.md) | 한국어
+[English](https://github.com/toss/es-toolkit/blob/main/README.md) | 한국어
 
 es-toolkit은 높은 성능과 작은 번들 사이즈, 강력한 타입을 자랑하는 현대적인 JavaScript 유틸리티 라이브러리예요.
 
@@ -16,7 +16,7 @@ es-toolkit은 높은 성능과 작은 번들 사이즈, 강력한 타입을 자�
 
 커뮤니티에 있는 모든 분들에게 기여를 환영해요. 아래에 작성되어 있는 기여 가이드를 확인하세요.
 
-[CONTRIBUTING](./.github/CONTRIBUTING.md)
+[CONTRIBUTING](https://github.com/toss/es-toolkit/blob/main/.github/CONTRIBUTING.md)
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # es-toolkit &middot; [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/toss/slash/blob/main/LICENSE)
 
-English | [한국어](./README-ko_kr.md)
+English | [한국어](https://github.com/toss/es-toolkit/blob/main/README-ko_kr.md)
 
 es-toolkit is a state-of-the-art, high-performance JavaScript utility library with a small bundle size and strong type annotations.
 
@@ -16,7 +16,7 @@ es-toolkit is a state-of-the-art, high-performance JavaScript utility library wi
 
 We welcome contribution from everyone in the community. Read below for detailed contribution guide.
 
-[CONTRIBUTING](./.github/CONTRIBUTING.md)
+[CONTRIBUTING](https://github.com/toss/es-toolkit/blob/main/.github/CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
Current README files include links like 
```markdown
English | [한국어](./README-ko_kr.md)
```
And these are not accessible outside github (such as [npm registry](https://www.npmjs.com/package/es-toolkit)). It is because those links are declared as a relative URLs.
So I changed them into absolute URLs:
```markdown
English | [한국어](https://github.com/toss/es-toolkit/blob/main/README-ko_kr.md)
```