### PR TITLE
feat(zipObjectDeep): add zipObjectDeep

### DIFF
--- a/benchmarks/zipObjectDeep.bench.ts
+++ b/benchmarks/zipObjectDeep.bench.ts
@@ -1,0 +1,13 @@
+import { bench, describe } from 'vitest';
+import { zipObjectDeep as zipObjectDeepToolkit } from 'es-toolkit';
+import { zipObjectDeep as zipObjectDeepLodash } from 'lodash';
+
+describe('zipObjectDeep', () => {
+  bench('es-toolkit/zipObject', () => {
+    zipObjectDeepToolkit(['a.b[0].c', 'a.b[1].d'], [1, 2]);
+  });
+
+  bench('lodash/zipObject', () => {
+    zipObjectDeepLodash(['a.b[0].c', 'a.b[1].d'], [1, 2]);
+  });
+});

--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -90,6 +90,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'xorWith', link: '/reference/array/xorWith' },
             { text: 'zip', link: '/reference/array/zip' },
             { text: 'zipObject', link: '/reference/array/zipObject' },
+            { text: 'zipObjectDeep', link: '/reference/array/zipObjectDeep' },
             { text: 'zipWith', link: '/reference/array/zipWith' },
             { text: 'head', link: '/reference/array/head' },
             { text: 'tail', link: '/reference/array/tail' },

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -89,6 +89,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'xorWith', link: '/ko/reference/array/xorWith' },
             { text: 'zip', link: '/ko/reference/array/zip' },
             { text: 'zipObject', link: '/ko/reference/array/zipObject' },
+            { text: 'zipObjectDeep', link: '/ko/reference/array/zipObjectDeep' },
             { text: 'zipWith', link: '/ko/reference/array/zipWith' },
             { text: 'head', link: '/ko/reference/array/head' },
             { text: 'tail', link: '/ko/reference/array/tail' },

--- a/docs/ko/reference/array/zipObjectDeep.md
+++ b/docs/ko/reference/array/zipObjectDeep.md
@@ -1,0 +1,41 @@
+# zipObjectDeep
+
+경로와 값 배열을 사용하여 깊게 중첩된 객체를 생성합니다.
+
+이 함수는 두 개의 배열을 사용합니다. 하나는 속성 경로의 배열이고 다른 하나는 해당 값의 배열입니다. 이 함수는 첫 번째 배열의 경로를 키 경로로 사용하여 값을 설정한 새 객체를 반환합니다. 두 번째 배열의 해당 요소는 값으로 사용됩니다. 경로는 점으로 구분된 문자열이나 속성 이름의 배열일 수 있습니다.
+
+프로퍼티 이름을 나타내는 배열이 값을 나타내는 배열보다 길면, 값들은 `undefined`로 채워져요.
+
+## 인터페이스
+
+```typescript
+function zipObjectDeep<P extends string | number | symbol, V>(keys: P[], values: V[]): { [K in P]: V };
+```
+
+### 파라미터
+
+- `keys` (`P[]`): 속성 이름이 포함된 배열이에요.
+- `values` (`V[]`): 속성 이름에 대응되는 값이 포함된 배열이에요.
+
+### 반환 값
+
+(`{ [K in P]: V }`): 주어진 속성 이름과 값으로 구성된 새로운 객체예요.
+
+## 예시
+
+```typescript
+const paths = ['a.b.c', 'd.e.f'];
+const values = [1, 2];
+const result = zipObjectDeep(paths, values);
+// result 는 { a: { b: { c: 1 } }, d: { e: { f: 2 } } }가 돼요
+
+const paths = [['a', 'b', 'c'], ['d', 'e', 'f']];
+const values = [1, 2];
+const result = zipObjectDeep(paths, values);
+// result 는 { a: { b: { c: 1 } }, d: { e: { f: 2 } } }가 돼요
+
+const paths = ['a.b[0].c', 'a.b[1].d'];
+const values = [1, 2];
+const result = zipObjectDeep(paths, values);
+// result 는 { 'a': { 'b': [{ 'c': 1 }, { 'd': 2 }] } }가 돼요
+```

