### PR TITLE
chore: Add internal types, KeyOf and ValueOf

### DIFF
--- a/src/_internal/types/KeyOf.ts
+++ b/src/_internal/types/KeyOf.ts
@@ -1,0 +1,1 @@
+export type KeyOf<T extends Record<PropertyKey, any>> = keyof T;

--- a/src/_internal/types/ValueOf.ts
+++ b/src/_internal/types/ValueOf.ts
@@ -1,0 +1,1 @@
+export type ValueOf<T> = T extends Record<PropertyKey, infer V> ? V : never;

--- a/src/_internal/types/index.ts
+++ b/src/_internal/types/index.ts
@@ -1,1 +1,2 @@
 export type { KeyOf } from './KeyOf';
+export type { ValueOf } from './ValueOf';

--- a/src/_internal/types/index.ts
+++ b/src/_internal/types/index.ts
@@ -1,0 +1,1 @@
+export type { KeyOf } from './KeyOf';


### PR DESCRIPTION
As I talked about ways to easily use types for KeyOf and ValueOf #182. After seeing that other contributors, including myself, agreed with this, I decided to leave this PR. 

I think KeyOf and ValueOf will be tools that can handle types declaratively when implmenting Object Utilities. 

The implmentation was in the `src/_internal` directory as in `es-hangul`.

Additionally, If you think this types are useful, would it be okay to modify the previously implmented parts such as `keyof T` and `T[keyof T]`? 👀 