### PR TITLE
feat(flattenDeep, flattenDepth): add compatibility with lodash

### DIFF
--- a/benchmarks/performance/flattenDeep.bench.ts
+++ b/benchmarks/performance/flattenDeep.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from 'vitest';
 import { flattenDeep as flattenDeepToolkit } from 'es-toolkit';
+import { flattenDeep as flattenDeepToolkitCompat } from 'es-toolkit/compat';
 import { flattenDeep as flattenDeepLodash } from 'lodash';
 
 const createNestedArray = (values: number[]) => {
@@ -15,6 +16,10 @@ describe('flattenDeep', () => {
 
   bench('es-toolkit/flattenDeep', () => {
     flattenDeepToolkit(arr);
+  });
+
+  bench('es-toolkit/flattenDeep (compat)', () => {
+    flattenDeepToolkitCompat(arr);
   });
 
   bench('lodash/flattenDeep', () => {

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -65,8 +65,8 @@ Even if a feature is marked "in review," it might already be under review to ens
 | [findIndex](https://lodash.com/docs/4.17.15#findIndex)                 | ❌                    |
 | [findLastIndex](https://lodash.com/docs/4.17.15#findIndex)             | ❌                    |
 | [flatten](https://lodash.com/docs/4.17.15#flatten)                     | ✅                    |
-| [flattenDeep](https://lodash.com/docs/4.17.15#flattenDeep)             | 📝                    |
-| [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | 📝                    |
+| [flattenDeep](https://lodash.com/docs/4.17.15#flattenDeep)             | ✅                    |
+| [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | ✅                    |
 | [fromPairs](https://lodash.com/docs/4.17.15#fromPairs)                 | ❌                    |
 | [head](https://lodash.com/docs/4.17.15#head)                           | ✅                    |
 | [indexOf](https://lodash.com/docs/4.17.15#indexOf)                     | ❌                    |

--- a/docs/ko/compatibility.md
+++ b/docs/ko/compatibility.md
@@ -66,8 +66,8 @@ chunk([1, 2, 3, 4], 0);
 | [findIndex](https://lodash.com/docs/4.17.15#findIndex)                 | ❌            |
 | [findLastIndex](https://lodash.com/docs/4.17.15#findIndex)             | ❌            |
 | [flatten](https://lodash.com/docs/4.17.15#flatten)                     | ✅            |
-| [flattenDeep](https://lodash.com/docs/4.17.15#flattenDeep)             | 📝            |
-| [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | 📝            |
+| [flattenDeep](https://lodash.com/docs/4.17.15#flattenDeep)             | ✅            |
+| [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | ✅            |
 | [fromPairs](https://lodash.com/docs/4.17.15#fromPairs)                 | ❌            |
 | [head](https://lodash.com/docs/4.17.15#head)                           | 📝            |
 | [indexOf](https://lodash.com/docs/4.17.15#indexOf)                     | ❌            |

--- a/docs/zh_hans/compatibility.md
+++ b/docs/zh_hans/compatibility.md
@@ -65,8 +65,8 @@ chunk([1, 2, 3, 4], 0);
 | [findIndex](https://lodash.com/docs/4.17.15#findIndex)                 | ❌         |
 | [findLastIndex](https://lodash.com/docs/4.17.15#findIndex)             | ❌         |
 | [flatten](https://lodash.com/docs/4.17.15#flatten)                     | ✅         |
-| [flattenDeep](https://lodash.com/docs/4.17.15#flattenDeep)             | 📝         |
-| [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | 📝         |
+| [flattenDeep](https://lodash.com/docs/4.17.15#flattenDeep)             | ✅         |
+| [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | ✅         |
 | [fromPairs](https://lodash.com/docs/4.17.15#fromPairs)                 | ❌         |
 | [head](https://lodash.com/docs/4.17.15#head)                           | 📝         |
 | [indexOf](https://lodash.com/docs/4.17.15#indexOf)                     | ❌         |

--- a/src/compat/array/flattenDeep.spec.ts
+++ b/src/compat/array/flattenDeep.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { flattenDeep } from './flattenDeep';
+import { args } from '../_internal/args';
+
+describe('flattenDeep', () => {
+  it('should flattenDeep `arguments` objects', () => {
+    const array = [args, [args]];
+    const expected = [1, 2, 3, 1, 2, 3];
+    const actual = flattenDeep(array);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should treat sparse arrays as dense', () => {
+    const array = [[1, 2, 3], Array(3)];
+    const expected = [1, 2, 3, undefined, undefined, undefined];
+    const actual = flattenDeep(array);
+
+    expect(actual).toEqual(expected);
+    expect('4' in actual).toBeTruthy();
+  });
+
+  it('should flattenDeep objects with a truthy `Symbol.isConcatSpreadable` value', () => {
+    const object = { 0: 'a', length: 1, [Symbol.isConcatSpreadable]: true };
+    const array = [object];
+    const expected = ['a'];
+    const actual = flattenDeep(array);
+    expect(actual).toEqual(expected);
+  });
+
+  it('should work with empty arrays', () => {
+    const array = [[], [[]], [[], [[[]]]]];
+    const expected: [] = [];
+    const actual = flattenDeep(array);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should support flattening of nested arrays', () => {
+    const array = [1, [2, [3, [4]], 5]];
+    const expected = [1, 2, 3, 4, 5];
+    const actual = flattenDeep(array);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return an empty array for non array-like objects', () => {
+    const nonArray = { 0: 'a' };
+    const expected: [] = [];
+    const actual = flattenDeep(nonArray);
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/compat/array/flattenDeep.ts
+++ b/src/compat/array/flattenDeep.ts
@@ -1,0 +1,28 @@
+import { flatten } from './flatten';
+
+/**
+ * Utility type for recursively unpacking nested array types to extract the type of the innermost element
+ *
+ * @example
+ * ExtractNestedArrayType<(number | (number | number[])[])[]>
+ * // number
+ *
+ * ExtractNestedArrayType<(boolean | (string | number[])[])[]>
+ * // string | number | boolean
+ */
+type ExtractNestedArrayType<T> = T extends ReadonlyArray<infer U> ? ExtractNestedArrayType<U> : T;
+
+/**
+ * Flattens all depths of a nested array.
+ *
+ * @template T - The type of elements within the array.
+ * @param {T[] | object} value - The value to flatten.
+ * @returns {Array<ExtractNestedArrayType<T>> | []} A new array that has been flattened.
+ *
+ * @example
+ * const value = flattenDeep([1, [2, [3]], [4, [5, 6]]]);
+ * // Returns: [1, 2, 3, 4, 5, 6]
+ */
+export function flattenDeep<T>(value: readonly T[] | object): Array<ExtractNestedArrayType<T>> | [] {
+  return flatten(value, Infinity) as Array<ExtractNestedArrayType<T>>;
+}

--- a/src/compat/array/flattenDepth.spec.ts
+++ b/src/compat/array/flattenDepth.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { flattenDepth } from './flattenDepth';
+import { args } from '../_internal/args';
+
+describe('flattenDepth', () => {
+  it('should flattenDepth `arguments` objects', () => {
+    const array = [args, [args]];
+    const expected = [1, 2, 3, 1, 2, 3];
+    const actual = flattenDepth(array, 2);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should treat sparse arrays as dense', () => {
+    const array = [[1, 2, 3], Array(3)];
+    const expected = [1, 2, 3, undefined, undefined, undefined];
+    const actual = flattenDepth(array);
+
+    expect(actual).toEqual(expected);
+    expect('4' in actual).toBeTruthy();
+  });
+
+  it('should flattenDepth objects with a truthy `Symbol.isConcatSpreadable` value', () => {
+    const object = { 0: 'a', length: 1, [Symbol.isConcatSpreadable]: true };
+    const array = [object];
+    const expected = ['a'];
+    const actual = flattenDepth(array);
+    expect(actual).toEqual(expected);
+  });
+
+  it('should work with empty arrays', () => {
+    const array = [[], [[]], [[], [[[]]]]];
+    const expected = [[[]]];
+    const actual = flattenDepth(array, 2);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should support flattening of nested arrays', () => {
+    const array = [1, [2, [3, [4]], 5]];
+    const expected = [1, 2, 3, [4], 5];
+    const actual = flattenDepth(array, 2);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return an empty array for non array-like objects', () => {
+    const nonArray = { 0: 'a' };
+    const expected: [] = [];
+    const actual = flattenDepth(nonArray, 2);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should use a default `depth` of `1`', () => {
+    const array = [1, [2, [3, [4]], 5]];
+    expect(flattenDepth(array)).toEqual([1, 2, [3, [4]], 5]);
+  });
+
+  it('should treat a `depth` of < `1` as a shallow clone', () => {
+    const array = [1, [2, [3, [4]], 5]];
+    for (const depth of [-1, 0]) {
+      expect(flattenDepth(array, depth)).toEqual([1, [2, [3, [4]], 5]]);
+    }
+  });
+
+  it('should coerce `depth` to an integer', () => {
+    const array = [1, [2, [3, [4]], 5]];
+    expect(flattenDepth(array, 2.2)).toEqual([1, 2, 3, [4], 5]);
+  });
+});

--- a/src/compat/array/flattenDepth.ts
+++ b/src/compat/array/flattenDepth.ts
@@ -1,0 +1,24 @@
+import { flatten } from './flatten';
+
+/**
+ * Flattens an array up to the specified depth.
+ *
+ * @template T - The type of elements within the array.
+ * @template D - The depth to which the array should be flattened.
+ * @param {T[] | object} value - The value to flatten.
+ * @param {D} depth - The depth level specifying how deep a nested array structure should be flattened. Defaults to 1.
+ * @returns {Array<FlatArray<T[], D>> | []} A new array that has been flattened.
+ *
+ * @example
+ * const arr = flatten([1, [2, 3], [4, [5, 6]]], 1);
+ * // Returns: [1, 2, 3, 4, [5, 6]]
+ *
+ * const arr = flatten([1, [2, 3], [4, [5, 6]]], 2);
+ * // Returns: [1, 2, 3, 4, 5, 6]
+ */
+export function flattenDepth<T, D extends number = 1>(
+  value: T[] | object,
+  depth = 1 as D
+): Array<FlatArray<T[], D>> | [] {
+  return flatten(value, depth);
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -29,6 +29,8 @@ export { concat } from './array/concat.ts';
 export { difference } from './array/difference.ts';
 export { fill } from './array/fill.ts';
 export { flatten } from './array/flatten.ts';
+export { flattenDeep } from './array/flattenDeep.ts';
+export { flattenDepth } from './array/flattenDepth.ts';
 export { zipObjectDeep } from './array/zipObjectDeep.ts';
 export { head as first } from '../index.ts';
 


### PR DESCRIPTION
## description 

I add `compat/flattenDeep` and `compat/flattenDepth` method based on `compat/flatten` function.

## benchmark

<img width="558" alt="Screenshot 2024-08-01 at 4 57 59 PM" src="https://github.com/user-attachments/assets/e4c0c7a6-ed33-48d2-b3b7-f5360b472f89">

I don't add flattenDepth benchmark, because `flattenDepth` is same as `flatten` function.

close #262 