### PR TITLE
chore: add provenance flags to npm publishing step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,9 @@ jobs:
           npm config set //registry.npmjs.org/:_authToken "$NPM_AUTH_TOKEN"
           npm whoami
           if [[ "$GITHUB_REF_TYPE" = "tag" ]]; then
-            npm publish --access public *.tgz
+            npm publish --provenance --access public *.tgz
           else
-            npm publish --access public --tag dev *.tgz
+            npm publish --provenance --access public --tag dev *.tgz
           fi
           deno publish --allow-dirty
         env:


### PR DESCRIPTION
This PR adds `provenance` flags of npm to npm publishing step of `.github/workflows/release.yml`.

To learn more about the flag, please refer the following doc:
https://github.blog/2023-04-19-introducing-npm-package-provenance/