### PR TITLE
feat(startsWith): add startsWith and endsWith string functions

### DIFF
--- a/benchmarks/performance/endsWith.bench.ts
+++ b/benchmarks/performance/endsWith.bench.ts
@@ -1,0 +1,17 @@
+import { bench, describe } from 'vitest';
+import { endsWith as endsWithToolkit } from 'es-toolkit';
+import { endsWith as endsWithLodash } from 'lodash';
+
+describe('endsWith', () => {
+  bench('es-toolkit/endsWith', () => {
+    const str = 'fooBar';
+    endsWithToolkit(str, 'Bar');
+    endsWithToolkit(str, 'foo', 3);
+  });
+
+  bench('lodash/endsWith', () => {
+    const str = 'fooBar';
+    endsWithLodash(str, 'Bar');
+    endsWithLodash(str, 'foo', 3);
+  });
+});

--- a/benchmarks/performance/startsWith.bench.ts
+++ b/benchmarks/performance/startsWith.bench.ts
@@ -1,0 +1,17 @@
+import { bench, describe } from 'vitest';
+import { startsWith as startsWithToolkit } from 'es-toolkit';
+import { startsWith as startsWithLodash } from 'lodash';
+
+describe('startsWith', () => {
+  bench('es-toolkit/startsWith', () => {
+    const str = 'fooBar';
+    startsWithToolkit(str, 'foo');
+    startsWithToolkit(str, 'Bar', 3);
+  });
+
+  bench('lodash/startsWith', () => {
+    const str = 'fooBar';
+    startsWithLodash(str, 'foo');
+    startsWithLodash(str, 'Bar', 3);
+  });
+});

--- a/docs/ko/reference/string/endsWith.md
+++ b/docs/ko/reference/string/endsWith.md
@@ -1,0 +1,34 @@
+ # endsWith
+ 
+ TODO translate to korean
+
+ Checks if a string contains another string at the end of the string.
+
+ Checks if one string ends with another string. Optional position parameter to search up the this position.
+
+ ## Signature
+
+ ```typescript
+ function endsWith(str: string, target: string, position: number = 0): string;
+ ```
+
+ ### Parameters
+
+ - `str` (`string`): The string that will be searched.
+ - `target` (`string`): The string that it should contain at the end.
+ - `position` (`number`, optional): Optional: position to search up to this character position.
+
+ ### Returns
+
+ (`boolean`) Whether or not the str string ends with the target string
+
+ ## Examples
+
+ ```typescript
+ import { endsWith } from 'es-toolkit/string';
+
+ endsWith('fooBar', 'foo') // returns true
+ endsWith('fooBar', 'Bar') // returns false
+ endsWith('fooBar', 'abcdef') // returns false
+ endsWith('fooBar', 'Bar', 3) // returns true
+ ```

--- a/docs/ko/reference/string/startsWith.md
+++ b/docs/ko/reference/string/startsWith.md
@@ -1,0 +1,34 @@
+ # startsWith
+ 
+TODO translate to korean
+
+ Converts a string to kebab case.
+
+ Snake case is the naming convention in which each word is written in lowercase and separated by an dash (\-) character. For example, `kebab_case`.
+
+ ## Signature
+
+ ```typescript
+ function startsWith(str: string, target: string, position: number = 0): string;
+ ```
+
+ ### Parameters
+
+ - `str` (`string`): The string that will be searched.
+ - `target` (`string`): The string that it should contain at the start.
+ - `position` (`number`, optional): Optional: offset to start searching in the str string.
+
+ ### Returns
+
+ (`boolean`) Whether or not the str string starts with the target string
+
+ ## Examples
+
+ ```typescript
+ import { startsWith } from 'es-toolkit/string';
+
+ startsWith('fooBar', 'foo') // returns true
+ startsWith('fooBar', 'Bar') // returns false
+ startsWith('fooBar', 'abcdef') // returns false
+ startsWith('fooBar', 'Bar', 3) // returns true
+ ```

--- a/docs/reference/string/endsWith.md
+++ b/docs/reference/string/endsWith.md
@@ -1,0 +1,32 @@
+ # endsWith
+
+ Checks if a string contains another string at the end of the string.
+
+ Checks if one string ends with another string. Optional position parameter to search up the this position.
+
+ ## Signature
+
+ ```typescript
+ function endsWith(str: string, target: string, position: number = 0): string;
+ ```
+
+ ### Parameters
+
+ - `str` (`string`): The string that will be searched.
+ - `target` (`string`): The string that it should contain at the end.
+ - `position` (`number`, optional): Optional: position to search up to this character position.
+
+ ### Returns
+
+ (`boolean`) Whether or not the str string ends with the target string
+
+ ## Examples
+
+ ```typescript
+ import { endsWith } from 'es-toolkit/string';
+
+ endsWith('fooBar', 'foo') // returns true
+ endsWith('fooBar', 'Bar') // returns false
+ endsWith('fooBar', 'abcdef') // returns false
+ endsWith('fooBar', 'foo', 3) // returns true
+ ```

