### PR TITLE
fix(isLength): modernize checking a safe integer

### DIFF
--- a/src/predicate/isLength.ts
+++ b/src/predicate/isLength.ts
@@ -1,3 +1,3 @@
 export function isLength(value: unknown): value is number {
-  return typeof value === 'number' && value > -1 && value % 1 === 0 && value <= Number.MAX_SAFE_INTEGER;
+  return Number.isSafeInteger(value) && (value as number) >= 0;
 }


### PR DESCRIPTION
## description

- By using `Number.isSafeInteger`, I simplify `typeof value === 'number' && value % 1 === 0 && value <= Number.MAX_SAFE_INTEGER` to `Number.isSafeInteger(value)`
- And I also change `value > -1` to `value >=0`, because I think that after code is more acceptable.
- There are no difference of performance.

## after

``` typescript
export function isLength(value: unknown): value is number {
  return Number.isSafeInteger(value) && (value as number) >= 0;
}
```

<img width="774" alt="Screenshot 2024-07-27 at 3 09 32 PM" src="https://github.com/user-attachments/assets/13f44bd5-6e8b-418e-a637-24396e3fe9f2">

## previous

``` typescript
export function isLength(value: unknown): value is number {
  return typeof value === 'number' && value > -1 && value % 1 === 0 && value <= Number.MAX_SAFE_INTEGER;
}
```

<img width="738" alt="Screenshot 2024-07-27 at 3 09 50 PM" src="https://github.com/user-attachments/assets/0a71fc39-9454-469e-888b-0e39cccd3863">
