### PR TITLE
feat(isEqual): add isEqual

### DIFF
--- a/docs/reference/predicate/isEqual.md
+++ b/docs/reference/predicate/isEqual.md
@@ -1,0 +1,79 @@
+# isEqual
+
+The `isEqual` function checks if two values are equal, including support for `Date`, `RegExp`, and deep object comparison.
+
+## Signature
+```typescript
+export function isEqual(a: unknown, b: unknown): boolean;
+```
+
+## Parameters
+- **`a`**: `unknown` - The first value to compare.
+- **`b`**: `unknown` - The second value to compare.
+
+## Returns
+- **`boolean`** - Returns `true` if the values are equal, otherwise `false`.
+
+## Examples
+### Example 1: Comparing Primitive Values
+```javascript
+isEqual(1, 1); // true
+isEqual('hello', 'hello'); // true
+isEqual(true, true); // true
+isEqual(1, 2); // false
+isEqual('hello', 'world'); // false
+isEqual(true, false); // false
+```
+
+### Example 2: Comparing Special Cases
+```javascript
+isEqual(NaN, NaN); // true
+isEqual(+0, -0); // false
+```
+
+### Example 3: Comparing Date Objects
+```javascript
+const date1 = new Date('2020-01-01');
+const date2 = new Date('2020-01-01');
+isEqual(date1, date2); // true
+
+const date3 = new Date('2021-01-01');
+isEqual(date1, date3); // false
+```
+
+### Example 4: Comparing RegExp Objects
+```javascript
+const regex1 = /hello/g;
+const regex2 = /hello/g;
+isEqual(regex1, regex2); // true
+
+const regex3 = /hello/i;
+isEqual(regex1, regex3); // false
+```
+
+### Example 5: Comparing Objects
+```javascript
+const obj1 = { a: 1, b: { c: 2 } };
+const obj2 = { a: 1, b: { c: 2 } };
+isEqual(obj1, obj2); // true
+
+const obj3 = { a: 1, b: { c: 3 } };
+isEqual(obj1, obj3); // false
+
+const obj4 = { a: 1, b: 2 };
+const obj5 = { a: 1, c: 2 };
+isEqual(obj4, obj5); // false
+```
+
+### Example 6: Comparing Arrays
+```javascript
+const arr1 = [1, 2, 3];
+const arr2 = [1, 2, 3];
+isEqual(arr1, arr2); // true
+
+const arr3 = [1, 2, 4];
+isEqual(arr1, arr3); // false
+
+const arr4 = [1, 2];
+isEqual(arr1, arr4); // false
+```

--- a/src/predicate/index.ts
+++ b/src/predicate/index.ts
@@ -1,3 +1,4 @@
+export { isEqual } from './isEqual.ts';
 export { isNil } from './isNil.ts';
 export { isNotNil } from './isNotNil.ts';
 export { isNull } from './isNull.ts';

