### PR TITLE
feat: add isEmpty function, check for empty values

### DIFF
--- a/benchmarks/isEmpty.bench.ts
+++ b/benchmarks/isEmpty.bench.ts
@@ -1,0 +1,19 @@
+import { bench, describe } from 'vitest';
+import { isEmpty as isEmptyToolkit } from 'es-toolkit';
+import { isEmpty as isEmptyLodash } from 'lodash';
+
+const falsyList = [null, undefined, false, 0, NaN, ''];
+
+describe('isEmpty', () => {
+  bench('es-toolkit', () => {
+    falsyList.forEach(falsy => isEmptyToolkit(falsy));
+    isEmptyToolkit([]);
+    isEmptyToolkit({});
+  });
+
+  bench('lodash', () => {
+    falsyList.forEach(falsy => isEmptyLodash(falsy));
+    isEmptyLodash([]);
+    isEmptyLodash({});
+  });
+});

--- a/docs/ko/reference/predicate/isEmpty.md
+++ b/docs/ko/reference/predicate/isEmpty.md
@@ -1,0 +1,51 @@
+## isEmpty
+
+주어진 값이 비어있는지 확인합니다.
+이 함수는 특정 기준에 따라 값이 비어있는지 여부를 결정합니다. 문자열, 배열, 객체, 맵, 셋 등 다양한 타입을 처리하며, 빈 값을 정확하게 식별합니다.
+
+## 서명
+
+```typescript
+function isEmpty<T>(value: T): boolean;
+```
+
+### 매개변수
+
+- value (T): 비어있는지 확인할 값.
+
+### 반환값
+
+- (boolean): 값이 비어있다면 true, 그렇지 않다면 false.
+
+### 비어있는 값의 기준
+
+다음 값들은 비어있는 것으로 간주됩니다:
+
+- null
+- undefined
+- false
+- 0
+- NaN
+- "" (빈 문자열)
+- 빈 배열
+- 빈 객체 (순회 가능한 자신의 속성이 없는 객체)
+- 빈 Map 및 Set
+- 0 또는 음수인 유효한 length 속성을 가진 객체
+
+## 예시
+
+```typescript
+isEmpty(null); // true
+isEmpty(undefined); // true
+isEmpty(false); // true
+isEmpty(0); // true
+isEmpty(NaN); // true
+isEmpty(''); // true
+isEmpty([]); // true
+isEmpty({}); // true
+isEmpty(new Map()); // true
+
+isEmpty('a'); // false
+isEmpty([0]); // false
+isEmpty(1); // false
+```

--- a/docs/reference/predicate/isEmpty.md
+++ b/docs/reference/predicate/isEmpty.md
@@ -1,0 +1,49 @@
+# isEmpty
+
+Checks if a given value is empty.
+This function determines whether a value is considered empty based on a specific set of criteria. It works with various types such as strings, arrays, objects, maps, and sets, and it correctly identifies empty values.
+
+## Signature
+
+function isEmpty<T>(value: T): boolean;
+
+### Parameters
+
+- value (T): The value to be checked for emptiness.
+
+### Returns
+
+- (boolean): true if the value is empty, otherwise false.
+
+### Empty Values
+
+The following values are considered empty:
+
+- null
+- undefined
+- false
+- 0
+- NaN
+- "" (empty string)
+- empty arrays
+- empty objects (objects with no enumerable own-properties)
+- empty Map and Set
+- objects with a valid length property that is 0 or negative
+
+## Examples
+
+```typescript
+isEmpty(null); // true
+isEmpty(undefined); // true
+isEmpty(false); // true
+isEmpty(0); // true
+isEmpty(NaN); // true
+isEmpty(''); // true
+isEmpty([]); // true
+isEmpty({}); // true
+isEmpty(new Map()); // true
+
+isEmpty('a'); // false
+isEmpty([0]); // false
+isEmpty(1); // false
+```

--- a/src/predicate/index.ts
+++ b/src/predicate/index.ts
@@ -2,3 +2,4 @@ export { isNil } from './isNil';
 export { isNotNil } from './isNotNil';
 export { isNull } from './isNull';
 export { isUndefined } from './isUndefined';
+export { isEmpty } from './isEmpty';

