### PR TITLE
chore: fix all lint errors

### DIFF
--- a/benchmarks/performance/ary.bench.ts
+++ b/benchmarks/performance/ary.bench.ts
@@ -4,10 +4,12 @@ import { ary as aryLodash } from 'lodash';
 
 describe('ary', () => {
   bench('es-toolkit/ary', () => {
-    aryToolkit((a, b, c) => undefined, 2);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    aryToolkit((_a, _b, _c) => undefined, 2);
   });
 
   bench('lodash/ary', () => {
-    aryLodash((a, b, c) => undefined, 2);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    aryLodash((_a, _b, _c) => undefined, 2);
   });
 });

--- a/benchmarks/performance/unary.bench.ts
+++ b/benchmarks/performance/unary.bench.ts
@@ -4,10 +4,12 @@ import { unary as unaryLodash } from 'lodash';
 
 describe('ary', () => {
   bench('es-toolkit/unary', () => {
-    unaryToolkit((a, b, c) => undefined);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    unaryToolkit((_a, _b, _c) => undefined);
   });
 
   bench('lodash/unary', () => {
-    unaryLodash((a, b, c) => undefined);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    unaryLodash((_a, _b, _c) => undefined);
   });
 });

--- a/benchmarks/performance/zipObjectDeep.bench.ts
+++ b/benchmarks/performance/zipObjectDeep.bench.ts
@@ -4,12 +4,10 @@ import { zipObjectDeep as zipObjectDeepLodash } from 'lodash';
 
 describe('zipObjectDeep', () => {
   bench('es-toolkit/zipObjectDeep', () => {
-    const str = 'kebab-case';
-    zipObjectDeepToolkit(['a.b[0].c', 'a.b[1].d'], [1, 2])
+    zipObjectDeepToolkit(['a.b[0].c', 'a.b[1].d'], [1, 2]);
   });
 
   bench('lodash/zipObjectDeep', () => {
-    const str = 'kebab-case';
-    zipObjectDeepLodash(['a.b[0].c', 'a.b[1].d'], [1, 2])
+    zipObjectDeepLodash(['a.b[0].c', 'a.b[1].d'], [1, 2]);
   });
 });

