### PR TITLE
test(omit, pick): Add test cases

### DIFF
--- a/src/object/omit.spec.ts
+++ b/src/object/omit.spec.ts
@@ -4,8 +4,8 @@ import { omit } from './omit';
 describe('omit', () => {
   it('should omit properties from an object', () => {
     const object = { foo: 1, bar: 2, baz: 3 };
-
-    expect(omit(object, ['foo', 'bar'])).toEqual({ baz: 3 });
+    const result = omit(object, ['foo', 'bar']);
+    expect(result).toEqual({ baz: 3 });
   });
 
   it('should return an empty object if all keys are omitted', () => {

--- a/src/object/pick.spec.ts
+++ b/src/object/pick.spec.ts
@@ -4,7 +4,25 @@ import { pick } from './pick';
 describe('pick', () => {
   it('should pick properties from an object', () => {
     const object = { foo: 1, bar: 2, baz: 3 };
+    const result = pick(object, ['foo', 'bar']);
+    expect(result).toEqual({ foo: 1, bar: 2 });
+  });
 
-    expect(pick(object, ['foo', 'bar'])).toEqual({ foo: 1, bar: 2 });
+  it('should return the same object if all keys are picked', () => {
+    const object = { a: 1, b: 2, c: 3 };
+    const result = pick(object, ['a', 'b', 'c']);
+    expect(result).toEqual(object);
+  });
+
+  it('should return an empty object if the key array is empty', () => {
+    const object = { a: 1, b: 2, c: 3 };
+    const result = pick(object, []);
+    expect(result).toEqual({});
+  });
+
+  it('should work with nested objects', () => {
+    const object = { a: 1, b: { nested: 'pick' }, c: 3 };
+    const result = pick(object, ['a', 'b', 'c']);
+    expect(result).toEqual({ a: 1, b: { nested: 'pick' }, c: 3 });
   });
 });


### PR DESCRIPTION
### Description

I added code in the `object` related function test. (consistency, add test case)

### Changes

#### Consistency

In the `omit`function, one test case was changed by not using the `result` variable.

#### Add test case

There was only one test case for the `pick` function.
I Added a test case.

- All keys are picked
- The key array is empty
- Nested objects
