### PR TITLE
Fix(capitalize): remove template for consistent code, capitalize in string

### DIFF
--- a/docs/ko/reference/string/capitalize.md
+++ b/docs/ko/reference/string/capitalize.md
@@ -5,12 +5,12 @@
 ## 인터페이스
 
 ```typescript
-function capitalize<T extends string>(str: T): Capitalize<T>;
+function capitalize(str: string): Capitalize<string>;
 ```
 
 ### 파라미터
 
-`str` (`T`): 대문자로 변환할 문자열.
+`str` (`string`): 대문자로 변환할 문자열.
 
 ### 반환 값
 

--- a/docs/reference/string/capitalize.md
+++ b/docs/reference/string/capitalize.md
@@ -5,12 +5,12 @@ Converts the first character of string to upper case and the remaining to lower 
 ## Signature
 
 ```typescript
-function capitalize<T extends string>(str: T): Capitalize<T>;
+function capitalize(str: string): Capitalize<string>;
 ```
 
 ### Parameters
 
-`str` (`T`): The string to be converted to uppercase.
+`str` (`string`): The string to be converted to uppercase.
 
 ### Returns
 

--- a/src/string/capitalize.ts
+++ b/src/string/capitalize.ts
@@ -1,15 +1,14 @@
 /**
  * Converts the first character of string to upper case and the remaining to lower case.
  *
- * @template T - Literal type of the string.
- * @param {T} str - The string to be converted to uppercase.
- * @returns {Capitalize<T>} - The capitalized string.
+ * @param {string} str - The string to be converted to uppercase.
+ * @returns {Capitalize<string>} - The capitalized string.
  *
  * @example
  * const result = capitalize('fred') // returns 'Fred'
  * const result2 = capitalize('FRED') // returns 'Fred'
  */
 
-export const capitalize = <T extends string>(str: T): Capitalize<T> => {
-  return (str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()) as Capitalize<T>;
+export const capitalize = (str: string): Capitalize<string> => {
+  return (str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()) as Capitalize<string>;
 };


### PR DESCRIPTION
Remove template `T` in `capitalize` for consistent code formatting in string directory (snakeCase, kebabCase, etc...)

It suggested in #172 issue.