--- a/docs/reference/array/zipObjectDeep.md
+++ b/docs/reference/array/zipObjectDeep.md
@@ -1,0 +1,39 @@
+# zipObjectDeep
+
+Creates a deeply nested object given arrays of paths and values.
+
+This function takes two arrays: one containing arrays of property paths, and the other containing corresponding values.It returns a new object where paths from the first array are used as key paths to set values, with corresponding elements from the second array as values.Paths can be dot-separated strings or arrays of property names.If the `keys` array is longer than the `values` array, the remaining keys will have `undefined` as their values.
+
+## Signature
+
+```typescript
+function zipObjectDeep<P extends string | number | symbol, V>(keys: P[], values: V[]): { [K in P]: V }
+```
+
+### Parameters
+
+- `keys` (`P[]`): An array of property names.
+- `values` (`V[]`): An array of values corresponding to the property names.
+
+### Returns
+
+(`{ [K in P]: V }`): A new object composed of the given property names and values.
+
+## Examples
+
+```typescript
+const paths = ['a.b.c', 'd.e.f'];
+const values = [1, 2];
+const result = zipObjectDeep(paths, values);
+// result will be { a: { b: { c: 1 } }, d: { e: { f: 2 } } }
+
+const paths = [['a', 'b', 'c'], ['d', 'e', 'f']];
+const values = [1, 2];
+const result = zipObjectDeep(paths, values);
+// result will be { a: { b: { c: 1 } }, d: { e: { f: 2 } } }
+
+const paths = ['a.b[0].c', 'a.b[1].d'];
+const values = [1, 2];
+const result = zipObjectDeep(paths, values);
+// result will be { 'a': { 'b': [{ 'c': 1 }, { 'd': 2 }] } }
+```

--- a/src/array/index.ts
+++ b/src/array/index.ts
@@ -40,6 +40,7 @@ export { xorBy } from './xorBy.ts';
 export { xorWith } from './xorWith.ts';
 export { zip } from './zip.ts';
 export { zipObject } from './zipObject.ts';
+export { zipObjectDeep } from './zipObjectDeep.ts';
 export { zipWith } from './zipWith.ts';
 export { without } from './without.ts';
 export { head } from './head.ts';

--- a/src/array/zipObjectDeep.spec.ts
+++ b/src/array/zipObjectDeep.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { zipObjectDeep } from './zipObjectDeep.ts';
+
+describe('zipObject', () => {
+  it('creates an object from two arrays of keys and values', () => {
+
+    const symbols = [Symbol('a'), Symbol('b')];
+    expect(zipObjectDeep(symbols, [1, 2])).toEqual({ [symbols[0]]: 1, [symbols[1]]: 2 });
+    expect(zipObjectDeep([], [])).toEqual({});
+    expect(zipObjectDeep(['a'], [1])).toEqual({ a: 1 });
+    expect(zipObjectDeep([0, 1], [1, 2])).toEqual({ 0: 1, 1: 2 });
+    expect(zipObjectDeep([0, 'a.b', symbols[0], 'a.c[0]', 'a.c[2].a'], [1, 2, 3, 4, 5])).toEqual({ 0: 1, [symbols[0]]: 3, a: { b: 2, c: [4, undefined, { a: 5 }] } });
+    expect(zipObjectDeep(['a', 'b'], [1, 2, 3])).toEqual({ a: 1, b: 2 });
+    expect(zipObjectDeep(['a', 'b', 'c'], [1, 2])).toEqual({ a: 1, b: 2, c: undefined });
+    expect(zipObjectDeep(['a.b.c', 'd.e.f'], [1, 2])).toEqual({ a: { b: { c: 1 } }, d: { e: { f: 2 } } });
+    expect(zipObjectDeep(['a.b.c', 'a.b.d', 'a.b.e.f'], [1, 2, 3])).toEqual({ a: { b: { c: 1, d: 2, e: { f: 3 } } } });
+    expect(zipObjectDeep(['a.b[0].c', 'a.b[1].d'], [1, 2])).toEqual({ 'a': { 'b': [{ 'c': 1 }, { 'd': 2 }] } });
+
+  });
+});

