### PR TITLE
docs(size): fix size title

### DIFF
--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -82,7 +82,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'sample', link: '/reference/array/sample' },
             { text: 'sampleSize', link: '/reference/array/sampleSize' },
             { text: 'shuffle', link: '/reference/array/shuffle' },
-            { text: 'shuffle', link: '/reference/array/size' },
+            { text: 'size', link: '/reference/array/size' },
             { text: 'take', link: '/reference/array/take' },
             { text: 'takeWhile', link: '/reference/array/takeWhile' },
             { text: 'takeRight', link: '/reference/array/takeRight' },

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -90,7 +90,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'sample', link: '/ko/reference/array/sample' },
             { text: 'sampleSize', link: '/ko/reference/array/sampleSize' },
             { text: 'shuffle', link: '/ko/reference/array/shuffle' },
-            { text: 'shuffle', link: '/ko/reference/array/size' },
+            { text: 'size', link: '/ko/reference/array/size' },
             { text: 'take', link: '/ko/reference/array/take' },
             { text: 'takeWhile', link: '/ko/reference/array/takeWhile' },
             { text: 'takeRight', link: '/ko/reference/array/takeRight' },


### PR DESCRIPTION
# Problem

The `reference/array/size.html` documentation page has the wrong "shuffle" title in the menu.
See:
![Screenshot 2024-07-31 at 21 48 23](https://github.com/user-attachments/assets/391beb00-905f-4f27-9048-68f85c134a08)

# Solution

Fix it.