--- a/docs/reference/string/startsWith.md
+++ b/docs/reference/string/startsWith.md
@@ -1,0 +1,32 @@
+ # startsWith
+
+ Checks if a string contains another string at the beginning of the string.
+
+ Checks if one string startsWith another string. Optional position parameter to start searching from a certain index.
+
+ ## Signature
+
+ ```typescript
+ function startsWith(str: string, target: string, position: number = 0): string;
+ ```
+
+ ### Parameters
+
+ - `str` (`string`): The string that will be searched.
+ - `target` (`string`): The string that it should contain at the start.
+ - `position` (`number`, optional): Optional: offset to start searching in the str string.
+
+ ### Returns
+
+ (`boolean`) Whether or not the str string starts with the target string
+
+ ## Examples
+
+ ```typescript
+ import { startsWith } from 'es-toolkit/string';
+
+ startsWith('fooBar', 'foo') // returns true
+ startsWith('fooBar', 'Bar') // returns false
+ startsWith('fooBar', 'abcdef') // returns false
+ startsWith('fooBar', 'Bar', 3) // returns true
+ ```

--- a/docs/zh_hans/reference/string/endsWith.md
+++ b/docs/zh_hans/reference/string/endsWith.md
@@ -1,0 +1,34 @@
+ # endsWith
+ 
+ TODO translate to chineese
+
+ Checks if a string contains another string at the end of the string.
+
+ Checks if one string ends with another string. Optional position parameter to search up the this position.
+
+ ## Signature
+
+ ```typescript
+ function endsWith(str: string, target: string, position: number = 0): string;
+ ```
+
+ ### Parameters
+
+ - `str` (`string`): The string that will be searched.
+ - `target` (`string`): The string that it should contain at the end.
+ - `position` (`number`, optional): Optional: position to search up to this character position.
+
+ ### Returns
+
+ (`boolean`) Whether or not the str string ends with the target string
+
+ ## Examples
+
+ ```typescript
+ import { endsWith } from 'es-toolkit/string';
+
+ endsWith('fooBar', 'foo') // returns true
+ endsWith('fooBar', 'Bar') // returns false
+ endsWith('fooBar', 'abcdef') // returns false
+ endsWith('fooBar', 'Bar', 3) // returns true
+ ```

--- a/docs/zh_hans/reference/string/startsWith.md
+++ b/docs/zh_hans/reference/string/startsWith.md
@@ -1,0 +1,34 @@
+ # startsWith
+ 
+TODO translate to chineese
+
+ Converts a string to kebab case.
+
+ Snake case is the naming convention in which each word is written in lowercase and separated by an dash (\-) character. For example, `kebab_case`.
+
+ ## Signature
+
+ ```typescript
+ function startsWith(str: string, target: string, position: number = 0): string;
+ ```
+
+ ### Parameters
+
+ - `str` (`string`): The string that will be searched.
+ - `target` (`string`): The string that it should contain at the start.
+ - `position` (`number`, optional): Optional: offset to start searching in the str string.
+
+ ### Returns
+
+ (`boolean`) Whether or not the str string starts with the target string
+
+ ## Examples
+
+ ```typescript
+ import { startsWith } from 'es-toolkit/string';
+
+ startsWith('fooBar', 'foo') // returns true
+ startsWith('fooBar', 'Bar') // returns false
+ startsWith('fooBar', 'abcdef') // returns false
+ startsWith('fooBar', 'Bar', 3) // returns true
+ ```

--- a/src/string/endsWith.spec.ts
+++ b/src/string/endsWith.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { endsWith } from './endsWith';
+
+describe('endsWith', () => {
+  it('should return true if the string ends with the target string', async () => {
+    expect(endsWith('fooBar', 'Bar')).toEqual(true);
+  });
+  it('should return false if the string does not end with the target string', async () => {
+    expect(endsWith('fooBar', 'abc')).toEqual(false);
+  });
+  it('should return false if the string does not end with the target string, but does contain it', async () => {
+    expect(endsWith('fooBar', 'foo')).toEqual(false);
+  });
+  it('should return true if the target string is an empty string', async () => {
+    expect(endsWith('fooBar', '')).toEqual(true);
+  });
+  it('should return true if the string and target string are empty strings', async () => {
+    expect(endsWith('', '')).toEqual(true);
+  });
+  it('should return false if the string past the provided position does not end with the target string', async () => {
+    expect(endsWith('fooBar', 'foo', 5)).toEqual(false);
+  });
+  it('should return true if the string before the provided position ends with the target string', async () => {
+    expect(endsWith('fooBar123', 'foo', 3)).toEqual(true);
+  });
+});

--- a/src/string/endsWith.ts
+++ b/src/string/endsWith.ts
@@ -16,9 +16,5 @@
  * const isPrefix = endsWith('fooBar', 'abc', 5) // returns false
  */
 export const endsWith = (str: string, target: string, position: number = str.length): boolean => {
-  if (position) {
-    return str.slice(0, position).endsWith(target);
-  } else {
-    return str.endsWith(target);
-  }
+  return str.endsWith(target, position);
 };

