### PR TITLE
fix(clamp): replace null check with typeof for undefined check

### DIFF
--- a/src/math/clamp.ts
+++ b/src/math/clamp.ts
@@ -18,7 +18,7 @@
 export function clamp(value: number, maximum: number): number;
 export function clamp(value: number, minimum: number, maximum: number): number;
 export function clamp(value: number, bound1: number, bound2?: number): number {
-  if (bound2 == null) {
+  if (typeof bound2 === 'undefined') {
     return Math.min(value, bound1);
   }
 


### PR DESCRIPTION
### Description
Replaced the null check with `typeof` check for undefined in the `clamp` function. This change improves type safety and code readability.

### Changes
- Updated clamp function to use `typeof bound2 === 'undefined'` instead of `bound2 == null`.

### Benchmarks

#### as-is
<img width="857" alt="origin_bench" src="https://github.com/toss/es-toolkit/assets/78058734/be0852e5-13b8-421b-a211-54288ffa0c0e">

#### to-be
<img width="857" alt="changed_bench" src="https://github.com/toss/es-toolkit/assets/78058734/4afea161-01d2-4f70-8368-529e70d7029a">


### References
While considering why it was initially written as `== null`, I came across this [PR](https://github.com/toss/slash/pull/396). However, I believe this case is slightly different, which is why I submitted the PR.

If it was for the same reason, please close this PR.

Thank you!