### PR TITLE
docs(isTypedArray): fix isTypedArray ko docs link

### DIFF
--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -173,7 +173,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'isNil', link: '/ko/reference/predicate/isNil' },
             { text: 'isNotNil', link: '/ko/reference/predicate/isNotNil' },
             { text: 'isNull', link: '/ko/reference/predicate/isNull' },
-            { text: 'isTypedArray', link: '/ko/reference/predicate/isNull' },
+            { text: 'isTypedArray', link: '/ko/reference/predicate/isTypedArray' },
             {
               text: 'isUndefined',
               link: '/ko/reference/predicate/isUndefined',


### PR DESCRIPTION
I corrected the link to the mismatched document. (`ko/isTypedArray`)