### PR TITLE
fea(take, compat) add `take` (compat version)

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -94,7 +94,7 @@ Even if a feature is marked "in review," it might already be under review to ens
 | [sortedUniq](https://lodash.com/docs/4.17.15#sortedUniq)               | No support            |
 | [sortedUniqBy](https://lodash.com/docs/4.17.15#sortedUniqBy)           | No support            |
 | [tail](https://lodash.com/docs/4.17.15#tail)                           | ✅                    |
-| [take](https://lodash.com/docs/4.17.15#take)                           | 📝                    |
+| [take](https://lodash.com/docs/4.17.15#take)                           | ✅                    |
 | [takeRight](https://lodash.com/docs/4.17.15#takeRight)                 | 📝                    |
 | [takeRightWhile](https://lodash.com/docs/4.17.15#takeRightWhile)       | 📝                    |
 | [takeWhile](https://lodash.com/docs/4.17.15#takeWhile)                 | 📝                    |

--- a/src/compat/array/take.spec.ts
+++ b/src/compat/array/take.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { take } from './take.ts';
+
+describe('take', () => {
+  const array = [1, 2, 3];
+
+  it('should take the first two elements', () => {
+    expect(take(array, 2)).toEqual([1, 2]);
+  });
+
+  it('should return an empty array when `n` < `1`', () => {
+    [0, -1, -Infinity].forEach(n => {
+      expect(take(array, n)).toEqual([]);
+    });
+  });
+
+  it('should return all elements when `n` >= `length`', () => {
+    [3, 4, 2 ** 32, Infinity].forEach(n => {
+      expect(take(array, n)).toEqual(array);
+    });
+  });
+
+  it('should work as an iteratee for methods like `_.map`', () => {
+    const array = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
+    const actual = array.map(item => take(item));
+
+    expect(actual).toEqual([[1], [4], [7]]);
+  });
+});

--- a/src/compat/array/take.ts
+++ b/src/compat/array/take.ts
@@ -1,0 +1,31 @@
+import { take as takeToolkit } from '../../array/take.ts';
+
+/**
+ * Returns a new array containing the first `count` elements from the input array `arr`.
+ * If `count` is greater than the length of `arr`, the entire array is returned.
+ *
+ * @template T - Type of elements in the input array.
+ *
+ * @param {T[]} arr - The array to take elements from.
+ * @param {number} count - The number of elements to take.
+ * @returns {T[]} A new array containing the first `count` elements from `arr`.
+ *
+ * @example
+ * // Returns [1, 2, 3]
+ * take([1, 2, 3, 4, 5], 3);
+ *
+ * @example
+ * // Returns ['a', 'b']
+ * take(['a', 'b', 'c'], 2);
+ *
+ * @example
+ * // Returns [1, 2, 3]
+ * take([1, 2, 3], 5);
+ */
+export function take<T>(arr: readonly T[], count: number = 1): T[] {
+  if (count < 1) {
+    return [];
+  }
+
+  return takeToolkit(arr, count);
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -29,6 +29,7 @@ export { concat } from './array/concat.ts';
 export { difference } from './array/difference.ts';
 export { zipObjectDeep } from './array/zipObjectDeep.ts';
 export { head as first } from '../index.ts';
+export { take } from './array/take.ts';
 
 export { get } from './object/get.ts';
 export { set } from './object/set.ts';


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4c49edfb-cc9a-452b-bff9-2aa024a082bd)

I implemented take in the compatibility version. 

The test codes are referenced from [lodash take.spec.js](https://github.com/lodash/lodash/blob/main/test/take.spec.js). 

I skipped `the should treat falsey 'n' values, except 'undefined', as '0'` test case because of type compatibility issues.