### PR TITLE
chore(ci): simplify prettier ci command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
       - run:
           name: Prettier
-          command: modifiedFiles=$(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)") && [ -n "$modifiedFiles" ] && yarn prettier -c $modifiedFiles || echo "No modified files."
+          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs -r yarn prettier -c
   typecheck:
     docker:
       - image: cimg/node:20.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
       - run:
           name: Prettier
-          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs -r yarn prettier -c
+          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs yarn prettier -c
   typecheck:
     docker:
       - image: cimg/node:20.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
       - run:
           name: Prettier
-          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs yarn prettier -c
+          command: modifiedFiles=$(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)") && [ -n "$modifiedFiles" ] && yarn prettier -c $modifiedFiles || echo "No modified files."
   typecheck:
     docker:
       - image: cimg/node:20.12

--- a/src/compat/array/flatten.ts
+++ b/src/compat/array/flatten.ts
@@ -1,0 +1,33 @@
+/**
+ * Flattens an array up to the specified depth.
+ *
+ * @template T - The depth to which the array should be flattened.
+ * @param {unknown} - The value to flatten.
+ * @param value
+ * @param {T} depth - The depth level specifying how deep a nested array structure should be flattened. Defaults to 1.
+ * @returns {Array<FlatArray<unknown, D>>} A new array that has been flattened.
+ *
+ * @example
+ * const arr = flatten([1, [2, 3], [4, [5, 6]]], 1);
+ * // Returns: [1, 2, 3, 4, [5, 6]]
+ *
+ * const arr = flatten([1, [2, 3], [4, [5, 6]]], 2);
+ * // Returns: [1, 2, 3, 4, 5, 6]
+ */
+export function flatten<T extends number = 1>(value: unknown, depth = 1 as T): Array<FlatArray<unknown, T>> {
+  const result: Array<FlatArray<T[], D>> = [];
+  const flooredDepth = Math.floor(depth);
+
+  const recursive = (arr: readonly T[], currentDepth: number) => {
+    for (const item of arr) {
+      if (Array.isArray(item) && currentDepth < flooredDepth) {
+        recursive(item, currentDepth + 1)
+      } else {
+        result.push(item as FlatArray<T[], D>);
+      }
+    }
+  };
+
+  recursive(arr, 0);
+  return result;
+}


### PR DESCRIPTION
If we don't have modified files, then prettier throws error.

But we use `xargs -r`, If we don't have modified files, then we don't run prettier command.