### PR TITLE
chore: Disable 'jsdoc/require-jsdoc' eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,5 +64,6 @@ module.exports = {
     ],
     'jsdoc/tag-lines': 'off',
     'jsdoc/no-defaults': 'off',
+    'jsdoc/require-jsdoc': 'off',
   },
 };


### PR DESCRIPTION
Previously, I [added a JSDoc ESLint rule](https://github.com/toss/es-toolkit/pull/112) to enforce consistent JSDoc comments. However, I found that 'jsdoc/require-jsdoc' is too strict because it requires JSDoc comments for **every** function. Therefore, I believe it would be better to disable this rule.