### PR TITLE
perf(capitalize): Improve performance for capitalize

### DIFF
--- a/benchmarks/capitalize.bench.ts
+++ b/benchmarks/capitalize.bench.ts
@@ -3,13 +3,26 @@ import { capitalize as capitalizeToolkit } from 'es-toolkit';
 import { capitalize as capitalizeLodash } from 'lodash';
 
 describe('capitalize', () => {
-  bench('es-toolkit/capitalize', () => {
-    const str = 'camelCase';
-    capitalizeToolkit(str);
+  describe('short string', () => {
+    bench('es-toolkit/capitalize', () => {
+      const str = 'camelCase';
+      capitalizeToolkit(str);
+    });
+
+    bench('lodash/capitalize', () => {
+      const str = 'camelCase';
+      capitalizeLodash(str);
+    });
   });
 
-  bench('lodash/capitalize', () => {
-    const str = 'camelCase';
-    capitalizeLodash(str);
+  describe('long string', () => {
+    const LONG_STR = 'camelCaseLongString'.repeat(100);
+    bench('es-toolkit/capitalize', () => {
+      capitalizeToolkit(LONG_STR);
+    });
+
+    bench('lodash/capitalize', () => {
+      capitalizeLodash(LONG_STR);
+    });
   });
 });

--- a/src/string/capitalize.ts
+++ b/src/string/capitalize.ts
@@ -11,5 +11,6 @@
  */
 
 export const capitalize = <T extends string>(str: T): Capitalize<T> => {
-  return (str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()) as Capitalize<T>;
+  const lowered = str.toLowerCase();
+  return (lowered.charAt(0).toUpperCase() + lowered.slice(1)) as Capitalize<T>;
 };


### PR DESCRIPTION
This PR improves performance for `capitalize` when it computes long string.


<table>
  <tr>
    <th>before</th>
    <th>after</th>
  </tr>
  <tr>
<td>

<img width="618" alt="Screenshot 2024-07-13 at 10 37 39 PM" src="https://github.com/user-attachments/assets/c3ca5cbb-fb37-45be-990b-037b09bb843c">

</td>
<td>

<img width="617" alt="Screenshot 2024-07-13 at 10 37 22 PM" src="https://github.com/user-attachments/assets/c7393bd3-5576-4c70-b1e0-5364605c7159">

</td>
  </tr>
</table>