--- a/src/predicate/isEqual.spec.ts
+++ b/src/predicate/isEqual.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { isEqual } from './isEqual';
+
+describe('isEqual', () => {
+  it('should return true for equal primitive values', () => {
+    expect(isEqual(1, 1)).toBe(true);
+    expect(isEqual('hello', 'hello')).toBe(true);
+    expect(isEqual(true, true)).toBe(true);
+  });
+
+  it('should return false for different primitive values', () => {
+    expect(isEqual(1, 2)).toBe(false);
+    expect(isEqual('hello', 'world')).toBe(false);
+    expect(isEqual(true, false)).toBe(false);
+  });
+
+  it('should return true for NaN comparisons', () => {
+    expect(isEqual(NaN, NaN)).toBe(true);
+  });
+
+  it('should return false for +0 and -0 comparisons', () => {
+    expect(isEqual(+0, -0)).toBe(false);
+  });
+
+  it('should return true for equal Date objects', () => {
+    const date1 = new Date('2020-01-01');
+    const date2 = new Date('2020-01-01');
+    expect(isEqual(date1, date2)).toBe(true);
+  });
+
+  it('should return false for different Date objects', () => {
+    const date1 = new Date('2020-01-01');
+    const date2 = new Date('2021-01-01');
+    expect(isEqual(date1, date2)).toBe(false);
+  });
+
+  it('should return true for equal RegExp objects', () => {
+    const regex1 = /hello/g;
+    const regex2 = /hello/g;
+    expect(isEqual(regex1, regex2)).toBe(true);
+  });
+
+  it('should return false for different RegExp objects', () => {
+    const regex1 = /hello/g;
+    const regex2 = /hello/i;
+    expect(isEqual(regex1, regex2)).toBe(false);
+  });
+
+  it('should return true for deeply equal objects', () => {
+    const obj1 = { a: 1, b: { c: 2 } };
+    const obj2 = { a: 1, b: { c: 2 } };
+    expect(isEqual(obj1, obj2)).toBe(true);
+  });
+
+  it('should return false for objects with different values', () => {
+    const obj1 = { a: 1, b: { c: 2 } };
+    const obj2 = { a: 1, b: { c: 3 } };
+    expect(isEqual(obj1, obj2)).toBe(false);
+  });
+
+  it('should return false for objects with different keys', () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { a: 1, c: 2 };
+    expect(isEqual(obj1, obj2)).toBe(false);
+  });
+
+  it('should return true for deeply equal arrays', () => {
+    const arr1 = [1, 2, 3];
+    const arr2 = [1, 2, 3];
+    expect(isEqual(arr1, arr2)).toBe(true);
+  });
+
+  it('should return false for arrays with different values', () => {
+    const arr1 = [1, 2, 3];
+    const arr2 = [1, 2, 4];
+    expect(isEqual(arr1, arr2)).toBe(false);
+  });
+
+  it('should return false for arrays with different lengths', () => {
+    const arr1 = [1, 2, 3];
+    const arr2 = [1, 2];
+    expect(isEqual(arr1, arr2)).toBe(false);
+  });
+});

--- a/src/predicate/isEqual.ts
+++ b/src/predicate/isEqual.ts
@@ -1,0 +1,45 @@
+import { union } from "../array";
+
+/**
+ * Checks if two values are equal, including support for `Date`, `RegExp`, and deep object comparison.
+ *
+ * @param {unknown} a - The first value to compare.
+ * @param {unknown} b - The second value to compare.
+ * @returns {boolean} `true` if the values are equal, otherwise `false`.
+ *
+ * @example
+ * isEqual(1, 1); // true
+ * isEqual({ a: 1 }, { a: 1 }); // true
+ * isEqual(/abc/g, /abc/g); // true
+ * isEqual(new Date('2020-01-01'), new Date('2020-01-01')); // true
+ * isEqual([1, 2, 3], [1, 2, 3]); // true
+ */
+export function isEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+
+  if (a instanceof RegExp && b instanceof RegExp) {
+    return a.source === b.source && a.flags === b.flags;
+  }
+
+  if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
+    const keysX = Object.keys(a as object);
+    const keysY = Object.keys(b as object);
+
+    if (keysX.length !== keysY.length) return false;
+
+    // check if all keys in both arrays match
+    if (union(keysX, keysY).length !== keysX.length) return false;
+
+    for (let i = 0; i < keysX.length; i++) {
+      const aa = (a as any)[i];
+      const bb = (b as any)[i];
+      if (!isEqual(aa, bb)) return false;
+    }
+  }
+
+  return true;
+}

--- a/src/predicate/isEqual.ts
+++ b/src/predicate/isEqual.ts
@@ -26,15 +26,15 @@ export function isEqual(a: unknown, b: unknown): boolean {
   }
 
   if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
-    const keysX = Object.keys(a as object);
-    const keysY = Object.keys(b as object);
+    const aKeys = Object.keys(a as object);
+    const bKeys = Object.keys(b as object);
 
-    if (keysX.length !== keysY.length) return false;
+    if (aKeys.length !== bKeys.length) return false;
 
     // check if all keys in both arrays match
