### PR TITLE
feat(indexOf): implement `indexOf` in `es-toolkit/compat`

### DIFF
--- a/benchmarks/performance/indexOf.bench.ts
+++ b/benchmarks/performance/indexOf.bench.ts
@@ -1,0 +1,23 @@
+import { bench, describe } from 'vitest';
+import { indexOf as indexOfToolkitComapt } from 'es-toolkit/compat';
+import { indexOf as indexOfLodash } from 'lodash';
+
+describe('indexOf', () => {
+  const array = [1, 2, 3, 4, NaN, '1', '2', '3', '4', 'NaN'];
+
+  bench('es-toolkit/compat/indexOf', () => {
+    indexOfToolkitComapt(array, 3);
+    indexOfToolkitComapt(array, NaN);
+    indexOfToolkitComapt(array, '1');
+    indexOfToolkitComapt(array, 'NaN', -5);
+    indexOfToolkitComapt(array, 'NaN', -100);
+  });
+
+  bench('lodash/indexOf', () => {
+    indexOfLodash(array, 3);
+    indexOfLodash(array, NaN);
+    indexOfLodash(array, '1');
+    indexOfLodash(array, 'NaN', -5);
+    indexOfLodash(array, 'NaN', -100);
+  });
+});

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -69,7 +69,7 @@ Even if a feature is marked "in review," it might already be under review to ens
 | [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | ✅                    |
 | [fromPairs](https://lodash.com/docs/4.17.15#fromPairs)                 | ❌                    |
 | [head](https://lodash.com/docs/4.17.15#head)                           | ✅                    |
-| [indexOf](https://lodash.com/docs/4.17.15#indexOf)                     | ❌                    |
+| [indexOf](https://lodash.com/docs/4.17.15#indexOf)                     | ✅                    |
 | [initial](https://lodash.com/docs/4.17.15#initial)                     | ✅                    |
 | [intersection](https://lodash.com/docs/4.17.15#intersection)           | 📝                    |
 | [intersectionBy](https://lodash.com/docs/4.17.15#intersectionBy)       | 📝                    |

--- a/docs/ko/compatibility.md
+++ b/docs/ko/compatibility.md
@@ -70,7 +70,7 @@ chunk([1, 2, 3, 4], 0);
 | [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | ✅            |
 | [fromPairs](https://lodash.com/docs/4.17.15#fromPairs)                 | ❌            |
 | [head](https://lodash.com/docs/4.17.15#head)                           | 📝            |
-| [indexOf](https://lodash.com/docs/4.17.15#indexOf)                     | ❌            |
+| [indexOf](https://lodash.com/docs/4.17.15#indexOf)                     | ✅            |
 | [initial](https://lodash.com/docs/4.17.15#initial)                     | ✅            |
 | [intersection](https://lodash.com/docs/4.17.15#intersection)           | 📝            |
 | [intersectionBy](https://lodash.com/docs/4.17.15#intersectionBy)       | 📝            |

--- a/docs/zh_hans/compatibility.md
+++ b/docs/zh_hans/compatibility.md
@@ -69,7 +69,7 @@ chunk([1, 2, 3, 4], 0);
 | [flattenDepth](https://lodash.com/docs/4.17.15#flattenDepth)           | ✅         |
 | [fromPairs](https://lodash.com/docs/4.17.15#fromPairs)                 | ❌         |
 | [head](https://lodash.com/docs/4.17.15#head)                           | 📝         |
-| [indexOf](https://lodash.com/docs/4.17.15#indexOf)                     | ❌         |
+| [indexOf](https://lodash.com/docs/4.17.15#indexOf)                     | ✅         |
 | [initial](https://lodash.com/docs/4.17.15#initial)                     | ✅         |
 | [intersection](https://lodash.com/docs/4.17.15#intersection)           | 📝         |
 | [intersectionBy](https://lodash.com/docs/4.17.15#intersectionBy)       | 📝         |

--- a/src/compat/_internal/stubZero.ts
+++ b/src/compat/_internal/stubZero.ts
@@ -1,0 +1,3 @@
+export const stubZero = function () {
+  return 0;
+};

--- a/src/compat/array/indexOf.spec.ts
+++ b/src/compat/array/indexOf.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { indexOf } from './indexOf';
+import { falsey } from '../_internal/falsey';
+import { stubZero } from '../_internal/stubZero';
+
+/**
+ * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/indexOf.spec.js
+ */
+describe('indexOf', () => {
+  const array = [1, 2, 3, 1, 2, 3];
+
+  it('should return the index of the first matched value', () => {
+    expect(indexOf(array, 3)).toBe(2);
+  });
+
+  it('should work with a positive `fromIndex`', () => {
+    expect(indexOf(array, 1, 2)).toBe(3);
+  });
+
+  it('should work with a `fromIndex` >= `length`', () => {
+    const values = [6, 8, 2 ** 32, Infinity];
+    const expected = values.map(() => [-1, -1, -1]);
+
+    const actual = values.map(fromIndex => [
+      indexOf(array, undefined, fromIndex),
+      indexOf(array, 1, fromIndex),
+      indexOf(array, '', fromIndex),
+    ]);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should work with a negative `fromIndex`', () => {
+    expect(indexOf(array, 2, -3)).toBe(4);
+  });
+
+  it('should work with a NaN `searchElement`', () => {
+    expect(indexOf([1, 2, 3, 4], NaN)).toBe(-1);
+    expect(indexOf([1, NaN, 3, NaN], NaN)).toBe(1);
+    expect(indexOf([1, NaN, 3, NaN], 3, 1)).toBe(2);
+    expect(indexOf([1, NaN, 3, NaN], 3, -2)).toBe(2);
+    expect(indexOf([1, NaN, 3, NaN], NaN, -32)).toBe(1);
+  });
+
+  it('should work with a negative `fromIndex` <= `-length`', () => {
+    const values = [-6, -8, -Infinity];
+    const expected = values.map(stubZero);
+
+    const actual = values.map(fromIndex => indexOf(array, 1, fromIndex));
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should treat falsey `fromIndex` values as `0`', () => {
+    const expected = falsey.map(stubZero);
+
+    const actual = falsey.map(fromIndex => indexOf(array, 1, fromIndex as number));
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return `-1` for array is `null` or `undefined`', () => {
+    expect(indexOf(null, 1)).toBe(-1);
+    expect(indexOf(undefined, 1)).toBe(-1);
+  });
+
+  it('should coerce `fromIndex` to an integer', () => {
+    expect(indexOf(array, 2, 1.2)).toBe(1);
+  });
+});

--- a/src/compat/array/indexOf.ts
+++ b/src/compat/array/indexOf.ts
@@ -1,0 +1,44 @@
+/**
+ * Finds the index of the first occurrence of a value in an array.
+ *
+ * This method is similar to `Array.prototype.indexOf`, but it also finds `NaN` values.
+ * It uses strict equality (`===`) to compare elements.
+ *
+ * @template T - The type of elements in the array.
+ * @template U - The type of the value to search for.
+ * @param {T[] | null | undefined} array - The array to search.
+ * @param {T | U} searchElement - The value to search for.
+ * @param {number} [fromIndex] - The index to start the search at.
+ * @returns {number} The index (zero-based) of the first occurrence of the value in the array, or `-1` if the value is not found.
+ *
+ * @example
+ * const array = [1, 2, 3, NaN];
+ * indexOf(array, 3); // => 2
+ * indexOf(array, NaN); // => 3
+ */
+export function indexOf<T, U>(array: T[] | null | undefined, searchElement: T | U, fromIndex?: number): number {
+  if (array == null) {
+    return -1;
+  }
+
+  // `Array.prototype.indexOf` doesn't find `NaN` values, so we need to handle that case separately.
+  if (Number.isNaN(searchElement)) {
+    fromIndex = fromIndex ?? 0;
+
+    if (fromIndex < 0) {
+      fromIndex = Math.max(0, array.length + fromIndex);
+    }
+
+    for (let i = fromIndex; i < array.length; i++) {
+      if (Number.isNaN(array[i])) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  // Array.prototype.indexOf already handles `fromIndex < -array.length`, `fromIndex >= array.length` and converts `fromIndex` to an integer, so we don't need to handle those cases here.
+  // And it uses strict equality (===) to compare elements like `lodash/indexOf` does.
+  return array.indexOf(searchElement as T, fromIndex);
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -36,6 +36,7 @@ export { orderBy } from './array/orderBy.ts';
 export { size } from './array/size.ts';
 export { zipObjectDeep } from './array/zipObjectDeep.ts';
 export { head as first } from '../array/head.ts';
+export { indexOf } from './array/indexOf.ts';
 
 export { ary } from './function/ary.ts';
 export { bind } from './function/bind.ts';


### PR DESCRIPTION
## Description

I implement this function based on `Array.prototype.indexOf`.

Its behavior is  already similar with `lodash/indexof`.

> https://tc39.es/ecma262/#sec-array.prototype.indexof

But it can't find a `NaN` searchElement, so I add codes handling this case.

### Benchmark

![Screenshot 2024-08-11 at 5 15 02 PM](https://github.com/user-attachments/assets/78dd029e-e814-4594-9252-d93a539f3b50)

close #377 