### PR TITLE
test(initial,last,takeRight,without,uniq): Add lodash compat tests

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -70,7 +70,7 @@ Even if a feature is marked "in review," it might already be under review to ens
 | [fromPairs](https://lodash.com/docs/4.17.15#fromPairs)                 | ❌                    |
 | [head](https://lodash.com/docs/4.17.15#head)                           | ✅                    |
 | [indexOf](https://lodash.com/docs/4.17.15#indexOf)                     | ❌                    |
-| [initial](https://lodash.com/docs/4.17.15#initial)                     | 📝                    |
+| [initial](https://lodash.com/docs/4.17.15#initial)                     | ✅                    |
 | [intersection](https://lodash.com/docs/4.17.15#intersection)           | 📝                    |
 | [intersectionBy](https://lodash.com/docs/4.17.15#intersectionBy)       | 📝                    |
 | [intersectionWith](https://lodash.com/docs/4.17.15#intersectionWith)   | 📝                    |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -96,7 +96,7 @@ Even if a feature is marked "in review," it might already be under review to ens
 | [sortedUniqBy](https://lodash.com/docs/4.17.15#sortedUniqBy)           | No support            |
 | [tail](https://lodash.com/docs/4.17.15#tail)                           | ✅                    |
 | [take](https://lodash.com/docs/4.17.15#take)                           | ✅                    |
-| [takeRight](https://lodash.com/docs/4.17.15#takeRight)                 | 📝                    |
+| [takeRight](https://lodash.com/docs/4.17.15#takeRight)                 | ✅                    |
 | [takeRightWhile](https://lodash.com/docs/4.17.15#takeRightWhile)       | 📝                    |
 | [takeWhile](https://lodash.com/docs/4.17.15#takeWhile)                 | 📝                    |
 | [union](https://lodash.com/docs/4.17.15#union)                         | 📝                    |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -75,7 +75,7 @@ Even if a feature is marked "in review," it might already be under review to ens
 | [intersectionBy](https://lodash.com/docs/4.17.15#intersectionBy)       | 📝                    |
 | [intersectionWith](https://lodash.com/docs/4.17.15#intersectionWith)   | 📝                    |
 | [join](https://lodash.com/docs/4.17.15#join)                           | ❌                    |
-| [last](https://lodash.com/docs/4.17.15#last)                           | 📝                    |
+| [last](https://lodash.com/docs/4.17.15#last)                           | ✅                    |
 | [lastIndexOf](https://lodash.com/docs/4.17.15#lastIndexOf)             | ❌                    |
 | [nth](https://lodash.com/docs/4.17.15#nth)                             | ❌                    |
 | [pull](https://lodash.com/docs/4.17.15#pull)                           | ❌                    |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -107,7 +107,7 @@ Even if a feature is marked "in review," it might already be under review to ens
 | [uniqWith](https://lodash.com/docs/4.17.15#uniqWith)                   | 📝                    |
 | [unzip](https://lodash.com/docs/4.17.15#unzip)                         | 📝                    |
 | [unzipWith](https://lodash.com/docs/4.17.15#unzipWith)                 | 📝                    |
-| [without](https://lodash.com/docs/4.17.15#without)                     | 📝                    |
+| [without](https://lodash.com/docs/4.17.15#without)                     | ✅                    |
 | [xor](https://lodash.com/docs/4.17.15#xor)                             | 📝                    |
 | [xorBy](https://lodash.com/docs/4.17.15#xorBy)                         | 📝                    |
 | [xorWith](https://lodash.com/docs/4.17.15#xorWith)                     | 📝                    |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -102,7 +102,7 @@ Even if a feature is marked "in review," it might already be under review to ens
 | [union](https://lodash.com/docs/4.17.15#union)                         | 📝                    |
 | [unionBy](https://lodash.com/docs/4.17.15#unionBy)                     | 📝                    |
 | [unionWith](https://lodash.com/docs/4.17.15#unionWith)                 | 📝                    |
-| [uniq](https://lodash.com/docs/4.17.15#uniq)                           | 📝                    |
+| [uniq](https://lodash.com/docs/4.17.15#uniq)                           | ✅                    |
 | [uniqBy](https://lodash.com/docs/4.17.15#uniqBy)                       | 📝                    |
 | [uniqWith](https://lodash.com/docs/4.17.15#uniqWith)                   | 📝                    |
 | [unzip](https://lodash.com/docs/4.17.15#unzip)                         | 📝                    |

--- a/src/array/takeRight.ts
+++ b/src/array/takeRight.ts
@@ -4,7 +4,7 @@
  *
  * @template T - The type of elements in the array.
  * @param {T[]} arr - The array to take elements from.
- * @param {number} count - The number of elements to take.
+ * @param {number} [count=1] - The number of elements to take.
  * @returns {T[]} A new array containing the last `count` elements from `arr`.
  *
  * @example
@@ -19,8 +19,8 @@
  * // Returns [1, 2, 3]
  * takeRight([1, 2, 3], 5);
  */
-export function takeRight<T>(arr: readonly T[], count: number): T[] {
-  if (count === 0) {
+export function takeRight<T>(arr: readonly T[], count = 1): T[] {
+  if (count <= 0) {
     return [];
   }
 

--- a/src/compat/array/last.spec.ts
+++ b/src/compat/array/last.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { last } from '../index';
+
+/**
+ * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/last.spec.js#L1
+ */
+describe('last', () => {
+  const array = [1, 2, 3, 4];
+
+  it('should return the last element', () => {
+    expect(last(array)).toBe(4);
+  });
+
+  it('should return `undefined` when querying empty arrays', () => {
+    const array: number[] = [];
+    array['-1'] = 1;
+
+    expect(last([])).toBe(undefined);
+  });
+
+  it('should work as an iteratee for methods like `_.map`', () => {
+    const array = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
+    const actual = array.map(last);
+
+    expect(actual).toEqual([3, 6, 9]);
+  });
+});

--- a/src/compat/array/last.spec.ts
+++ b/src/compat/array/last.spec.ts
@@ -18,7 +18,7 @@ describe('last', () => {
     expect(last([])).toBe(undefined);
   });
 
-  it('should work as an iteratee for methods like `_.map`', () => {
+  it('should work as an iteratee for methods like `map`', () => {
     const array = [
       [1, 2, 3],
       [4, 5, 6],

--- a/src/compat/array/takeRight.spec.ts
+++ b/src/compat/array/takeRight.spec.ts
@@ -23,7 +23,7 @@ describe('takeRight', () => {
     });
   });
 
-  it('should work as an iteratee for methods like `_.map`', () => {
+  it('should work as an iteratee for methods like `map`', () => {
     const array = [
       [1, 2, 3],
       [4, 5, 6],

--- a/src/compat/array/takeRight.spec.ts
+++ b/src/compat/array/takeRight.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { takeRight } from '../index';
+
+/**
+ * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/takeRight.spec.js#L1
+ */
+describe('takeRight', () => {
+  const array = [1, 2, 3];
+
+  it('should take the last two elements', () => {
+    expect(takeRight(array, 2)).toEqual([2, 3]);
+  });
+
+  it('should return an empty array when `n` < `1`', () => {
+    [0, -1, -Infinity].forEach(n => {
+      expect(takeRight(array, n)).toEqual([]);
+    });
+  });
+
+  it('should return all elements when `n` >= `length`', () => {
+    [3, 4, 2 ** 32, Infinity].forEach(n => {
+      expect(takeRight(array, n)).toEqual(array);
+    });
+  });
+
+  it('should work as an iteratee for methods like `_.map`', () => {
+    const array = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
+    const actual = array.map(item => takeRight(item));
+    expect(actual).toEqual([[3], [6], [9]]);
+  });
+});

--- a/src/compat/array/uniq.spec.ts
+++ b/src/compat/array/uniq.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { uniq } from '../index';
+
+/**
+ * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/uniq.spec.js#L1
+ */
+describe('uniq', () => {
+  it('should perform an unsorted uniq when used as an iteratee for methods like `map`', () => {
+    const array = [
+      [2, 1, 2],
+      [1, 2, 1],
+    ];
+    const actual = array.map(uniq);
+
+    expect(actual).toEqual([
+      [2, 1],
+      [1, 2],
+    ]);
+  });
+});

--- a/src/compat/initial.spec.ts
+++ b/src/compat/initial.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { initial } from '../index';
+
+/**
+ * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/initial.spec.js#L1
+ */
+describe('initial', () => {
+  const array = [1, 2, 3];
+
+  it('should exclude last element', () => {
+    expect(initial(array)).toEqual([1, 2]);
+  });
+
+  it('should return an empty when querying empty arrays', () => {
+    expect(initial([])).toEqual([]);
+  });
+
+  it('should work as an iteratee for methods like `_.map`', () => {
+    const array = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
+    const actual = array.map(initial);
+
+    expect(actual).toEqual([
+      [1, 2],
+      [4, 5],
+      [7, 8],
+    ]);
+  });
+});

--- a/src/compat/initial.spec.ts
+++ b/src/compat/initial.spec.ts
@@ -15,7 +15,7 @@ describe('initial', () => {
     expect(initial([])).toEqual([]);
   });
 
-  it('should work as an iteratee for methods like `_.map`', () => {
+  it('should work as an iteratee for methods like `map`', () => {
     const array = [
       [1, 2, 3],
       [4, 5, 6],

--- a/src/compat/without.spec.ts
+++ b/src/compat/without.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { without } from '../index';
+
+/**
+ * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/without.spec.js#L1
+ */
+describe('without', () => {
+  it('should return the difference of values', () => {
+    const actual = without([2, 1, 2, 3], 1, 2);
+    expect(actual).toEqual([3]);
+  });
+
+  it('should use strict equality to determine the values to reject', () => {
+    const object1 = { a: 1 };
+    const object2 = { b: 2 };
+    const array = [object1, object2];
+
+    expect(without(array, { a: 1 })).toEqual(array);
+    expect(without(array, object1)).toEqual([object2]);
+  });
+
+  it('should remove all occurrences of each value from an array', () => {
+    const array = [1, 2, 3, 1, 2, 3];
+    expect(without(array, 1, 2)).toEqual([3, 3]);
+  });
+});


### PR DESCRIPTION
Add the lodash compat tests for:
- [initial](https://lodash.com/docs/4.17.15#initial)
- [last](https://lodash.com/docs/4.17.15#last)
- [takeRight](https://lodash.com/docs/4.17.15#takeRight)
- [without](https://lodash.com/docs/4.17.15#without)
- [uniq](https://lodash.com/docs/4.17.15#uniq)

It also makes `takeRight` handle negative count correctly, let me know if it should be in a different PR or a different intended behavior is expected.