### PR TITLE
fix(bind, CD): add sloppy-import flag and explicit symbol type for publishing deno

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           else
             npm publish --provenance --access public --tag dev *.tgz
           fi
-          deno publish --allow-dirty
+          deno publish --allow-dirty --unstable-sloppy-imports
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ${{ github.workspace }}/out/

--- a/src/function/bind.ts
+++ b/src/function/bind.ts
@@ -45,4 +45,4 @@ export function bind(func: (...args: any[]) => any, thisArg?: any, ...partials: 
   return wrapper;
 }
 
-bind.placeholder = Symbol('bind.placeholder');
+bind.placeholder = Symbol('bind.placeholder') as symbol;


### PR DESCRIPTION
## Description

Normally, deno doesn't infer file extensions from imports.

But we add `--unstable-sloppy-imports` flag, then deno will infer file extensions.

> ref. https://docs.deno.com/runtime/manual/tools/unstable_flags/#--unstable-sloppy-imports

And I also add explicit symbol type in `bind` function for fixing deno error.

## Before

<img width="927" alt="Screenshot 2024-08-04 at 9 44 46 PM" src="https://github.com/user-attachments/assets/66b0f895-452e-4d3f-8c23-e3c414986a08">

## After

<img width="560" alt="Screenshot 2024-08-04 at 9 44 52 PM" src="https://github.com/user-attachments/assets/9d983915-eb19-4b7c-a3e1-e8bdc7337018">

