### PR TITLE
perf(meanBy): Improve performance of `meanBy` by not using map

### DIFF
--- a/benchmarks/meanBy.bench.ts
+++ b/benchmarks/meanBy.bench.ts
@@ -3,13 +3,27 @@ import { meanBy as meanByToolkit } from 'es-toolkit';
 import { meanBy as meanByLodash } from 'lodash';
 
 describe('meanBy', () => {
-  bench('es-toolkit/meanBy', () => {
-    const items = [{ a: 1 }, { a: 2 }, { a: 3 }];
-    meanByToolkit(items, x => x.a);
+  describe('small array', () => {
+    bench('es-toolkit/meanBy', () => {
+      const items = [{ a: 1 }, { a: 2 }, { a: 3 }];
+      meanByToolkit(items, x => x.a);
+    });
+
+    bench('lodash/meanBy', () => {
+      const items = [{ a: 1 }, { a: 2 }, { a: 3 }];
+      meanByLodash(items, x => x.a);
+    });
   });
 
-  bench('lodash/meanBy', () => {
-    const items = [{ a: 1 }, { a: 2 }, { a: 3 }];
-    meanByLodash(items, x => x.a);
+  describe('large array', () => {
+    bench('es-toolkit/meanBy', () => {
+      const items = Array.from({ length: 1000 }, (_, i) => ({ a: i }));
+      meanByToolkit(items, x => x.a);
+    });
+
+    bench('lodash/meanBy', () => {
+      const items = Array.from({ length: 1000 }, (_, i) => ({ a: i }));
+      meanByLodash(items, x => x.a);
+    });
   });
 });

--- a/src/math/meanBy.ts
+++ b/src/math/meanBy.ts
@@ -16,7 +16,11 @@ import { mean } from './mean.ts';
  * meanBy([], x => x.a); // Returns: NaN
  */
 export function meanBy<T>(items: readonly T[], getValue: (element: T) => number): number {
-  const nums = items.map(x => getValue(x));
+  const nums = new Array(items.length);
+
+  for (let i = 0; i < items.length; i++) {
+    nums[i] = getValue(items[i]);
+  }
 
   return mean(nums);
 }


### PR DESCRIPTION
This PR improves the performance of `meanBy` when it computes a large array.

<table>
  <tr>
    <th>before</th>
    <th>after</th>
  </tr>
  <tr>
<td>

<img width="528" alt="before" src="https://github.com/user-attachments/assets/1371e184-a984-4c7f-bd3e-009fa6fe1ebb">

</td>
<td>

<img width="516" alt="after" src="https://github.com/user-attachments/assets/aadbcccc-2c17-4293-9680-69ea8415f6ef">


</td>
  </tr>
</table>
