### PR TITLE
chore: add comment explaining purpose of root .d.ts files

### DIFF
--- a/.scripts/postbuild.sh
+++ b/.scripts/postbuild.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Create root .d.ts files for package exports, for compatibility with
+# TypeScript projects configured with "moduleResolution": "node10"
+# (which is the default when using "module": "commonjs").
 echo "export * from './dist/array';" > array.d.ts
 echo "export * from './dist/compat';" > compat.d.ts
 echo "export * from './dist/function';" > function.d.ts


### PR DESCRIPTION
Fixes #287.

This adds a couple lines of developer documentation in `.scripts/postbuild.sh` to convey this answer: https://github.com/toss/es-toolkit/issues/287#issuecomment-2248325627

Rationale: this might help other contributors to figure out the purpose of this setup, and could help down the line when deciding if these file are still needed (e.g. if future TypeScript versions change their defaults).

My personal taste veers towards documenting choices in code a lot, but if you'd rather avoid verbose developer comments that's perfectly fine. In that case, feel free to reject this PR and close #287 as needing no changes.