--- a/src/predicate/isEmpty.spec.ts
+++ b/src/predicate/isEmpty.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { isEmpty } from './isEmpty';
+
+const falsyList = [null, undefined, false, 0, NaN, ''];
+
+class Foo {
+  length: number;
+  constructor(length = 0) {
+    this.length = length;
+  }
+}
+
+describe('isEmpty', () => {
+  it('should return `true` for empty values', () => {
+    const expected = Array(falsyList.length).fill(true);
+    const actual = falsyList.map(falsy => isEmpty(falsy));
+
+    expect(actual).toEqual(expected);
+
+    expect(isEmpty(NaN)).toBe(true);
+    expect(isEmpty([])).toBe(true);
+    expect(isEmpty({})).toBe(true);
+  });
+
+  it('should return `false` for non-empty values', () => {
+    expect(isEmpty([0])).toBe(false);
+    expect(isEmpty('a')).toBe(false);
+    expect(isEmpty({ a: 0 })).toBe(false);
+    expect(isEmpty(1)).toBe(false);
+  });
+
+  it('should work with an object that has a `length` property', () => {
+    expect(isEmpty({ length: 0 })).toBe(false);
+  });
+
+  it('should work with maps', () => {
+    if (Map) {
+      const map = new Map();
+      expect(isEmpty(map)).toBe(true);
+      map.set('a', 1);
+      expect(isEmpty(map)).toBe(false);
+      map.clear();
+    }
+  });
+
+  it('should work with sets', () => {
+    if (Set) {
+      const set = new Set();
+      expect(isEmpty(set)).toBe(true);
+      set.add(1);
+      expect(isEmpty(set)).toBe(false);
+      set.clear();
+    }
+  });
+
+  it('should not treat objects with negative lengths as array-like', () => {
+    expect(isEmpty(new Foo(-1))).toBe(true);
+  });
+
+  it('should not treat objects with lengths larger than `MAX_SAFE_INTEGER` as array-like', () => {
+    expect(isEmpty(new Foo(Number.MAX_SAFE_INTEGER + 1))).toBe(true);
+  });
+
+  it('should not treat objects with non-number lengths as array-like', () => {
+    expect(isEmpty({ length: '0' })).toBe(false);
+  });
+});

--- a/src/predicate/isEmpty.ts
+++ b/src/predicate/isEmpty.ts
@@ -1,0 +1,61 @@
+/**
+ * Checks if a value is empty.
+ *
+ * The following values are considered empty:
+ * - `null`
+ * - `undefined`
+ * - `false`
+ * - `0`
+ * - `NaN`
+ * - `""` (empty string)
+ * - empty arrays
+ * - empty objects (objects with no enumerable own-properties)
+ * - empty `Map` and `Set`
+ * - objects with a valid length property that is 0 or negative
+ *
+ * @template T The type of the value.
+ * @param {T} value The value to check.
+ * @returns {boolean} Returns `true` if the value is empty, else `false`.
+ *
+ * @example
+ * isEmpty(null); // true
+ * isEmpty(undefined); // true
+ * isEmpty(false); // true
+ * isEmpty(0); // true
+ * isEmpty(NaN); // true
+ * isEmpty(''); // true
+ * isEmpty([]); // true
+ * isEmpty([1]); // false
+ * isEmpty('a'); // false
+ */
+export function isEmpty<T>(value: T): boolean {
+  if (value == null) {
+    return true;
+  }
+
+  if (value === false || value === 0 || value === '' || (typeof value === 'number' && isNaN(value))) {
+    return true;
+  }
+
+  if (typeof value === 'string' || Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (value instanceof Map || value instanceof Set) {
+    return value.size === 0;
+  }
+
+  if (typeof value === 'object') {
+    if (
+      'length' in value &&
+      typeof value.length === 'number' &&
+      (value.length > Number.MAX_SAFE_INTEGER || value.length < 0)
+    ) {
+      return true;
+    }
+
+    return Object.keys(value).length === 0;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Implemented a new `isEmpty` function to check if a value is empty. This function works with various data types like strings, arrays, objects, maps, and sets. 

#### The following values are considered empty:

- null
- undefined
- false
- 0
- NaN
- "" (empty string)
- empty arrays
- empty objects (objects with no enumerable own-properties)
- empty Map and Set
- objects with a valid length property that is 0 or negative

Benchmarks demonstrating the performance of this function are included in the attached images below.
![image](https://github.com/toss/es-toolkit/assets/23359043/4914c23c-75b8-40bd-bc40-ac22e52794d4)
