### PR TITLE
docs(last-ko): delete error category in last-ko docs

### DIFF
--- a/docs/ko/reference/array/last.md
+++ b/docs/ko/reference/array/last.md
@@ -19,10 +19,6 @@ function last<T>(arr: T[]): T | undefined;
 
 (`T | undefined`): 배열의 마지막 요소, 빈 배열의 경우, `undefined`를 반환해요.
 
-### 에러
-
-`arr`이 배열이 아닌 경우 에러를 던져요.
-
 ## 예시
 
 ```typescript


### PR DESCRIPTION
hello @raon0211. 

I remember that unnecessary error handling was deleted from the last function in the last pr #149. 
The English and Chinese are missing, but only the Korean docs are currently included, so I'll post a correction. 
thank you

- delete unnecessary error section in last-ko docs.