### PR TITLE
docs: fix formatting of CODE_OF_CONDUCT.md

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,38 +1,43 @@
-Contributor Covenant Code of Conduct
-Our Pledge
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
-Our Standards
+
+## Our Standards
 
 Examples of behavior that contributes to creating a positive environment include:
 
-    Using welcoming and inclusive language
-    Being respectful of differing viewpoints and experiences
-    Gracefully accepting constructive criticism
-    Focusing on what is best for the community
-    Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-    The use of sexualized language or imagery and unwelcome sexual attention or advances
-    Trolling, insulting/derogatory comments, and personal or political attacks
-    Public or private harassment
-    Publishing others' private information, such as a physical or electronic address, without explicit permission
-    Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
-Our Responsibilities
+## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
-Scope
+
+## Scope
 
 This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
-Enforcement
+
+## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at frontend.devops@toss.im. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
-Attribution
 
-This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at http://contributor-covenant.org/version/1/4
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct/


### PR DESCRIPTION
When reading the [contributing guide](https://github.com/toss/es-toolkit/blob/main/.github/CONTRIBUTING.md), it directed me to the [code of conduct](https://github.com/toss/es-toolkit/blob/main/.github/CODE_OF_CONDUCT.md), which I found hard to read as rendered by GitHub because it seems to be lacking basic Markdown syntax despite using a `.md` extension.

In particular:

- headings were not marked as such;
- a list of bullet points was indented with 4 spaces (which is markdown syntax for a code block).

I referred to https://www.contributor-covenant.org/version/1/4/code-of-conduct/ to make sure the formatting I used matches the original document's structure.

I did not change any content. These changes are for readability only.