### PR TITLE
fix(difference): Add missing readonly to parameter

### DIFF
--- a/src/array/difference.ts
+++ b/src/array/difference.ts
@@ -20,7 +20,7 @@
  * const result = difference(array1, array2);
  * // result will be [1, 3, 5] since 2 and 4 are in both arrays and are excluded from the result.
  */
-export function difference<T>(firstArr: readonly T[], secondArr: T[]): T[] {
+export function difference<T>(firstArr: readonly T[], secondArr: readonly T[]): T[] {
   const secondSet = new Set(secondArr);
 
   return firstArr.filter(item => !secondSet.has(item));


### PR DESCRIPTION
I guess that when supporting read-only arrays, [the `readonly` keyword was mistakenly omitted](https://github.com/toss/es-toolkit/commit/e595e5e017e1f2cb138b1ad3d708635efc5e289e#diff-c6fd3af3ba9f40b9d78d4fbcdfaced66ca7ab40cdf9568ce602b006f045bb9ffL23-R23) from the `difference` parameter.

