### PR TITLE
refactor(sortBy, orderBy): use same compareValues function in internal and fix type

### DIFF
--- a/docs/reference/array/sortBy.md
+++ b/docs/reference/array/sortBy.md
@@ -10,7 +10,7 @@ The function returns the array of objects sorted in ascending order. If two obje
 ## Signature
 
 ```typescript
-function sortBy<T extends object>(arr: T[], criteria: Array<keyof T | ((item: T) => unknown)>): T[];
+function sortBy<T extends object>(arr: T[], criteria: Array<((item: T) => unknown) | keyof T>): T[];
 ```
 
 ### Parameters

--- a/docs/zh_hans/reference/array/sortBy.md
+++ b/docs/zh_hans/reference/array/sortBy.md
@@ -10,7 +10,7 @@
 ## 签名
 
 ```typescript
-function sortBy<T extends object>(arr: T[], criteria: Array<keyof T | ((item: T) => unknown)>): T[];
+function sortBy<T extends object>(arr: T[], criteria: Array<((item: T) => unknown) | keyof T>): T[];
 ```
 
 ### 参数

--- a/src/_internal/compareValues.ts
+++ b/src/_internal/compareValues.ts
@@ -1,9 +1,9 @@
-export function compareValues(a: any, b: any): 0 | -1 | 1 {
+export function compareValues(a: any, b: any, order: 'asc' | 'desc'): 0 | -1 | 1 {
   if (a < b) {
-    return -1;
+    return order === 'asc' ? -1 : 1;
   }
   if (a > b) {
-    return 1;
+    return order === 'asc' ? 1 : -1;
   }
   return 0;
 }

--- a/src/array/orderBy.ts
+++ b/src/array/orderBy.ts
@@ -1,3 +1,5 @@
+import { compareValues } from '../_internal/compareValues';
+
 type Order = 'asc' | 'desc';
 
 /**
@@ -32,16 +34,6 @@ type Order = 'asc' | 'desc';
  * // ]
  */
 export function orderBy<T>(collection: T[], keys: Array<keyof T>, orders: Order[]): T[] {
-  const compareValues = (a: T[keyof T], b: T[keyof T], order: Order) => {
-    if (a < b) {
-      return order === 'asc' ? -1 : 1;
-    }
-    if (a > b) {
-      return order === 'asc' ? 1 : -1;
-    }
-    return 0;
-  };
-
   const effectiveOrders = keys.map((_, index) => orders[index] || orders[orders.length - 1]);
 
   return collection.slice().sort((a, b) => {

--- a/src/array/sortBy.ts
+++ b/src/array/sortBy.ts
@@ -11,7 +11,8 @@ import { compareValues } from '../_internal/compareValues';
  *
  * @template T - The type of the objects in the array.
  * @param {T[]} arr - The array of objects to be sorted.
- * @param {Array<(item: T) => unknown | keyof T>} criteria - The criteria for sorting. This can be an array of object keys or functions that return values used for sorting.
+ * @param {Array<((item: T) => unknown) | keyof T>} criteria - The criteria for sorting. This can be an array of object keys or functions that return values used for sorting.
+ * @returns {T[]} - The sorted array.
  *
  * @example
  * const users = [
@@ -31,7 +32,7 @@ import { compareValues } from '../_internal/compareValues';
  * //   { user : 'foo', age: 24 },
  * // ]
  */
-export function sortBy<T extends object>(arr: T[], criteria: Array<(item: T) => unknown | keyof T>): T[] {
+export function sortBy<T extends object>(arr: T[], criteria: Array<((item: T) => unknown) | keyof T>): T[] {
   return arr.slice().sort((a, b) => {
     for (let i = 0; i < criteria.length; i++) {
       const iteratee = criteria[i];

--- a/src/array/sortBy.ts
+++ b/src/array/sortBy.ts
@@ -40,7 +40,7 @@ export function sortBy<T extends object>(arr: T[], criteria: Array<(item: T) => 
       const valueA = iterateeIsFunction ? iteratee(a) : a[iteratee];
       const valueB = iterateeIsFunction ? iteratee(b) : b[iteratee];
 
-      const result = compareValues(valueA, valueB);
+      const result = compareValues(valueA, valueB, 'asc');
 
       if (result !== 0) {
         return result;


### PR DESCRIPTION
## Description

I think that `orderBy` function also has to use `_internal/compareValues` function.

So I add a `order` argument in `_internal/compareValues` function.

## ⚠️ And I fix type of a criteria argument, it forgot parentheses.