### PR TITLE
fix(dropWhile): `dropWhile` returns the whole array when every element does not match the predicate

### DIFF
--- a/src/array/dropRightWhile.spec.ts
+++ b/src/array/dropRightWhile.spec.ts
@@ -21,5 +21,7 @@ describe('dropRightWhile', () => {
         enabled: true,
       },
     ]);
+
+    expect(dropRightWhile([1, 2, 3], x => x < 4)).toEqual([]);
   });
 });

--- a/src/array/dropWhile.spec.ts
+++ b/src/array/dropWhile.spec.ts
@@ -18,5 +18,7 @@ describe('dropWhile', () => {
       },
       { id: 3, enabled: false },
     ]);
+
+    expect(dropWhile([1, 2, 3], x => x < 4)).toEqual([]);
   });
 });

--- a/src/array/dropWhile.ts
+++ b/src/array/dropWhile.ts
@@ -17,5 +17,9 @@
  */
 export function dropWhile<T>(arr: readonly T[], canContinueDropping: (item: T) => boolean): T[] {
   const dropEndIndex = arr.findIndex(item => !canContinueDropping(item));
-  return dropEndIndex === -1 ? [] : arr.slice(dropEndIndex);
+  if (dropEndIndex === -1) {
+    return [];
+  }
+  
+  return arr.slice(dropEndIndex);
 }

--- a/src/array/dropWhile.ts
+++ b/src/array/dropWhile.ts
@@ -17,5 +17,5 @@
  */
 export function dropWhile<T>(arr: readonly T[], canContinueDropping: (item: T) => boolean): T[] {
   const dropEndIndex = arr.findIndex(item => !canContinueDropping(item));
-  return arr.slice(dropEndIndex);
+  return dropEndIndex === -1 ? [] : arr.slice(dropEndIndex);
 }


### PR DESCRIPTION
Thank you for making this lib!
I found an edge case for `dropWhile` function and I fixed it.