### PR TITLE
fix(invert): Fixed `invert` not to invert inherited properties

### DIFF
--- a/src/object/invert.spec.ts
+++ b/src/object/invert.spec.ts
@@ -27,4 +27,20 @@ describe('invert', () => {
   it('should handle objects with duplicate values by keeping the last key', () => {
     expect(invert({ a: 1, b: 1, c: 2 })).toEqual({ 1: 'b', 2: 'c' });
   });
+
+  it('should work with values that shadow keys on `Object.prototype`', () => {
+    const object = { a: 'hasOwnProperty', b: 'constructor' };
+    expect(invert(object)).toEqual({ hasOwnProperty: 'a', constructor: 'b' });
+  });
+
+  it('should work with an object that has a `length` property', () => {
+    const object = { 0: 'a', 1: 'b', length: 2 };
+    expect(invert(object)).toEqual({ a: '0', b: '1', 2: 'length' });
+  });
+
+  it('should not invert inherited properties', () => {
+    const object = Object.create({ a: 1 });
+    object.b = 2;
+    expect(invert(object)).toEqual({ 2: 'b' });
+  });
 });

--- a/src/object/invert.ts
+++ b/src/object/invert.ts
@@ -19,9 +19,9 @@
 export function invert<K extends PropertyKey, V extends PropertyKey>(obj: Record<K, V>): { [key in V]: K } {
   const result = {} as { [key in V]: K };
 
-  for (const key in obj) {
+  for (const key of Object.keys(obj)) {
     const value = obj[key as K] as V;
-    result[value] = key;
+    result[value] = key as K;
   }
 
   return result;

--- a/src/object/invert.ts
+++ b/src/object/invert.ts
@@ -19,9 +19,11 @@
 export function invert<K extends PropertyKey, V extends PropertyKey>(obj: Record<K, V>): { [key in V]: K } {
   const result = {} as { [key in V]: K };
 
-  for (const key of Object.keys(obj)) {
-    const value = obj[key as K] as V;
-    result[value] = key as K;
+  const keys = Object.keys(obj) as K[];
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = obj[key];
+    result[value] = key;
   }
 
   return result;

--- a/src/object/invert.ts
+++ b/src/object/invert.ts
@@ -20,6 +20,7 @@ export function invert<K extends PropertyKey, V extends PropertyKey>(obj: Record
   const result = {} as { [key in V]: K };
 
   const keys = Object.keys(obj) as K[];
+  
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     const value = obj[key];


### PR DESCRIPTION
`lodash's invert` does not invert inherited properties.
This PR fixes the implementation of invert to be compatible with lodash's implementation

You may close this PR if you want inherited properties to be inverted :)