### PR TITLE
feat(invert): add invert

### DIFF
--- a/benchmarks/invert.bench.ts
+++ b/benchmarks/invert.bench.ts
@@ -1,0 +1,18 @@
+import { bench, describe } from 'vitest';
+import { invert as invertByLodash } from 'lodash';
+import { invert as invertByToolkit } from 'es-toolkit';
+
+const object: { [key: string]: string } = {};
+for (let i = 0; i < 10000; i++) {
+  object[`key${i}`] = `value${i}`;
+}
+
+describe('invert function benchmark', () => {
+  bench('Lodash invert', () => {
+    invertByLodash(object);
+  });
+
+  bench('Custom invert', () => {
+    invertByToolkit(object);
+  });
+});

--- a/benchmarks/invert.bench.ts
+++ b/benchmarks/invert.bench.ts
@@ -8,11 +8,11 @@ for (let i = 0; i < 10000; i++) {
 }
 
 describe('invert function benchmark', () => {
-  bench('Lodash invert', () => {
-    invertByLodash(object);
+  bench('es-toolkit/invert', () => {
+    invertByToolkit(object);
   });
 
-  bench('Custom invert', () => {
-    invertByToolkit(object);
+  bench('lodash/invert', () => {
+    invertByLodash(object);
   });
 });

--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -114,7 +114,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'omitBy', link: '/reference/object/omitBy' },
             { text: 'pick', link: '/reference/object/pick' },
             { text: 'pickBy', link: '/reference/object/pickBy' },
-            { text: 'invert', link: '/ko/reference/object/invert' },
+            { text: 'invert', link: '/reference/object/invert' },
           ],
         },
         {

--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -114,6 +114,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'omitBy', link: '/reference/object/omitBy' },
             { text: 'pick', link: '/reference/object/pick' },
             { text: 'pickBy', link: '/reference/object/pickBy' },
+            { text: 'invert', link: '/ko/reference/object/invert' },
           ],
         },
         {

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -113,6 +113,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'omitBy', link: '/ko/reference/object/omitBy' },
             { text: 'pick', link: '/ko/reference/object/pick' },
             { text: 'pickBy', link: '/ko/reference/object/pickBy' },
