### PR TITLE
chore(ci): add Prettier format check to CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - setup
       - run:
           name: Lint
-          command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$|.tsx$)")
+          command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
   formatcheck:
     docker:
       - image: cimg/node:20.12
@@ -40,7 +40,7 @@ jobs:
       - setup
       - run:
           name: Format Check
-          command: yarn prettier --check $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$|.tsx$)")
+          command: yarn prettier -c $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
   typecheck:
     docker:
       - image: cimg/node:20.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,7 @@ jobs:
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
       - run:
           name: Prettier
-          command: yarn prettier -c $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
-  typecheck:
+          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs -r yarn prettier -c
     docker:
       - image: cimg/node:20.12
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
       - run:
           name: Prettier
-          command: modifiedFiles=$(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)") && [ -n "$modifiedFiles" ] && yarn prettier -c $modifiedFiles || echo "No modified JavaScript or TypeScript files."
+          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs -r yarn prettier -c
   typecheck:
     docker:
       - image: cimg/node:20.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
       - run:
           name: Prettier
-          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs -r yarn prettier -c
+          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs yarn prettier -c
+  typecheck:
     docker:
       - image: cimg/node:20.12
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,14 +32,8 @@ jobs:
       - run:
           name: Lint
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
-  formatcheck:
-    docker:
-      - image: cimg/node:20.12
-    steps:
-      - checkout
-      - setup
       - run:
-          name: Format Check
+          name: Prettier
           command: yarn prettier -c $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
   typecheck:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
       - run:
           name: Prettier
-          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs yarn prettier -c
+          command: modifiedFiles=$(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)") && [ -n "$modifiedFiles" ] && yarn prettier -c $modifiedFiles || echo "No modified JavaScript or TypeScript files."
   typecheck:
     docker:
       - image: cimg/node:20.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - checkout
       - setup
       - run:
-          name: Lint
+          name: ESLint
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
       - run:
           name: Prettier

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,15 @@ jobs:
       - run:
           name: Lint
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$|.tsx$)")
+  formatcheck:
+    docker:
+      - image: cimg/node:20.12
+    steps:
+      - checkout
+      - setup
+      - run:
+          name: Format Check
+          command: yarn prettier --check $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$|.tsx$)")
   typecheck:
     docker:
       - image: cimg/node:20.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
       - run:
           name: Prettier
-          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs -r yarn prettier -c
+          command: modifiedFiles=$(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)") && [ -n "$modifiedFiles" ] && yarn prettier -c $modifiedFiles || echo "No modified files."
   typecheck:
     docker:
       - image: cimg/node:20.12


### PR DESCRIPTION
This pull request adds a prettier format check to our CI workflow, ensuring that only modified {js, ts, tsx} files are checked against the formatting rules. The comparison is made with the origin/main branch.

close #241 

> Additionally, there are currently many unformatted files, so we will also need a pull request to format these files using the yarn format command.