--- a/src/string/endsWith.ts
+++ b/src/string/endsWith.ts
@@ -1,0 +1,24 @@
+/**
+ * Checks if a string contains another string at the end of the string.
+ *
+ * Checks if one string endsWith another string. Optional position parameter to offset searching before a certain index.
+ *
+ * @param {string} str - The string that might contain the target string.
+ * @param {string} target - The string to search for.
+ * @param {number} position - An optional position from the start to search up to this index
+ * @returns {boolean} - True if the str string ends with the target string.
+ *
+ * @example
+ * const isPrefix = endsWith('fooBar', 'foo') // returns true
+ * const isPrefix = endsWith('fooBar', 'bar') // returns false
+ * const isPrefix = endsWith('fooBar', 'abc') // returns false
+ * const isPrefix = endsWith('fooBar', 'foo', 3) // returns true
+ * const isPrefix = endsWith('fooBar', 'abc', 5) // returns false
+ */
+export const endsWith = (str: string, target: string, position: number = str.length): boolean => {
+  if (position) {
+    return str.slice(0, position).endsWith(target);
+  } else {
+    return str.endsWith(target);
+  }
+};

--- a/src/string/index.ts
+++ b/src/string/index.ts
@@ -3,4 +3,6 @@ export { snakeCase } from './snakeCase.ts';
 export { kebabCase } from './kebabCase.ts';
 export { lowerCase } from './lowerCase.ts';
 export { startCase } from './startCase.ts';
+export { startsWith } from './startsWith.ts';
+export { endsWith } from './endsWith.ts';
 export { capitalize } from './capitalize.ts';

--- a/src/string/startsWith.spec.ts
+++ b/src/string/startsWith.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { startsWith } from './startsWith';
+
+describe('startsWith', () => {
+  it('should return true if the string starts with the target string', async () => {
+    expect(startsWith('fooBar', 'foo')).toEqual(true);
+  });
+  it('should return false if the string does not start with the target string', async () => {
+    expect(startsWith('fooBar', 'abc')).toEqual(false);
+  });
+  it('should return false if the string does not start with the target string, but does contain it', async () => {
+    expect(startsWith('fooBar', 'Bar')).toEqual(false);
+  });
+  it('should return true if the target string is an empty string', async () => {
+    expect(startsWith('fooBar', '')).toEqual(true);
+  });
+  it('should return true if the string and target string are empty strings', async () => {
+    expect(startsWith('', '')).toEqual(true);
+  });
+  it('should return false if the string past the provided position does not start with the target string', async () => {
+    expect(startsWith('fooBar', 'Bar', 5)).toEqual(false);
+  });
+  it('should return true if the string past the provided position does start with the target string', async () => {
+    expect(startsWith('fooBar', 'Bar', 3)).toEqual(true);
+  });
+});

--- a/src/string/startsWith.ts
+++ b/src/string/startsWith.ts
@@ -1,0 +1,20 @@
+/**
+ * Checks if a string contains another string at the beginning of the string.
+ *
+ * Checks if one string startsWith another string. Optional position parameter to start searching from a certain index.
+ *
+ * @param {string} str - The string that might contain the target string.
+ * @param {string} target - The string to search for.
+ * @param {number} position - An optional offset to start searching in the str string
+ * @returns {boolean} - True if the str string starts with the target string.
+ *
+ * @example
+ * const isPrefix = startsWith('fooBar', 'foo') // returns true
+ * const isPrefix = startsWith('fooBar', 'bar') // returns false
+ * const isPrefix = startsWith('fooBar', 'abc') // returns false
+ * const isPrefix = startsWith('fooBar', 'Bar', 2) // returns true
+ * const isPrefix = startsWith('fooBar', 'Bar', 5) // returns false
+ */
+export const startsWith = (str: string, target: string, position: number = 0): boolean => {
+  return str.indexOf(target, position) === position;
+};

--- a/src/string/startsWith.ts
+++ b/src/string/startsWith.ts
@@ -16,5 +16,5 @@
  * const isPrefix = startsWith('fooBar', 'Bar', 5) // returns false
  */
 export const startsWith = (str: string, target: string, position: number = 0): boolean => {
-  return str.indexOf(target, position) === position;
+  return str.startsWith(target, position);
 };


### PR DESCRIPTION
similar to
* https://lodash.com/docs/4.17.15#startsWith
* https://lodash.com/docs/4.17.15#endsWith

 ```typescript
 import { startsWith } from 'es-toolkit/string';

 startsWith('fooBar', 'foo') // returns true
 startsWith('fooBar', 'Bar') // returns false
 startsWith('fooBar', 'abcdef') // returns false
 startsWith('fooBar', 'Bar', 3) // returns true
 ```

 ```typescript
 import { endsWith } from 'es-toolkit/string';

 endsWith('fooBar', 'foo') // returns true
 endsWith('fooBar', 'Bar') // returns false
 endsWith('fooBar', 'abcdef') // returns false
 endsWith('fooBar', 'foo', 3) // returns true
 ```
