### PR TITLE
style(*): Add eslint-plugin-jsdoc for improved JSDoc validation and update codebase accordingly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,8 +14,8 @@ module.exports = {
     ecmaFeatures: { jsx: true },
   },
 
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
-  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier', 'plugin:jsdoc/recommended'],
+  plugins: ['@typescript-eslint', 'jsdoc'],
   rules: {
     'no-implicit-coercion': 'error',
     'no-warning-comments': [
@@ -62,5 +62,7 @@ module.exports = {
         ],
       },
     ],
+    'jsdoc/tag-lines': 'off',
+    'jsdoc/no-defaults': 'off',
   },
 };

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "broken-link-checker": "^0.7.8",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-jsdoc": "^48.5.0",
     "lodash": "^4.17.21",
     "prettier": "^3.2.5",
     "tsup": "^8.1.0",

--- a/src/array/compact.ts
+++ b/src/array/compact.ts
@@ -3,6 +3,7 @@ type NotFalsey<T> = Exclude<T, false | null | 0 | '' | undefined>;
 /**
  * Removes falsey values (false, null, 0, '', undefined, NaN) from an array.
  *
+ * @template T - The type of elements in the array.
  * @param {readonly T[]} arr - The input array to remove falsey values.
  * @returns {Array<Exclude<T, false | null | 0 | '' | undefined>>} - A new array with all falsey values removed.
  *

--- a/src/array/drop.ts
+++ b/src/array/drop.ts
@@ -4,6 +4,7 @@
  * This function takes an array and a number, and returns a new array with the specified number
  * of elements removed from the start.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr - The array from which to drop elements.
  * @param {number} itemsCount - The number of elements to drop from the beginning of the array.
  * @returns {T[]} A new array with the specified number of elements removed from the start.

--- a/src/array/dropRight.ts
+++ b/src/array/dropRight.ts
@@ -4,6 +4,7 @@
  * This function takes an array and a number, and returns a new array with the specified number
  * of elements removed from the end.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr - The array from which to drop elements.
  * @param {number} itemsCount - The number of elements to drop from the end of the array.
  * @returns {T[]} A new array with the specified number of elements removed from the end.

--- a/src/array/dropRightWhile.ts
+++ b/src/array/dropRightWhile.ts
@@ -6,6 +6,7 @@ import { dropWhile } from './dropWhile.ts';
  * This function iterates over an array from the end and drops elements until the provided
  * predicate function returns false. It then returns a new array with the remaining elements.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr - The array from which to drop elements.
  * @param {(item: T) => boolean} canContinueDropping - A predicate function that determines
  * whether to continue dropping elements. The function is called with each element from the end,

--- a/src/array/dropWhile.ts
+++ b/src/array/dropWhile.ts
@@ -4,6 +4,7 @@
  * This function iterates over an array and drops elements from the start until the provided
  * predicate function returns false. It then returns a new array with the remaining elements.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr - The array from which to drop elements.
  * @param {(item: T) => boolean} canContinueDropping - A predicate function that determines
  * whether to continue dropping elements. The function is called with each element, and dropping

--- a/src/array/groupBy.ts
+++ b/src/array/groupBy.ts
@@ -5,6 +5,8 @@
  * an object where the keys are the generated keys and the values are arrays of elements that share
  * the same key.
  *
+ * @template T - The type of elements in the array.
+ * @template K - The type of keys.
  * @param {T[]} arr - The array to group.
  * @param {(item: T) => K} getKeyFromItem - A function that generates a key from an element.
  * @returns {Record<K, T[]>} An object where each key is associated with an array of elements that

--- a/src/array/intersection.ts
+++ b/src/array/intersection.ts
@@ -5,6 +5,7 @@
  * present in both arrays. It effectively filters out any elements from the first array that
  * are not found in the second array.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} firstArr - The first array to compare.
  * @param {T[]} secondArr - The second array to compare.
  * @returns {T[]} A new array containing the elements that are present in both arrays.

--- a/src/array/intersectionBy.ts
+++ b/src/array/intersectionBy.ts
@@ -6,6 +6,8 @@
  * mapped elements in the second array. It effectively filters out any elements from the first array
  * that do not have corresponding mapped values in the second array.
  *
+ * @template T - The type of elements in the array.
+ * @template U - The type of mapped elements.
  * @param {T[]} firstArr - The first array to compare.
  * @param {T[]} secondArr - The second array to compare.
  * @param {(item: T) => U} mapper - A function to map the elements of both arrays for comparison.

--- a/src/array/intersectionWith.ts
+++ b/src/array/intersectionWith.ts
@@ -6,6 +6,7 @@
  * by the custom equality function. It effectively filters out any elements from the first array that
  * do not have corresponding matches in the second array according to the equality function.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} firstArr - The first array to compare.
  * @param {T[]} secondArr - The second array to compare.
  * @param {(x: T, y: T) => boolean} areItemsEqual - A custom function to determine if two elements are equal.

--- a/src/array/keyBy.ts
+++ b/src/array/keyBy.ts
@@ -6,6 +6,8 @@
  * If there are multiple elements generating the same key, the last element among them is used
  * as the value.
  *
+ * @template T - The type of elements in the array.
+ * @template K - The type of keys.
  * @param {T[]} arr - The array of elements to be mapped.
  * @param {(item: T) => K} getKeyFromItem - A function that generates a key from an element.
  * @returns {Record<K, T>} An object where keys are mapped to each element of an array.

--- a/src/array/maxBy.ts
+++ b/src/array/maxBy.ts
@@ -2,6 +2,7 @@
  * Finds the element in an array that has the maximum value when applying
  * the `getValue` function to each element.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} items The array of elements to search.
  * @param {(element: T) => number} getValue A function that selects a numeric value from each element.
  * @returns {T} The element with the maximum value as determined by the `getValue` function.

--- a/src/array/minBy.ts
+++ b/src/array/minBy.ts
@@ -2,6 +2,7 @@
  * Finds the element in an array that has the minimum value when applying
  * the `getValue` function to each element.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} items The array of elements to search.
  * @param {(element: T) => number} getValue A function that selects a numeric value from each element.
  * @returns {T} The element with the minimum value as determined by the `getValue` function.

--- a/src/array/partition.ts
+++ b/src/array/partition.ts
@@ -5,6 +5,7 @@
  * the first array contains elements for which the predicate function returns true, and
  * the second array contains elements for which the predicate function returns false.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr - The array to partition.
  * @param {(value: T) => boolean} isInTruthy - A predicate function that determines
  * whether an element should be placed in the truthy array. The function is called with each

--- a/src/array/sample.ts
+++ b/src/array/sample.ts
@@ -3,6 +3,7 @@
  *
  * This function takes an array and returns a single element selected randomly from the array.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr - The array to sample from.
  * @returns {T} A random element from the array.
  *

--- a/src/array/sampleSize.ts
+++ b/src/array/sampleSize.ts
@@ -7,6 +7,7 @@ import { randomInt } from '../math';
  *
  * {@link https://www.nowherenearithaca.com/2013/05/robert-floyds-tiny-and-beautiful.html Floyd's algoritm}
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} array - The array to sample from.
  * @param {number} size - The size of sample.
  * @returns {T[]} A new array with sample size applied.

--- a/src/array/shuffle.ts
+++ b/src/array/shuffle.ts
@@ -3,6 +3,7 @@
  *
  * This function takes an array and returns a new array with its elements shuffled in a random order.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr - The array to shuffle.
  * @returns {T[]} A new array with its elements shuffled in random order.
  *

--- a/src/array/takeRight.ts
+++ b/src/array/takeRight.ts
@@ -2,6 +2,7 @@
  * Returns a new array containing the last `count` elements from the input array `arr`.
  * If `count` is greater than the length of `arr`, the entire array is returned.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr - The array to take elements from.
  * @param {number} count - The number of elements to take.
  * @returns {T[]} A new array containing the last `count` elements from `arr`.

--- a/src/array/union.ts
+++ b/src/array/union.ts
@@ -6,6 +6,7 @@ import { uniq } from './uniq.ts';
  * This function takes two arrays, merges them into a single array, and returns a new array
  * containing only the unique values from the merged array.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr1 - The first array to merge and filter for unique values.
  * @param {T[]} arr2 - The second array to merge and filter for unique values.
  * @returns {T[]} A new array of unique values.

--- a/src/array/unionBy.ts
+++ b/src/array/unionBy.ts
@@ -1,6 +1,8 @@
 /**
  * Creates an array of unique values, in order, from all given arrays using a provided mapping function to determine equality.
  *
+ * @template T - The type of elements in the array.
+ * @template U - The type of mapped elements.
  * @param {T[]} arr1 - The first array.
  * @param {T[]} arr2 - The second array.
  * @param {(item: T) => U} mapper - The function to map array elements to comparison values.

--- a/src/array/unionWith.ts
+++ b/src/array/unionWith.ts
@@ -6,6 +6,7 @@ import { uniqWith } from './uniqWith.ts';
  * This function takes two arrays and a custom equality function, merges the arrays, and returns
  * a new array containing only the unique values as determined by the custom equality function.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr1 - The first array to merge and filter for unique values.
  * @param {T[]} arr2 - The second array to merge and filter for unique values.
  * @param {(item1: T, item2: T) => boolean} areItemsEqual - A custom function to determine if two elements are equal.

--- a/src/array/uniq.ts
+++ b/src/array/uniq.ts
@@ -4,6 +4,7 @@
  * This function takes an array and returns a new array containing only the unique values
  * from the original array, preserving the order of first occurrence.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr - The array to process.
  * @returns {T[]} A new array with only unique values from the original array.
  *

--- a/src/array/uniqBy.ts
+++ b/src/array/uniqBy.ts
@@ -2,6 +2,8 @@
  * Returns a new array containing only the unique elements from the original array,
  * based on the values returned by the mapper function.
  *
+ * @template T - The type of elements in the array.
+ * @template U - The type of mapped elements.
  * @param {T[]} arr - The array to process.
  * @param {(item: T) => U} mapper - The function used to convert the array elements.
  * @returns {T[]} A new array containing only the unique elements from the original array, based on the values returned by the mapper function.

--- a/src/array/uniqWith.ts
+++ b/src/array/uniqWith.ts
@@ -2,6 +2,7 @@
  * Returns a new array containing only the unique elements from the original array,
  * based on the values returned by the comparator function.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr - The array to process.
  * @param {(item1: T, item2: T) => boolean} areItemsEqual - The function used to compare the array elements.
  * @returns {T[]} A new array containing only the unique elements from the original array, based on the values returned by the comparator function.

--- a/src/array/xor.ts
+++ b/src/array/xor.ts
@@ -6,6 +6,7 @@ import { union } from './union.ts';
  * Computes the symmetric difference between two arrays. The symmetric difference is the set of elements
  * which are in either of the arrays, but not in their intersection.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} arr1 - The first array.
  * @param {T[]} arr2 - The second array.
  * @returns {T[]} An array containing the elements that are present in either `arr1` or `arr2` but not in both.

--- a/src/array/zipObject.ts
+++ b/src/array/zipObject.ts
@@ -6,6 +6,8 @@
  * from the second array are values. If the `keys` array is longer than the `values` array, the remaining keys will
  * have `undefined` as their values.
  *
+ * @template P - The type of elements in the array.
+ * @template V - The type of elements in the array.
  * @param {P[]} keys - An array of property names.
  * @param {V[]} values - An array of values corresponding to the property names.
  * @returns {{ [K in P]: V }} A new object composed of the given property names and values.

--- a/src/error/AbortError.ts
+++ b/src/error/AbortError.ts
@@ -1,6 +1,6 @@
 /**
  * An error class representing an aborted operation.
- * @extends Error
+ * @augments Error
  */
 export class AbortError extends Error {
   constructor(message = 'The operation was aborted') {

--- a/src/function/debounce.ts
+++ b/src/function/debounce.ts
@@ -7,6 +7,7 @@ interface DebounceOptions {
  * have elapsed since the last time the debounced function was invoked. The debounced function also has a `cancel`
  * method to cancel any pending execution.
  *
+ * @template F - The type of function.
  * @param {F} func - The function to debounce.
  * @param {number} debounceMs - The number of milliseconds to delay.
  * @param {DebounceOptions} options - The options object.

--- a/src/function/once.ts
+++ b/src/function/once.ts
@@ -2,6 +2,7 @@
  * Creates a function that is restricted to invoking the provided function `func` once.
  * Repeated calls to the function will return the value from the first invocation.
  *
+ * @template F - The type of function.
  * @param {F} func - The function to restrict.
  * @returns {F} A new function that invokes `func` once and caches the result.
  *

--- a/src/function/throttle.ts
+++ b/src/function/throttle.ts
@@ -3,6 +3,7 @@
  * per every `throttleMs` milliseconds. Subsequent calls to the throttled function
  * within the wait time will not trigger the execution of the original function.
  *
+ * @template F - The type of function.
  * @param {F} func - The function to throttle.
  * @param {number} throttleMs - The number of milliseconds to throttle executions to.
  * @returns {F} A new throttled function that accepts the same parameters as the original function.

--- a/src/math/meanBy.ts
+++ b/src/math/meanBy.ts
@@ -6,6 +6,7 @@ import { mean } from './mean';
  *
  * If the array is empty, this function returns `NaN`.
  *
+ * @template T - The type of elements in the array.
  * @param {T[]} items An array to calculate the average.
  * @param {(element: T) => number} getValue A function that selects a numeric value from each element.
  * @returns {number} The average of all the numbers as determined by the `getValue` function.
@@ -14,7 +15,6 @@ import { mean } from './mean';
  * meanBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: 2
  * meanBy([], x => x.a); // Returns: NaN
  */
-
 export function meanBy<T>(items: readonly T[], getValue: (element: T) => number): number {
   const nums = items.map(x => getValue(x));
 

--- a/src/object/omit.ts
+++ b/src/object/omit.ts
@@ -4,6 +4,8 @@
  * This function takes an object and an array of keys, and returns a new object that
  * excludes the properties corresponding to the specified keys.
  *
+ * @template T - The type of object.
+ * @template K - The type of keys in object.
  * @param {T} obj - The object to omit keys from.
  * @param {K[]} keys - An array of keys to be omitted from the object.
  * @returns {Omit<T, K>} A new object with the specified keys omitted.

--- a/src/object/omitBy.ts
+++ b/src/object/omitBy.ts
@@ -4,6 +4,7 @@
  * This function takes an object and a predicate function, and returns a new object that
  * includes only the properties for which the predicate function returns false.
  *
+ * @template T - The type of object.
  * @param {T} obj - The object to omit properties from.
  * @param {(value: T[string], key: keyof T) => boolean} shouldOmit - A predicate function that determines
  * whether a property should be omitted. It takes the property's key and value as arguments and returns `true`

--- a/src/object/pick.ts
+++ b/src/object/pick.ts
@@ -4,6 +4,8 @@
  * This function takes an object and an array of keys, and returns a new object that
  * includes only the properties corresponding to the specified keys.
  *
+ * @template T - The type of object.
+ * @template K - The type of keys in object.
  * @param {T} obj - The object to pick keys from.
  * @param {K[]} keys - An array of keys to be picked from the object.
  * @returns {Pick<T, K>} A new object with the specified keys picked.

--- a/src/object/pickBy.ts
+++ b/src/object/pickBy.ts
@@ -4,6 +4,7 @@
  * This function takes an object and a predicate function, and returns a new object that
  * includes only the properties for which the predicate function returns true.
  *
+ * @template T - The type of object.
  * @param {T} obj - The object to pick properties from.
  * @param {(value: T[keyof T], key: keyof T) => boolean} shouldPick - A predicate function that determines
  * whether a property should be picked. It takes the property's key and value as arguments and returns `true`

--- a/src/predicate/isNotNil.ts
+++ b/src/predicate/isNotNil.ts
@@ -3,6 +3,7 @@
  *
  * The main use of this function is to be used with TypeScript as a type predicate.
  *
+ * @template T - The type of value.
  * @param {T | null | undefined} x - The value to test if it is not null nor undefined.
  * @returns {x is T} True if the value is not null nor undefined, false otherwise.
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,6 +2083,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@es-joy/jsdoccomment@npm:~0.43.1":
+  version: 0.43.1
+  resolution: "@es-joy/jsdoccomment@npm:0.43.1"
+  dependencies:
+    "@types/eslint": "npm:^8.56.5"
+    "@types/estree": "npm:^1.0.5"
+    "@typescript-eslint/types": "npm:^7.2.0"
+    comment-parser: "npm:1.4.1"
+    esquery: "npm:^1.5.0"
+    jsdoc-type-pratt-parser: "npm:~4.0.0"
+  checksum: 10c0/2a4842b0e37eb937d55e3028ab2cd7ece7097e1f8c878bb9e28c3309371844688c2869d25bb949e2664c9ba63e388ea09b769c9f42f77515d328ec40e6fcfed1
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.20.2":
   version: 0.20.2
   resolution: "@esbuild/aix-ppc64@npm:0.20.2"
@@ -2626,6 +2640,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pkgr/core@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "@pkgr/core@npm:0.1.1"
+  checksum: 10c0/3f7536bc7f57320ab2cf96f8973664bef624710c403357429fbf680a5c3b4843c1dbd389bb43daa6b1f6f1f007bb082f5abcb76bb2b5dc9f421647743b71d3d8
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-android-arm-eabi@npm:4.16.4":
   version: 4.16.4
   resolution: "@rollup/rollup-android-arm-eabi@npm:4.16.4"
@@ -2928,14 +2949,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.5, @types/estree@npm:^1.0.0":
+"@types/eslint@npm:^8.56.5":
+  version: 8.56.10
+  resolution: "@types/eslint@npm:8.56.10"
+  dependencies:
+    "@types/estree": "npm:*"
+    "@types/json-schema": "npm:*"
+  checksum: 10c0/674349d6c342c3864d70f4d5a9965f96fb253801532752c8c500ad6a1c2e8b219e01ccff5dc8791dcb58b5483012c495708bb9f3ff929f5c9322b3da126c15d3
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:*, @types/estree@npm:1.0.5, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.5":
   version: 1.0.5
   resolution: "@types/estree@npm:1.0.5"
   checksum: 10c0/b3b0e334288ddb407c7b3357ca67dbee75ee22db242ca7c56fe27db4e1a31989cb8af48a84dd401deb787fe10cc6b2ab1ee82dc4783be87ededbe3d53c79c70d
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.15":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.15":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
@@ -3100,6 +3131,13 @@ __metadata:
   version: 7.7.1
   resolution: "@typescript-eslint/types@npm:7.7.1"
   checksum: 10c0/7d240503d9d0b12d68c8204167690609f02ededb77dcb035c1c8b932da08cf43553829c29a5f7889824a7337463c300343bc5abe532479726d4c83443a7e2704
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:^7.2.0":
+  version: 7.15.0
+  resolution: "@typescript-eslint/types@npm:7.15.0"
+  checksum: 10c0/935387b21d9fdff65de86f6350cdda1f0614e269324f3a4f0a2ca1b0d72ef4b1d40c7de2f3a20a6f8c83edca6507bfbac3168c860625859e59fc455c80392bed
   languageName: node
   linkType: hard
 
@@ -3636,6 +3674,13 @@ __metadata:
     normalize-path: "npm:^3.0.0"
     picomatch: "npm:^2.0.4"
   checksum: 10c0/57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
+  languageName: node
+  linkType: hard
+
+"are-docs-informative@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "are-docs-informative@npm:0.0.2"
+  checksum: 10c0/f0326981bd699c372d268b526b170a28f2e1aec2cf99d7de0686083528427ecdf6ae41fef5d9988e224a5616298af747ad8a76e7306b0a7c97cc085a99636d60
   languageName: node
   linkType: hard
 
@@ -4317,6 +4362,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"comment-parser@npm:1.4.1":
+  version: 1.4.1
+  resolution: "comment-parser@npm:1.4.1"
+  checksum: 10c0/d6c4be3f5be058f98b24f2d557f745d8fe1cc9eb75bebbdccabd404a0e1ed41563171b16285f593011f8b6a5ec81f564fb1f2121418ac5cbf0f49255bf0840dd
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -4835,6 +4887,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^1.5.3":
+  version: 1.5.4
+  resolution: "es-module-lexer@npm:1.5.4"
+  checksum: 10c0/300a469488c2f22081df1e4c8398c78db92358496e639b0df7f89ac6455462aaf5d8893939087c1a1cbcbf20eed4610c70e0bcb8f3e4b0d80a5d2611c539408c
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0":
   version: 1.0.0
   resolution: "es-object-atoms@npm:1.0.0"
@@ -4896,6 +4955,7 @@ __metadata:
     broken-link-checker: "npm:^0.7.8"
     eslint: "npm:^8.56.0"
     eslint-config-prettier: "npm:^8.5.0"
+    eslint-plugin-jsdoc: "npm:^48.5.0"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.2.5"
     tsup: "npm:^8.1.0"
@@ -5096,6 +5156,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-jsdoc@npm:^48.5.0":
+  version: 48.5.0
+  resolution: "eslint-plugin-jsdoc@npm:48.5.0"
+  dependencies:
+    "@es-joy/jsdoccomment": "npm:~0.43.1"
+    are-docs-informative: "npm:^0.0.2"
+    comment-parser: "npm:1.4.1"
+    debug: "npm:^4.3.4"
+    escape-string-regexp: "npm:^4.0.0"
+    esquery: "npm:^1.5.0"
+    parse-imports: "npm:^2.1.0"
+    semver: "npm:^7.6.2"
+    spdx-expression-parse: "npm:^4.0.0"
+    synckit: "npm:^0.9.0"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+  checksum: 10c0/1c5eb83df06cb228e44ad2c9da5b31987347a45b99d9e7a68957d178487a81603ad3c4c7db1ecba7e8a62d7ae20d9de1aec18a8cf2aa0e9169731cec54f78ab7
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:^7.2.2":
   version: 7.2.2
   resolution: "eslint-scope@npm:7.2.2"
@@ -5182,7 +5262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.4.2":
+"esquery@npm:^1.4.2, esquery@npm:^1.5.0":
   version: 1.5.0
   resolution: "esquery@npm:1.5.0"
   dependencies:
@@ -6527,6 +6607,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsdoc-type-pratt-parser@npm:~4.0.0":
+  version: 4.0.0
+  resolution: "jsdoc-type-pratt-parser@npm:4.0.0"
+  checksum: 10c0/b23ef7bbbe2f56d72630d1c5a233dc9fecaff399063d373c57bef136908c1b05e723dac107177303c03ccf8d75aa51507510b282aa567600477479c5ea0c36d1
+  languageName: node
+  linkType: hard
+
 "jsesc@npm:^2.5.1":
   version: 2.5.2
   resolution: "jsesc@npm:2.5.2"
@@ -7574,6 +7661,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-imports@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "parse-imports@npm:2.1.0"
+  dependencies:
+    es-module-lexer: "npm:^1.5.3"
+    slashes: "npm:^3.0.12"
+  checksum: 10c0/18ef58008868d2d09e472bb540d63efc7cc27f2c33607e5d09c256ece7a30062cac292bda96d820438e94f3dbf558c85e4b084c10d238baa858796794e6cf628
+  languageName: node
+  linkType: hard
+
 "parse-json@npm:^5.0.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
@@ -8418,6 +8515,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.6.2":
+  version: 7.6.2
+  resolution: "semver@npm:7.6.2"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/97d3441e97ace8be4b1976433d1c32658f6afaff09f143e52c593bae7eef33de19e3e369c88bd985ce1042c6f441c80c6803078d1de2a9988080b66684cbb30c
+  languageName: node
+  linkType: hard
+
 "set-blocking@npm:^2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
@@ -8532,6 +8638,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slashes@npm:^3.0.12":
+  version: 3.0.12
+  resolution: "slashes@npm:3.0.12"
+  checksum: 10c0/71ca2a1fcd1ab6814b0fdb8cf9c33a3d54321deec2aa8d173510f0086880201446021a9b9e6a18561f7c472b69a2145977c6a8fb9c53a8ff7be31778f203d175
+  languageName: node
+  linkType: hard
+
 "smart-buffer@npm:^4.2.0":
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
@@ -8626,6 +8739,16 @@ __metadata:
     spdx-exceptions: "npm:^2.1.0"
     spdx-license-ids: "npm:^3.0.0"
   checksum: 10c0/6f8a41c87759fa184a58713b86c6a8b028250f158159f1d03ed9d1b6ee4d9eefdc74181c8ddc581a341aa971c3e7b79e30b59c23b05d2436d5de1c30bdef7171
+  languageName: node
+  linkType: hard
+
+"spdx-expression-parse@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "spdx-expression-parse@npm:4.0.0"
+  dependencies:
+    spdx-exceptions: "npm:^2.1.0"
+    spdx-license-ids: "npm:^3.0.0"
+  checksum: 10c0/965c487e77f4fb173f1c471f3eef4eb44b9f0321adc7f93d95e7620da31faa67d29356eb02523cd7df8a7fc1ec8238773cdbf9e45bd050329d2b26492771b736
   languageName: node
   linkType: hard
 
@@ -8960,6 +9083,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"synckit@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "synckit@npm:0.9.0"
+  dependencies:
+    "@pkgr/core": "npm:^0.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b5c1e7c03fefe3d36a9ab4e71dd21859cb32be4138712c31a893382a568fd00efc59ede8f521dd7e53d43a2fea92bdf717e987ea9ed6ad94f97ef28d71d0ba2f
+  languageName: node
+  linkType: hard
+
 "tabbable@npm:^6.2.0":
   version: 6.2.0
   resolution: "tabbable@npm:6.2.0"
@@ -9162,6 +9295,13 @@ __metadata:
   version: 0.1.13
   resolution: "ts-interface-checker@npm:0.1.13"
   checksum: 10c0/232509f1b84192d07b81d1e9b9677088e590ac1303436da1e92b296e9be8e31ea042e3e1fd3d29b1742ad2c959e95afe30f63117b8f1bc3a3850070a5142fea7
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.6.2":
+  version: 2.6.3
+  resolution: "tslib@npm:2.6.3"
+  checksum: 10c0/2598aef53d9dbe711af75522464b2104724d6467b26a60f2bdac8297d2b5f1f6b86a71f61717384aa8fd897240467aaa7bcc36a0700a0faf751293d1331db39a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
close #105 

### Description

- Added [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc):
   - Disabled `jsdoc/tag-lines` rule, which enforces line breaks between tags (considering moving this responsibility to Prettier due to restricted customization options - I will research this).
   - Disabled `jsdoc/no-defaults` rule, allowing the use of default tags with `@param`.

- Resolved most issues flagged by `eslint-plugin-jsdoc`, except for overloading functions.


### Suggestion

While considering improvements to JSDoc for overloaded functions, I propose providing distinct JSDoc entries for each overload. Currently, functions like `range` display comprehensive information in a single entry, potentially overwhelming developers.

<img width="619" alt="스크린샷 2024-07-02 오후 11 06 17" src="https://github.com/toss/es-toolkit/assets/70563791/3a595b3f-f3dc-4501-88cd-8cdff8aeca6f">

However, if we write separate JSDoc entries for each overload, we can provide only the necessary information for developers. Although maintainers would need to write more documentation for each function, library users will save time understanding its usage.

<img width="475" alt="스크린샷 2024-07-02 오후 11 14 24" src="https://github.com/toss/es-toolkit/assets/70563791/56ffbfbc-fb6f-4544-9556-5ec0846d3484">

<img width="609" alt="스크린샷 2024-07-02 오후 11 14 51" src="https://github.com/toss/es-toolkit/assets/70563791/53e68a2e-a27c-4fdd-96bc-8d803980190a">

This is just my idea. feel free to share your opinion.