### PR TITLE
test(chunk,compact): Add property testing using fast-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-jsdoc": "^48.5.0",
+    "fast-check": "^3.20.0",
     "lodash": "^4.17.21",
     "prettier": "^3.2.5",
     "tsup": "^8.1.0",

--- a/src/array/chunk.spec.ts
+++ b/src/array/chunk.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { chunk } from './chunk';
+import fc from 'fast-check';
 
 describe('chunk', () => {
   it('should return an empty array when the input array is empty', () => {
@@ -31,5 +32,24 @@ describe('chunk', () => {
   it('should place the remaining elements in the last chunk when the total length is not a multiple of the size', () => {
     expect(chunk([1, 2, 3, 4], 6)).toEqual([[1, 2, 3, 4]]);
     expect(chunk([1, 2, 3, 4, 5, 6, 7], 2)).toEqual([[1, 2], [3, 4], [5, 6], [7]]);
+  });
+});
+
+describe('chunk property', () => {
+  it('should split an array into chunks of the specified size', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 100 }).chain(size => {
+          const evenlyChunked = fc.array(fc.array(fc.anything(), { minLength: size, maxLength: size }));
+          const tail = fc.array(fc.anything(), { minLength: 0, maxLength: size - 1 });
+          return fc.tuple(fc.constant(size), evenlyChunked, tail);
+        }),
+        ([size, chunked, tail]) => {
+          const input = chunked.flat().concat(tail);
+          const output = chunked.concat(tail.length ? [tail] : []);
+          expect(chunk(input, size)).toEqual(output);
+        }
+      )
+    );
   });
 });

--- a/src/array/compact.spec.ts
+++ b/src/array/compact.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { compact } from './compact';
+import fc from 'fast-check';
 
 describe('compact', () => {
   it('removes falsey values from array', () => {
@@ -10,5 +11,21 @@ describe('compact', () => {
       'hello',
       { age: 30 },
     ]);
+  });
+});
+
+describe('compact property', () => {
+  it('should remove falsey values from array', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string().filter(s => s.length > 0)),
+        fc.array(fc.falsy()),
+        fc.array(fc.falsy()),
+        (arr, head, tail) => {
+          const falseMixedArray = arr.flatMap(value => [...head, value, ...tail]);
+          expect(compact(falseMixedArray)).toEqual(arr);
+        }
+      )
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4956,6 +4956,7 @@ __metadata:
     eslint: "npm:^8.56.0"
     eslint-config-prettier: "npm:^8.5.0"
     eslint-plugin-jsdoc: "npm:^48.5.0"
+    fast-check: "npm:^3.20.0"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.2.5"
     tsup: "npm:^8.1.0"
@@ -5394,6 +5395,15 @@ __metadata:
   version: 1.4.1
   resolution: "extsprintf@npm:1.4.1"
   checksum: 10c0/e10e2769985d0e9b6c7199b053a9957589d02e84de42832c295798cb422a025e6d4a92e0259c1fb4d07090f5bfde6b55fd9f880ac5855bd61d775f8ab75a7ab0
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^3.20.0":
+  version: 3.20.0
+  resolution: "fast-check@npm:3.20.0"
+  dependencies:
+    pure-rand: "npm:^6.1.0"
+  checksum: 10c0/860daef1337c96077ba7f2d0238391eb7de24aced5b0f43c699ad4ba683a1a61044dd8d17b86f914be728b97cbb5bbaf2625c2be4e1c0bf685f09432c29624c9
   languageName: node
   linkType: hard
 
@@ -7974,6 +7984,13 @@ __metadata:
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
+  languageName: node
+  linkType: hard
+
+"pure-rand@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10c0/1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Implemented [property testing](https://en.wikipedia.org/wiki/Property_testing) using the [fast-check](https://github.com/dubzzz/fast-check) library.
Applied it to the `chunk` and `compact` functions as examples.
I hope to implement property tests for all functions in the future.