### PR TITLE
chore: move browser build from umd dir to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "files": [
     "dist",
-    "umd",
     "*.d.ts"
   ],
   "publishConfig": {
@@ -36,7 +35,7 @@
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
-    "browser": "./umd/browser.global.js",
+    "browser": "./dist/browser.global.js",
     "exports": {
       ".": {
         "import": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -24,7 +24,6 @@ const testPatterns = ['**/*.bench.ts', '**/*.spec.ts', '**/*.test.ts'];
 
 export default () => {
   clearDir('dist');
-  clearDir('umd');
 
   const entrypoints = Object.values(packageJson.exports).filter(f => /^(\.\/)?src\//.test(f) && f.endsWith('.ts'));
 


### PR DESCRIPTION
Fixes #284.

There were two issues reported in #284:

1. The source map for the `umd/browser.global.js` bundle was generated but not published in the package: fixed in #255.
2. The `umd/browser.global.js` path conveys the wrong information, because this bundle uses a simpler IIFE format declaring a global `_` variable, and not the UMD format.

This PR moves this bundle to `dist/browser.global.js`.

Because the Rollup config takes this path from `package.json#publishConfig#browser`, we only have to update it in `package.json`.