+            { text: 'invert', link: '/ko/reference/object/invert' },
           ],
         },
         {

--- a/docs/ko/reference/object/invert.md
+++ b/docs/ko/reference/object/invert.md
@@ -1,0 +1,29 @@
+# invert
+
+객체의 키와 값을 뒤집는 새로운 객체를 생성해요.
+
+이 함수는 객체를 받아서 그 객체의 키를 값으로, 값을 키로 하는 새로운 객체를 생성해요. 만약 입력된 객체에 중복된 값이 있을 경우, 마지막에 등장한 키가 새로운 키로 사용돼요.
+
+## 인터페이스
+
+```typescript
+function invert<K extends string | number | symbol, V extends string | number | symbol>(
+  obj: Record<K, V>
+): { [key in V]: K };
+```
+
+### 파라미터
+
+- `obj` (`Record<K, V>`): 키와 값을 뒤집을 객체예요.
+
+### 반환 값
+
+(`{ [key in V]: K }`): 키와 값이 뒤집힌 새로운 객체예요.
+
+## 예시
+
+```typescript
+const obj = { a: 1, b: 1, c: 2 };
+const result = invert(obj);
+// 결과는 다음과 같아요 { 1: 'b', 2: 'c' }
+```

--- a/docs/reference/object/invert.md
+++ b/docs/reference/object/invert.md
@@ -1,0 +1,29 @@
+# invert
+
+Creates a new object by swapping the keys and values of the given object.
+
+This function takes an object and creates a new object where the keys are the values and the values are the keys of the original object. If there are duplicate values in the input object, the key that appears last will be used as the new key.
+
+## Signature
+
+```typescript
+function invert<K extends string | number | symbol, V extends string | number | symbol>(
+  obj: Record<K, V>
+): { [key in V]: K };
+```
+
+### Parameters
+
+- `obj` (`Record<K, V>`): The object to invert.
+
+### Returns
+
+(`{ [key in V]: K }`): A new object with keys and values inverted.
+
+## Examples
+
+```typescript
+const obj = { a: 1, b: 1, c: 2 };
+const result = invert(obj);
+// result will be { 1: 'b', 2: 'c' }
+```

--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -2,3 +2,4 @@ export { omit } from './omit.ts';
 export { omitBy } from './omitBy.ts';
 export { pick } from './pick.ts';
 export { pickBy } from './pickBy.ts';
+export { invert } from './invert.ts';

--- a/src/object/invert.spec.ts
+++ b/src/object/invert.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { invert } from './invert';
+
+describe('invert', () => {
+  it('should invert a simple object with string keys and number values', () => {
+    expect(invert({ a: 1, b: 2, c: 3 })).toEqual({ 1: 'a', 2: 'b', 3: 'c' });
+  });
+
+  it('should invert an object with number keys and string values', () => {
+    expect(invert({ 1: 'a', 2: 'b', 3: 'c' })).toEqual({ a: '1', b: '2', c: '3' });
+  });
+
+  it('should handle an object with mixed key and value types', () => {
+    expect(invert({ a: 1, 2: 'b', c: 3, 4: 'd' })).toEqual({ 1: 'a', b: '2', 3: 'c', d: '4' });
+  });
+
+  it('should handle an object with symbol keys', () => {
+    const sym1 = Symbol('sym1');
+    const sym2 = Symbol('sym2');
+    expect(invert({ a: sym1, b: sym2 })).toEqual({ [sym1]: 'a', [sym2]: 'b' });
+  });
+
+  it('should handle an empty object', () => {
+    expect(invert({})).toEqual({});
+  });
+
+  it('should handle objects with duplicate values by keeping the last key', () => {
+    expect(invert({ a: 1, b: 1, c: 2 })).toEqual({ 1: 'b', 2: 'c' });
+  });
+});

--- a/src/object/invert.ts
+++ b/src/object/invert.ts
@@ -1,0 +1,31 @@
+/**
+ * Inverts the keys and values of an object. The keys of the input object become the values of the output object and vice versa.
+ *
+ * This function takes an object and creates a new object by inverting its keys and values. If the input object has duplicate values,
+ * the key of the last occurrence will be used as the value for the new key in the output object. It effectively creates a reverse mapping
+ * of the input object's key-value pairs.
+ *
+ * @template K - Type of the keys in the input object (string, number, symbol)
+ * @template V - Type of the values in the input object (string, number, symbol)
+ * @param {Record<K, V>} obj - The input object whose keys and values are to be inverted
+ * @returns {{ [key in V]: K }} - A new object with keys and values inverted
+ *
+ * @example
+ * invert({ a: 1, b: 2, c: 3 }); // { 1: 'a', 2: 'b', 3: 'c' }
+ * invert({ 1: 'a', 2: 'b', 3: 'c' }); // { a: '1', b: '2', c: '3' }
+ * invert({ a: 1, 2: 'b', c: 3, 4: 'd' }); // { 1: 'a', b: '2', 3: 'c', d: '4' }
+ * invert({ a: Symbol('sym1'), b: Symbol('sym2') }); // { [Symbol('sym1')]: 'a', [Symbol('sym2')]: 'b' }
+ */
+
+export function invert<K extends string | number | symbol, V extends string | number | symbol>(
+  obj: Record<K, V>
+): { [key in V]: K } {
+  const result = {} as { [key in V]: K };
+
+  for (const key of Object.keys(obj) as K[]) {
+    const value = obj[key as K] as V;
+    result[value] = key;
+  }
+
+  return result;
+}

--- a/src/object/invert.ts
+++ b/src/object/invert.ts
@@ -17,9 +17,9 @@
  * invert({ a: Symbol('sym1'), b: Symbol('sym2') }); // { [Symbol('sym1')]: 'a', [Symbol('sym2')]: 'b' }
  */
 
-export function invert<K extends string | number | symbol, V extends string | number | symbol>(
-  obj: Record<K, V>
-): { [key in V]: K } {
+type PropertyKey = string | number | symbol;
+
+export function invert<K extends PropertyKey, V extends PropertyKey>(obj: Record<K, V>): { [key in V]: K } {
   const result = {} as { [key in V]: K };
 
   for (const key of Object.keys(obj) as K[]) {

--- a/src/object/invert.ts
+++ b/src/object/invert.ts
@@ -22,7 +22,7 @@ type PropertyKey = string | number | symbol;
 export function invert<K extends PropertyKey, V extends PropertyKey>(obj: Record<K, V>): { [key in V]: K } {
   const result = {} as { [key in V]: K };
 
-  for (const key of Object.keys(obj) as K[]) {
+  for (const key in obj) {
     const value = obj[key as K] as V;
     result[value] = key;
   }


### PR DESCRIPTION
close: #116 

I added an invert function to the es-toolkit library. The invert function takes an object as input and returns a new object where the keys and values are swapped. This functionality is available in lodash but was not present in es-toolkit.

The invert function is particularly useful when you need to reverse the mapping of an object. For example, given an object with key-value pairs, the invert function will produce a new object where the original values become the keys and the original keys become the values.


![스크린샷 2024-07-04 오전 1 45 37](https://github.com/toss/es-toolkit/assets/55338435/fc90a801-69c1-440a-8303-81491a804b08)

For reference, you can see the lodash invert function [here.](https://lodash.com/docs/4.17.15#invert)