### PR TITLE
docs(README.md): add codecov badge to expose test coverage 100%

### DIFF
--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -1,6 +1,6 @@
 ![](./docs/public/og.png)
 
-# es-toolkit &middot; [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/toss/slash/blob/main/LICENSE)
+# es-toolkit &middot; [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/toss/slash/blob/main/LICENSE) [![codecov](https://codecov.io/gh/toss/es-toolkit/graph/badge.svg?token=8N5S3AR3C7)](https://codecov.io/gh/toss/es-toolkit)
 
 [English](https://github.com/toss/es-toolkit/blob/main/README.md) | 한국어
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](./docs/public/og.png)
 
-# es-toolkit &middot; [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/toss/slash/blob/main/LICENSE)
+# es-toolkit &middot; [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/toss/slash/blob/main/LICENSE) [![codecov](https://codecov.io/gh/toss/es-toolkit/graph/badge.svg?token=8N5S3AR3C7)](https://codecov.io/gh/toss/es-toolkit)
 
 English | [한국어](https://github.com/toss/es-toolkit/blob/main/README-ko_kr.md)
 


### PR DESCRIPTION
Test coverage 100%

### TO BE

<img width="506" alt="image" src="https://github.com/toss/es-toolkit/assets/61593290/e4cd248c-a91b-4255-bf85-318f0e9a4978">
