### PR TITLE
perf(lowerCase): improves performance for lowerCase

### DIFF
--- a/benchmarks/lowerCase.bench.ts
+++ b/benchmarks/lowerCase.bench.ts
@@ -3,13 +3,26 @@ import { lowerCase as lowerCaseToolkit } from 'es-toolkit';
 import { lowerCase as lowerCaseLodash } from 'lodash';
 
 describe('lowerCase', () => {
-  bench('es-toolkit/lowerCase', () => {
-    const str = 'camelCase';
-    lowerCaseToolkit(str);
+  describe('short string', () => {
+    bench('es-toolkit/lowerCase', () => {
+      const str = 'camelCase';
+      lowerCaseToolkit(str);
+    });
+
+    bench('lodash/lowerCase', () => {
+      const str = 'camelCase';
+      lowerCaseLodash(str);
+    });
   });
 
-  bench('lodash/lowerCase', () => {
-    const str = 'camelCase';
-    lowerCaseLodash(str);
+  describe('long string', () => {
+    const LONG_STR = 'camelCase'.repeat(100);
+    bench('es-toolkit/lowerCase', () => {
+      lowerCaseToolkit(LONG_STR);
+    });
+
+    bench('lodash/lowerCase', () => {
+      lowerCaseLodash(LONG_STR);
+    });
   });
 });

--- a/benchmarks/lowerCase.bench.ts
+++ b/benchmarks/lowerCase.bench.ts
@@ -16,7 +16,7 @@ describe('lowerCase', () => {
   });
 
   describe('long string', () => {
-    const LONG_STR = 'camelCase'.repeat(100);
+    const LONG_STR = 'camelCaseLongString'.repeat(1000);
     bench('es-toolkit/lowerCase', () => {
       lowerCaseToolkit(LONG_STR);
     });

--- a/src/string/lowerCase.ts
+++ b/src/string/lowerCase.ts
@@ -17,5 +17,15 @@ import { CASE_SPLIT_PATTERN } from '../constants';
 
 export const lowerCase = (str: string): string => {
   const splitWords = str.match(CASE_SPLIT_PATTERN) || [];
-  return splitWords.map(word => word.toLowerCase()).join(' ');
+
+  if (splitWords.length === 0) {
+    return '';
+  }
+
+  let result = splitWords[0]!.toLowerCase();
+  for (let i = 1; i < splitWords.length; i++) {
+    result += ' ' + splitWords[i]!.toLowerCase();
+  }
+
+  return result;
 };


### PR DESCRIPTION
This PR improves performance for lowerCase.


<table>
  <tr>
    <th>before</th>
    <th>after</th>
  </tr>
  <tr>
<td>

<img width="582" alt="Screenshot 2024-07-13 at 5 03 46 PM" src="https://github.com/user-attachments/assets/eb79543b-254c-4a5e-b498-deb2de4bafa1">

</td>
<td>

<img width="595" alt="Screenshot 2024-07-13 at 5 04 24 PM" src="https://github.com/user-attachments/assets/76eea814-d4ff-4bbb-8491-ed0bd952c5e0">


</td>
  </tr>
</table>
