### PR TITLE
fix(falsey): remove unused `falsey` constant in `src/compat`

### DIFF
--- a/src/compat/_internal/falsey.ts
+++ b/src/compat/_internal/falsey.ts
@@ -1,1 +1,0 @@
-export const falsey = [, null, undefined, false, 0, NaN, ''];


### PR DESCRIPTION
The `falsey` constant was removed as it was not being used anywhere in the codebase. I think that removing unused code helps in maintaining a cleaner and more maintainable codebase. So, I removed it.