### PR TITLE
ci(broken-link-checker): add default url for schedule

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -18,4 +18,4 @@ jobs:
           cache-dependency-path: 'yarn.lock'
           node-version-file: '.nvmrc'
       - run: yarn install
-      - run: yarn blc ${{ github.event.inputs.url }} --ro
+      - run: yarn blc ${{ github.event.inputs.url || 'https://es-toolkit.slash.page' }} --ro


### PR DESCRIPTION
This change fix https://github.com/toss/es-toolkit/actions/workflows/broken-link-checker.yml

![image](https://github.com/toss/es-toolkit/assets/61593290/9e2cd1e4-85a9-4e4b-a45a-d21b007042b2)
