### PR TITLE
docs(endsWith): Fix wrong returns in Examples

### DIFF
--- a/docs/reference/compat/string/endsWith.md
+++ b/docs/reference/compat/string/endsWith.md
@@ -29,8 +29,8 @@ function endsWith(str: string, target: string, position: number = 0): string;
 ```typescript
 import { endsWith } from 'es-toolkit/string';
 
-endsWith('fooBar', 'foo') // returns true
-endsWith('fooBar', 'Bar') // returns false
+endsWith('fooBar', 'foo') // returns false
+endsWith('fooBar', 'Bar') // returns true
 endsWith('fooBar', 'abcdef') // returns false
 endsWith('fooBar', 'foo', 3) // returns true
 ```


### PR DESCRIPTION
endsWith('fooBar', 'foo') // returns true -> false
endsWith('fooBar', 'Bar') // returns false -> true