### PR TITLE
feat(flatten): add flatten

### DIFF
--- a/benchmarks/flatten.bench.ts
+++ b/benchmarks/flatten.bench.ts
@@ -1,0 +1,27 @@
+import { bench, describe } from 'vitest';
+import { flatten as flattenToolkit } from 'es-toolkit';
+import { flattenDepth as flattenDepthLodash } from 'lodash';
+
+const createNestedArray = (values: any[]) => {
+  if (values.length === 0) {
+    return [];
+  }
+  const [first, ...rest] = values;
+  return [first, createNestedArray(rest)];
+};
+
+describe('flatten', () => {
+  const arr = createNestedArray(Array.from({ length: 30 }, (_, index) => index));
+
+  bench('es-toolkit/flatten', () => {
+    flattenToolkit(arr, 30);
+  });
+
+  bench('lodash/flattenDepth', () => {
+    flattenDepthLodash(arr, 30);
+  });
+
+  bench('js built-in/flat', () => {
+    arr.flat(30);
+  });
+});

--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -58,6 +58,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'dropRight', link: '/reference/array/dropRight' },
             { text: 'dropRightWhile', link: '/reference/array/dropRightWhile' },
             { text: 'fill', link: '/reference/array/fill' },
+            { text: 'flatten', link: '/reference/array/flatten' },
             { text: 'forEachRight', link: '/reference/array/forEachRight' },
             { text: 'groupBy', link: '/reference/array/groupBy' },
             { text: 'intersection', link: '/reference/array/intersection' },

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -57,6 +57,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'dropRight', link: '/ko/reference/array/dropRight' },
             { text: 'dropRightWhile', link: '/ko/reference/array/dropRightWhile' },
             { text: 'fill', link: '/ko/reference/array/fill' },
+            { text: 'flatten', link: '/ko/reference/array/flatten' },
             { text: 'forEachRight', link: '/reference/array/forEachRight' },
             { text: 'groupBy', link: '/ko/reference/array/groupBy' },
             { text: 'intersection', link: '/ko/reference/array/intersection' },

--- a/docs/ko/reference/array/flatten.md
+++ b/docs/ko/reference/array/flatten.md
@@ -12,8 +12,8 @@ function flatten<T, D extends number = 1>(arr: T[], depth?: D): Array<FlatArray<
 
 ### 파라미터
 
-- `arr` (`T[]`): 평탄화 할 배열이에요.
-- `depth` (`D`): 평탄화 할 깊이에요. 기본 값은 1이에요.
+- `arr` (`T[]`): 평탄화할 중첩 배열이에요.
+- `depth` (`D`): 평탄화할 깊이에요. 기본값은 1이에요.
 
 ### 반환 값
 

--- a/docs/ko/reference/array/flatten.md
+++ b/docs/ko/reference/array/flatten.md
@@ -2,12 +2,12 @@
 
 인자로 넣은 중첩 배열을 원하는 깊이까지 평탄화해요.
 
-JS에서 기본적으로 제공하는 [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)와 동일한 동작과 타입을 반환해요.
+JavaScript에서 기본적으로 제공하는 [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)과 동일한 동작과 반환 타입을 가져요. 하지만 성능은 더 우수합니다.
 
 ## 인터페이스
 
 ```typescript
-function flatten<T, D extends number = 1>(arr: T[], depth?: D): FlatArray<T[], D>[];
+function flatten<T, D extends number = 1>(arr: T[], depth?: D): Array<FlatArray<T[], D>>;
 ```
 
 ### 파라미터
@@ -17,7 +17,7 @@ function flatten<T, D extends number = 1>(arr: T[], depth?: D): FlatArray<T[], D
 
 ### 반환 값
 
-(`FlatArray<T[], D>[]`) 원하는 깊이로 평탄화 된 새로운 배열이에요.
+(`Array<FlatArray<T[], D>>`) 원하는 깊이로 평탄화 된 새로운 배열이에요.
 
 ## 예시
 

