### PR TITLE
feat(clone): add clone

### DIFF
--- a/benchmarks/clone.bench.ts
+++ b/benchmarks/clone.bench.ts
@@ -3,7 +3,7 @@ import { clone } from 'es-toolkit';
 import { clone as lodashClone } from 'lodash';
 
 const obj = {
-  number: 42,
+  number: 29,
   string: 'es-toolkit',
   boolean: true,
   array: [1, 2, 3],

--- a/benchmarks/clone.bench.ts
+++ b/benchmarks/clone.bench.ts
@@ -1,0 +1,23 @@
+import { bench, describe } from 'vitest';
+import { clone } from 'es-toolkit';
+import { clone as lodashClone } from 'lodash';
+
+const obj = {
+  number: 42,
+  string: 'es-toolkit',
+  boolean: true,
+  array: [1, 2, 3],
+  object: { a: 1, b: 'es-toolkit' },
+  date: new Date(),
+  regex: /abc/g,
+  nested: { a: [1, 2, 3], b: { c: 'es-toolkit' }, d: new Date() },
+};
+
+describe('clone', () => {
+  bench('es-toolkit/clone', () => {
+    clone(obj);
+  });
+  bench('lodash/clone', () => {
+    lodashClone(obj);
+  });
+});

--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -119,6 +119,7 @@ function sidebar(): DefaultTheme.Sidebar {
         {
           text: 'Object Utilities',
           items: [
+            { text: 'clone', link: '/reference/object/clone' },
             { text: 'omit', link: '/reference/object/omit' },
             { text: 'omitBy', link: '/reference/object/omitBy' },
             { text: 'pick', link: '/reference/object/pick' },

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -118,6 +118,7 @@ function sidebar(): DefaultTheme.Sidebar {
         {
           text: '객체',
           items: [
+            { text: 'clone', link: '/ko/reference/object/clone' },
             { text: 'omit', link: '/ko/reference/object/omit' },
             { text: 'omitBy', link: '/ko/reference/object/omitBy' },
             { text: 'pick', link: '/ko/reference/object/pick' },

--- a/docs/ko/reference/object/clone.md
+++ b/docs/ko/reference/object/clone.md
@@ -31,6 +31,6 @@ console.log(clonedArr === arr); // false
 
 const obj = { a: 1, b: 'es-toolkit', c: [1, 2, 3] };
 const clonedObj = clone(obj);
-console.log(clonedObj); // { a: 1, b: 'es-toolkit' }
+console.log(clonedObj); // { a: 1, b: 'es-toolkit', c: [1, 2, 3] }
 console.log(clonedObj === obj); // false
 ```

--- a/docs/ko/reference/object/clone.md
+++ b/docs/ko/reference/object/clone.md
@@ -1,0 +1,36 @@
+# clone
+
+주어진 객체의 얇은 복사본을 생성해요.
+
+## Signature
+
+```typescript
+function clone<T>(value: T): T;
+```
+
+### Parameters
+
+- `obj` (`T`): 복사할 객체예요.
+
+### Returns
+
+(`T`): 주어진 객체의 얇은 복사본이에요.
+
+## Examples
+
+```typescript
+const num = 29;
+const clonedNum = clone(num);
+console.log(clonedNum); // 29
+console.log(clonedNum === num); // true
+
+const arr = [1, 2, 3];
+const clonedArr = clone(arr);
+console.log(clonedArr); // [1, 2, 3]
+console.log(clonedArr === arr); // false
+
+const obj = { a: 1, b: 'es-toolkit', c: [1, 2, 3] };
+const clonedObj = clone(obj);
+console.log(clonedObj); // { a: 1, b: 'es-toolkit' }
+console.log(clonedObj === obj); // false
+```

--- a/docs/reference/object/clone.md
+++ b/docs/reference/object/clone.md
@@ -1,0 +1,36 @@
+# clone
+
+Creates a shallow clone of the given objects.
+
+## Signature
+
+```typescript
+function clone<T>(value: T): T;
+```
+
+### Parameters
+
+- `obj` (`T`): The object to clone.
+
+### Returns
+
+(`T`): A shallow clone of the given object
+
+## Examples
+
+```typescript
+const num = 29;
+const clonedNum = clone(num);
+console.log(clonedNum); // 29
+console.log(clonedNum === num); // true
+
+const arr = [1, 2, 3];
+const clonedArr = clone(arr);
+console.log(clonedArr); // [1, 2, 3]
+console.log(clonedArr === arr); // false
+
+const obj = { a: 1, b: 'es-toolkit', c: [1, 2, 3] };
+const clonedObj = clone(obj);
+console.log(clonedObj); // { a: 1, b: 'es-toolkit' }
+console.log(clonedObj === obj); // false
+```

--- a/src/object/clone.spec.ts
+++ b/src/object/clone.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { clone } from './clone';
+
+describe('clone', () => {
+  it('should return primitive values as is', () => {
+    const symbol = Symbol('symbol');
+
+    expect(clone(42)).toBe(42);
+    expect(clone('es-toolkit')).toBe('es-toolkit');
+    expect(clone(symbol)).toBe(symbol);
+    expect(clone(true)).toBe(true);
+    expect(clone(null)).toBe(null);
+    expect(clone(undefined)).toBe(undefined);
+  });
+
+  it('should clone arrays', () => {
+    const arr = [1, 2, 3];
+    const clonedArr = clone(arr);
+
+    expect(clonedArr).toEqual(arr);
+    expect(clonedArr).not.toBe(arr);
+  });
+
+  it('should clone objects', () => {
+    const obj = { a: 1, b: 'es-toolkit' };
+    const clonedObj = clone(obj);
+
+    expect(clonedObj).toEqual(obj);
+    expect(clonedObj).not.toBe(obj);
+  });
+
+  it('should clone dates', () => {
+    const date = new Date();
+    const clonedDate = clone(date);
+
+    expect(clonedDate).toEqual(date);
+    expect(clonedDate).not.toBe(date);
+  });
+
+  it('should clone regular expressions', () => {
+    const regex = /abc/g;
+    const clonedRegex = clone(regex);
+
+    expect(clonedRegex).toEqual(regex);
+    expect(clonedRegex).not.toBe(regex);
+  });
+
+  it('should shallow clone nested objects', () => {
+    const nestedObj = { a: [1, 2, 3], b: { c: 'es-toolkit' }, d: new Date() };
+    const clonedNestedObj = clone(nestedObj);
+
+    expect(clonedNestedObj).toEqual(nestedObj);
+    expect(clonedNestedObj).not.toBe(nestedObj);
+    expect(clonedNestedObj.a).toEqual(nestedObj.a);
+    expect(clonedNestedObj.a[2]).toEqual(nestedObj.a[2]);
+  });
+
+  it('should return functions as is', () => {
+    const func = () => {};
+    const clonedFunc = clone(func);
+
+    expect(clonedFunc).toBe(func);
+  });
+});

--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -1,0 +1,51 @@
+/**
+ * Creates a shallow clone of the given value.
+ *
+ * @template T - The type of the value.
+ * @param {T} value - The value to clone.
+ * @returns {T} - A shallow clone of the value.
+ *
+ * @example
+ * // Clone a primitive values
+ * const num = 29;
+ * const clonedNum = clone(num);
+ * console.log(clonedNum); // 29
+ *
+ * @example
+ * // Clone an array
+ * const arr = [1, 2, 3];
+ * const clonedArr = clone(arr);
+ * console.log(clonedArr); // [1, 2, 3]
+ * console.log(clonedArr === arr); // false
+ *
+ * @example
+ * // Clone an object
+ * const obj = { a: 1, b: 'es-toolkit' };
+ * const clonedObj = clone(obj);
+ * console.log(clonedObj); // { a: 1, b: 'es-toolkit' }
+ * console.log(clonedObj === obj); // false
+ */
+export function clone<T>(value: T): T {
+  if (isPrimitive(value)) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.slice() as T;
+  }
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+  if (value instanceof RegExp) {
+    return new RegExp(value.source, value.flags) as T;
+  }
+  if (typeof value === 'object') {
+    return Object.assign({}, value) as T;
+  }
+  return value;
+}
+
+type Primitive = null | undefined | string | number | boolean | symbol | bigint;
+
+function isPrimitive(value: unknown): value is Primitive {
+  return value == null || (typeof value !== 'object' && typeof value !== 'function');
+}

--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -1,15 +1,16 @@
 /**
- * Creates a shallow clone of the given value.
+ * Creates a shallow clone of the given object.
  *
- * @template T - The type of the value.
- * @param {T} value - The value to clone.
- * @returns {T} - A shallow clone of the value.
+ * @template T - The type of the object.
+ * @param {T} obj - The object to clone.
+ * @returns {T} - A shallow clone of the given object.
  *
  * @example
  * // Clone a primitive values
  * const num = 29;
  * const clonedNum = clone(num);
  * console.log(clonedNum); // 29
+ * console.log(clonedNum === num) ; // true
  *
  * @example
  * // Clone an array
@@ -20,28 +21,28 @@
  *
  * @example
  * // Clone an object
- * const obj = { a: 1, b: 'es-toolkit' };
+ * const obj = { a: 1, b: 'es-toolkit', c: [1, 2, 3] };
  * const clonedObj = clone(obj);
- * console.log(clonedObj); // { a: 1, b: 'es-toolkit' }
+ * console.log(clonedObj); // { a: 1, b: 'es-toolkit', c: [1, 2, 3] }
  * console.log(clonedObj === obj); // false
  */
-export function clone<T>(value: T): T {
-  if (isPrimitive(value)) {
-    return value;
+export function clone<T>(obj: T): T {
+  if (isPrimitive(obj)) {
+    return obj;
   }
-  if (Array.isArray(value)) {
-    return value.slice() as T;
+  if (Array.isArray(obj)) {
+    return obj.slice() as T;
   }
-  if (value instanceof Date) {
-    return new Date(value.getTime()) as T;
+  if (obj instanceof Date) {
+    return new Date(obj.getTime()) as T;
   }
-  if (value instanceof RegExp) {
-    return new RegExp(value.source, value.flags) as T;
+  if (obj instanceof RegExp) {
+    return new RegExp(obj.source, obj.flags) as T;
   }
-  if (typeof value === 'object') {
-    return Object.assign({}, value) as T;
+  if (typeof obj === 'object') {
+    return Object.assign({}, obj) as T;
   }
-  return value;
+  return obj;
 }
 
 type Primitive = null | undefined | string | number | boolean | symbol | bigint;

--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -3,3 +3,4 @@ export { omitBy } from './omitBy.ts';
 export { pick } from './pick.ts';
 export { pickBy } from './pickBy.ts';
 export { invert } from './invert.ts';
+export { clone } from './clone.ts';


### PR DESCRIPTION
Hello, @raon0211! 😁 I have implemented a clone function with shallow copy. However, I have some questions!

<img width="865" alt="image" src="https://github.com/toss/es-toolkit/assets/26808056/71e72d96-a051-4f86-8727-1108face448c">


### Why `clone` function in es-toolkit targets only plain objects and plain arrays? 🤔
By plain objects, do you mean objects that are pure key-value pairs, excluding Date, Regex, Map, etc.? If so, I'm curious why you requested a clone that targets only plain objects and plain arrays in the issue.

Since this library is intended to target `lodash`, I wondered if it should support other types of data structures as well.

For now, I've added support for other data types, but I can change this based on your response :)

### Implementation of cloneDeep
This is not directly related to clone, but I have a question since it overlaps with the topic of plain objects and plain arrays.

The relatively recent API, [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone), supports deep cloning. It is available in most modern browsers except IE, and there are quite a few libraries written using this API ([remeda](https://remedajs.com/docs/#clone), [atomic-fns](https://atomic-fns.dev/functions/collections.clone.html)).

<img width="1429" alt="image" src="https://github.com/toss/es-toolkit/assets/26808056/50254d2d-3db6-477f-94c9-256c4cc1f700">


Since es-toolkit is a modern JavaScript library, I think it would be good to use this API. However, if we are only targeting plain objects and plain arrays, I'm wondering if there is a need to implement cloneDeep separately.

On the other hand, structuredClone throws an error when used with unsupported data types, so it might be worthwhile to provide deepClone to handle these cases!

Please read my thoughts and give me your feedback, and I'll adjust the pull request accordingly. Thank you :)

