### PR TITLE
fix(drop): Fixed `drop` and `dropRight` only to allow positive integers

### DIFF
--- a/src/array/drop.spec.ts
+++ b/src/array/drop.spec.ts
@@ -6,4 +6,17 @@ describe('drop', () => {
     expect(drop([1.2, 2.3, 3.4], 1)).toEqual([2.3, 3.4]);
     expect(drop(['a', 'b', 'c', 'd'], 2)).toEqual(['c', 'd']);
   });
+
+  it('should return all elements if n < 1', () => {
+    expect(drop([1.2, 2.3, 3.4], 0)).toEqual([1.2, 2.3, 3.4]);
+    expect(drop([1.2, 2.3, 3.4], -1)).toEqual([1.2, 2.3, 3.4]);
+  });
+
+  it('should coerce n to an integer', () => {
+    expect(drop([1.2, 2.3, 3.4], 1.5)).toEqual([2.3, 3.4]);
+  });
+
+  it('should return empty array if n > arr.length', () => {
+    expect(drop([1.2, 2.3, 3.4], 4)).toEqual([]);
+  });
 });

--- a/src/array/drop.spec.ts
+++ b/src/array/drop.spec.ts
@@ -16,7 +16,7 @@ describe('drop', () => {
     expect(drop([1.2, 2.3, 3.4], 1.5)).toEqual([2.3, 3.4]);
   });
 
-  it('should return empty array if n > arr.length', () => {
+  it('should return empty array if n >= arr.length', () => {
     expect(drop([1.2, 2.3, 3.4], 4)).toEqual([]);
   });
 });

--- a/src/array/drop.spec.ts
+++ b/src/array/drop.spec.ts
@@ -7,16 +7,16 @@ describe('drop', () => {
     expect(drop(['a', 'b', 'c', 'd'], 2)).toEqual(['c', 'd']);
   });
 
-  it('should return all elements if n < 1', () => {
+  it('should return all elements if itemsCount < 1', () => {
     expect(drop([1.2, 2.3, 3.4], 0)).toEqual([1.2, 2.3, 3.4]);
     expect(drop([1.2, 2.3, 3.4], -1)).toEqual([1.2, 2.3, 3.4]);
   });
 
-  it('should coerce n to an integer', () => {
+  it('should coerce itemsCount to an integer', () => {
     expect(drop([1.2, 2.3, 3.4], 1.5)).toEqual([2.3, 3.4]);
   });
 
-  it('should return empty array if n >= arr.length', () => {
+  it('should return empty array if itemsCount >= arr.length', () => {
     expect(drop([1.2, 2.3, 3.4], 4)).toEqual([]);
   });
 });

--- a/src/array/drop.ts
+++ b/src/array/drop.ts
@@ -15,5 +15,5 @@
  * // result will be [3, 4, 5] since the first two elements are dropped.
  */
 export function drop<T>(arr: readonly T[], itemsCount: number): T[] {
-  return arr.slice(itemsCount);
+  return arr.slice(Math.max(itemsCount, 0));
 }

--- a/src/array/dropRight.spec.ts
+++ b/src/array/dropRight.spec.ts
@@ -6,4 +6,17 @@ describe('dropRight', () => {
     expect(dropRight([1.2, 2.3, 3.4], 1)).toEqual([1.2, 2.3]);
     expect(dropRight(['a', 'b', 'c', 'd'], 2)).toEqual(['a', 'b']);
   });
+
+  it('should return all elements if itemsCount < 1', () => {
+    expect(dropRight([1.2, 2.3, 3.4], 0)).toEqual([1.2, 2.3, 3.4]);
+    expect(dropRight([1.2, 2.3, 3.4], -1)).toEqual([1.2, 2.3, 3.4]);
+  });
+
+  it('should coerce itemsCount to an integer', () => {
+    expect(dropRight([1.2, 2.3, 3.4], 1.5)).toEqual([1.2, 2.3]);
+  });
+
+  it('should return empty array if itemsCount >= arr.length', () => {
+    expect(dropRight([1.2, 2.3, 3.4], 4)).toEqual([]);
+  });
 });

--- a/src/array/dropRight.ts
+++ b/src/array/dropRight.ts
@@ -20,5 +20,5 @@ export function dropRight<T>(arr: readonly T[], itemsCount: number): T[] {
     return arr.slice();
   }
 
-  return arr.slice(0, Math.min(-itemsCount, 0));
+  return arr.slice(0, count);
 }

--- a/src/array/dropRight.ts
+++ b/src/array/dropRight.ts
@@ -15,5 +15,10 @@
  * // result will be [1, 2, 3] since the last two elements are dropped.
  */
 export function dropRight<T>(arr: readonly T[], itemsCount: number): T[] {
-  return arr.slice(0, -itemsCount);
+  const count = Math.min(-itemsCount, 0);
+  if (count === 0) {
+    return arr.slice();
+  }
+
+  return arr.slice(0, Math.min(-itemsCount, 0));
 }


### PR DESCRIPTION
This PR fixes `drop` and `dropRight` to only allow positive integers.
This makes `drop` and `dropRight` compatible with lodash.