### PR TITLE
docs(negate): fix link of function-negate on ko docs

### DIFF
--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -125,7 +125,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'after', link: '/ko/reference/function/after' },
             { text: 'debounce', link: '/ko/reference/function/debounce' },
             { text: 'throttle', link: '/ko/reference/function/throttle' },
-            { text: 'negate', link: '/reference/function/negate' },
+            { text: 'negate', link: '/ko/reference/function/negate' },
             { text: 'once', link: '/ko/reference/function/once' },
             { text: 'noop', link: '/ko/reference/function/noop' },
           ],


### PR DESCRIPTION
While looking at the official documentation in Korean, I saw that the link to 'function-negate' was specified as a link to the official documentation in English, so I created a pull request.