### PR TITLE
feat(concat): Add concat funciton

### DIFF
--- a/benchmarks/performance/concat.bench.ts
+++ b/benchmarks/performance/concat.bench.ts
@@ -1,15 +1,15 @@
 import { bench, describe } from 'vitest';
-import { camelCase as camelCaseToolkit } from 'es-toolkit';
-import { camelCase as camelCaseLodash } from 'lodash';
+import { concat as concatToolkit } from 'es-toolkit';
+import { concat as concatLodash } from 'lodash';
 
-describe('camelCase', () => {
-  bench('es-toolkit/camelCase', () => {
-    const str = 'kebab-case';
-    camelCaseToolkit(str);
+const arr = Array.from({ length: 10 }, (_, i) => i);
+
+describe('concat', () => {
+  bench('es-toolkit/concat', () => {
+    concatToolkit(arr, arr, arr, arr, arr);
   });
 
-  bench('lodash/camelCase', () => {
-    const str = 'kebab-case';
-    camelCaseLodash(str);
+  bench('lodash/concat', () => {
+    concatLodash(arr, arr, arr, arr, arr);
   });
 });

--- a/src/array/concat.spec.ts
+++ b/src/array/concat.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { concat } from './concat';
+
+describe('concat', () => {
+  it('should shallow clone `array`', () => {
+    const array = [1, 2, 3];
+    const actual = concat(array);
+
+    expect(actual).toEqual(array);
+    expect(actual === array).toBe(false);
+  });
+
+  it('should concat arrays and values', () => {
+    const array = [1];
+    const actual = concat<unknown>(array, 2, [3], [[4]]);
+
+    expect(actual).toEqual([1, 2, 3, [4]]);
+    expect(array).toEqual([1]);
+  });
+
+  it('should cast non-array `array` values to arrays', () => {
+    // eslint-disable-next-line no-sparse-arrays
+    const values = [, null, undefined, false, true, 1, NaN, 'a'];
+
+    let expected: unknown[] = values.map((value, index) => (index ? [value] : []));
+
+    let actual: unknown[] = values.map((value, index) => (index ? concat(value) : concat()));
+
+    expect(actual).toEqual(expected);
+
+    expected = values.map(value => [value, 2, [3]]);
+
+    actual = values.map(value => concat<unknown>(value, [2], [[3]]));
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should treat sparse arrays as dense', () => {
+    const expected = [];
+    const actual = concat(Array(1), Array(1));
+
+    expected.push(undefined, undefined);
+
+    expect('0' in actual).toBeTruthy();
+    expect('1' in actual).toBeTruthy();
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return a new wrapped array', () => {
+    const array = [1];
+    const actual = concat(array, [2, 3]);
+
+    expect(array).toEqual([1]);
+    expect(actual).toEqual([1, 2, 3]);
+  });
+});

--- a/src/array/concat.ts
+++ b/src/array/concat.ts
@@ -1,0 +1,32 @@
+import { flatten } from '../array/flatten.ts';
+
+/**
+ * Concatenates multiple arrays and values into a single array.
+ *
+ * @template T The type of elements in the array.
+ * @param {...(T | T[])} values - The values and/or arrays to concatenate.
+ * @returns {T[]} A new array containing all the input values.
+ *
+ * @example
+ * // Concatenate individual values
+ * concat(1, 2, 3);
+ * // returns [1, 2, 3]
+ *
+ * @example
+ * // Concatenate arrays of values
+ * concat([1, 2], [3, 4]);
+ * // returns [1, 2, 3, 4]
+ *
+ * @example
+ * // Concatenate a mix of individual values and arrays
+ * concat(1, [2, 3], 4);
+ * // returns [1, 2, 3, 4]
+ *
+ * @example
+ * // Concatenate nested arrays
+ * concat([1, [2, 3]], 4);
+ * // returns [1, [2, 3], 4]
+ */
+export function concat<T>(...values: Array<T | readonly T[]>): T[] {
+  return flatten(values) as T[];
+}

--- a/src/array/index.ts
+++ b/src/array/index.ts
@@ -1,5 +1,6 @@
 export { chunk } from './chunk.ts';
 export { compact } from './compact.ts';
+export { concat } from './concat.ts';
 export { countBy } from './countBy.ts';
 export { difference } from './difference.ts';
 export { differenceBy } from './differenceBy.ts';


### PR DESCRIPTION
Is there a reason why `concat` only exists in `compat`?

First of all, the benchmark test files need to be modified. The rest seems to be worth checking.