### PR TITLE
fix(ci): simplify and integrate lint code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,11 @@ jobs:
       - setup
       - run:
           name: ESLint
-          command: yarn eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)")
+          shell: bash -e
+          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs -r yarn eslint -c .eslintrc.js
       - run:
           name: Prettier
-          command: modifiedFiles=$(git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)") && [ -n "$modifiedFiles" ] && yarn prettier -c $modifiedFiles || echo "No modified files."
+          command: git diff --name-only --diff-filter=ACMRUXB origin/main | xargs -r yarn prettier -c --ignore-unknown
   typecheck:
     docker:
       - image: cimg/node:20.12


### PR DESCRIPTION
### Why

I think that integrating commands of eslint and prettier by using `xargs` is good for maintenance.

### ESLint

Add a shell property for unsetting `-o pipefail` option.

Circle CI sets this option by defaults. So If we don't have `.js` or `.ts` files, `grep` returns a `non-zero` exit code and as a result, this command also returns a `non-zero` exit code.

But we unset this option, even if `grep` returns a `non-zero` exit code, this command return a `zero` exit code.

### Prettier

We also have to check `.json` or etc files that has a javascript or json code.

> The file extension type is not matter, the language or content of file is matter.

So I remove `grep` command, because we have to check all of changed files includes `.json` and etc files.

But If we remove `grep` command, we can check unknown file like `.prettierignore`.

So I add `--ignore-unknown` argument for ignoring parser errors.