--- a/docs/ko/reference/array/flatten.md
+++ b/docs/ko/reference/array/flatten.md
@@ -1,0 +1,35 @@
+# flatten
+
+인자로 넣은 중첩 배열을 원하는 깊이까지 평탄화해요.
+
+JS에서 기본적으로 제공하는 [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)와 동일한 동작과 타입을 반환해요.
+
+## 인터페이스
+
+```typescript
+function flatten<T, D extends number = 1>(arr: T[], depth?: D): FlatArray<T[], D>[];
+```
+
+### 파라미터
+
+- `arr` (`T[]`): 평탄화 할 배열이에요.
+- `depth` (`D`): 평탄화 할 깊이에요. 기본 값은 1이에요.
+
+### 반환 값
+
+(`FlatArray<T[], D>[]`) 원하는 깊이로 평탄화 된 새로운 배열이에요.
+
+## 예시
+
+```typescript
+const originArr = [1, [2, 3], [4, [5, 6]]];
+
+const array1 = flatten(originArr);
+// [1, 2, 3, 4, [5, 6]]를 반환해요.
+
+const array2 = flatten(originArr, 1);
+// [1, 2, 3, 4, [5, 6]]를 반환해요.
+
+const array3 = flatten(originArr, 2);
+// [1, 2, 3, 4, 5, 6]를 반환해요.
+```

--- a/docs/ko/reference/array/flatten.md
+++ b/docs/ko/reference/array/flatten.md
@@ -1,8 +1,8 @@
 # flatten
 
-인자로 넣은 중첩 배열을 원하는 깊이까지 평탄화해요.
+중첩된 배열을 원하는 깊이까지 풀어서 평탄화해요.
 
