### PR TITLE
chore(*): add codspeed for benchmark visualization

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,25 @@
+name: codspeed-benchmarks
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'yarn'
+        name: Install dependencies
+      - run: yarn install
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v2
+        with:
+          run: yarn vitest bench
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/benchmarks/chunk.bench.ts
+++ b/benchmarks/chunk.bench.ts
@@ -3,11 +3,11 @@ import { chunk as chunkToolkit } from 'es-toolkit';
 import { chunk as chunkLodash } from 'lodash';
 
 describe('chunk', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/chunk', () => {
     chunkToolkit([1, 2, 3, 4, 5, 6], 3);
   });
 
-  bench('lodash', () => {
+  bench('lodash/chunk', () => {
     chunkLodash([1, 2, 3, 4, 5, 6], 3);
   });
 });

--- a/benchmarks/clamp.bench.ts
+++ b/benchmarks/clamp.bench.ts
@@ -3,12 +3,12 @@ import { clamp as clampToolkit } from 'es-toolkit';
 import { clamp as clampLodash } from 'lodash';
 
 describe('clamp', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/clamp', () => {
     clampToolkit(10, 5, 15);
     clampToolkit(10, 5);
   });
 
-  bench('lodash', () => {
+  bench('lodash/clamp', () => {
     clampLodash(10, 5, 15);
     clampLodash(10, 5);
   });

--- a/benchmarks/difference.bench.ts
+++ b/benchmarks/difference.bench.ts
@@ -3,11 +3,11 @@ import { difference as differenceToolkit } from 'es-toolkit';
 import { difference as differenceLodash } from 'lodash';
 
 describe('difference', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/difference', () => {
     differenceToolkit([1, 2, 3], [2]);
   });
 
-  bench('lodash', () => {
+  bench('lodash/difference', () => {
     differenceLodash([1, 2, 3], [2]);
   });
 });

--- a/benchmarks/differenceBy.bench.ts
+++ b/benchmarks/differenceBy.bench.ts
@@ -3,11 +3,11 @@ import { differenceBy as differenceByToolkit } from 'es-toolkit';
 import { differenceBy as differenceByLodash } from 'lodash';
 
 describe('differenceBy', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/differenceBy', () => {
     differenceByToolkit([1.2, 2.3, 3.4], [1.2], Math.floor);
   });
 
-  bench('lodash', () => {
+  bench('lodash/differenceBy', () => {
     differenceByLodash([1.2, 2.3, 3.4], [1.2], Math.floor);
   });
 });

--- a/benchmarks/differenceWith.bench.ts
+++ b/benchmarks/differenceWith.bench.ts
@@ -3,11 +3,11 @@ import { differenceWith as differenceWithToolkit } from 'es-toolkit';
 import { differenceWith as differenceWithLodash } from 'lodash';
 
 describe('differenceWith', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/differenceWith', () => {
     differenceWithToolkit([1.2, 2.3, 3.4], [1.2], (x, y) => Math.floor(x) === Math.floor(y));
   });
 
-  bench('lodash', () => {
+  bench('lodash/differenceWith', () => {
     differenceWithLodash([1.2, 2.3, 3.4], [1.2], (x, y) => Math.floor(x) === Math.floor(y));
   });
 });

--- a/benchmarks/drop.bench.ts
+++ b/benchmarks/drop.bench.ts
@@ -3,11 +3,11 @@ import { drop as dropToolkit } from 'es-toolkit';
 import { drop as dropLodash } from 'lodash';
 
 describe('drop', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/drop', () => {
     dropToolkit([1, 2, 3, 4, 5, 6], 3);
   });
 
-  bench('lodash', () => {
+  bench('lodash/drop', () => {
     dropLodash([1, 2, 3, 4, 5, 6], 3);
   });
 });

