### PR TITLE
fix(pickBy, omitBy): Enforce stricter argument types in `shouldPick` and `shouldOmit`

### DIFF
--- a/docs/ko/reference/object/omitBy.md
+++ b/docs/ko/reference/object/omitBy.md
@@ -7,13 +7,13 @@
 ## 인터페이스
 
 ```typescript
-function omitBy<T extends Record<string, any>>(obj: T, shouldOmit: (value: any, key: string) => boolean): Partial<T>;
+function omitBy<T extends Record<string, any>>(obj: T, shouldOmit: (value: T[keyof T], key: keyof T) => boolean): Partial<T>;
 ```
 
 ### 파라미터
 
 - `obj` (`T`): 프로퍼티를 생략할 객체예요.
-- `shouldOmit` (`(value: any, key: string) => boolean`): 프로퍼티를 생략할지 결정하는 조건 함수예요. 이 함수는 프로퍼티의 키와 값을 인자로 받아, 프로퍼티를 생략해야 하면 true, 그렇지 않으면 false를 반환해요.
+- `shouldOmit` (`(value: T[keyof T], key: keyof T) => boolean`): 프로퍼티를 생략할지 결정하는 조건 함수예요. 이 함수는 프로퍼티의 키와 값을 인자로 받아, 프로퍼티를 생략해야 하면 true, 그렇지 않으면 false를 반환해요.
 
 ### 반환 값
 

--- a/docs/ko/reference/object/pickBy.md
+++ b/docs/ko/reference/object/pickBy.md
@@ -9,14 +9,14 @@
 ```typescript
 function pickBy<T extends Record<string, any>>(
   obj: T,
-  shouldPick: (value: T[keyof T], key: string) => boolean
+  shouldPick: (value: T[keyof T], key: keyof T) => boolean
 ): Partial<T>;
 ```
 
 ### 파라미터
 
 - `obj` (`T`): 프로퍼티를 선택할 객체예요.
-- `shouldPick` (`(value: T[keyof T], key: string) => boolean`): 프로퍼티를 선택할지를 결정하는 조건 함수예요. 이 함수는 프로퍼티의 키와 값을 인수로 받아, 프로퍼티를 선택해야 하면 true, 그렇지 않으면 false를 반환해요.
+- `shouldPick` (`(value: T[keyof T], key: keyof T) => boolean`): 프로퍼티를 선택할지를 결정하는 조건 함수예요. 이 함수는 프로퍼티의 키와 값을 인수로 받아, 프로퍼티를 선택해야 하면 true, 그렇지 않으면 false를 반환해요.
 
 ### 반환 값
 

--- a/docs/reference/object/omitBy.md
+++ b/docs/reference/object/omitBy.md
@@ -8,13 +8,13 @@ includes only the properties for which the predicate function returns false.
 ## Signature
 
 ```typescript
-function omitBy<T extends Record<string, any>>(obj: T, shouldOmit: (value: any, key: string) => boolean): Partial<T>;
+function omitBy<T extends Record<string, any>>(obj: T, shouldOmit: (value: T[keyof T], key: keyof T) => boolean): Partial<T>;
 ```
 
 ### Parameters
 
 - `obj` (`T`): The object to omit properties from.
-- `shouldOmit` (`(value: any, key: string) => boolean`): A predicate function that determines
+- `shouldOmit` (`(value: T[keyof T], key: keyof T) => boolean`): A predicate function that determines
   whether a property should be omitted. It takes the property's key and value as arguments and returns `true`
   if the property should be omitted, and `false` otherwise.
 

--- a/docs/reference/object/pickBy.md
+++ b/docs/reference/object/pickBy.md
@@ -10,14 +10,14 @@ includes only the properties for which the predicate function returns true.
 ```typescript
 function pickBy<T extends Record<string, any>>(
   obj: T,
-  shouldPick: (value: T[keyof T], key: string) => boolean
+  shouldPick: (value: T[keyof T], key: keyof T) => boolean
 ): Partial<T>;
 ```
 
 ### Parameters
 
 - `obj` (`T`): The object to pick properties from.
-- `shouldPick` (`(value: T[keyof T], key: string) => boolean`): A predicate function that determines whether a property should be picked. It takes the property's key and value as arguments and returns `true` if the property should be picked, and `false` otherwise.
+- `shouldPick` (`(value: T[keyof T], key: keyof T) => boolean`): A predicate function that determines whether a property should be picked. It takes the property's key and value as arguments and returns `true` if the property should be picked, and `false` otherwise.
 
 ### Returns
 

--- a/src/object/omitBy.ts
+++ b/src/object/omitBy.ts
@@ -5,7 +5,7 @@
  * includes only the properties for which the predicate function returns false.
  *
  * @param {T} obj - The object to omit properties from.
- * @param {(value: T[string], key: string) => boolean} shouldOmit - A predicate function that determines
+ * @param {(value: T[string], key: keyof T) => boolean} shouldOmit - A predicate function that determines
  * whether a property should be omitted. It takes the property's key and value as arguments and returns `true`
  * if the property should be omitted, and `false` otherwise.
  * @returns {Partial<T>} A new object with the properties that do not satisfy the predicate function.
@@ -18,7 +18,7 @@
  */
 export function omitBy<T extends Record<string, any>>(
   obj: T,
-  shouldOmit: (value: T[keyof T], key: string) => boolean
+  shouldOmit: (value: T[keyof T], key: keyof T) => boolean
 ): Partial<T> {
   const result: Partial<T> = {};
 

--- a/src/object/pickBy.ts
+++ b/src/object/pickBy.ts
@@ -5,7 +5,7 @@
  * includes only the properties for which the predicate function returns true.
  *
  * @param {T} obj - The object to pick properties from.
- * @param {(value: T[keyof T], key: string) => boolean} shouldPick - A predicate function that determines
+ * @param {(value: T[keyof T], key: keyof T) => boolean} shouldPick - A predicate function that determines
  * whether a property should be picked. It takes the property's key and value as arguments and returns `true`
  * if the property should be picked, and `false` otherwise.
  * @returns {Partial<T>} A new object with the properties that satisfy the predicate function.
@@ -18,7 +18,7 @@
  */
 export function pickBy<T extends Record<string, any>>(
   obj: T,
-  shouldPick: (value: T[keyof T], key: string) => boolean
+  shouldPick: (value: T[keyof T], key: keyof T) => boolean
 ): Partial<T> {
   const result: Partial<T> = {};
 


### PR DESCRIPTION
Resolves #58.

### Changed type of `key` from `string` to `keyof T` in `shouldPick` and `shouldOmit`.
Previously typescript should assume all `key`s as just `string`.
    <img width="425" alt="스크린샷 2024-06-15 17 44 42" src="https://github.com/toss/es-toolkit/assets/84632077/050d1818-2504-462a-94b3-1f665bfb210e">
Now typescript knows specific types of `key`s
<img width="553" alt="스크린샷 2024-06-15 17 44 17" src="https://github.com/toss/es-toolkit/assets/84632077/376cb17e-6b4a-4b2a-b9b3-a55a7596a886">
<img width="558" alt="스크린샷 2024-06-15 17 44 56" src="https://github.com/toss/es-toolkit/assets/84632077/f4de42c1-90fc-43ed-80c7-3b36c3d84036">


And edited existing document as to made changes.
Also, I found that type of `value` had set to `any`, unlike real implementation. So I've fixed that too.

closes #58 