### PR TITLE
fix(cloneDeep): SharedArrayBuffer could be undefined

### DIFF
--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -87,7 +87,7 @@ export function cloneDeep<T>(obj: T): Resolved<T> {
 
   if (
     obj instanceof ArrayBuffer ||
-    (typeof window.SharedArrayBuffer !== 'undefined' && obj instanceof SharedArrayBuffer)
+    (typeof SharedArrayBuffer !== 'undefined' && obj instanceof SharedArrayBuffer)
   ) {
     return obj.slice(0) as Resolved<T>;
   }

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -85,7 +85,8 @@ export function cloneDeep<T>(obj: T): Resolved<T> {
     return result as Resolved<T>;
   }
 
-  if (obj instanceof ArrayBuffer || obj instanceof SharedArrayBuffer) {
+  if (obj instanceof ArrayBuffer ||
+    (typeof window.SharedArrayBuffer !== 'undefined' && obj instanceof SharedArrayBuffer)) {
     return obj.slice(0) as Resolved<T>;
   }
 

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -85,8 +85,10 @@ export function cloneDeep<T>(obj: T): Resolved<T> {
     return result as Resolved<T>;
   }
 
-  if (obj instanceof ArrayBuffer ||
-    (typeof window.SharedArrayBuffer !== 'undefined' && obj instanceof SharedArrayBuffer)) {
+  if (
+    obj instanceof ArrayBuffer ||
+    (typeof window.SharedArrayBuffer !== 'undefined' && obj instanceof SharedArrayBuffer)
+  ) {
     return obj.slice(0) as Resolved<T>;
   }
 


### PR DESCRIPTION
According to MDN

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#description

the website must enable
```
Cross-Origin-Opener-Policy: same-origin
Cross-Origin-Embedder-Policy: require-corp
```
Otherwise, you'll get error: SharedArrayBuffer undefined