### PR TITLE
perf(dropRightWhile): improve performance for dropRightWhile

### DIFF
--- a/src/array/dropRightWhile.ts
+++ b/src/array/dropRightWhile.ts
@@ -1,5 +1,3 @@
-import { dropWhile } from './dropWhile.ts';
-
 /**
  * Removes elements from the end of an array until the predicate returns false.
  *
@@ -19,7 +17,11 @@ import { dropWhile } from './dropWhile.ts';
  * // result will be [1, 2, 3] since elements greater than 3 are dropped from the end.
  */
 export function dropRightWhile<T>(arr: readonly T[], canContinueDropping: (item: T) => boolean): T[] {
-  const reversed = arr.slice().reverse();
-  const dropped = dropWhile(reversed, canContinueDropping);
-  return dropped.slice().reverse();
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (!canContinueDropping(arr[i])) {
+      return arr.slice(0, i + 1);
+    }
+  }
+
+  return [];
 }


### PR DESCRIPTION
This PR improves the performance for dropRightWhile

<table>
  <tr>
    <th>before</th>
    <th>after</th>
  </tr>
  <tr>
<td>


![before](https://github.com/user-attachments/assets/6eae059a-4f2d-4600-8b62-14d1bb888dbf)


</td>
<td>

![after](https://github.com/user-attachments/assets/94c18c61-5c8d-4217-a0ec-fcb52b0d674c)

</td>
  </tr>
</table>