### PR TITLE
feat(sumBy): add sumBy

### DIFF
--- a/benchmarks/sumBy.bench.ts
+++ b/benchmarks/sumBy.bench.ts
@@ -1,0 +1,15 @@
+import { bench, describe } from 'vitest';
+import { sumBy as sumByToolkit } from 'es-toolkit';
+import { sumBy as sumByLodash } from 'lodash';
+
+describe('sumBy', () => {
+  bench('es-toolkit/sumBy', () => {
+    const items = [{ a: 1 }, { a: 2 }, { a: 3 }];
+    sumByToolkit(items, x => x.a);
+  });
+
+  bench('lodash/sumBy', () => {
+    const items = [{ a: 1 }, { a: 2 }, { a: 3 }];
+    sumByLodash(items, x => x.a);
+  });
+});

--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -125,6 +125,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: "range", link: "/reference/math/range" },
             { text: "round", link: "/reference/math/round" },
             { text: "sum", link: "/reference/math/sum" },
+            { text: "sumBy", link: "/reference/math/sumBy" },
           ],
         },
         {

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -137,6 +137,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: "round", link: "/ko/reference/math/round" },
             { text: "range", link: "/ko/reference/math/range" },
             { text: "sum", link: "/ko/reference/math/sum" },
+            { text: "sumBy", link: "/ko/reference/math/sumBy" },
           ],
         },
         {

--- a/docs/.vitepress/zh_hans.mts
+++ b/docs/.vitepress/zh_hans.mts
@@ -144,6 +144,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: "range", link: "/zh_hans/reference/math/range" },
             { text: "round", link: "/zh_hans/reference/math/round" },
             { text: "sum", link: "/zh_hans/reference/math/sum" },
+            { text: "sumBy", link: "/zh_hans/reference/math/sumBy" },
           ],
         },
         {

--- a/docs/ko/reference/math/sumBy.md
+++ b/docs/ko/reference/math/sumBy.md
@@ -1,0 +1,27 @@
+# sumBy
+
+`getValue` 함수가 반환하는 값을 기준으로, 숫자 배열의 모든 요소를 더한 합계를 반환해요.
+
+빈 배열에 대해서는 `0`을 반환해요.
+
+## 인터페이스
+
+```typescript
+export function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+```
+
+### 파라미터
+
+- `items` (`T[]`): 합계를 계산할 숫자 배열이에요.
+- `getValue` (`(item: T) => number`): 각 요소에서 숫자 값을 선택하는 함수에요.
+
+### 반환 값
+
+(`number`): `getValue` 함수를 기준으로, 배열에 있는 모든 숫자의 합계를 반환해요.
+
+## 예시
+
+```typescript
+sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // 6을 반환해요.
+sumBy([], x => x.a); // 0을 반환해요.
+```

--- a/docs/reference/math/sumBy.md
+++ b/docs/reference/math/sumBy.md
@@ -1,0 +1,27 @@
+# sumBy
+
+Calculates the sum of an array of numbers when applying the `getValue` function to each element.
+
+If the array is empty, this function returns `0`.
+
+## Signature
+
+```typescript
+export function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+```
+
+### Parameters
+
+- `items` (`T[]`): An array to calculate the sum.
+- `getValue` (`(item: T) => number`): A function that selects a numeric value from each element.
+
+### Returns
+
+(`number`): The sum of all the numbers as determined by the `getValue` function.
+
+## Examples
+
+```typescript
+sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: 6
+sumBy([], x => x.a); // Returns: 0
+```

--- a/docs/zh_hans/reference/math/sumBy.md
+++ b/docs/zh_hans/reference/math/sumBy.md
@@ -1,0 +1,27 @@
+# sumBy
+
+计算数字数组的总和，通过对每个元素应用 `getValue` 函数来选择数值。
+
+如果数组为空，则此函数返回 `0`。
+
+## 签名
+
+```typescript
+export function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+```
+
+### 参数
+
+- `items` (`T[]`): 要计算总和的数组。
+- `getValue` (`(item: T) => number`): 从每个元素选择数值的函数。
+
+### 返回值
+
+(`number`): 根据 `getValue` 函数确定的所有数值的平均值。
+
+## 示例
+
+```typescript
+sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // 返回: 6
+sumBy([], x => x.a); // 返回: 0
+```

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -6,4 +6,5 @@ export { random } from './random.ts';
 export { randomInt } from './randomInt.ts';
 export { round } from './round.ts';
 export { sum } from './sum.ts';
+export { sumBy } from './sumBy.ts';
 export { range } from './range.ts';

--- a/src/math/sumBy.spec.ts
+++ b/src/math/sumBy.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { sumBy } from './sumBy.ts';
+
+describe('sumBy function', () => {
+  it('calculates the sum of values extracted from objects', () => {
+    const result = sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a);
+    expect(result).toBe(6);
+  });
+
+  it('returns 0 for empty arrays', () => {
+    type Person = { name: string; age: number };
+    const people: Person[] = [];
+
+    expect(sumBy(people, x => x.age)).toEqual(0);
+  });
+});

--- a/src/math/sumBy.ts
+++ b/src/math/sumBy.ts
@@ -1,0 +1,22 @@
+import { sum } from './sum.ts';
+
+/**
+ * Calculates the sum of an array of numbers when applying
+ * the `getValue` function to each element.
+ *
+ * If the array is empty, this function returns `0`.
+ *
+ * @template T - The type of elements in the array.
+ * @param {T[]} items An array to calculate the average.
+ * @param {(element: T) => number} getValue A function that selects a numeric value from each element.
+ * @returns {number} The average of all the numbers as determined by the `getValue` function.
+ *
+ * @example
+ * sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: 6
+ * sumBy([], x => x.a); // Returns: 0
+ */
+export function sumBy<T>(items: readonly T[], getValue: (element: T) => number): number {
+  const nums = items.map(x => getValue(x));
+
+  return sum(nums);
+}


### PR DESCRIPTION
- Added the `sumBy` function to sum array elements by mapping them to numeric values using a provided iteratee function.
    - This function reuses the existing `sum` function.
- Added comprehensive documentation for `sumBy`in Korean, English and Chinese.

### Benchmark
 <img width="422" alt="스크린샷 2024-07-15 오전 12 33 06" src="https://github.com/user-attachments/assets/aa0d98a9-686a-48bc-948d-a19cd860edd6">

### Documentation

<table>
 <tr>
  <th> en </th>
  <th> ko </th>
</tr>
<tr>
  <td>
<img width="850" alt="스크린샷 2024-07-15 오전 12 40 36" src="https://github.com/user-attachments/assets/6520956f-0dad-41da-a9d2-43a1d9f0fea1">
</td>
  <td> <img width="784" alt="스크린샷 2024-07-15 오전 12 40 45" src="https://github.com/user-attachments/assets/28c725b2-2277-4f1d-a45b-7dd170d96571">
</td>
</tr>
 <tr>
  <th> zh </th>
</tr>
<tr>
  <td> 
<img width="757" alt="스크린샷 2024-07-15 오전 12 40 52" src="https://github.com/user-attachments/assets/96ea930f-617f-4f10-b44b-95f757dee2bc">
</td>
</tr>
</table>
