### PR TITLE
feat(compat): add `padEnd`

### DIFF
--- a/benchmarks/performance/padEnd.bench.ts
+++ b/benchmarks/performance/padEnd.bench.ts
@@ -1,0 +1,15 @@
+import { bench, describe } from 'vitest';
+import { padEnd as padStartToolkit } from 'es-toolkit/compat';
+import { padEnd as padStartLodash } from 'lodash';
+
+describe('padEnd', () => {
+  bench('es-toolkit/padEnd', () => {
+    const str = 'abc';
+    padStartToolkit(str, 6, '_-');
+  });
+
+  bench('lodash/padEnd', () => {
+    const str = 'abc';
+    padStartLodash(str, 6, '_-');
+  });
+});

--- a/benchmarks/performance/padStart.bench.ts
+++ b/benchmarks/performance/padStart.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from 'vitest';
-import { padStart as padStartToolkit } from 'es-toolkit';
+import { padStart as padStartToolkit } from 'es-toolkit/compat';
 import { padStart as padStartLodash } from 'lodash';
 
 describe('padStart', () => {

--- a/docs/reference/compat/string/padEnd.md
+++ b/docs/reference/compat/string/padEnd.md
@@ -1,0 +1,36 @@
+# padEnd
+
+::: info
+This function is only available in `es-toolkit/compat` for compatibility reasons. It either has alternative native JavaScript APIs or isn’t fully optimized yet.
+
+When imported from `es-toolkit/compat`, it behaves exactly like lodash and provides the same functionalities, as detailed [here](../../../compatibility.md).
+:::
+
+Pads the end of a string with a given character until it reaches the specified length.
+
+If the length is less than or equal to the original string's length, or if the padding character is an empty string,
+the original string is returned unchanged.
+
+## Signature
+
+```typescript
+function padEnd(str: string, length = 0, chars = ' '): string;
+```
+
+## Parameters
+
+- `str` (`string`): The string to pad.
+- `length` (`number`): The length of the resulting string. Defaults to `0`.
+- `char` (`string`): The character to pad the string with. Defaults to `' '`.
+
+## Returns
+
+Returns a new string padded with the specified character until it reaches the specified length.
+
+## Examples
+
+```javascript
+padEnd('hello', 10, 'a'); // 'helloaaaaa'
+padEnd('hello', 3, 'a'); // 'hello'
+padEnd('hello', 5, ''); // 'hello'
+```

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -66,6 +66,7 @@ export { matchesProperty } from './predicate/matchesProperty.ts';
 export { startsWith } from './string/startsWith.ts';
 export { endsWith } from './string/endsWith.ts';
 export { padStart } from './string/padStart.ts';
+export { padEnd } from './string/padEnd.ts';
 
 export { max } from './math/max.ts';
 export { min } from './math/min.ts';

--- a/src/compat/string/padEnd.spec.ts
+++ b/src/compat/string/padEnd.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { padEnd } from './padEnd';
+
+describe('padEnd', () => {
+  it('should return the original string if no length and char is provided', () => {
+    expect(padEnd('abc')).toBe('abc');
+  });
+
+  it('should pad a string on the right side if it is shorter than the length', () => {
+    expect(padEnd('abc', 6)).toBe('abc   ');
+  });
+
+  it('should pad a string on the right side with custom characters', () => {
+    expect(padEnd('abc', 6, '_-')).toBe('abc_-_');
+  });
+
+  it('should not pad a string if it has the same length', () => {
+    expect(padEnd('abc', 3)).toBe('abc');
+  });
+
+  it('should not pad a string if the length is less than the string length', () => {
+    expect(padEnd('abc', 2)).toBe('abc');
+  });
+
+  it('should not pad a string if the length is not a number', () => {
+    expect(padEnd('abc', NaN)).toBe('abc');
+  });
+
+  it('should not pad a string if the length is not an integer', () => {
+    expect(padEnd('abc', 3.5)).toBe('abc');
+  });
+
+  it('should not pad a string if the length is negative', () => {
+    expect(padEnd('abc', -3)).toBe('abc');
+  });
+});

--- a/src/compat/string/padEnd.ts
+++ b/src/compat/string/padEnd.ts
@@ -1,0 +1,21 @@
+/**
+ * Pads the end of a string with a given character until it reaches the specified length.
+ *
+ * If the length is less than or equal to the original string's length, or if the padding character is an empty string,
+ * the original string is returned unchanged.
+ *
+ * @param {string} str - The string to pad.
+ * @param {number} [length] - The length of the resulting string once padded.
+ * @param {string} [chars] - The character(s) to use for padding.
+ * @returns {string} - The padded string, or the original string if padding is not required.
+ *
+ * @example
+ * const result1 = padEnd('abc', 6);          // result will be 'abc   '
+ * const result2 = padEnd('abc', 6, '_-');    // result will be 'abc_-_'
+ * const result3 = padEnd('abc', 3);          // result will be 'abc'
+ * const result4 = padEnd('abc', 2);          // result will be 'abc'
+ */
+
+export function padEnd(str: string, length = 0, chars = ' '): string {
+  return str.padEnd(length, chars);
+}


### PR DESCRIPTION
### Solution

We can use the native [padEnd](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd) API instead of a custom solution.

<img width="883" alt="Screenshot 2024-08-11 at 18 17 00" src="https://github.com/user-attachments/assets/a513d532-642f-4019-9d58-cbadbd13d02c">

Resolves #332