### PR TITLE
perf(intersection): Improved performance for `intersection` function when the size of array is large

### DIFF
--- a/src/array/intersection.spec.ts
+++ b/src/array/intersection.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { intersection } from './intersection';
+import { randomInt } from 'crypto';
 
 describe('intersection', () => {
   it('should return the intersection of two arrays', () => {
@@ -7,5 +8,13 @@ describe('intersection', () => {
     expect(intersection([1, 2], [3, 1])).toEqual([1]);
     expect(intersection([1, 2], [3, 4])).toEqual([]);
     expect(intersection([], [1, 2])).toEqual([]);
+  });
+
+  it('handles large arrays', () => {
+    const array1 = Array.from({ length: 130 }, () => randomInt(0, 1000));
+    expect(intersection(array1, array1)).toEqual(array1);
+
+    const array2 = Array.from({ length: 130 }, () => randomInt(0, 1000));
+    expect(intersection(array1, array2)).toEqual(array1.filter(x => array2.includes(x)));
   });
 });

--- a/src/array/intersection.ts
+++ b/src/array/intersection.ts
@@ -18,11 +18,13 @@ import { FastMap } from '../utils/FastMap';
  * // result will be [3, 4, 5] since these elements are in both arrays.
  */
 export function intersection<T>(firstArr: readonly T[], secondArr: readonly T[]): T[] {
-  if (firstArr.length < 120) {
-    return intersectionSmallArrays(firstArr, secondArr);
+  const [largerArr, smallerArr] = distinguishLargerOrSmallerArray(firstArr, secondArr);
+
+  if (largerArr.length < 120) {
+    return intersectionSmallArrays(largerArr, smallerArr);
   }
 
-  return intersectionLargeArrays(firstArr, secondArr);
+  return intersectionLargeArrays(smallerArr, largerArr);
 }
 
 function intersectionSmallArrays<T>(firstArr: readonly T[], secondArr: readonly T[]): T[] {
@@ -48,4 +50,11 @@ function intersectionLargeArrays<T>(firstArr: readonly T[], secondArr: readonly 
     }
   }
   return result;
+}
+
+function distinguishLargerOrSmallerArray<T>(
+  firstArr: readonly T[],
+  secondArr: readonly T[]
+): [readonly T[], readonly T[]] {
+  return firstArr.length > secondArr.length ? [firstArr, secondArr] : [secondArr, firstArr];
 }

--- a/src/array/intersection.ts
+++ b/src/array/intersection.ts
@@ -21,17 +21,17 @@ export function intersection<T>(firstArr: readonly T[], secondArr: readonly T[])
   const [largerArr, smallerArr] = distinguishLargerOrSmallerArray(firstArr, secondArr);
 
   if (largerArr.length < 120) {
-    return intersectionSmallArrays(largerArr, smallerArr);
+    return intersectionSmallArrays(smallerArr, largerArr);
   }
 
   return intersectionLargeArrays(smallerArr, largerArr);
 }
 
-function intersectionSmallArrays<T>(firstArr: readonly T[], secondArr: readonly T[]): T[] {
-  const secondSet = new Set(secondArr);
+function intersectionSmallArrays<T>(smallerArr: readonly T[], largerArr: readonly T[]): T[] {
+  const set = new Set(smallerArr);
 
-  return firstArr.filter(item => {
-    return secondSet.has(item);
+  return largerArr.filter(item => {
+    return set.has(item);
   });
 }
 

--- a/src/array/intersection.ts
+++ b/src/array/intersection.ts
@@ -1,3 +1,5 @@
+import { FastMap } from '../utils/FastMap';
+
 /**
  * Returns the intersection of two arrays.
  *
@@ -16,9 +18,34 @@
  * // result will be [3, 4, 5] since these elements are in both arrays.
  */
 export function intersection<T>(firstArr: readonly T[], secondArr: readonly T[]): T[] {
+  if (firstArr.length < 120) {
+    return intersectionSmallArrays(firstArr, secondArr);
+  }
+
+  return intersectionLargeArrays(firstArr, secondArr);
+}
+
+function intersectionSmallArrays<T>(firstArr: readonly T[], secondArr: readonly T[]): T[] {
   const secondSet = new Set(secondArr);
 
   return firstArr.filter(item => {
     return secondSet.has(item);
   });
+}
+
+function intersectionLargeArrays<T>(firstArr: readonly T[], secondArr: readonly T[]): T[] {
+  const map = new FastMap();
+
+  for (const item of secondArr) {
+    map.set(item, true);
+  }
+
+  const result = [];
+  for (const item of firstArr) {
+    if (map.has(item)) {
+      result.push(item);
+      map.set(item, true);
+    }
+  }
+  return result;
 }

--- a/src/utils/FastMap.spec.ts
+++ b/src/utils/FastMap.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { FastMap } from './FastMap';
+
+describe('FastMap', () => {
+  it('should set and get values properly', () => {
+    const map = new FastMap<number | string, string>();
+
+    map.set(1, 'one');
+    map.set('2', 'two');
+
+    expect(map.get(1)).toBe('one');
+    expect(map.get('2')).toBe('two');
+    expect(map.get(2)).toBeUndefined();
+  });
+
+  it('should return undefined for non-existent keys', () => {
+    const map = new FastMap<number, string>();
+
+    expect(map.get(1)).toBeUndefined();
+  });
+
+  it('should return true for has() if key exists', () => {
+    const map = new FastMap<number, string>();
+
+    map.set(1, 'one');
+
+    expect(map.has(1)).toBe(true);
+    expect(map.has(2)).toBe(false);
+  });
+
+  it('should delete keys', () => {
+    const map = new FastMap<number, string>();
+
+    map.set(1, 'one');
+    map.delete(1);
+
+    expect(map.has(1)).toBe(false);
+  });
+
+  it('should clear all keys', () => {
+    const map = new FastMap<number, string>();
+
+    map.set(1, 'one');
+    map.set(2, 'two');
+    map.clear();
+
+    expect(map.has(1)).toBe(false);
+    expect(map.has(2)).toBe(false);
+  });
+
+  it('should return the size of the map', () => {
+    const map = new FastMap<number, string>();
+
+    map.set(1, 'one');
+    map.set(2, 'two');
+
+    expect(map.size).toBe(2);
+  });
+
+  it('should handle non-keyable keys', () => {
+    const map = new FastMap<object, string>();
+    const key1 = {};
+    const key2 = {};
+
+    map.set(key1, 'one');
+    map.set(key2, 'two');
+
+    expect(map.get(key1)).toBe('one');
+    expect(map.get(key2)).toBe('two');
+  });
+
+  it('should handle non-keyable keys with the same string representation', () => {
+    const map = new FastMap<object, string>();
+    const key1 = { toString: () => 'key' };
+    const key2 = { toString: () => 'key' };
+
+    map.set(key1, 'one');
+    map.set(key2, 'two');
+
+    expect(map.get(key1)).toBe('one');
+    expect(map.get(key2)).toBe('two');
+  });
+});

--- a/src/utils/FastMap.ts
+++ b/src/utils/FastMap.ts
@@ -1,0 +1,102 @@
+type ObjectKeyType = string | number | symbol;
+
+/**
+ * A faster alternative to the built-in Map class for use cases where there are a large number of
+ * keys and values.
+ *
+ * NOTE!!) If you are using the size < 120, using the built-in Map class instead is much more performant.
+ *
+ * @example
+ * const map = new FastMap();
+ * map.set('key', 'value');
+ * map.get('key'); // 'value'
+ */
+export class FastMap<T, U> implements Map<T, U> {
+  [Symbol.toStringTag] = '__FastMap_es_toolkit__';
+
+  private _keyableMap: Record<ObjectKeyType, U> = Object.create(null);
+  private _nonKeyableMap: Map<T, U> = new Map();
+
+  constructor(entries?: ReadonlyArray<readonly [T, U]> | null) {
+    if (entries) {
+      for (const [key, value] of entries) {
+        this.set(key, value);
+      }
+    }
+  }
+
+  set(key: T, value: U): this {
+    if (this._isKeyable(key)) {
+      this._keyableMap[key] = value;
+    } else {
+      this._nonKeyableMap.set(key, value);
+    }
+    return this;
+  }
+
+  get(key: T): U | undefined {
+    if (this._isKeyable(key)) {
+      return this._keyableMap[key];
+    } else {
+      return this._nonKeyableMap.get(key);
+    }
+  }
+
+  has(key: T): boolean {
+    if (this._isKeyable(key)) {
+      return key in this._keyableMap;
+    } else {
+      return this._nonKeyableMap.has(key);
+    }
+  }
+
+  clear(): void {
+    this._keyableMap = Object.create(null);
+    this._nonKeyableMap.clear();
+  }
+
+  delete(key: T): boolean {
+    if (this._isKeyable(key)) {
+      return delete this._keyableMap[key];
+    } else {
+      return this._nonKeyableMap.delete(key);
+    }
+  }
+
+  get size(): number {
+    return Object.keys(this._nonKeyableMap).length + this._nonKeyableMap.size;
+  }
+
+  [Symbol.iterator](): IterableIterator<[T, U]> {
+    return this.entries();
+  }
+
+  entries(): IterableIterator<[T, U]> {
+    const keyableEntries = Object.entries(this._keyableMap) as Array<[T, U]>;
+    const nonKeyableEntries = Array.from(this._nonKeyableMap.entries());
+    return keyableEntries.concat(nonKeyableEntries)[Symbol.iterator]();
+  }
+
+  keys(): IterableIterator<T> {
+    const keyableKeys = Object.keys(this._keyableMap) as T[];
+    const nonKeyableKeys = Array.from(this._nonKeyableMap.keys());
+    return keyableKeys.concat(nonKeyableKeys)[Symbol.iterator]();
+  }
+
+  values(): IterableIterator<U> {
+    const keyableValues = Object.values(this._keyableMap) as U[];
+    const nonKeyableValues = Array.from(this._nonKeyableMap.values());
+    return keyableValues.concat(nonKeyableValues)[Symbol.iterator]();
+  }
+
+  forEach(callbackfn: (value: U, key: T, map: Map<T, U>) => void, thisArg?: any): void {
+    for (const [key, value] of this) {
+      callbackfn.call(thisArg, value, key, this);
+    }
+  }
+
+  private _isKeyable(key: unknown): key is ObjectKeyType {
+    const type = typeof key;
+    return type === 'string' || type === 'number' || type === 'symbol';
+  }
+}

--- a/src/utils/FastMap.ts
+++ b/src/utils/FastMap.ts
@@ -62,8 +62,8 @@ export class FastMap<T, U> implements IFastMap<T, U> {
   }
 
   clear(): void {
-    this._keyableMapForOthers = new HashMap();
-    this._keyableMapForStr = new HashMap();
+    this._keyableMapForOthers.clear();
+    this._keyableMapForStr.clear();
     this._nonKeyableMap.clear();
   }
 
@@ -118,13 +118,5 @@ class HashMap<T extends ObjectKeyType, U> implements IFastMap<T, U> {
 
   get size() {
     return Object.keys(this._table).length;
-  }
-
-  keys() {
-    return Object.keys(this._table);
-  }
-
-  values() {
-    return Object.values(this._table);
   }
 }

--- a/src/utils/FastMap.ts
+++ b/src/utils/FastMap.ts
@@ -48,14 +48,6 @@ export class FastMap<T, U> implements IFastMap<T, U> {
   private _keyableMapForStr = new HashMap<ObjectKeyType, U>();
   private _nonKeyableMap: Map<T, U> = new Map();
 
-  constructor(entries?: ReadonlyArray<readonly [T, U]> | null) {
-    if (entries) {
-      for (const [key, value] of entries) {
-        this.set(key, value);
-      }
-    }
-  }
-
   set(key: T, value: U): this {
     this._getMap(key).set(key as any, value);
     return this;


### PR DESCRIPTION
This PR is related to this comment https://github.com/toss/es-toolkit/issues/57#issuecomment-2169311834

It seems that using pure object rather than Map object is more performant when dealing with lots of I/O.
So, I made the `intersection` function to use pure object when it is dealing with the array of size bigger than 120.
For convenience, I made `FastMap` class to abstract the behavior of my job. 
During this job, I referred to `MapCache` in `lodash` (https://github.com/lodash/lodash/blob/main/src/.internal/MapCache.ts)

I tested lengths for all combinations that I could make with the set { 10, 100, 1000, 10000, 100000 }.
My new implementation was more performant than lodash except for `{ 100, 100000 }`, `{10, 100000}`, `{100000, 10}`.

### Before (Length 10000)
<img width="809" alt="Screenshot 2024-06-15 at 10 02 28 PM" src="https://github.com/toss/es-toolkit/assets/64240134/c554a661-eb1c-438e-868a-43f937e1de02">

### After (Length 10000)
<img width="814" alt="Screenshot 2024-06-15 at 10 02 04 PM" src="https://github.com/toss/es-toolkit/assets/64240134/250bcab4-8ad1-4544-94ee-b46e9a576009">

## NOTE
I'm not sure this is the case for all environment. So PLEASE RUN BENCHMARK ON YOUR ENVIRONMENT when you review this PR.