### PR TITLE
fix(round): Throw an exception when `precision` is not an integer

### DIFF
--- a/docs/ko/reference/math/round.md
+++ b/docs/ko/reference/math/round.md
@@ -25,4 +25,5 @@ function round(value: number, precision?: number): number;
 const result1 = round(1.2345); // result1은 1이 되어요.
 const result2 = round(1.2345, 2); // result2는 1.23이 되어요.
 const result3 = round(1.2345, 3); // result3는 1.235가 되어요.
+const result4 = round(1.2345, 3.1); // precision이 integer가 아니면 오류를 반환해요.
 ```

--- a/docs/reference/math/round.md
+++ b/docs/reference/math/round.md
@@ -26,4 +26,5 @@ function round(value: number, precision?: number): number;
 const result1 = round(1.2345); // result1 will be 1
 const result2 = round(1.2345, 2); // result2 will be 1.23
 const result3 = round(1.2345, 3); // result3 will be 1.235
+const result4 = round(1.2345, 3.1); // This will throw an error
 ```

--- a/src/math/round.spec.ts
+++ b/src/math/round.spec.ts
@@ -51,4 +51,12 @@ describe('round function', () => {
   it('works with precision leading to no rounding', () => {
     expect(round(8.88888, 5)).toBe(8.88888);
   });
+
+  it('handles edge cases where precision is not integer', () => {
+    const value = 1.2345;
+    const precision = 3.1;
+    expect(() => round(value, precision)).toThrow(
+      'Precision must be an integer.'
+    );
+  });
 });

--- a/src/math/round.ts
+++ b/src/math/round.ts
@@ -7,13 +7,18 @@
  * @param {number} value - The number to round.
  * @param {number} [precision=0] - The number of decimal places to round to. Defaults to 0.
  * @returns {number} The rounded number.
+ * @throws {Error} Throws an error if `Precision` is not integer.
  *
  * @example
  * const result1 = round(1.2345); // result1 will be 1
  * const result2 = round(1.2345, 2); // result2 will be 1.23
  * const result3 = round(1.2345, 3); // result3 will be 1.235
+ * const result4 = round(1.2345, 3.1); // This will throw an error
  */
 export function round(value: number, precision = 0): number {
+  if (!Number.isInteger(precision)) {
+    throw new Error('Precision must be an integer.');
+  }
   const multiplier = Math.pow(10, precision);
   return Math.round(value * multiplier) / multiplier;
 }


### PR DESCRIPTION
## Description
When rounding, the type of the second parameter, `precision`, is Number, which can also accept float values. Therefore, I added exception handling for cases where it is not an Integer.

## Changes
When attempting to use the round function with inputs like round(1.2345, 3.1), the result was 1.2343860767615331, which does not behave as desired for a rounding function. To fix this, I added exception handling with the following code.
```
if (!Number.isInteger(precision)) {
  throw new Error('Precision must be an integer.');
}
```
This ensures that the `precision` parameter must be an integer, preventing incorrect rounding behavior.
