### PR TITLE
docs(isPrimitive): fix isPrimitive function documentations

### DIFF
--- a/docs/ko/reference/predicate/isPrimitive.md
+++ b/docs/ko/reference/predicate/isPrimitive.md
@@ -7,16 +7,16 @@ JavaScript 원시 값은 null, undefined, string, number, symbol, bigint를 말�
 ## 인터페이스
 
 ```typescript
-function isPrimitive(x: unknown): x is null | undefined | string | number | boolean | symbol | bigint;
+function isPrimitive(value: unknown): value is null | undefined | string | number | boolean | symbol | bigint;
 ```
 
 ### 파라미터
 
-- `x` (`unknown`): 검사할 값.
+- `value` (`unknown`): 검사할 값.
 
 ### 반환 값
 
-(`x is null | undefined | string | number | boolean | symbol | bigint`): 값이 원시 값이면 `true`, 아니면 `false`.
+(`value is null | undefined | string | number | boolean | symbol | bigint`): 값이 원시 값이면 `true`, 아니면 `false`.
 
 ## 예시
 

--- a/docs/reference/predicate/isPrimitive.md
+++ b/docs/reference/predicate/isPrimitive.md
@@ -7,16 +7,16 @@ JavaScript primitives include null, undefined, strings, numbers, booleans, symbo
 ## Signature
 
 ```typescript
-function isPrimitive(x: unknown): x is null | undefined | string | number | boolean | symbol | bigint;
+function isPrimitive(value: unknown): value is null | undefined | string | number | boolean | symbol | bigint;
 ```
 
 ### Parameters
 
-- `x` (`unknown`): The value to check.
+- `value` (`unknown`): The value to check.
 
 ### Returns
 
-(`x is null | undefined | string | number | boolean | symbol | bigint`): True if the value is a primitive, otherwise false.
+(`value is null | undefined | string | number | boolean | symbol | bigint`): True if the value is a primitive, otherwise false.
 
 ## Examples
 

--- a/docs/zh_hans/reference/predicate/isPrimitive.md
+++ b/docs/zh_hans/reference/predicate/isPrimitive.md
@@ -7,16 +7,16 @@ JavaScript 的原始类型包括 null、undefined、字符串、数字、布尔�
 ## 签名
 
 ```typescript
-function isPrimitive(x: unknown): x is null | undefined | string | number | boolean | symbol | bigint;
+function isPrimitive(value: unknown): value is null | undefined | string | number | boolean | symbol | bigint;
 ```
 
 ### 参数
 
-- `x` (`unknown`): 要检查的值。
+- `value` (`unknown`): 要检查的值。
 
 ### 返回
 
-(`x is null | undefined | string | number | boolean | symbol | bigint`): 如果值是原始类型则返回 true，否则返回 false。
+(`value is null | undefined | string | number | boolean | symbol | bigint`): 如果值是原始类型则返回 true，否则返回 false。
 
 ## 示例
 

--- a/src/predicate/isPrimitive.ts
+++ b/src/predicate/isPrimitive.ts
@@ -2,7 +2,7 @@
  * Checks whether a value is a JavaScript primitive.
  * JavaScript primitives include null, undefined, strings, numbers, booleans, symbols, and bigints.
  *
- * @param {unknown} x The value to check.
+ * @param {unknown} value The value to check.
  * @returns {x is
  *   | null
  *   | undefined
@@ -13,5 +13,5 @@
  *   | bigint} Returns true if `x` is a primitive, false otherwise.
  */
 export function isPrimitive(value: unknown): value is null | undefined | string | number | boolean | symbol | bigint {
-  return value == null || (typeof value !== 'object' && typeof value !== 'function');
+  return Object(value) !== value;
 }

--- a/src/predicate/isPrimitive.ts
+++ b/src/predicate/isPrimitive.ts
@@ -13,5 +13,5 @@
  *   | bigint} Returns true if `x` is a primitive, false otherwise.
  */
 export function isPrimitive(value: unknown): value is null | undefined | string | number | boolean | symbol | bigint {
-  return Object(value) !== value;
+  return value == null || (typeof value !== 'object' && typeof value !== 'function');
 }

--- a/src/predicate/isPrimitive.ts
+++ b/src/predicate/isPrimitive.ts
@@ -3,14 +3,14 @@
  * JavaScript primitives include null, undefined, strings, numbers, booleans, symbols, and bigints.
  *
  * @param {unknown} value The value to check.
- * @returns {x is
+ * @returns {value is
  *   | null
  *   | undefined
  *   | string
  *   | number
  *   | boolean
  *   | symbol
- *   | bigint} Returns true if `x` is a primitive, false otherwise.
+ *   | bigint} Returns true if `value` is a primitive, false otherwise.
  */
 export function isPrimitive(value: unknown): value is null | undefined | string | number | boolean | symbol | bigint {
   return value == null || (typeof value !== 'object' && typeof value !== 'function');


### PR DESCRIPTION
Object wrapper `object` makes it a little simpler to determine if it's a primitive.

This logic is possible because

1. undefined, null values return a new object. 

```ts
Object(); // {}
Object(undefined); // {}
Object(null); // {}
```

2. The primitive value is returned as an object wrapped in a wrapper object.
```ts
Object(true); // Boolean {true}
Object(1); // Number {1}
Object('str'); // String {''}
```

3. If the argument is an object, return it as is. 
```ts
const obj = { a: 1 }
const newObj = Object(obj); // { a: 1 }

obj === newObj; // true

const set = new Set();
const newSet = Object(set);

set === newSet; // true
```

So if the return value of `Object(value)` is different from `value`, it means it's an object.
Doesn't this make the implementation logic much simpler? 