### PR TITLE
chore(once): fix docs and test, add bench

### DIFF
--- a/benchmarks/once.bench.ts
+++ b/benchmarks/once.bench.ts
@@ -1,0 +1,13 @@
+import { once as onceToolkit } from 'es-toolkit';
+import { once as onceLodash } from 'lodash';
+import { bench, describe } from 'vitest';
+
+describe('once', () => {
+  bench('es-toolkit/once', () => {
+    onceToolkit(() => undefined);
+  });
+
+  bench('lodash/once', () => {
+    onceLodash(() => undefined);
+  });
+});

--- a/docs/ko/reference/function/once.md
+++ b/docs/ko/reference/function/once.md
@@ -5,13 +5,15 @@
 
 ## 인터페이스
 
+```typescript
 function once<F extends () => any>(func: F): F;
+```
 
 ### 파라미터
 
 - `func` (`F extends () => any`): 한 번만 호출하도록 제한할 함수예요.
 
-### 결과 값
+### 반환 값
 
 (`F`): `func`가 한 번 호출되면 결과를 캐시하고 반환할 새로운 함수예요.
 

--- a/src/function/once.spec.ts
+++ b/src/function/once.spec.ts
@@ -26,8 +26,8 @@ describe('once', () => {
     });
     const onceFunc = once(func);
 
-    onceFunc();
-    onceFunc();
+    expect(onceFunc()).toBeUndefined();
+    expect(onceFunc()).toBeUndefined();
     expect(func).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Fix docs

I found a mistake in the documentation and fixed it.

<img width="728" alt="스크린샷 2024-07-01 오후 6 35 26" src="https://github.com/toss/es-toolkit/assets/79239852/dae5c1b7-90b0-41f2-bbe6-0509578833bc">

## Fix test code

I think it's more explicit to check `toBeUndefined` if there is no return value.

## Add benchmark

I add `once.bench.ts`.

<img width="848" alt="스크린샷 2024-07-01 오후 6 24 37" src="https://github.com/toss/es-toolkit/assets/79239852/09d21b14-499c-4feb-b0c2-a631ddce07f8">