--- a/benchmarks/dropRight.bench.ts
+++ b/benchmarks/dropRight.bench.ts
@@ -3,7 +3,7 @@ import { dropRight as dropRightToolkit } from 'es-toolkit';
 import { dropRight as dropRightLodash } from 'lodash';
 
 describe('dropRight', () => {
-  bench('es-toolki/dropRight', () => {
+  bench('es-toolkit/dropRight', () => {
     dropRightToolkit([1, 2, 3, 4, 5, 6], 3);
   });
 

--- a/benchmarks/dropRight.bench.ts
+++ b/benchmarks/dropRight.bench.ts
@@ -3,11 +3,11 @@ import { dropRight as dropRightToolkit } from 'es-toolkit';
 import { dropRight as dropRightLodash } from 'lodash';
 
 describe('dropRight', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolki/dropRight', () => {
     dropRightToolkit([1, 2, 3, 4, 5, 6], 3);
   });
 
-  bench('lodash', () => {
+  bench('lodash/dropRight', () => {
     dropRightLodash([1, 2, 3, 4, 5, 6], 3);
   });
 });

--- a/benchmarks/dropRightWhile.bench.ts
+++ b/benchmarks/dropRightWhile.bench.ts
@@ -3,11 +3,11 @@ import { dropRightWhile as dropRightWhileToolkit } from 'es-toolkit';
 import { dropRightWhile as dropRightWhileLodash } from 'lodash';
 
 describe('dropRightWhile', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/dropRightWhile', () => {
     dropRightWhileToolkit([1.2, 2.3, 3.4], x => x < 2);
   });
 
-  bench('lodash', () => {
+  bench('lodash/dropRightWhile', () => {
     dropRightWhileLodash([1.2, 2.3, 3.4], x => x < 2);
   });
 });

--- a/benchmarks/dropWhile.bench.ts
+++ b/benchmarks/dropWhile.bench.ts
@@ -3,11 +3,11 @@ import { dropWhile as dropWhileToolkit } from 'es-toolkit';
 import { dropWhile as dropWhileLodash } from 'lodash';
 
 describe('dropWhile', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/dropWhile', () => {
     dropWhileToolkit([1.2, 2.3, 3.4], x => x < 2);
   });
 
-  bench('lodash', () => {
+  bench('lodash/dropWhile', () => {
     dropWhileLodash([1.2, 2.3, 3.4], x => x < 2);
   });
 });

--- a/benchmarks/groupBy.bench.ts
+++ b/benchmarks/groupBy.bench.ts
@@ -3,7 +3,7 @@ import { groupBy as groupByToolkit } from 'es-toolkit';
 import { groupBy as groupByLodash } from 'lodash';
 
 describe('groupBy', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/groupBy', () => {
     const array = [
       { category: 'fruit', name: 'apple' },
       { category: 'fruit', name: 'banana' },
@@ -15,7 +15,7 @@ describe('groupBy', () => {
     groupByToolkit(array, item => item.category);
   });
 
-  bench('lodash', () => {
+  bench('lodash/groupBy', () => {
     const array = [
       { category: 'fruit', name: 'apple' },
       { category: 'fruit', name: 'banana' },

--- a/benchmarks/intersection.bench.ts
+++ b/benchmarks/intersection.bench.ts
@@ -6,11 +6,11 @@ describe('intersection, small arrays', () => {
   const array1 = [1, 2, 3];
   const array2 = [2, 4];
 
-  bench('es-toolkit', () => {
+  bench('es-toolkit/intersection', () => {
     intersectionToolkit(array1, array2);
   });
 
-  bench('lodash', () => {
+  bench('lodash/intersection', () => {
     intersectionLodash(array1, array2);
   });
 });
@@ -19,11 +19,11 @@ describe('intersection, large arrays', () => {
   const array1 = Array.from({ length: 10000 }, () => Math.floor(Math.random() * 1000));
   const array2 = Array.from({ length: 10000 }, () => Math.floor(Math.random() * 1000));
 
-  bench('es-toolkit', () => {
+  bench('es-toolkit/intersection', () => {
     intersectionToolkit(array1, array2);
   });
 
-  bench('lodash', () => {
+  bench('lodash/intersection', () => {
     intersectionLodash(array1, array2);
   });
 });

--- a/benchmarks/intersectionBy.bench.ts
+++ b/benchmarks/intersectionBy.bench.ts
@@ -3,14 +3,14 @@ import { intersectionBy as intersectionByToolkit } from 'es-toolkit';
 import { intersectionBy as intersectionByLodash } from 'lodash';
 
 describe('intersectionBy', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/intersectionBy', () => {
     const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
     const array2 = [{ id: 2 }, { id: 4 }];
     const mapper = item => item.id;
     intersectionByToolkit(array1, array2, mapper);
   });
 
-  bench('lodash', () => {
+  bench('lodash/intersectionBy', () => {
     const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
     const array2 = [{ id: 2 }, { id: 4 }];
     const mapper = item => item.id;

--- a/benchmarks/intersectionWith.bench.ts
+++ b/benchmarks/intersectionWith.bench.ts
@@ -3,14 +3,14 @@ import { intersectionWith as intersectionWithToolkit } from 'es-toolkit';
 import { intersectionWith as intersectionWithLodash } from 'lodash';
 
 describe('intersectionWith', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/intersectionWith', () => {
     const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
     const array2 = [{ id: 2 }, { id: 4 }];
     const areItemsEqual = (a, b) => a.id === b.id;
     intersectionWithToolkit(array1, array2, areItemsEqual);
   });
 
-  bench('lodash', () => {
+  bench('lodash/intersectionWith', () => {
     const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
     const array2 = [{ id: 2 }, { id: 4 }];
     const areItemsEqual = (a, b) => a.id === b.id;

--- a/benchmarks/isNil.bench.ts
+++ b/benchmarks/isNil.bench.ts
@@ -3,14 +3,14 @@ import { isNil as isNilToolkit } from 'es-toolkit';
 import { isNil as isNilLodash } from 'lodash';
 
 describe('isNil', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/isNil', () => {
     isNilToolkit(null);
     isNilToolkit(undefined);
     isNilToolkit(123);
     isNilToolkit([1, 2, 3]);
   });
 
-  bench('lodash', () => {
+  bench('lodash/isNil', () => {
     isNilLodash(null);
     isNilLodash(undefined);
     isNilLodash(123);

--- a/benchmarks/maxBy.bench.ts
+++ b/benchmarks/maxBy.bench.ts
@@ -3,7 +3,7 @@ import { maxBy as maxByToolkit } from 'es-toolkit';
 import { maxBy as maxByLodash } from 'lodash';
 
 describe('maxBy', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/maxBy', () => {
     const people = [
       { name: 'Mark', age: 25 },
       { name: 'Nunu', age: 30 },
@@ -12,7 +12,7 @@ describe('maxBy', () => {
     maxByToolkit(people, person => person.age);
   });
 
-  bench('lodash', () => {
+  bench('lodash/maxBy', () => {
     const people = [
       { name: 'Mark', age: 25 },
       { name: 'Nunu', age: 30 },

--- a/benchmarks/minBy.bench.ts
+++ b/benchmarks/minBy.bench.ts
@@ -3,7 +3,7 @@ import { minBy as minByToolkit } from 'es-toolkit';
 import { minBy as minByLodash } from 'lodash';
 
 describe('minBy', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/minBy', () => {
     const people = [
       { name: 'Mark', age: 30 },
       { name: 'Nunu', age: 20 },
@@ -12,7 +12,7 @@ describe('minBy', () => {
     minByToolkit(people, person => person.age);
   });
 
-  bench('lodash', () => {
+  bench('lodash/minBy', () => {
     const people = [
       { name: 'Mark', age: 30 },
       { name: 'Nunu', age: 20 },

--- a/benchmarks/omit.bench.ts
+++ b/benchmarks/omit.bench.ts
@@ -3,11 +3,11 @@ import { omit as omitToolkit } from 'es-toolkit';
 import { omit as omitLodash } from 'lodash';
 
 describe('omit', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/omit', () => {
     omitToolkit({ foo: 1, bar: 2, baz: 3 }, ['foo', 'bar']);
   });
 
-  bench('lodash', () => {
+  bench('lodash/omit', () => {
     omitLodash({ foo: 1, bar: 2, baz: 3 }, ['foo', 'bar']);
   });
 });

--- a/benchmarks/omitBy.bench.ts
+++ b/benchmarks/omitBy.bench.ts
@@ -3,13 +3,13 @@ import { omitBy as omitByLodash } from 'lodash';
 import { bench, describe } from 'vitest';
 
 describe('omitBy', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/omitBy', () => {
     const obj = { a: 1, b: 'omit', c: 3 };
     const shouldOmit = (value: number | string) => typeof value === 'string';
     omitByToolkit(obj, shouldOmit);
   });
 
-  bench('lodash', () => {
+  bench('lodash/omitBy', () => {
     const obj = { a: 1, b: 'omit', c: 3 };
     const shouldOmit = (value: number | string) => typeof value === 'string';
     omitByLodash(obj, shouldOmit);

--- a/benchmarks/partition.bench.ts
+++ b/benchmarks/partition.bench.ts
@@ -3,7 +3,7 @@ import { partition as partitionToolkit } from 'es-toolkit';
 import { partition as partitionLodash } from 'lodash';
 
 describe('partition', () => {
-  bench('es-toolkit/', () => {
+  bench('es-toolkit/partition', () => {
     partitionToolkit([1, 2, 3, 4, 5], x => x < 3);
   });
 

--- a/benchmarks/partition.bench.ts
+++ b/benchmarks/partition.bench.ts
@@ -3,11 +3,11 @@ import { partition as partitionToolkit } from 'es-toolkit';
 import { partition as partitionLodash } from 'lodash';
 
 describe('partition', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/', () => {
     partitionToolkit([1, 2, 3, 4, 5], x => x < 3);
   });
 
-  bench('lodash', () => {
+  bench('lodash/partition', () => {
     partitionLodash([1, 2, 3], x => x < 3);
   });
 });

--- a/benchmarks/pick.bench.ts
+++ b/benchmarks/pick.bench.ts
@@ -3,11 +3,11 @@ import { pick as pickToolkit } from 'es-toolkit';
 import { pick as pickLodash } from 'lodash';
 
 describe('pick', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/pick', () => {
     pickToolkit({ foo: 1, bar: 2, baz: 3 }, ['foo', 'bar']);
   });
 
-  bench('lodash', () => {
+  bench('lodash/pick', () => {
     pickLodash({ foo: 1, bar: 2, baz: 3 }, ['foo', 'bar']);
   });
 });

--- a/benchmarks/random.bench.ts
+++ b/benchmarks/random.bench.ts
@@ -3,11 +3,11 @@ import { random as randomToolkit } from 'es-toolkit';
 import { random as randomLodash } from 'lodash';
 
 describe('random', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/random', () => {
     randomToolkit(1, 10);
   });
 
-  bench('lodash', () => {
+  bench('lodash/random', () => {
     randomLodash(1, 10, true);
   });
 });

--- a/benchmarks/round.bench.ts
+++ b/benchmarks/round.bench.ts
@@ -3,11 +3,11 @@ import { round as roundToolkit } from 'es-toolkit';
 import { round as roundLodash } from 'lodash';
 
 describe('round', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/round', () => {
     roundToolkit(1.2345, 2);
   });
 
-  bench('lodash', () => {
+  bench('lodash/round', () => {
     roundLodash(1.2345, 2);
   });
 });

--- a/benchmarks/sample.bench.ts
+++ b/benchmarks/sample.bench.ts
@@ -3,12 +3,12 @@ import { sample as sampleToolkit } from 'es-toolkit';
 import { sample as sampleLodash } from 'lodash';
 
 describe('sample', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/sample', () => {
     const array = [1, 2, 3, 4, 5];
     sampleToolkit(array);
   });
 
-  bench('lodash', () => {
+  bench('lodash/sample', () => {
     const array = [1, 2, 3, 4, 5];
     sampleLodash(array);
   });

--- a/benchmarks/shuffle.bench.ts
+++ b/benchmarks/shuffle.bench.ts
@@ -3,12 +3,12 @@ import { shuffle as shuffleToolkit } from 'es-toolkit';
 import { shuffle as shuffleLodash } from 'lodash';
 
 describe('shuffle', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/shuffle', () => {
     const array = [1, 2, 3, 4, 5];
     shuffleToolkit(array);
   });
 
-  bench('lodash', () => {
+  bench('lodash/shuffle', () => {
     const array = [1, 2, 3, 4, 5];
     shuffleLodash(array);
   });

--- a/benchmarks/sum.bench.ts
+++ b/benchmarks/sum.bench.ts
@@ -3,11 +3,11 @@ import { sum as sumToolkit } from 'es-toolkit';
 import { sum as sumLodash } from 'lodash';
 
 describe('sum', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/sum', () => {
     sumToolkit([1, 2, 3]);
   });
 
-  bench('lodash', () => {
+  bench('lodash/sum', () => {
     sumLodash([1, 2, 3]);
   });
 });

--- a/benchmarks/take.bench.ts
+++ b/benchmarks/take.bench.ts
@@ -3,11 +3,11 @@ import { take as takeToolkit } from 'es-toolkit';
 import { take as takeLodash } from 'lodash';
 
 describe('take', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/take', () => {
     takeToolkit([1, 2, 3, 4], 2);
   });
 
-  bench('lodash', () => {
+  bench('lodash/take', () => {
     takeLodash([1, 2, 3, 4], 2);
   });
 });

--- a/benchmarks/takeRight.bench.ts
+++ b/benchmarks/takeRight.bench.ts
@@ -3,11 +3,11 @@ import { takeRight as takeRightToolkit } from 'es-toolkit';
 import { takeRight as takeRightLodash } from 'lodash';
 
 describe('takeRight', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/takeRight', () => {
     takeRightToolkit([1, 2, 3, 4], 2);
   });
 
-  bench('lodash', () => {
+  bench('lodash/takeRight', () => {
     takeRightLodash([1, 2, 3, 4], 2);
   });
 });

--- a/benchmarks/takeRightWhile.bench.ts
+++ b/benchmarks/takeRightWhile.bench.ts
@@ -3,11 +3,11 @@ import { takeRightWhile as takeRightWhileToolkit } from 'es-toolkit';
 import { takeRightWhile as takeRightWhileLodash } from 'lodash';
 
 describe('takeRightWhile', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/takeRightWhile', () => {
     takeRightWhileToolkit([5, 4, 3, 2, 1], n => n < 4);
   });
 
-  bench('lodash', () => {
+  bench('lodash/takeRightWhile', () => {
     takeRightWhileLodash([5, 4, 3, 2, 1], n => n < 4);
   });
 });

--- a/benchmarks/takeWhile.bench.ts
+++ b/benchmarks/takeWhile.bench.ts
@@ -3,11 +3,11 @@ import { takeWhile as takeWhileToolkit } from 'es-toolkit';
 import { takeWhile as takeWhileLodash } from 'lodash';
 
 describe('takeWhile', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/takeWhile', () => {
     takeWhileToolkit([5, 4, 3, 2, 1], n => n < 4);
   });
 
-  bench('lodash', () => {
+  bench('lodash/takeWhile', () => {
     takeWhileLodash([5, 4, 3, 2, 1], n => n < 4);
   });
 });

--- a/benchmarks/union.bench.ts
+++ b/benchmarks/union.bench.ts
@@ -3,13 +3,13 @@ import { union as unionLodash } from 'lodash';
 import { bench, describe } from 'vitest';
 
 describe('union', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/union', () => {
     const array1 = [1, 2, 3];
     const array2 = [3, 4, 5];
     unionToolkit(array1, array2);
   });
 
-  bench('lodash', () => {
+  bench('lodash/union', () => {
     const array1 = [1, 2, 3];
     const array2 = [3, 4, 5];
     unionLodash(array1, array2);

--- a/benchmarks/unionBy.bench.ts
+++ b/benchmarks/unionBy.bench.ts
@@ -3,11 +3,11 @@ import { unionBy as unionByToolkit } from 'es-toolkit';
 import { unionBy as unionByLodash } from 'lodash';
 
 describe('unionBy', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/unionBy', () => {
     unionByToolkit([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], x => x.id);
   });
 
-  bench('lodash', () => {
+  bench('lodash/unionBy', () => {
     unionByLodash([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], x => x.id);
   });
 });

--- a/benchmarks/unionWith.bench.ts
+++ b/benchmarks/unionWith.bench.ts
@@ -3,14 +3,14 @@ import { unionWith as unionWithToolkit } from 'es-toolkit';
 import { unionWith as unionWithLodash } from 'lodash';
 
 describe('unionWith', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/unionWith', () => {
     const array1 = [{ id: 1 }, { id: 2 }];
     const array2 = [{ id: 2 }, { id: 3 }];
     const areItemsEqual = (a, b) => a.id === b.id;
     unionWithToolkit(array1, array2, areItemsEqual);
   });
 
-  bench('lodash', () => {
+  bench('lodash/unionWith', () => {
     const array1 = [{ id: 1 }, { id: 2 }];
     const array2 = [{ id: 2 }, { id: 3 }];
     const areItemsEqual = (a, b) => a.id === b.id;

--- a/benchmarks/uniq.bench.ts
+++ b/benchmarks/uniq.bench.ts
@@ -3,11 +3,11 @@ import { uniq as uniqToolkit } from 'es-toolkit';
 import { uniq as uniqLodash } from 'lodash';
 
 describe('uniq', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/uniq', () => {
     uniqToolkit([11, 2, 3, 44, 11, 2, 3]);
   });
 
-  bench('lodash', () => {
+  bench('lodash/uniq', () => {
     uniqLodash([11, 2, 3, 44, 11, 2, 3]);
   });
 });

--- a/benchmarks/uniqBy.bench.ts
+++ b/benchmarks/uniqBy.bench.ts
@@ -4,11 +4,11 @@ import { uniqBy as uniqByLodash } from 'lodash';
 import { randomInt } from 'crypto';
 
 describe('uniqBy, small arrays', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/uniqBy', () => {
     uniqByToolkit([2.1, 1.2, 2.3], Math.floor);
   });
 
-  bench('lodash', () => {
+  bench('lodash/uniqBy', () => {
     uniqByLodash([2.1, 1.2, 2.3], Math.floor);
   });
 });
@@ -16,11 +16,11 @@ describe('uniqBy, small arrays', () => {
 describe('uniqBy, large arrays', () => {
   const array = Array.from({ length: 10000 }).map(() => randomInt(0, 10000));
 
-  bench('es-toolkit', () => {
+  bench('es-toolkit/uniqBy', () => {
     uniqByToolkit(array, Math.floor);
   });
 
-  bench('lodash', () => {
+  bench('lodash/uniqBy', () => {
     uniqByLodash(array, Math.floor);
   });
 });

--- a/benchmarks/uniqWith.bench.ts
+++ b/benchmarks/uniqWith.bench.ts
@@ -4,11 +4,11 @@ import { uniqWith as uniqWithLodash } from 'lodash';
 import { randomInt } from 'crypto';
 
 describe('uniqWith, small arrays', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/uniqWith', () => {
     uniqWithToolkit([2.1, 1.2, 2.3], (x, y) => Math.floor(x) === Math.floor(y));
   });
 
-  bench('lodash', () => {
+  bench('lodash/uniqWith', () => {
     uniqWithLodash([2.1, 1.2, 2.3], (x, y) => Math.floor(x) === Math.floor(y));
   });
 });
@@ -17,11 +17,11 @@ describe('uniqWith, large arrays', () => {
   const array = Array.from({ length: 10000 }).map(() => randomInt(0, 10000));
   const comparator = (x, y) => Math.floor(x) === Math.floor(y);
 
-  bench('es-toolkit', () => {
+  bench('es-toolkit/uniqWith', () => {
     uniqWithToolkit(array, comparator);
   });
 
-  bench('lodash', () => {
+  bench('lodash/uniqWith', () => {
     uniqWithLodash(array, comparator);
   });
 });

--- a/benchmarks/xor.bench.ts
+++ b/benchmarks/xor.bench.ts
@@ -3,11 +3,11 @@ import { xor as xorToolkit } from 'es-toolkit';
 import { xor as xorLodash } from 'lodash';
 
 describe('xor', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/xor', () => {
     xorToolkit([1, 2, 3, 4], [3, 4, 5, 6]);
   });
 
-  bench('lodash', () => {
+  bench('lodash/xor', () => {
     xorLodash([1, 2, 3, 4], [3, 4, 5, 6]);
   });
 });

--- a/benchmarks/xorBy.bench.ts
+++ b/benchmarks/xorBy.bench.ts
@@ -3,12 +3,12 @@ import { xorBy as xorByToolkit } from 'es-toolkit';
 import { xorBy as xorByLodash } from 'lodash';
 
 describe('xorBy', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/xorBy', () => {
     const idMapper = obj => obj.id;
     xorByToolkit([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], idMapper);
   });
 
-  bench('lodash', () => {
+  bench('lodash/xorBy', () => {
     const idMapper = obj => obj.id;
     xorByLodash([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], idMapper);
   });

--- a/benchmarks/xorWith.bench.ts
+++ b/benchmarks/xorWith.bench.ts
@@ -3,11 +3,11 @@ import { xorWith as xorWithLodash } from 'lodash';
 import { bench, describe } from 'vitest';
 
 describe('xorWith', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/xorWith', () => {
     xorWithToolkit([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], (x, y) => x.id === y.id);
   });
 
-  bench('lodash', () => {
+  bench('lodash/xorWith', () => {
     xorWithLodash([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], (x, y) => x.id === y.id);
   });
 });

--- a/benchmarks/zip.bench.ts
+++ b/benchmarks/zip.bench.ts
@@ -3,11 +3,11 @@ import { zip as zipToolkit } from 'es-toolkit';
 import { zip as zipLodash } from 'lodash';
 
 describe('zip', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/zip', () => {
     zipToolkit([1, 2, 3, 4], [3, 4, 5, 6]);
   });
 
-  bench('lodash', () => {
+  bench('lodash/zip', () => {
     zipLodash([1, 2, 3, 4], [3, 4, 5, 6]);
   });
 });

--- a/benchmarks/zipWith.bench.ts
+++ b/benchmarks/zipWith.bench.ts
@@ -3,14 +3,14 @@ import { zipWith as zipWithToolkit } from 'es-toolkit';
 import { zipWith as zipWithLodash } from 'lodash';
 
 describe('zipWith', () => {
-  bench('es-toolkit', () => {
+  bench('es-toolkit/zipWith', () => {
     const arr1 = [1, 2];
     const arr2 = [3, 4];
     const arr3 = [5, 6];
     zipWithToolkit(arr1, arr2, arr3, (a, b, c) => `${a}${b}${c}`);
   });
 
-  bench('lodash', () => {
+  bench('lodash/zipWith', () => {
     const arr1 = [1, 2];
     const arr2 = [3, 4];
     const arr3 = [5, 6];

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@babel/preset-typescript": "^7.24.1",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
+    "@codspeed/vitest-plugin": "^3.1.0",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",
     "@types/broken-link-checker": "^0",
@@ -127,6 +128,7 @@
     "prepack": "yarn build",
     "build": "tsup && ./.scripts/postbuild.sh",
     "test": "vitest run --coverage --typecheck",
+    "bench": "vitest bench",
     "lint": "eslint ./src --ext .ts",
     "format": "prettier --write ."
   }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitest/config';
 import packageJson from './package.json';
+import codspeedPlugin from '@codspeed/vitest-plugin';
 
 export default defineConfig({
+  ...(process.env.CI === 'true' ? { plugins: [codspeedPlugin()] } : {}),
   test: {
     name: packageJson.name,
     coverage: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2016,6 +2016,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@codspeed/core@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@codspeed/core@npm:3.1.0"
+  dependencies:
+    axios: "npm:^1.4.0"
+    find-up: "npm:^6.3.0"
+    form-data: "npm:^4.0.0"
+    node-gyp-build: "npm:^4.6.0"
+  checksum: 10c0/577cefd0b3b7d6eb471f1ceb24d34f5cb6a7c1bebf3f8b9aa80f0f2b8f2deffac55561e8161c497bcf39fd5effa7a39432e286131eb8f7dfece29b3d0117c075
+  languageName: node
+  linkType: hard
+
+"@codspeed/vitest-plugin@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@codspeed/vitest-plugin@npm:3.1.0"
+  dependencies:
+    "@codspeed/core": "npm:^3.1.0"
+  peerDependencies:
+    vite: ^4.2.0 || ^5.0.0
+    vitest: ">=1.2.2"
+  checksum: 10c0/eae8a9823f77c469b59f8f109f8c4961fd8a4538b540c1493e8929bd13c6f87753caf32309fcc1ad1af0a3268d690856296db7dd89f55cf64fc3ae3f0a482338
+  languageName: node
+  linkType: hard
+
 "@docsearch/css@npm:3.6.0, @docsearch/css@npm:^3.6.0":
   version: 3.6.0
   resolution: "@docsearch/css@npm:3.6.0"
@@ -3736,6 +3760,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.4.0":
+  version: 1.7.2
+  resolution: "axios@npm:1.7.2"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/cbd47ce380fe045313364e740bb03b936420b8b5558c7ea36a4563db1258c658f05e40feb5ddd41f6633fdd96d37ac2a76f884dad599c5b0224b4c451b3fa7ae
+  languageName: node
+  linkType: hard
+
 "babel-plugin-polyfill-corejs2@npm:^0.4.10":
   version: 0.4.11
   resolution: "babel-plugin-polyfill-corejs2@npm:0.4.11"
@@ -4266,7 +4301,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.6, combined-stream@npm:~1.0.6":
+"combined-stream@npm:^1.0.6, combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.6":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
@@ -4849,6 +4884,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.24.1"
     "@changesets/changelog-github": "npm:^0.5.0"
     "@changesets/cli": "npm:^2.27.1"
+    "@codspeed/vitest-plugin": "npm:^3.1.0"
     "@types/babel__core": "npm:^7"
     "@types/babel__preset-env": "npm:^7"
     "@types/broken-link-checker": "npm:^0"
@@ -5371,6 +5407,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-up@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "find-up@npm:6.3.0"
+  dependencies:
+    locate-path: "npm:^7.1.0"
+    path-exists: "npm:^5.0.0"
+  checksum: 10c0/07e0314362d316b2b13f7f11ea4692d5191e718ca3f7264110127520f3347996349bf9e16805abae3e196805814bc66ef4bff2b8904dc4a6476085fc9b0eba07
+  languageName: node
+  linkType: hard
+
 "find-yarn-workspace-root2@npm:1.2.16":
   version: 1.2.16
   resolution: "find-yarn-workspace-root2@npm:1.2.16"
@@ -5405,6 +5451,16 @@ __metadata:
   dependencies:
     tabbable: "npm:^6.2.0"
   checksum: 10c0/c09e12b957862b2608977ff90de782645f99c3555cc5d93977240c179befa8723b9b1183e93890b4ad9d364d52a1af36416e63a728522ecce656a447d9ddd945
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10c0/9ff767f0d7be6aa6870c82ac79cf0368cd73e01bbc00e9eb1c2a16fbb198ec105e3c9b6628bb98e9f3ac66fe29a957b9645bcb9a490bb7aa0d35f908b6b85071
   languageName: node
   linkType: hard
 
@@ -5444,6 +5500,17 @@ __metadata:
     mime: "npm:^1.3.4"
     uuid: "npm:^2.0.1"
   checksum: 10c0/1e1909525b94c7e443f9bcb16a1d6f0293b3f9fe3ff700539e059a5f909a0f84f9720b8cc4c11f3d3a50b3f0d6c3ee8ca5613a19ae9b59b4c205304f3acc3904
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    mime-types: "npm:^2.1.12"
+  checksum: 10c0/cb6f3ac49180be03ff07ba3ff125f9eba2ff0b277fb33c7fc47569fc5e616882c5b1c69b9904c4c4187e97dd0419dd03b134174756f296dec62041e6527e2c6e
   languageName: node
   linkType: hard
 
@@ -6664,6 +6731,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"locate-path@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "locate-path@npm:7.2.0"
+  dependencies:
+    p-locate: "npm:^6.0.0"
+  checksum: 10c0/139e8a7fe11cfbd7f20db03923cacfa5db9e14fa14887ea121345597472b4a63c1a42a8a5187defeeff6acf98fd568da7382aa39682d38f0af27433953a97751
+  languageName: node
+  linkType: hard
+
 "lodash.clonedeep@npm:^4.5.0":
   version: 4.5.0
   resolution: "lodash.clonedeep@npm:4.5.0"
@@ -7149,6 +7225,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-gyp-build@npm:^4.6.0":
+  version: 4.8.1
+  resolution: "node-gyp-build@npm:4.8.1"
+  bin:
+    node-gyp-build: bin.js
+    node-gyp-build-optional: optional.js
+    node-gyp-build-test: build-test.js
+  checksum: 10c0/e36ca3d2adf2b9cca316695d7687207c19ac6ed326d6d7c68d7112cebe0de4f82d6733dff139132539fcc01cf5761f6c9082a21864ab9172edf84282bc849ce7
+  languageName: node
+  linkType: hard
+
 "node-gyp@npm:latest":
   version: 10.1.0
   resolution: "node-gyp@npm:10.1.0"
@@ -7403,6 +7490,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-limit@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "p-limit@npm:4.0.0"
+  dependencies:
+    yocto-queue: "npm:^1.0.0"
+  checksum: 10c0/a56af34a77f8df2ff61ddfb29431044557fcbcb7642d5a3233143ebba805fc7306ac1d448de724352861cb99de934bc9ab74f0d16fe6a5460bdbdf938de875ad
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^5.0.0":
   version: 5.0.0
   resolution: "p-limit@npm:5.0.0"
@@ -7427,6 +7523,15 @@ __metadata:
   dependencies:
     p-limit: "npm:^3.0.2"
   checksum: 10c0/2290d627ab7903b8b70d11d384fee714b797f6040d9278932754a6860845c4d3190603a0772a663c8cb5a7b21d1b16acb3a6487ebcafa9773094edc3dfe6009a
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "p-locate@npm:6.0.0"
+  dependencies:
+    p-limit: "npm:^4.0.0"
+  checksum: 10c0/d72fa2f41adce59c198270aa4d3c832536c87a1806e0f69dffb7c1a7ca998fb053915ca833d90f166a8c082d3859eabfed95f01698a3214c20df6bb8de046312
   languageName: node
   linkType: hard
 
@@ -7494,6 +7599,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
   checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
+  languageName: node
+  linkType: hard
+
+"path-exists@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "path-exists@npm:5.0.0"
+  checksum: 10c0/b170f3060b31604cde93eefdb7392b89d832dfbc1bed717c9718cbe0f230c1669b7e75f87e19901da2250b84d092989a0f9e44d2ef41deb09aa3ad28e691a40a
   languageName: node
   linkType: hard
 
@@ -7730,6 +7842,13 @@ __metadata:
     err-code: "npm:^2.0.2"
     retry: "npm:^0.12.0"
   checksum: 10c0/9c7045a1a2928094b5b9b15336dcd2a7b1c052f674550df63cc3f36cd44028e5080448175b6f6ca32b642de81150f5e7b1a98b728f15cb069f2dd60ac2616b96
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
related https://github.com/toss/es-toolkit/issues/57

### Background
Recently, contributions to improve the performance of the es-toolkit have been ongoing. Many people have been measuring performance improvements using the experimental bench feature applied to vitest. ([like this](https://github.com/toss/es-toolkit/pull/53#issue-2353572060))

So I have discovered [codspeed](https://docs.codspeed.io/), a tool that further automates this process, and I want to install it. We can easliy install this package because we already have `*.bench.ts` files. [Prisma](https://github.com/prisma/prisma/pull/24554) is already using it, and it is available for [free](https://codspeed.io/pricing) in public open source projects.

<img width="916" alt="image" src="https://github.com/toss/es-toolkit/assets/26808056/61bc0465-b3eb-44b0-9a35-e9b9d8430282">

### Features
CodSpeed visualizes performance metrics, allowing us to see improvements or regressions by comparing with previous benchmarks. We can view these visualizations both in PR comments and on the codSpeed dashboard. (maybe it would be https://codspeed.io/toss/es-toolkit/benchmarks)

###  Changes
When I tested it in the forked repository, and it was difficult to identify which function belonged to lodash and es-toolkit. So, I added delimiters like `lodash/uniq` and `es-toolkit/uniq` in the `*.bench.ts` file.

<img width="922" alt="image" src="https://github.com/toss/es-toolkit/assets/26808056/43ddd2df-8efc-4c51-bb49-741dfc245319">