### PR TITLE
docs(groupBy, keyBy): Update type of key to PropertyKey

### DIFF
--- a/docs/ko/reference/array/groupBy.md
+++ b/docs/ko/reference/array/groupBy.md
@@ -8,7 +8,7 @@
 ## 인터페이스
 
 ```typescript
-function groupBy<T, K extends string>(arr: T[], getKeyFromItem: (item: T) => K): Record<K, T[]>;
+function groupBy<T, K extends PropertyKey>(arr: T[], getKeyFromItem: (item: T) => K): Record<K, T[]>;
 ```
 
 ### 파라미터

--- a/docs/ko/reference/array/keyBy.md
+++ b/docs/ko/reference/array/keyBy.md
@@ -9,7 +9,7 @@
 ## 인터페이스
 
 ```typescript
-function keyBy<T, K extends string>(arr: readonly T[], getKeyFromItem: (item: T) => K): Record<K, T>;
+function keyBy<T, K extends PropertyKey>(arr: readonly T[], getKeyFromItem: (item: T) => K): Record<K, T>;
 ```
 
 ### 파라미터

--- a/docs/reference/array/groupBy.md
+++ b/docs/reference/array/groupBy.md
@@ -9,7 +9,7 @@ the same key.
 ## Signature
 
 ```typescript
-function groupBy<T, K extends string>(arr: T[], getKeyFromItem: (item: T) => K): Record<K, T[]>;
+function groupBy<T, K extends PropertyKey>(arr: T[], getKeyFromItem: (item: T) => K): Record<K, T[]>;
 ```
 
 ### Parameters

--- a/docs/reference/array/keyBy.md
+++ b/docs/reference/array/keyBy.md
@@ -9,7 +9,7 @@ If there are multiple elements generating the same key, the last element among t
 ## Signature
 
 ```typescript
-function keyBy<T, K extends string>(arr: readonly T[], getKeyFromItem: (item: T) => K): Record<K, T>;
+function keyBy<T, K extends PropertyKey>(arr: readonly T[], getKeyFromItem: (item: T) => K): Record<K, T>;
 ```
 
 ### Parameters


### PR DESCRIPTION
I missed to update docs after accepting number and symbol keys in  `groupBy` and `keyBy`