### PR TITLE
feat(chunk): Add type inference for tuple type to `chunk`

### DIFF
--- a/src/array/chunk.spec.ts
+++ b/src/array/chunk.spec.ts
@@ -2,6 +2,65 @@ import { describe, expect, it } from 'vitest';
 import { chunk } from './chunk';
 
 describe('chunk', () => {
+  it('if tuple with size 1, it should be divided according to the size.', () => {
+    type Response = ReturnType<typeof chunk<[1, 2, 3, 4, 5, 6], 1>>;
+    const response: Response = [[1], [2], [3], [4], [5], [6]];
+
+    expect(response).toBeDefined();
+  });
+
+  it('if tuple with size 2, it should be divided according to the size.', () => {
+    type Response = ReturnType<typeof chunk<[1, 2, 3, 4, 5, 6], 2>>;
+    const response: Response = [
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ];
+
+    expect(response).toBeDefined();
+  });
+
+  it('if tuple with size 3, it should be divided according to the size.', () => {
+    type Response = ReturnType<typeof chunk<[1, 2, 3, 4, 5, 6], 3>>;
+    const response: Response = [
+      [1, 2, 3],
+      [4, 5, 6],
+    ];
+
+    expect(response).toBeDefined();
+  });
+
+  it('if tuple with size 4, it should be divided according to the size.', () => {
+    type Response = ReturnType<typeof chunk<[1, 2, 3, 4, 5, 6], 4>>;
+    const response: Response = [
+      [1, 2, 3, 4],
+      [5, 6],
+    ];
+
+    expect(response).toBeDefined();
+  });
+
+  it('if tuple with size 5, it should be divided according to the size.', () => {
+    type Response = ReturnType<typeof chunk<[1, 2, 3, 4, 5, 6], 5>>;
+    const response: Response = [[1, 2, 3, 4, 5], [6]];
+
+    expect(response).toBeDefined();
+  });
+
+  it('if tuple with size 6, it should be divided according to the size.', () => {
+    type Response = ReturnType<typeof chunk<[1, 2, 3, 4, 5, 6], 6>>;
+    const response: Response = [[1, 2, 3, 4, 5, 6]];
+
+    expect(response).toBeDefined();
+  });
+
+  it("if tuple with size more than tuple' length, it will be same as devided according to the tuple's length", () => {
+    type Response = ReturnType<typeof chunk<[1, 2, 3, 4, 5, 6], 7>>;
+    const response: Response = [[1, 2, 3, 4, 5, 6]];
+
+    expect(response).toBeDefined();
+  });
+
   it('should return an empty array when the input array is empty', () => {
     expect(chunk([], 3)).toEqual([]);
   });

--- a/src/array/chunk.ts
+++ b/src/array/chunk.ts
@@ -1,4 +1,34 @@
 /**
+ * Type that returns true if it is a tuple type with a fixed length.
+ */
+type IsTuple<T extends any[] | { length: number }> = [T] extends [never]
+  ? false
+  : T extends any[]
+    ? number extends T['length']
+      ? false
+      : true
+    : false;
+
+/**
+ * Type to infer the element type of an array or tuple
+ */
+type ElementOf<T extends readonly any[] | any[]> = T extends Array<infer E> ? E : never;
+
+/**
+ * {@link chunk}'s Return Type.
+ */
+type Chunk<T extends readonly any[] | any[], N extends number, R extends any[] = []> =
+  IsTuple<T> extends true
+    ? R['length'] extends N
+      ? [R, ...Chunk<T, N>]
+      : T extends [infer First, ...infer Rest]
+        ? Chunk<Rest, N, [...R, First]>
+        : R extends []
+          ? []
+          : [R]
+    : Array<Array<ElementOf<T>>>;
+
+/**
  * Splits an array into smaller arrays of a specified length.
  *
  * This function takes an input array and divides it into multiple smaller arrays,
@@ -21,7 +51,7 @@
  * chunk(['a', 'b', 'c', 'd', 'e', 'f', 'g'], 3);
  * // Returns: [['a', 'b', 'c'], ['d', 'e', 'f'], ['g']]
  */
-export function chunk<T>(arr: readonly T[], size: number): T[][] {
+export function chunk<T extends readonly any[], Size extends number>(arr: T, size: Size): Chunk<T, Size> {
   if (!Number.isInteger(size) || size <= 0) {
     throw new Error('Size must be an integer greater than zero.');
   }
@@ -36,5 +66,5 @@ export function chunk<T>(arr: readonly T[], size: number): T[][] {
     result[index] = arr.slice(start, end);
   }
 
-  return result;
+  return result as Chunk<T, Size>;
 }


### PR DESCRIPTION
I'm wondering if it's what you'd expect from this library to help you infer more accurate types. I can often make contributions if these contributions match your expectations.
If you find this PR interesting, please allow me to install an additional library so that I can do tests on the type. Or, set it up to catch compilation errors when operating the test code so that I can do those tests.

<img width="698" alt="image" src="https://github.com/user-attachments/assets/2ff1293c-aa8c-4f94-b058-2cf34a722795">