--- a/src/array/zipObjectDeep.ts
+++ b/src/array/zipObjectDeep.ts
@@ -1,0 +1,91 @@
+/**
+ * Creates a deeply nested object given arrays of paths and values.
+ *
+ * This function takes two arrays: one containing arrays of property paths, and the other containing corresponding values.
+ * It returns a new object where paths from the first array are used as key paths to set values, with corresponding elements from the second array as values.
+ * Paths can be dot-separated strings or arrays of property names.
+ * 
+ * If the `keys` array is longer than the `values` array, the remaining keys will have `undefined` as their values.
+ *
+ * @template V - The type of elements in the array.
+ * @param {string[] | string[][]} keys - An array of property paths, each path can be a dot-separated string or an array of property names.
+ * @param {V[]} values - An array of values corresponding to the property paths.
+ * @returns {object} A new object composed of the given property paths and values.
+ *
+ * @example
+ * const paths = ['a.b.c', 'd.e.f'];
+ * const values = [1, 2];
+ * const result = zipObjectDeep(paths, values);
+ * // result will be { a: { b: { c: 1 } }, d: { e: { f: 2 } } }
+ *
+ * @example
+ * const paths = [['a', 'b', 'c'], ['d', 'e', 'f']];
+ * const values = [1, 2];
+ * const result = zipObjectDeep(paths, values);
+ * // result will be { a: { b: { c: 1 } }, d: { e: { f: 2 } } }
+ * 
+ * @example
+ * const paths = ['a.b[0].c', 'a.b[1].d'];
+ * const values = [1, 2];
+ * const result = zipObjectDeep(paths, values);
+ * // result will be { 'a': { 'b': [{ 'c': 1 }, { 'd': 2 }] } }
+ */
+export function zipObjectDeep<P extends string | number | symbol, V>(keys: P[], values: V[]): { [K in P]: V } {
+  const result = {} as { [K in P]: V }
+
+  for (let pathIndex = 0; pathIndex < keys.length; pathIndex++) {
+    const path = keys[pathIndex]
+    if (typeof path === 'string') {
+      const pathArray = path.split('.')
+
+      pathArray.reduce((acc, key, index) => {
+        if (key.includes('[')) {
+          const [k, v] = key.split('[')
+          const value = v.replace(']', '')
+          if (!acc[k]) {
+            acc[k] = []
+          }
+          if (index === pathArray.length - 1) {
+            acc[k][value] = values[pathIndex]
+          }
+          return acc[k]
+        }
+
+        if (Array.isArray(acc)) {
+          const parentKey = path.match(/\[(\d+)\]/)
+          if (parentKey === null) {
+            throw new Error('Invalid path')
+          }
+          const arrIndex = parseInt(String(parentKey[1]))
+
+          if (!acc[arrIndex]) {
+            acc[arrIndex] = {}
+          }
+          if (index === pathArray.length - 1) {
+            acc[arrIndex][key] = values[pathIndex]
+          }
+        } else {
+          if (!acc[key]) {
+            acc[key] = {}
+          }
+          if (index === pathArray.length - 1) {
+            acc[key] = values[pathIndex]
+          }
+        }
+
+        return acc[key]
+      }, result as any)
+    } else {
+      // path is number not NaN, Infinity, etc.
+      if (typeof path === 'number' && Number.isInteger(path)) {
+        result[path] = values[pathIndex]
+      }
+      // path is Symbol
+      if (typeof path === 'symbol') {
+        result[path] = values[pathIndex]
+      }
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
#138

This pull request implements a function zipObjectDeep. This function takes two arrays: one containing arrays of property paths, and the other containing corresponding values.It returns a new object where paths from the first array are used as key paths to set values, with corresponding elements from the second array as values.Paths can be dot-separated strings or arrays of property names.If the `keys` array is longer than the `values` array, the remaining keys will have `undefined` as their values.

Below is a benchmark comparison between our head implementation and Lodash's head.

![image](https://github.com/toss/es-toolkit/assets/37231523/ce965a51-1ea8-4a77-b7f3-0c74c89288c4)
