### PR TITLE
fix(size, clonedeep): specify a file and ignore type error for deno

### DIFF
--- a/src/array/size.ts
+++ b/src/array/size.ts
@@ -1,4 +1,4 @@
-import { isNil } from '../predicate';
+import { isNil } from '../predicate/isNil.ts';
 
 /**
  * Returns the length of an array, string, or object.

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'node:buffer';
 import { isPrimitive } from '../predicate/isPrimitive.ts';
 import { isTypedArray } from '../predicate/isTypedArray.ts';
 
@@ -70,12 +69,12 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
     }
 
     // For RegExpArrays
-    if (obj.hasOwnProperty('index')) {
+    if (Object.prototype.hasOwnProperty.call(obj, 'index')) {
       // eslint-disable-next-line
       // @ts-ignore
       result.index = obj.index;
     }
-    if (obj.hasOwnProperty('input')) {
+    if (Object.prototype.hasOwnProperty.call(obj, 'input')) {
       // eslint-disable-next-line
       // @ts-ignore
       result.input = obj.input;

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -69,12 +69,12 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
     }
 
     // For RegExpArrays
-    if (Object.prototype.hasOwnProperty.call(obj, 'index')) {
+    if (obj.hasOwnProperty('index')) {
       // eslint-disable-next-line
       // @ts-ignore
       result.index = obj.index;
     }
-    if (Object.prototype.hasOwnProperty.call(obj, 'input')) {
+    if (obj.hasOwnProperty('input')) {
       // eslint-disable-next-line
       // @ts-ignore
       result.input = obj.input;

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { isPrimitive } from '../predicate/isPrimitive.ts';
 import { isTypedArray } from '../predicate/isTypedArray.ts';
 

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -69,12 +69,12 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
     }
 
     // For RegExpArrays
-    if (obj.hasOwnProperty('index')) {
+    if (Object.prototype.hasOwnProperty.call(obj, 'index')) {
       // eslint-disable-next-line
       // @ts-ignore
       result.index = obj.index;
     }
-    if (obj.hasOwnProperty('input')) {
+    if (Object.prototype.hasOwnProperty.call(obj, 'input')) {
       // eslint-disable-next-line
       // @ts-ignore
       result.input = obj.input;
@@ -117,7 +117,11 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
     return result as T;
   }
 
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   if (typeof Buffer !== 'undefined' && Buffer.isBuffer(obj)) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     return obj.subarray() as T;
   }
 


### PR DESCRIPTION
## description

We have two errors when running a release workflow. So I fixed them.

### Error in `size`

```bash
error: Is a directory (os error 21) Maybe specify path to 'index.ts' file in directory instead or run with --unstable-sloppy-imports
    at file:///home/runner/work/es-toolkit/es-toolkit/src/array/size.ts:1:23
```

Before, it skip a filename in import path. So I just added it

### Error in `cloneDeep`

``` bash
Check file:///Users/dayong/es-toolkit/src/object/cloneDeep.ts
error: TS2580 [ERROR]: Cannot find name 'Buffer'.
  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(obj)) {
             ~~~~~~
    at file:///Users/dayong/es-toolkit/src/object/cloneDeep.ts:120:14

TS2580 [ERROR]: Cannot find name 'Buffer'.
  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(obj)) {
                                       ~~~~~~
    at file:///Users/dayong/es-toolkit/src/object/cloneDeep.ts:120:40

TS2339 [ERROR]: Property 'subarray' does not exist on type 'T'.
    return obj.subarray() as T;
               ~~~~~~~~
    at file:///Users/dayong/es-toolkit/src/object/cloneDeep.ts:121:16

Found 3 errors.
```

The Buffer class is only supported in Node.js.

So I have to load `@types/node` package. But I can't apply this solution in `es-toolkit` project. So I just add `ts-ignore` comment.

> ref. https://docs.deno.com/runtime/manual/node/npm_specifiers/#including-node-types

And I also fix [`no-prototype-builtin`](https://eslint.org/docs/latest/rules/no-prototype-builtins) rule.