-    if (union(keysX, keysY).length !== keysX.length) return false;
+    if (union(aKeys, bKeys).length !== aKeys.length) return false;
 
-    for (let i = 0; i < keysX.length; i++) {
+    for (let i = 0; i < aKeys.length; i++) {
       const aa = (a as any)[i];
       const bb = (b as any)[i];
       if (!isEqual(aa, bb)) return false;

--- a/src/predicate/isEqual.ts
+++ b/src/predicate/isEqual.ts
@@ -1,4 +1,4 @@
-import { union } from "../array";
+import { union } from "../array.ts";
 
 /**
  * Checks if two values are equal, including support for `Date`, `RegExp`, and deep object comparison.
@@ -15,7 +15,9 @@ import { union } from "../array";
  * isEqual([1, 2, 3], [1, 2, 3]); // true
  */
 export function isEqual(a: unknown, b: unknown): boolean {
-  if (Object.is(a, b)) return true;
+  if (Object.is(a, b)) {
+    return true;
+  }
 
   if (a instanceof Date && b instanceof Date) {
     return a.getTime() === b.getTime();
@@ -32,16 +34,23 @@ export function isEqual(a: unknown, b: unknown): boolean {
   const aKeys = Object.keys(a as object);
   const bKeys = Object.keys(b as object);
 
-  if (aKeys.length !== bKeys.length) return false;
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
 
   // check if all keys in both arrays match
-  if (union(aKeys, bKeys).length !== aKeys.length) return false;
+  if (union(aKeys, bKeys).length !== aKeys.length) {
+    return false;
+  }
 
   for (let i = 0; i < aKeys.length; i++) {
     const propKey = aKeys[i];
     const aProp = (a as any)[propKey];
     const bProp = (b as any)[propKey];
-    if (!isEqual(aProp, bProp)) return false;
+    
+    if (!isEqual(aProp, bProp)) {
+      return false;
+    }
   }
 
   return true;

--- a/src/predicate/isEqual.ts
+++ b/src/predicate/isEqual.ts
@@ -25,20 +25,23 @@ export function isEqual(a: unknown, b: unknown): boolean {
     return a.source === b.source && a.flags === b.flags;
   }
 
-  if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
-    const aKeys = Object.keys(a as object);
-    const bKeys = Object.keys(b as object);
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) {
+    return false;
+  }
 
-    if (aKeys.length !== bKeys.length) return false;
+  const aKeys = Object.keys(a as object);
+  const bKeys = Object.keys(b as object);
 
-    // check if all keys in both arrays match
-    if (union(aKeys, bKeys).length !== aKeys.length) return false;
+  if (aKeys.length !== bKeys.length) return false;
 
-    for (let i = 0; i < aKeys.length; i++) {
-      const aa = (a as any)[i];
-      const bb = (b as any)[i];
-      if (!isEqual(aa, bb)) return false;
-    }
+  // check if all keys in both arrays match
+  if (union(aKeys, bKeys).length !== aKeys.length) return false;
+
+  for (let i = 0; i < aKeys.length; i++) {
+    const propKey = aKeys[i];
+    const aProp = (a as any)[propKey];
+    const bProp = (b as any)[propKey];
+    if (!isEqual(aProp, bProp)) return false;
   }
 
   return true;

--- a/src/predicate/isEqual.ts
+++ b/src/predicate/isEqual.ts
@@ -1,4 +1,4 @@
-import { union } from "../array.ts";
+import { union } from "../array/union.ts";
 
 /**
  * Checks if two values are equal, including support for `Date`, `RegExp`, and deep object comparison.


### PR DESCRIPTION
This PR adds the `isEqual` function to the codebase. The `isEqual` function checks if two values are equal, including support for `Date`, `RegExp`, and deep object comparison. Additionally, this PR includes comprehensive tests and detailed documentation for the `isEqual` function.

### Changes

- Added the `isEqual` function.
- Created test cases for `isEqual` using `vitest` to ensure the function works correctly for various scenarios.
- Added detailed documentation for the `isEqual` function in markdown format.

Please review the changes and provide feedback or approval for merging. Thank you!