### PR TITLE
config(build): remove sourcemaps for esm/cjs builds

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -114,7 +114,20 @@ function browserBuildConfig({ inputFile, outFile, name, sourcemap }) {
       }),
     ],
     output: {
-      plugins: [terserPlugin()],
+      plugins: [
+        // Minify with terser, but with a configuration that optimizes for
+        // readability in browser DevTools (after re-indenting by DevTools).
+        terserPlugin({
+          // Terser defaults to ES5 for syntax it adds or rewrites
+          ecma: 2018,
+          // Readable function names (not just in final export)
+          keep_fnames: true,
+          // Turn off compress.sequences to keep the assignments to the toolkit
+          // object readable, instead of turning them into a huge list of
+          // comma-separated expressions.
+          compress: { sequences: false },
+        }),
+      ],
       format: 'iife',
       name,
       file: outFile,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -74,8 +74,8 @@ function libBuildOptions({ entrypoints, extension, format, outDir, sourcemap }) 
         compilerOptions: {
           sourceMap: sourcemap,
           inlineSources: sourcemap || undefined,
+          removeComments: !sourcemap,
           declaration: false,
-          removeComments: true,
         },
       }),
     ],


### PR DESCRIPTION
Fixes #285.

The goal of this PR is to minimize the download and disk size of the `es-toolkit` package, while keeping a good developer experience for users of the package.

### Context for changes

See https://github.com/toss/es-toolkit/issues/285#issue-2424501137 for an overview of the problem. In summary: the current configuration ships the contents of this library's TypeScript sources several times in sourcemaps.

@raon0211 suggested that sourcemaps might not be necessary if the code shipped in `dist` was itself human readable (https://github.com/toss/es-toolkit/issues/285#issuecomment-2248418461).

The other option discussed was shipping the `src/**/*.ts` files in the package (excluding `src/**/*.spec.ts`), and sourcemaps that reference those files but don't copy their contents (this looks like: `"sources": ["../../src/array/difference.ts"], "sourcesContent": [null]`).

I tried many permutations of options for:

- sourcemaps with inline sources
- sourcemaps with refrences to `src` files only
- no sourcemaps
- JSDoc comments in JS output or not

and have posted my results and analysis here:
https://github.com/toss/es-toolkit/issues/285#issuecomment-2250501965

My takeaways were:

- Publishing `src/**/*.ts` and using sourcemaps with references to those files is not much of a win, compared to sourcemaps with inline sources.
- Best trade-off between package size and DX seems to be: no sourcemaps for ESM/CJS outputs, but with JSDoc comments conserved in those outputs.

### Summary of changes

As a result, this PR proposes the following changes:

1. Add JSDoc comments in ESM/CJS outputs (such as `dist/array/index.js` and `dist/array/difference.mjs`).
   - Cost: increases package size a little bit (mostly on disk, because those comments are identical between the `.js`, `.mjs`, `.d.ts` and `.d.mts` outputs, and should gzip well).
   - Benefit: better DX in contexts where TypeScript types are not used or not relevant, e.g. when stepping in and out of code in a debugger.

2. Remove sourcemaps for ESM/CJS outputs.
   - Cost: in some cases, debuggers might be able to map debugged code (such as a ESM module) back to the original TS source, and users might benefit from seeing the TS types in the debugger.
   - Mitigation of cost: shipping JSDoc comments in the debugged modules (see first point) is a decent alternative for this use case.
   - Benefit: big reduction in package size.

3. Keep a sourcemap for the browser bundle, and generate the browser bundle from the ESM build. Given that the ESM build will contain human-readable sources with JSDoc comments, treating it as the “source of truth” for the browser bundle is reasonable.
    - Cost: users of an in-browser debugger (e.g. Chrome DevTools's Sources panel) will be able to inspect unminified and JSDoc-documented sources for the toolkit, but won't see the TS types in those sources (they will see `dist/array/difference.mjs` and not `src/array/difference.ts`).
    - Benefit: small reduction in package size.

4. Tweak the browser bundle's minification to make the output more human-readable once the code is beautified (which DevTools does automatically).
    - Benefit: errors in the DevTools Console will use original function names; following the code in the beautified bundle in DevTools Sources will be easier.
    - Cost: +11% increase of `browser.global.js` (

### File and package size changes

| File | Bytes: before | Bytes: after |
| --- | --- | --- |
| `package.tgz` \* | 179,598 | 111,247 (-38%) |
| `package.tar` \* | 1,512,448 | 958,464 (-37%) |
| `dist/browser.global.js` | 16,762 | 18,686 (+11%) |
| `dist/browser.global.js.gz` \* | 5,169 | 5,573 (+8%) |
| `dist/browser.global.js.map` | 189,974 | 191,442 (+1%) |

Note: file names followed by a `\*` are not part of the package, but reflect what the size of the package itself might be over the wire or on disk:

- `package.tgz`: size of the package downloaded from repository
- `package.tar`: rough proxy for the size of the package on disk (e.g. at `node_modules/es-toolkit`)
- `dist/browser.global.js.gz`: size of the browser bundle served from a CDN (over HTTP(S), with gzip compression)