--- a/src/compat/_internal/isSetMatch.spec.ts
+++ b/src/compat/_internal/isSetMatch.spec.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { isMapMatch } from './isMapMatch';
 import { isSetMatch } from './isSetMatch';
 
 describe('isSetMatch', () => {

--- a/src/compat/object/cloneDeep.spec.ts
+++ b/src/compat/object/cloneDeep.spec.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { cloneDeep } from "./cloneDeep";
-import { range } from "../../math/range";
-import { LARGE_ARRAY_SIZE } from "../_internal/LARGE_ARRAY_SIZE";
-import { args } from "../_internal/args";
-import { stubTrue } from "../_internal/stubTrue";
+import { describe, expect, it } from 'vitest';
+import { cloneDeep } from './cloneDeep';
+import { range } from '../../math/range';
+import { LARGE_ARRAY_SIZE } from '../_internal/LARGE_ARRAY_SIZE';
+import { args } from '../_internal/args';
+import { stubTrue } from '../_internal/stubTrue';
 
 describe('cloneDeep', () => {
   it('should deep clone objects with circular references', () => {
@@ -25,7 +25,7 @@ describe('cloneDeep', () => {
   it('should deep clone objects with lots of circular references', () => {
     const cyclical: any = {};
 
-    range(LARGE_ARRAY_SIZE + 1).forEach((index) => {
+    range(LARGE_ARRAY_SIZE + 1).forEach(index => {
       cyclical[`v${index}`] = [index ? cyclical[`v${index - 1}`] : cyclical];
     });
 
@@ -36,44 +36,6 @@ describe('cloneDeep', () => {
     expect(actual).toBe(clone[`v${LARGE_ARRAY_SIZE - 1}`]);
     expect(actual).not.toBe(cyclical[`v${LARGE_ARRAY_SIZE - 1}`]);
   });
-
-
-  class Foo {
-    a = 1;
-  }
-
-  // eslint-disable-next-line
-  // @ts-ignore
-  Foo.prototype.b = 1;
-  // eslint-disable-next-line
-  // @ts-ignore
-  Foo.c = function () { };
-
-  var map = new Map();
-  map.set('a', 1);
-  map.set('b', 2);
-
-  var set = new Set();
-  set.add(1);
-  set.add(2);
-
-  const objects = {
-    booleans: false,
-    'boolean objects': Object(false),
-    'date objects': new Date(),
-    'Foo instances': new Foo(),
-    objects: { a: 0, b: 1, c: 2 },
-    'objects with object values': { a: /a/, b: ['B'], c: { C: 1 } },
-    maps: map,
-    'null values': null,
-    numbers: 0,
-    'number objects': Object(0),
-    regexes: /a/gim,
-    sets: set,
-    strings: 'a',
-    'string objects': Object('a'),
-    'undefined values': undefined,
-  };
 
   it(`should clone arguments objects`, () => {
     const actual = cloneDeep(args);
@@ -230,7 +192,6 @@ describe('cloneDeep', () => {
     expect(actual).toBe(object);
   });
 
-
   it(`should clone array buffers`, () => {
     const arrayBuffer = new ArrayBuffer(2);
     const actual = cloneDeep(arrayBuffer);
@@ -252,7 +213,6 @@ describe('cloneDeep', () => {
     expect(actual[0]).toBe(2);
   });
 
-
   it(`should clone \`index\` and \`input\` array properties`, () => {
     const array = /c/.exec('abcde');
     const actual = cloneDeep(array);
@@ -261,7 +221,6 @@ describe('cloneDeep', () => {
     expect(actual?.input).toBe('abcde');
   });
 
-
   it(`should clone \`lastIndex\` regexp property`, () => {
     const regexp = /c/g;
     regexp.exec('abcde');
@@ -269,9 +228,8 @@ describe('cloneDeep', () => {
     expect(cloneDeep(regexp).lastIndex).toBe(3);
   });
 
-
   it(`should clone expando properties`, () => {
-    const values = [false, true, 1, 'a'].map((value) => {
+    const values = [false, true, 1, 'a'].map(value => {
       const object = Object(value);
       object.a = 1;
       return object;
@@ -279,13 +237,10 @@ describe('cloneDeep', () => {
 
     const expected = values.map(stubTrue);
 
-    const actual = values.map((value) => {
-      return cloneDeep(value).a === 1
+    const actual = values.map(value => {
+      return cloneDeep(value).a === 1;
     });
 
     expect(actual).toEqual(expected);
   });
 });
-
-
-

--- a/src/compat/object/cloneDeep.spec.ts
+++ b/src/compat/object/cloneDeep.spec.ts
@@ -37,6 +37,21 @@ describe('cloneDeep', () => {
     expect(actual).not.toBe(cyclical[`v${LARGE_ARRAY_SIZE - 1}`]);
   });
 
+  class Foo {
+    a = 1;
+    b = 1;
+
+    static c = function () {};
+  }
+  Foo.prototype.b = 1;
+
+  const map = new Map([
+    ['a', 1],
+    ['b', 2],
+  ]);
+
+  const set = new Set([1, 2]);
+
   it(`should clone arguments objects`, () => {
     const actual = cloneDeep(args);
 

--- a/src/compat/object/mapKeys.spec.ts
+++ b/src/compat/object/mapKeys.spec.ts
@@ -1,4 +1,3 @@
-
 import { describe, expect, it } from 'vitest';
 import { mapKeys } from './mapKeys';
 
@@ -23,13 +22,14 @@ describe('mapKeys', () => {
 
   it('should use `_.identity` when `iteratee` is nullish', () => {
     const object = { a: 1, b: 2 };
+    // eslint-disable-next-line no-sparse-arrays
     const values = [, null, undefined];
-    const expected = values.map(() => ({ 1: 1, 2: 2 }))
+    const expected = values.map(() => ({ 1: 1, 2: 2 }));
 
     const actual = values.map((value, index) =>
-      // eslint-disable-next-line
-      // @ts-ignore
-      index ? mapKeys(object, value) : mapKeys(object),
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      index ? mapKeys(object, value) : mapKeys(object)
     );
 
     expect(actual).toEqual(expected);

--- a/src/compat/object/mapKeys.ts
+++ b/src/compat/object/mapKeys.ts
@@ -19,9 +19,9 @@ import { property } from './property.ts';
  * const result = mapKeys(obj, (value, key) => key + value);
  * console.log(result); // { a1: 1, b2: 2 }
  */
-export function mapKeys<T extends {}>(
+export function mapKeys<T extends object>(
   object: T,
-  getNewKey?: PropertyKey | readonly PropertyKey[],
+  getNewKey?: PropertyKey | readonly PropertyKey[]
 ): Record<PropertyKey, T[keyof T]>;
 
 /**
@@ -42,16 +42,16 @@ export function mapKeys<T extends {}>(
  * const result = mapKeys(obj, (value, key) => key + value);
  * console.log(result); // { a1: 1, b2: 2 }
  */
-export function mapKeys<T extends {}, K1 extends keyof T, K2 extends PropertyKey>(
+export function mapKeys<T extends object, K1 extends keyof T, K2 extends PropertyKey>(
   object: T,
   getNewKey?: (value: T[K1], key: K1, object: T) => K2
 ): Record<K2, T[K1]>;
 
-export function mapKeys<T extends {}, K1 extends keyof T, K2 extends PropertyKey>(
+export function mapKeys<T extends object, K1 extends keyof T, K2 extends PropertyKey>(
   object: T,
   getNewKey?: PropertyKey | readonly PropertyKey[] | ((value: T[K1], key: K1, object: T) => K2)
 ): Record<K2, T[K1]> {
-  getNewKey = getNewKey ?? identity as (value: T[K1], key: K1, object: T) => K2;
+  getNewKey = getNewKey ?? (identity as (value: T[K1], key: K1, object: T) => K2);
 
   switch (typeof getNewKey) {
     case 'string':

--- a/src/compat/object/property.spec.ts
+++ b/src/compat/object/property.spec.ts
@@ -6,40 +6,42 @@ describe('property', () => {
   it('should create a function that plucks a property value of a given object', () => {
     const object = { a: 1 };
 
-    ['a', ['a']].forEach((path) => {
+    ['a', ['a']].forEach(path => {
       const prop = property(path);
       expect(prop.length).toBe(1);
       expect(prop(object)).toBe(1);
-    })
+    });
   });
 
   it('should pluck deep property values', () => {
     const object = { a: { b: 2 } };
 
-    ['a.b', ['a', 'b']].forEach((path) => {
+    ['a.b', ['a', 'b']].forEach(path => {
       const prop = property(path);
       expect(prop(object)).toBe(2);
     });
   });
 
   it('should pluck inherited property values', () => {
-    function Foo() { }
+    function Foo() {}
     Foo.prototype.a = 1;
 
-    ['a', ['a']].forEach((path) => {
+    ['a', ['a']].forEach(path => {
       const prop = property(path);
-      expect(prop(
-        // eslint-disable-next-line
-        // @ts-ignore
-        new Foo()
-      )).toBe(1);
+      expect(
+        prop(
+          // eslint-disable-next-line
+          // @ts-ignore
+          new Foo()
+        )
+      ).toBe(1);
     });
   });
 
   it('should work with a non-string `path`', () => {
     const array = [1, 2, 3];
 
-    [1, [1]].forEach((path) => {
+    [1, [1]].forEach(path => {
       const prop = property(path);
       expect(prop(array)).toBe(2);
     });
@@ -49,7 +51,7 @@ describe('property', () => {
     const object = { '-0': 'a', 0: 'b' };
     const props = [-0, Object(-0), 0, Object(0)];
 
-    const actual = props.map((key) => {
+    const actual = props.map(key => {
       const prop = property(key);
       return prop(object);
     });
@@ -60,7 +62,7 @@ describe('property', () => {
   it('should pluck a key over a path', () => {
     const object = { 'a.b': 1, a: { b: 2 } };
 
-    ['a.b', ['a.b']].forEach((path) => {
+    ['a.b', ['a.b']].forEach(path => {
       const prop = property(path);
       expect(prop(object)).toBe(1);
     });
@@ -70,10 +72,10 @@ describe('property', () => {
     const values = [null, undefined];
     const expected = values.map(noop);
 
-    ['constructor', ['constructor']].forEach((path) => {
+    ['constructor', ['constructor']].forEach(path => {
       const prop = property(path);
 
-      const actual = values.map((value) => prop(value))
+      const actual = values.map(value => prop(value));
 
       expect(actual).toEqual(expected);
     });
@@ -83,22 +85,19 @@ describe('property', () => {
     const values = [null, undefined];
     const expected = values.map(noop);
 
-    ['constructor.prototype.valueOf', ['constructor', 'prototype', 'valueOf']]
-      .forEach(
-        (path) => {
-          const prop = property(path);
+    ['constructor.prototype.valueOf', ['constructor', 'prototype', 'valueOf']].forEach(path => {
+      const prop = property(path);
 
-          const actual = values.map((value, index) => prop(value));
+      const actual = values.map(value => prop(value));
 
-          expect(actual).toEqual(expected);
-        },
-      );
+      expect(actual).toEqual(expected);
+    });
   });
 
   it('should return `undefined` if parts of `path` are missing', () => {
     const object = {};
 
-    ['a', 'a[1].b.c', ['a'], ['a', '1', 'b', 'c']].forEach((path) => {
+    ['a', 'a[1].b.c', ['a'], ['a', '1', 'b', 'c']].forEach(path => {
       const prop = property(path);
       expect(prop(object)).toBe(undefined);
     });

--- a/src/compat/predicate/isMatch.spec.ts
+++ b/src/compat/predicate/isMatch.spec.ts
@@ -6,7 +6,7 @@ import { isMatch } from './isMatch';
 
 describe('isMatch', () => {
   it(`should perform a deep comparison between \`source\` and \`object\``, () => {
-    let object: any = { a: 1, b: 2, c: 3 };
+    const object: any = { a: 1, b: 2, c: 3 };
 
     expect(isMatch(object, { a: 1 })).toBe(true);
     expect(isMatch(object, { b: 2 })).toBe(true);
@@ -22,7 +22,7 @@ describe('isMatch', () => {
     }
 
     interface FooConstructor {
-      new(): Foo;
+      new (): Foo;
     }
 
     const Foo = function Foo(this: Foo) {
@@ -42,7 +42,7 @@ describe('isMatch', () => {
     }
 
     interface FooConstructor {
-      new(): Foo;
+      new (): Foo;
     }
 
     const Foo = function Foo(this: Foo) {
@@ -77,7 +77,7 @@ describe('isMatch', () => {
 
   it(`should compare functions by reference`, () => {
     const object1 = { a: noop };
-    const object2 = { a: () => { } };
+    const object2 = { a: () => {} };
     const object3 = { a: {} };
 
     expect(isMatch(object1, object1)).toBe(true);
@@ -86,16 +86,16 @@ describe('isMatch', () => {
   });
 
   it(`should work with a function for \`object\``, () => {
-    function Foo() { }
+    function Foo() {}
     Foo.a = { b: 2, c: 3 };
 
     expect(isMatch(Foo, { a: { b: 2 } })).toBe(true);
   });
 
   it(`should work with a function for \`source\``, () => {
-    function Foo() { }
+    function Foo() {}
     Foo.a = 1;
-    Foo.b = function () { };
+    Foo.b = function () {};
     Foo.c = 3;
 
     const objects = [{ a: 1 }, { a: 1, b: Foo.b, c: 3 }];
@@ -112,7 +112,7 @@ describe('isMatch', () => {
     }
 
     interface FooConstructor {
-      new(arg: Partial<Foo>): Foo;
+      new (arg: Partial<Foo>): Foo;
     }
 
     const Foo = function Foo(this: Foo, object: Partial<Foo>) {
@@ -272,13 +272,16 @@ describe('isMatch', () => {
   });
 
   it(`should return \`false\` when \`object\` is nullish`, () => {
+    // eslint-disable-next-line no-sparse-arrays
     const values = [, null, undefined];
     const expected = values.map(() => false);
 
     const actual = values.map((value, index) => {
       try {
         return index ? isMatch(value, { a: 1 }) : isMatch(undefined, { a: 1 });
-      } catch (e: any) { }
+      } catch (e: unknown) {
+        /* empty */
+      }
     });
 
     expect(actual).toEqual(expected);
@@ -296,13 +299,16 @@ describe('isMatch', () => {
   });
 
   it(`should return \`true\` when comparing an empty \`source\` to a nullish \`object\``, () => {
+    // eslint-disable-next-line no-sparse-arrays
     const values = [, null, undefined];
     const expected = values.map(stubTrue);
 
     const actual = values.map((value, index) => {
       try {
         return index ? isMatch(value, {}) : isMatch(undefined, {});
-      } catch (e: any) { }
+      } catch (e: unknown) {
+        /* empty */
+      }
     });
 
     expect(actual).toEqual(expected);

--- a/src/compat/predicate/matches.spec.ts
+++ b/src/compat/predicate/matches.spec.ts
@@ -6,7 +6,7 @@ import { matches } from './matches';
 
 describe('matches', () => {
   it(`should perform a deep comparison between \`source\` and \`object\``, () => {
-    let object: any = { a: 1, b: 2, c: 3 };
+    const object: any = { a: 1, b: 2, c: 3 };
 
     const isMatch1 = matches({ a: 1 });
     expect(isMatch1(object)).toBe(true);
@@ -297,6 +297,7 @@ describe('matches', () => {
   });
 
   it(`should return \`false\` when \`object\` is nullish`, () => {
+    // eslint-disable-next-line no-sparse-arrays
     const values = [, null, undefined];
     const expected = values.map(() => false);
 
@@ -305,7 +306,9 @@ describe('matches', () => {
     const actual = values.map((value, index) => {
       try {
         return index ? isMatch(value) : isMatch(undefined);
-      } catch (e: any) {}
+      } catch (e: unknown) {
+        /* empty */
+      }
     });
 
     expect(actual).toEqual(expected);
@@ -315,7 +318,7 @@ describe('matches', () => {
     const object = { a: 1 };
     const expected = empties.map(stubTrue);
 
-    const actual = empties.map(value => {
+    const actual = empties.map(() => {
       const isMatch = matches(object);
 
       return isMatch(object);
@@ -325,6 +328,7 @@ describe('matches', () => {
   });
 
   it(`should return \`true\` when comparing an empty \`source\` to a nullish \`object\``, () => {
+    // eslint-disable-next-line no-sparse-arrays
     const values = [, null, undefined];
     const expected = values.map(stubTrue);
 
@@ -333,7 +337,9 @@ describe('matches', () => {
     const actual = values.map((value, index) => {
       try {
         return index ? isMatch(value) : isMatch(undefined);
-      } catch (e: any) {}
+      } catch (e: unknown) {
+        /* empty */
+      }
     });
 
     expect(actual).toEqual(expected);

--- a/src/object/mapKeys.ts
+++ b/src/object/mapKeys.ts
@@ -16,7 +16,7 @@
  * const result = mapKeys(obj, (value, key) => key + value);
  * console.log(result); // { a1: 1, b2: 2 }
  */
-export function mapKeys<T extends {}, K1 extends keyof T, K2 extends PropertyKey>(
+export function mapKeys<T extends object, K1 extends keyof T, K2 extends PropertyKey>(
   object: T,
   getNewKey: (value: T[K1], key: K1, object: T) => K2
 ): Record<K2, T[K1]> {

--- a/tests/utils/streamToBuffer.ts
+++ b/tests/utils/streamToBuffer.ts
@@ -1,4 +1,4 @@
-import { Readable } from "node:stream";
+import { Readable } from 'node:stream';
 
 export async function streamToBuffer(stream: Readable) {
   return await new Promise<Buffer>((resolve, reject) => {

--- a/tests/utils/streamToBuffer.ts
+++ b/tests/utils/streamToBuffer.ts
@@ -2,7 +2,7 @@ import { Readable } from "node:stream";
 
 export async function streamToBuffer(stream: Readable) {
   return await new Promise<Buffer>((resolve, reject) => {
-    const chunks: Array<Buffer> = [];
+    const chunks: Buffer[] = [];
 
     stream.on(`error`, error => {
       reject(error);


### PR DESCRIPTION
## Description

- `benchmarks/performance/ary.bench.ts`: `no-unused-vars` error. This is a test code, so just add eslint-disable comment.
- `benchmarks/performance/unary.bench.ts`: `no-unused-vars` error. This is a test code, so just add eslint-disable comment.
- `benchmarks/performance/zipObjectDeep.bench.ts`: Remove unused variable.
- `src/compat/_internal/isSetMatch.spec.ts`: Remove unused import.
- `src/compat/object/cloneDeep.spec.ts`: Remove unused objects and style format.
- `src/compat/object/mapKeys.spec.ts`: `no-sparse-arrays` error. This is a test code, so just add eslint-disable comment.
- `src/compat/object/mapKeys.ts`: `[@typescript-eslint/ban-types](https://typescript-eslint.io/rules/ban-types)` error. I change to object type.
- `src/compat/object/property.spec.ts`: `no-unused-vars` error. I removed the unused variable and style format.
- `src/compat/predicate/isMatch.spec.ts`: `prefer-const` error. I change to `const`.
- `src/compat/predicate/matches.spec.ts`: `prefer-const` error. I change to `const`.
- `src/object/mapKeys.ts`:`[@typescript-eslint/ban-types](https://typescript-eslint.io/rules/ban-types)` error. I change to object type.
- `tests/utils/streamToBuffer.ts`:[@typescript-eslint/array-type](https://typescript-eslint.io/rules/array-type) error. I change to `Buffer[]` type.

close #341 