### PR TITLE
chore(package.json): add details

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/toss/es-toolkit.git"
   },
+  "license": "MIT",
   "workspaces": [
     "docs"
   ],

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "es-toolkit",
   "description": "A state-of-the-art, high-performance JavaScript utility library with a small bundle size and strong type annotations.",
   "version": "1.6.1",
+  "homepage": "https://es-toolkit.slash.page",
+  "bugs": "https://github.com/toss/es-toolkit/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/es-toolkit.git"
+  },
   "workspaces": [
     "docs"
   ],


### PR DESCRIPTION
es-toolkit should have more detail in package.json

1. repository
2. issue
3. hompage
4. license

Compare https://www.npmjs.com/package/es-toolkit with https://www.npmjs.com/package/@suspensive/react
<img width="405" alt="image" src="https://github.com/toss/es-toolkit/assets/61593290/4d7780e9-7dcf-4790-9f51-b8f90febdf2f">

<img width="427" alt="image" src="https://github.com/toss/es-toolkit/assets/61593290/d08e308a-0fc2-4b54-a17a-e847b1592f8f">

https://npmtrends.com/@suspensive/react-vs-@suspensive/react-query-vs-es-hangul-vs-es-toolkit-vs-overlay-kit

<img width="1350" alt="image" src="https://github.com/toss/es-toolkit/assets/61593290/c395053c-d23d-4e59-8e0a-62cfa90a9bf9">
