### PR TITLE
fix(snakeCase): Fixed snakeCase to parse the string with intermediate number well

### DIFF
--- a/benchmarks/snakeCase.bench.ts
+++ b/benchmarks/snakeCase.bench.ts
@@ -3,13 +3,28 @@ import { snakeCase as snakeCaseToolkit } from 'es-toolkit';
 import { snakeCase as snakeCaseLodash } from 'lodash';
 
 describe('snakeCase', () => {
-  bench('es-toolkit/snakeCase', () => {
-    const str = 'camelCase';
-    snakeCaseToolkit(str);
+  describe('short string', () => {
+    bench('es-toolkit/snakeCase', () => {
+      const str = 'camelCase';
+      snakeCaseToolkit(str);
+    });
+
+    bench('lodash/snakeCase', () => {
+      const str = 'camelCase';
+      snakeCaseLodash(str);
+    });
   });
 
-  bench('lodash/snakeCase', () => {
-    const str = 'camelCase';
-    snakeCaseLodash(str);
+  describe('long string', () => {
+    const LONG_STRING = 'thisIsAVeryLongStringThatContainsMultipleWords'.repeat(50);
+    bench('es-toolkit/snakeCase', () => {
+      const str = LONG_STRING;
+      snakeCaseToolkit(str);
+    });
+
+    bench('lodash/snakeCase', () => {
+      const str = LONG_STRING;
+      snakeCaseLodash(str);
+    });
   });
 });

--- a/src/constants/caseSplitPattern.ts
+++ b/src/constants/caseSplitPattern.ts
@@ -15,4 +15,4 @@
  * // matchs: ['camel', 'Case', 'HTTP', 'Request']
  */
 
-export const CASE_SPLIT_PATTERN = /[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]+|[0-9]+/g;
+export const CASE_SPLIT_PATTERN = /[A-Z]?[a-z]+|[0-9]+|[A-Z]+(?![a-z])/g;

--- a/src/string/snakeCase.spec.ts
+++ b/src/string/snakeCase.spec.ts
@@ -37,4 +37,12 @@ describe('snakeCase', () => {
   it('should work with screaming snake case', async () => {
     expect(snakeCase('FOO_BAR')).toEqual('foo_bar');
   });
+
+  it('should work with hyphens ', () => {
+    expect(snakeCase('--FOO-BAR--')).toEqual('foo_bar');
+  });
+
+  it('should work with numbers', () => {
+    expect(snakeCase('foo2bar')).toEqual('foo_2_bar');
+  });
 });

--- a/src/string/snakeCase.ts
+++ b/src/string/snakeCase.ts
@@ -17,5 +17,15 @@ import { CASE_SPLIT_PATTERN } from '../constants';
 
 export const snakeCase = (str: string): string => {
   const splitWords = str.match(CASE_SPLIT_PATTERN) || [];
-  return splitWords.map(word => word.toLowerCase()).join('_');
+
+  if (splitWords.length === 0) {
+    return '';
+  }
+
+  let result = splitWords[0]!.toLowerCase();
+  for (let i = 1; i < splitWords.length; i++) {
+    result += '_' + splitWords[i].toLowerCase();
+  }
+
+  return result;
 };


### PR DESCRIPTION
This PR fixes the string with intermediate number and improves the performance when it parses a long string.

In lodash, `foo2bar` is converted into `foo_2_bar` while es-toolkit doesn't. So I fixed it.
Moreover, I made es-toolkit faster than lodash when it computes a long string.


<table>
  <tr>
    <th>before</th>
    <th>after</th>
  </tr>
  <tr>
<td>

<img width="610" alt="Screenshot 2024-07-13 at 3 22 18 PM" src="https://github.com/user-attachments/assets/5da99714-7b9c-4217-8901-7c9aefc3502b">

</td>
<td>

<img width="607" alt="Screenshot 2024-07-13 at 3 21 54 PM" src="https://github.com/user-attachments/assets/3523719d-b700-44e2-9a0e-74f8281d2d3b">

</td>
  </tr>
</table>
