### PR TITLE
perf(intersectionBy): optimize time complexity

### DIFF
--- a/src/array/intersectionBy.ts
+++ b/src/array/intersectionBy.ts
@@ -19,9 +19,6 @@
  * // result will be [{ id: 2 }] since only this element has a matching id in both arrays.
  */
 export function intersectionBy<T, U>(firstArr: T[], secondArr: T[], mapper: (item: T) => U): T[] {
-  const mappedSecondArr = secondArr.map(x => mapper(x));
-
-  return firstArr.filter(item => {
-    return mappedSecondArr.includes(mapper(item));
-  });
+  const mappedSecondSet = new Set(secondArr.map(mapper));
+  return firstArr.filter(item => mappedSecondSet.has(mapper(item)));
 }


### PR DESCRIPTION
This pull request optimizes the time complexity of the intersectionBy function from O(n*m) to O(n + m). The previous implementation used an array and the includes method, leading to quadratic time complexity due to repeated linear searches. The optimized implementation leverages a Set for constant-time lookups, thus improving the overall performance significantly.


* Benchmark1: small size of array
array 1 size: 10
array 2 size: 5
<img width="1010" alt="스크린샷 2024-06-13 오후 7 13 53" src="https://github.com/toss/es-toolkit/assets/47740690/1bebe77f-183e-4978-9f91-fd57186eee76">

* Benchmark2: large size of array
array 1 size: 10000
array 2 size: 5000
<img width="1030" alt="image" src="https://github.com/toss/es-toolkit/assets/47740690/5c71c89c-58f4-4c46-a82d-25e2aabb6f3b">
