### PR TITLE
chore(ci): add a branch linting all files in CI when .eslintrc.js, .prettierrc, .prettierignore files are changed 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,25 @@ jobs:
       - run:
           name: ESLint
           shell: bash -e
-          command: git diff --name-only --diff-filter=ACMRUXB origin/main | grep -E "(.js$|.ts$)" | xargs -r yarn eslint -c .eslintrc.js
+          command: |
+            changed_files=$(git diff --name-only --diff-filter=ACMRUXB origin/main)
+
+            if echo "$changed_files" | grep -q "^.eslintrc.js$"; then
+              yarn eslint -c .eslintrc.js .
+            else
+              echo "$changed_files" | grep -E "(.js$|.ts$)" | xargs -r yarn eslint -c .eslintrc.js
+            fi
       - run:
           name: Prettier
-          command: git diff --name-only --diff-filter=ACMRUXB origin/main | xargs -r yarn prettier -c --ignore-unknown
+          command: |
+            changed_files=$(git diff --name-only --diff-filter=ACMRUXB origin/main)
+
+            if echo "$changed_files" | grep -q -E "^\.prettierrc$|^\.prettierignore$"; then
+              yarn prettier -c .
+            else
+
+              echo "$changed_files" | xargs -r yarn prettier -c --ignore-unknown
+            fi
   typecheck:
     docker:
       - image: cimg/node:20.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,6 @@ parameters:
     type: boolean
     default: false
 
-orbs:
-  slack: circleci/slack@4.5.0
-
 commands:
   setup:
     steps:


### PR DESCRIPTION
## Description

- I removed a unused slack orb.
- I add a branch linting all files in CI when .eslintrc.js, .prettierrc, .prettierignore files are changed.
  - Because when we change the configure files, then maybe their rules are changed. So we need to lint all files that may have lint errors.

close #340 