-JavaScript에서 기본적으로 제공하는 [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)과 동일한 동작과 반환 타입을 가져요. 하지만 성능은 더 우수합니다.
+JavaScript 언어에 포함된 [Array#flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)과 동일하게 동작하지만, 더 빨라요.
 
 ## 인터페이스
 

--- a/docs/ko/reference/array/flatten.md
+++ b/docs/ko/reference/array/flatten.md
@@ -17,7 +17,7 @@ function flatten<T, D extends number = 1>(arr: T[], depth?: D): Array<FlatArray<
 
 ### 반환 값
 
-(`Array<FlatArray<T[], D>>`) 원하는 깊이로 평탄화 된 새로운 배열이에요.
+(`Array<FlatArray<T[], D>>`): 원하는 깊이까지 평탄해진 새로운 배열이에요.
 
 ## 예시
 

--- a/docs/reference/array/flatten.md
+++ b/docs/reference/array/flatten.md
@@ -1,0 +1,35 @@
+# flatten
+
+Flattens the nested array given as an argument to the desired depth.
+
+It behaves the same as and returns the same type as the built-in [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) provided by JavaScript, but with superior performance.
+
+## Signature
+
+```typescript
+function flatten<T, D extends number = 1>(arr: T[], depth?: D): FlatArray<T[], D>[];
+```
+
+### Parameters
+
+- `arr` (`T[]`):The array to flatten.
+- `depth` (`D`): The depth to flatten, which defaults to 1.
+
+### Returns
+
+(`FlatArray<T[], D>[]`) A new array that has been flattened.
+
+## Examples
+
+```typescript
+const originArr = [1, [2, 3], [4, [5, 6]]];
+
+const array1 = flatten(originArr);
+// Return [1, 2, 3, 4, [5, 6]]
+
+const array2 = flatten(originArr, 1);
+// Return [1, 2, 3, 4, [5, 6]]
+
+const array3 = flatten(originArr, 2);
+// Return [1, 2, 3, 4, 5, 6]
+```

--- a/docs/reference/array/flatten.md
+++ b/docs/reference/array/flatten.md
@@ -2,12 +2,12 @@
 
 Flattens the nested array given as an argument to the desired depth.
 
-It behaves the same as and returns the same type as the built-in [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) provided by JavaScript, but with superior performance.
+It works the same as [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) provided by default in JavaScript and returns the same type. However, its performance is superior.
 
 ## Signature
 
 ```typescript
-function flatten<T, D extends number = 1>(arr: T[], depth?: D): FlatArray<T[], D>[];
+function flatten<T, D extends number = 1>(arr: T[], depth?: D): Array<FlatArray<T[], D>>;
 ```
 
 ### Parameters
@@ -17,7 +17,7 @@ function flatten<T, D extends number = 1>(arr: T[], depth?: D): FlatArray<T[], D
 
 ### Returns
 
-(`FlatArray<T[], D>[]`) A new array that has been flattened.
+(`Array<FlatArray<T[], D>>`) A new array that has been flattened.
 
 ## Examples
 

--- a/docs/reference/array/flatten.md
+++ b/docs/reference/array/flatten.md
@@ -12,7 +12,7 @@ function flatten<T, D extends number = 1>(arr: T[], depth?: D): Array<FlatArray<
 
 ### Parameters
 
-- `arr` (`T[]`):The array to flatten.
+- `arr` (`T[]`): The array to flatten.
 - `depth` (`D`): The depth to flatten, which defaults to 1.
 
 ### Returns

--- a/src/array/flatten.spec.ts
+++ b/src/array/flatten.spec.ts
@@ -25,7 +25,7 @@ describe('flatten', () => {
     expect(originArr.flat(3)).toEqual(expectedArr3);
   });
 
-  it('should return the same array if depth is 0 or NaN or negative or -Infinity', () => {
+  it('should return the same array if depth is 0 or NaN or negative', () => {
     const expectedArr = [1, [2, [3, [4]]]];
 
     expect(flatten(originArr, 0)).toEqual(expectedArr);

--- a/src/array/flatten.spec.ts
+++ b/src/array/flatten.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { flatten } from '.';
+
+describe('flatten', () => {
+  const originArr = [1, [2, [3, [4]]]];
+
+  it('should flatten a array to the default depth of 1', () => {
+    const expectedArr = [1, 2, [3, [4]]];
+
+    expect(flatten(originArr)).toEqual(expectedArr);
+    expect(originArr.flat()).toEqual(expectedArr);
+  });
+
+  it('should flatten a deeply nested array to the specified depth', () => {
+    const expectedArr1 = [1, 2, [3, [4]]];
+    expect(flatten(originArr, 1)).toEqual(expectedArr1);
+    expect(originArr.flat(1)).toEqual(expectedArr1);
+
+    const expectedArr2 = [1, 2, 3, [4]];
+    expect(flatten(originArr, 2)).toEqual(expectedArr2);
+    expect(originArr.flat(2)).toEqual(expectedArr2);
+
+    const expectedArr3 = [1, 2, 3, 4];
+    expect(flatten(originArr, 3)).toEqual(expectedArr3);
+    expect(originArr.flat(3)).toEqual(expectedArr3);
+  });
+
+  it('should return the same array if depth is 0 or NaN or negative or -Infinity', () => {
+    const expectedArr = [1, [2, [3, [4]]]];
+
+    expect(flatten(originArr, 0)).toEqual(expectedArr);
+    expect(originArr.flat(0)).toEqual(expectedArr);
+
+    expect(flatten(originArr, NaN)).toEqual(expectedArr);
+    expect(originArr.flat(NaN)).toEqual(expectedArr);
+
+    expect(flatten(originArr, -1)).toEqual(expectedArr);
+    expect(originArr.flat(-1)).toEqual(expectedArr);
+  });
+
+  it('should flatten arrays to the specified depth considering floating point values', () => {
+    const expectedArr1 = [1, 2, [3, [4]]];
+    expect(flatten(originArr, 1.5)).toEqual(expectedArr1);
+    expect(originArr.flat(1.3)).toEqual(expectedArr1);
+
+    const expectedArr2 = [1, 2, 3, [4]];
+    expect(flatten(originArr, 2.5)).toEqual(expectedArr2);
+    expect(originArr.flat(2.5)).toEqual(expectedArr2);
+  });
+
+  it('should handle empty arrays', () => {
+    const originArr: number[] = [];
+
+    expect(flatten(originArr, 2)).toEqual([]);
+  });
+});

--- a/src/array/flatten.spec.ts
+++ b/src/array/flatten.spec.ts
@@ -23,6 +23,9 @@ describe('flatten', () => {
     const expectedArr3 = [1, 2, 3, 4];
     expect(flatten(originArr, 3)).toEqual(expectedArr3);
     expect(originArr.flat(3)).toEqual(expectedArr3);
+
+    expect(flatten(originArr, Infinity)).toEqual(expectedArr3);
+    expect(originArr.flat(Infinity)).toEqual(expectedArr3);
   });
 
   it('should return the same array if depth is 0 or NaN or negative', () => {
@@ -40,15 +43,19 @@ describe('flatten', () => {
 
   it('should flatten arrays to the specified depth considering floating point values', () => {
     const expectedArr1 = [1, 2, [3, [4]]];
-    expect(flatten(originArr, 1.5)).toEqual(expectedArr1);
+    expect(flatten(originArr, 1.3)).toEqual(expectedArr1);
     expect(originArr.flat(1.3)).toEqual(expectedArr1);
 
     const expectedArr2 = [1, 2, 3, [4]];
     expect(flatten(originArr, 2.5)).toEqual(expectedArr2);
     expect(originArr.flat(2.5)).toEqual(expectedArr2);
+
+    const expectedArr3 = [1, 2, 3, 4];
+    expect(flatten(originArr, 3.9)).toEqual(expectedArr3);
+    expect(originArr.flat(3.9)).toEqual(expectedArr3);
   });
 
-  it('should handle empty arrays', () => {
+  it('should handle empty array', () => {
     const originArr: number[] = [];
 
     expect(flatten(originArr, 2)).toEqual([]);

--- a/src/array/flatten.ts
+++ b/src/array/flatten.ts
@@ -4,8 +4,8 @@
  * @template T - The type of elements within the array.
  * @template D - The depth to which the array should be flattened.
  * @param {T[]} arr - The array to flatten.
- * @param {D} [depth=1] - The depth level specifying how deep a nested array structure should be flattened. Defaults to 1.
- * @returns {FlatArray<T[], D>[]} A new array that has been flattened.
+ * @param {D} depth - The depth level specifying how deep a nested array structure should be flattened. Defaults to 1.
+ * @returns {Array<FlatArray<T[], D>>} A new array that has been flattened.
  *
  * @example
  * const arr = flatten([1, [2, 3], [4, [5, 6]]], 1);
@@ -14,8 +14,8 @@
  * const arr = flatten([1, [2, 3], [4, [5, 6]]], 2);
  * // Returns: [1, 2, 3, 4, 5, 6]
  */
-export function flatten<T, D extends number = 1>(arr: readonly T[], depth = 1 as D): FlatArray<T[], D>[] {
-  const result: FlatArray<T[], D>[] = [];
+export function flatten<T, D extends number = 1>(arr: readonly T[], depth = 1 as D): Array<FlatArray<T[], D>> {
+  const result: Array<FlatArray<T[], D>> = [];
   const flooredDepth = Math.floor(depth);
 
   const recursive = (arr: readonly T[], currentDepth: number) => {

--- a/src/array/flatten.ts
+++ b/src/array/flatten.ts
@@ -1,0 +1,33 @@
+/**
+ * Flattens an array up to the specified depth.
+ *
+ * @template T - The type of elements within the array.
+ * @template D - The depth to which the array should be flattened.
+ * @param {T[]} arr - The array to flatten.
+ * @param {D} [depth=1] - The depth level specifying how deep a nested array structure should be flattened. Defaults to 1.
+ * @returns {FlatArray<T[], D>[]} A new array that has been flattened.
+ *
+ * @example
+ * const arr = flatten([1, [2, 3], [4, [5, 6]]], 1);
+ * // Returns: [1, 2, 3, 4, [5, 6]]
+ *
+ * const arr = flatten([1, [2, 3], [4, [5, 6]]], 2);
+ * // Returns: [1, 2, 3, 4, 5, 6]
+ */
+export function flatten<T, D extends number = 1>(arr: readonly T[], depth = 1 as D): FlatArray<T[], D>[] {
+  const result: FlatArray<T[], D>[] = [];
+  const flooredDepth = Math.floor(depth);
+
+  const recursive = (arr: readonly T[], currentDepth: number) => {
+    for (const item of arr) {
+      if (Array.isArray(item) && currentDepth < flooredDepth) {
+        recursive(item, currentDepth + 1);
+      } else {
+        result.push(item as FlatArray<T[], D>);
+      }
+    }
+  };
+
+  recursive(arr, 0);
+  return result;
+}

--- a/src/array/index.ts
+++ b/src/array/index.ts
@@ -9,6 +9,7 @@ export { dropRight } from './dropRight.ts';
 export { dropRightWhile } from './dropRightWhile.ts';
 export { dropWhile } from './dropWhile.ts';
 export { fill } from './fill.ts';
+export { flatten } from './flatten.ts';
 export { forEachRight } from './forEachRight.ts';
 export { groupBy } from './groupBy.ts';
 export { intersection } from './intersection.ts';


### PR DESCRIPTION
close: #137 

Implement the same function as `lodash's flattenDepth` under the name `flatten(arr, depth)`.

It works the same as [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) provided by default in JavaScript and returns the same type. However, its performance is superior.


## benchmark
![스크린샷 2024-07-10 오전 1 23 39](https://github.com/toss/es-toolkit/assets/64779472/5c30db90-3adc-4467-9d78-ecc0ffe72773)

