### PR TITLE
docs(isUndefined): Polish document styles and fix incorrect comments

### DIFF
--- a/docs/ko/reference/predicate/isUndefined.md
+++ b/docs/ko/reference/predicate/isUndefined.md
@@ -1,6 +1,6 @@
 # isUndefined
 
-주어진 값이 undefined인지 확인해요.
+주어진 값이 `undefined`인지 확인해요.
 
 이 함수는 주어진 값이 `undefined` 인지 엄격 일치 (===) 기준으로 확인합니다.
 값이 `undefined` 이면 `true`, 아니면 `false` 를 반환해요.
@@ -15,11 +15,11 @@ function isUndefined(x: unknown): x is undefined;
 
 ### 파라미터
 
-- `x` (`unknown`): undefined인지 확인할 값
+- `x` (`unknown`): `undefined`인지 확인할 값
 
 ### 반환 값
 
-(`x is undefined`): 값이 undefined이면 true, 아니면 false.
+(`x is undefined`): 값이 `undefined`이면 `true`, 아니면 `false`.
 
 ## 예시
 

--- a/docs/reference/predicate/isUndefined.md
+++ b/docs/reference/predicate/isUndefined.md
@@ -1,6 +1,6 @@
 # isUndefined
 
-Checks if the given value is undefined.
+Checks if the given value is `undefined`.
 
 This function tests whether the provided value is strictly equal to `undefined`.
 It returns `true` if the value is `undefined`, and `false` otherwise.
@@ -15,11 +15,11 @@ function isUndefined(x: unknown): x is undefined;
 
 ### Parameters
 
-- `x` (`unknown`): The value to test if it is undefined.
+- `x` (`unknown`): The value to test if it is `undefined`.
 
 ### Returns
 
-(`x is undefined`): True if the value is undefined, false otherwise.
+(`x is undefined`): `true` if the value is `undefined`, `false` otherwise.
 
 ## Examples
 

--- a/src/predicate/isUndefined.spec.ts
+++ b/src/predicate/isUndefined.spec.ts
@@ -17,7 +17,7 @@ describe('isUndefined', () => {
 
     const result = arr.filter(isUndefined);
 
-    // Here the type of result should be `undefined[]`.
+    // Here the type of result should be `null[]`.
     expect(result).toStrictEqual([undefined]);
   });
 });

--- a/src/predicate/isUndefined.spec.ts
+++ b/src/predicate/isUndefined.spec.ts
@@ -17,7 +17,7 @@ describe('isUndefined', () => {
 
     const result = arr.filter(isUndefined);
 
-    // Here the type of result should be `null[]`.
+    // Here the type of result should be `undefined[]`.
     expect(result).toStrictEqual([undefined]);
   });
 });


### PR DESCRIPTION
### Description

I fix documentation and comments related to `isUndefined`.

### Changes

#### Applying inline code markdown

I applied inline code markdown for `undefined`, `true`, and `false`.
I think this will improve readability.

#### Fix comments

I changed `null[]` to `undefined[]`.

<img width="444" alt="스크린샷 2024-06-16 오후 4 56 47" src="https://github.com/toss/es-toolkit/assets/79239852/15fb54f4-9efc-4eba-9d5c-bf29b5bb41e0">

**AS-IS**

```ts
    // Here the type of result should be `null[]`.
    expect(result).toStrictEqual([undefined]);
```

**TO-BE**

```ts
    // Here the type of result should be `undefined[]`.
    expect(result).toStrictEqual([undefined]);
```
