### PR TITLE
fix(package.json): build script

### DIFF
--- a/.scripts/postbuild.sh
+++ b/.scripts/postbuild.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 echo "export * from './dist/array';" > array.d.ts
 echo "export * from './dist/function';" > function.d.ts
 echo "export * from './dist/math';" > math.d.ts

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   "sideEffects": false,
   "scripts": {
     "prepack": "yarn build",
-    "build": "tsup && sh ./.scripts/postbuild.sh",
+    "build": "tsup && ./.scripts/postbuild.sh",
     "test": "vitest run --coverage --typecheck",
     "bench": "vitest bench",
     "lint": "eslint ./src --ext .ts",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   "sideEffects": false,
   "scripts": {
     "prepack": "yarn build",
-    "build": "tsup && ./.scripts/postbuild.sh",
+    "build": "tsup && sh ./.scripts/postbuild.sh",
     "test": "vitest run --coverage --typecheck",
     "bench": "vitest bench",
     "lint": "eslint ./src --ext .ts",


### PR DESCRIPTION
When I run the "yarn build" command, I get the following error. I think it's a matter of executive authority. Rather than setting the executive authority separately, I solved it by adding the "sh" command.

![image](https://github.com/toss/es-toolkit/assets/55759551/16335328-a069-4c3c-8a65-8e395bc75c30)
