### PR TITLE
feat(difference): Add type inference for tupe type to `difference`

### DIFF
--- a/src/array/difference.spec.ts
+++ b/src/array/difference.spec.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { difference } from './difference';
 
 describe('difference', () => {
+  it('if tuple with size 1, it should be divided according to the size.', () => {
+    type Response = ReturnType<typeof difference<[1, 2, 3], [1]>>;
+    const response: Response = [2, 3];
+
+    expect(response).toBeDefined();
+  });
+
   it('should the difference of two arrays', () => {
     expect(difference([1, 2, 3], [1])).toEqual([2, 3]);
     expect(difference([], [1, 2, 3])).toEqual([]);

--- a/src/array/difference.ts
+++ b/src/array/difference.ts
@@ -1,4 +1,39 @@
 /**
+ * Type that returns true if it is a tuple type with a fixed length.
+ */
+type IsTuple<T extends any[] | { length: number }> = [T] extends [never]
+  ? false
+  : T extends any[]
+    ? number extends T['length']
+      ? false
+      : true
+    : false;
+
+/**
+ * Type to infer the element type of an array or tuple
+ */
+type ElementOf<T extends readonly any[] | any[]> = T extends Array<infer E> ? E : never;
+
+/**
+ * Type to infer the value of array
+ */
+type ValueOf<T extends any[]> = T[number];
+
+/**
+ * {@link difference}'s return type
+ */
+type Difference<F extends any[], S extends any[]> =
+  IsTuple<F> extends true
+    ? IsTuple<S> extends true
+      ? F extends [infer FE, ...infer Rest]
+        ? FE extends ValueOf<S>
+          ? Difference<Rest, S>
+          : [FE, ...Difference<Rest, S>]
+        : []
+      : Array<ElementOf<F>>
+    : Array<ElementOf<F>>;
+
+/**
  * Computes the difference between two arrays.
  *
  * This function takes two arrays and returns a new array containing the elements
@@ -20,8 +55,8 @@
  * const result = difference(array1, array2);
  * // result will be [1, 3, 5] since 2 and 4 are in both arrays and are excluded from the result.
  */
-export function difference<T>(firstArr: readonly T[], secondArr: readonly T[]): T[] {
+export function difference<F extends any[], S extends any[]>(firstArr: F, secondArr: S): Difference<F, S> {
   const secondSet = new Set(secondArr);
 
-  return firstArr.filter(item => !secondSet.has(item));
+  return firstArr.filter(item => !secondSet.has(item)) as Difference<F, S>;
 }


### PR DESCRIPTION
```ts
difference([1, 2, 'a', 'b', true, false] as const, [1, 2, true] as const); // ["a", "b", false]
```

Like this #190,
I would like to support type inference for tuple type.
As I said in the PR before, please let me know if these PRs are not what you expect from this project.
