### PR TITLE
feat(flatten): add compatibility with lodash

### DIFF
--- a/benchmarks/performance/flatten.bench.ts
+++ b/benchmarks/performance/flatten.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from 'vitest';
 import { flatten as flattenToolkit } from 'es-toolkit';
+import { flatten as flattenCompatToolkit } from 'es-toolkit/compat';
 import { flattenDepth as flattenDepthLodash } from 'lodash';
 
 const createNestedArray = (values: any[]) => {
@@ -15,6 +16,10 @@ describe('flatten', () => {
 
   bench('es-toolkit/flatten', () => {
     flattenToolkit(arr, 30);
+  });
+
+  bench('es-toolkit/flatten (compat)', () => {
+    flattenCompatToolkit(arr, 30);
   });
 
   bench('lodash/flattenDepth', () => {

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -64,7 +64,7 @@ Even if a feature is marked "in review," it might already be under review to ens
 | [fill](https://lodash.com/docs/4.17.15#fill)                           | ✅                    |
 | [findIndex](https://lodash.com/docs/4.17.15#findIndex)                 | ❌                    |
 | [findLastIndex](https://lodash.com/docs/4.17.15#findIndex)             | ❌                    |
-| [flatten](https://lodash.com/docs/4.17.15#flatten)                     | 📝                    |
+| [flatten](https://lodash.com/docs/4.17.15#flatten)                     | ✅                    |
 | [flattenDeep](https://lodash.com/docs/4.17.15#flattenDeep)             | 📝                    |
 | [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | 📝                    |
 | [fromPairs](https://lodash.com/docs/4.17.15#fromPairs)                 | ❌                    |

--- a/docs/ko/compatibility.md
+++ b/docs/ko/compatibility.md
@@ -65,7 +65,7 @@ chunk([1, 2, 3, 4], 0);
 | [fill](https://lodash.com/docs/4.17.15#fill)                           | ✅            |
 | [findIndex](https://lodash.com/docs/4.17.15#findIndex)                 | ❌            |
 | [findLastIndex](https://lodash.com/docs/4.17.15#findIndex)             | ❌            |
-| [flatten](https://lodash.com/docs/4.17.15#flatten)                     | 📝            |
+| [flatten](https://lodash.com/docs/4.17.15#flatten)                     | ✅            |
 | [flattenDeep](https://lodash.com/docs/4.17.15#flattenDeep)             | 📝            |
 | [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | 📝            |
 | [fromPairs](https://lodash.com/docs/4.17.15#fromPairs)                 | ❌            |

--- a/docs/zh_hans/compatibility.md
+++ b/docs/zh_hans/compatibility.md
@@ -64,7 +64,7 @@ chunk([1, 2, 3, 4], 0);
 | [fill](https://lodash.com/docs/4.17.15#fill)                           | ✅         |
 | [findIndex](https://lodash.com/docs/4.17.15#findIndex)                 | ❌         |
 | [findLastIndex](https://lodash.com/docs/4.17.15#findIndex)             | ❌         |
-| [flatten](https://lodash.com/docs/4.17.15#flatten)                     | 📝         |
+| [flatten](https://lodash.com/docs/4.17.15#flatten)                     | ✅         |
 | [flattenDeep](https://lodash.com/docs/4.17.15#flattenDeep)             | 📝         |
 | [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | 📝         |
 | [fromPairs](https://lodash.com/docs/4.17.15#fromPairs)                 | ❌         |

--- a/src/compat/array/flatten.spec.ts
+++ b/src/compat/array/flatten.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { flatten } from './flatten';
+import { args } from '../_internal/args';
+
+describe('flatten', () => {
+  it('should flatten `arguments` objects', () => {
+    const array = [args, [args]];
+    const expected = [1, 2, 3, args];
+    const actual = flatten(array);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should treat sparse arrays as dense', () => {
+    const array = [[1, 2, 3], Array(3)];
+    const expected = [1, 2, 3, undefined, undefined, undefined];
+    const actual = flatten(array);
+
+    expect(actual).toEqual(expected);
+    expect('4' in actual).toBeTruthy();
+  });
+
+  it('should flatten objects with a truthy `Symbol.isConcatSpreadable` value', () => {
+    const object = { 0: 'a', length: 1, [Symbol.isConcatSpreadable]: true };
+    const array = [object];
+    const expected = ['a'];
+    const actual = flatten(array);
+    expect(actual).toEqual(expected);
+  });
+
+  it('should work with empty arrays', () => {
+    const array = [[], [[]], [[], [[[]]]]];
+    const expected = [[], [], [[[]]]];
+    const actual = flatten(array);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should support flattening of nested arrays', () => {
+    const array = [1, [2, [3, [4]], 5]];
+    const expected = [1, 2, [3, [4]], 5];
+    const actual = flatten(array);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return an empty array for non array-like objects', () => {
+    const nonArray = { 0: 'a' };
+    const expected: [] = [];
+    const actual = flatten(nonArray);
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/compat/array/flatten.ts
+++ b/src/compat/array/flatten.ts
@@ -3,9 +3,9 @@
  *
  * @template T - The type of elements within the array.
  * @template D - The depth to which the array should be flattened.
- * @param {T[] | object} value - The array to flatten.
+ * @param {T[] | object} value - The object to flatten.
  * @param {D} depth - The depth level specifying how deep a nested array structure should be flattened. Defaults to 1.
- * @returns {Array<FlatArray<T[], D>>} A new array that has been flattened.
+ * @returns {Array<FlatArray<T[], D>> | []} A new array that has been flattened.
  *
  * @example
  * const arr = flatten([1, [2, 3], [4, [5, 6]]], 1);
@@ -14,7 +14,7 @@
  * const arr = flatten([1, [2, 3], [4, [5, 6]]], 2);
  * // Returns: [1, 2, 3, 4, 5, 6]
  */
-export function flatten<T, D extends number = 1>(value: T[] | object, depth = 1 as D): Array<FlatArray<T[], D>> {
+export function flatten<T, D extends number = 1>(value: T[] | object, depth = 1 as D): Array<FlatArray<T[], D>> | [] {
   const result: Array<FlatArray<T[], D>> = [];
   const flooredDepth = Math.floor(depth);
 

--- a/src/compat/array/flatten.ts
+++ b/src/compat/array/flatten.ts
@@ -1,0 +1,47 @@
+/**
+ * Flattens an array up to the specified depth.
+ *
+ * @template T - The type of elements within the array.
+ * @template D - The depth to which the array should be flattened.
+ * @param {T[] | object} value - The array to flatten.
+ * @param {D} depth - The depth level specifying how deep a nested array structure should be flattened. Defaults to 1.
+ * @returns {Array<FlatArray<T[], D>>} A new array that has been flattened.
+ *
+ * @example
+ * const arr = flatten([1, [2, 3], [4, [5, 6]]], 1);
+ * // Returns: [1, 2, 3, 4, [5, 6]]
+ *
+ * const arr = flatten([1, [2, 3], [4, [5, 6]]], 2);
+ * // Returns: [1, 2, 3, 4, 5, 6]
+ */
+export function flatten<T, D extends number = 1>(value: T[] | object, depth = 1 as D): Array<FlatArray<T[], D>> {
+  const result: Array<FlatArray<T[], D>> = [];
+  const flooredDepth = Math.floor(depth);
+
+  if (!Array.isArray(value)) {
+    return result;
+  }
+
+  const recursive = (arr: T[], currentDepth: number) => {
+    for (const item of arr) {
+      if (
+        currentDepth < flooredDepth &&
+        (Array.isArray(item) ||
+          Boolean(item?.[Symbol.isConcatSpreadable as keyof object]) ||
+          (item !== null && typeof item === 'object' && Object.prototype.toString.call(item) === '[object Arguments]'))
+      ) {
+        if (Array.isArray(item)) {
+          recursive(item, currentDepth + 1);
+        } else {
+          recursive(Array.from(item as T[]), currentDepth + 1);
+        }
+      } else {
+        result.push(item as FlatArray<T[], D>);
+      }
+    }
+  };
+
+  recursive(value, 0);
+
+  return result;
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -28,6 +28,7 @@ export { chunk } from './array/chunk.ts';
 export { concat } from './array/concat.ts';
 export { difference } from './array/difference.ts';
 export { fill } from './array/fill.ts';
+export { flatten } from './array/flatten.ts';
 export { zipObjectDeep } from './array/zipObjectDeep.ts';
 export { head as first } from '../index.ts';
 


### PR DESCRIPTION
## Description

- **Array Type Checking:** Added a check to ensure the input value is an array. If the value is not an array, the function returns an empty array.
- **Flattening Items:** Enhanced the flattening mechanism for items that are either:
  - Marked with `item[Symbol.isConcatSpreadable]` set to `true`
    - Even though the `Array.prototype.flat` method does not support this, it was added for compatibility with lodash.
  - Instances of `arguments`
    - Instead of using the `isArguments` function, expressions are directly added for better performance.
  - Items are forced to be of array type using `Array.prototype.from` for flattening the above types.

## benchmark

<img width="801" alt="Screenshot 2024-07-30 at 5 52 14 PM" src="https://github.com/user-attachments/assets/981fd025-4c7f-4e74-8be3-7aef4b5d93e4">
