### PR TITLE
test(flattenObject): change using constant date in test case

### DIFF
--- a/src/object/flattenObject.spec.ts
+++ b/src/object/flattenObject.spec.ts
@@ -13,7 +13,7 @@ describe('flattenObject', function () {
       'a.b': 'yay'
     })
 
-    const date= new Date();
+    const date = new Date();
 
     const result2 = flattenObject({
       a: {

--- a/src/object/flattenObject.spec.ts
+++ b/src/object/flattenObject.spec.ts
@@ -39,7 +39,7 @@ describe('flattenObject', function () {
   })
 
   it('flattens multiple keys', () => {
-    const date= new Date();
+    const date = new Date();
 
     const result = flattenObject({
       a: {

--- a/src/object/flattenObject.spec.ts
+++ b/src/object/flattenObject.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import { flattenObject } from "./flattenObject";
 
 describe('flattenObject', function () {
@@ -13,6 +13,8 @@ describe('flattenObject', function () {
       'a.b': 'yay'
     })
 
+    const date= new Date();
+
     const result2 = flattenObject({
       a: {
         b: {
@@ -21,7 +23,7 @@ describe('flattenObject', function () {
           boolean: true,
           null: null,
           undefined: undefined,
-          date: new Date(),
+          date: date,
         }
       }
     })
@@ -32,11 +34,13 @@ describe('flattenObject', function () {
       'a.b.boolean': true,
       'a.b.null': null,
       'a.b.undefined': undefined,
-      'a.b.date': new Date(),
+      'a.b.date': date,
     })
   })
 
   it('flattens multiple keys', () => {
+    const date= new Date();
+
     const result = flattenObject({
       a: {
         b: {
@@ -45,7 +49,7 @@ describe('flattenObject', function () {
         d: {
           e: {
             f: {
-              g: new Date()
+              g: date
             }
           }
         }
@@ -57,7 +61,7 @@ describe('flattenObject', function () {
 
     expect(result).toEqual({
       'a.b.c': 1,
-      'a.d.e.f.g': new Date(),
+      'a.d.e.f.g': date,
       'h.i': 'hi'
     })
   })


### PR DESCRIPTION
I have made a PR regarding the [take(compat) function](https://github.com/toss/es-toolkit/pull/252), but it failed due to issues in the flattenObject test case. 

The failure was caused by different date objects being used for comparison in the test cases. 

To fix this, I have modified the test cases to use a consistent date object for comparisons, ensuring that the date objects being compared are identical.

<table>
 <tr>
  <th>AS-IS </th>
</tr>
<tr>
  <td>
<img src="https://github.com/user-attachments/assets/e69dfb0e-6dfa-446d-a401-89b34440cfef"/>
</td>
</td>
</tr>
 <tr>
  <th>TO-BE</th>
</tr>
<tr>
  <td> 
<img width="757" alt="스크린샷 2024-07-15 오전 12 40 52" src="https://github.com/user-attachments/assets/943b859f-6baa-4695-9366-d1a4255e3f18">
</td>
</tr>
</table>
