### PR TITLE
fix(flatten): improve the performance of the flatten

### DIFF
--- a/src/array/flatten.ts
+++ b/src/array/flatten.ts
@@ -1,3 +1,8 @@
+interface FlattenStack<T> {
+  array: readonly T[];
+  currentDepth: number;
+}
+
 /**
  * Flattens an array up to the specified depth.
  *
@@ -16,18 +21,20 @@
  */
 export function flatten<T, D extends number = 1>(arr: readonly T[], depth = 1 as D): Array<FlatArray<T[], D>> {
   const result: Array<FlatArray<T[], D>> = [];
+  const stack: Array<FlattenStack<T>> = [{ array: arr, currentDepth: 0 }];
   const flooredDepth = Math.floor(depth);
 
-  const recursive = (arr: readonly T[], currentDepth: number) => {
-    for (const item of arr) {
+  while (stack.length > 0) {
+    const { array, currentDepth } = stack.pop()!;
+
+    for (const item of array) {
       if (Array.isArray(item) && currentDepth < flooredDepth) {
-        recursive(item, currentDepth + 1);
+        stack.push({ array: item, currentDepth: currentDepth + 1 });
       } else {
         result.push(item as FlatArray<T[], D>);
       }
     }
-  };
+  }
 
-  recursive(arr, 0);
   return result;
 }


### PR DESCRIPTION
I've been thinking about how `flatten` could be improved further.

Change the approach to tracking arrays and array depth from recursive calls to the stack. This reduces the `overhead` of the function call, which can further improve performance. 

- Each time a function is called recursively, it builds up execution context in the callstack, which can increase memory usage. In particular, memory usage increases dramatically as arrays are deeply nested.

By changing to the stack approach, we see further performance improvements over the traditional approach.
In particular, it becomes more pronounced as the nesting depth increases.

It also passes all the tests we've already written 👍

## benchmark
### **depth 10**
- This is a performance improvement over the previously written `flatten`. 

![스크린샷 2024-07-12 오후 6 48 44](https://github.com/user-attachments/assets/815c561c-1e10-4cc4-a886-cd26efd724e7)

### **depth 50**
- At this point, it performs about 2 times better than `lodash's flattenDepth`.
- At this point, it performs about 8~9 times better than `Array#flat`.

![스크린샷 2024-07-12 오후 6 52 59](https://github.com/user-attachments/assets/6182ad46-ff3e-4f55-822d-5fc886b28e92)

### **depth 100**
- At this point, it performs about 10 times better than `Array#flat`.

![스크린샷 2024-07-12 오후 6 58 23](https://github.com/user-attachments/assets/3bcbdd59-c31f-4083-ba06-478924dce3b3)