### PR TITLE
feat(orderBy): implement a feature of custom key functions in a `compat/orderBy`

### DIFF
--- a/benchmarks/performance/orderBy.bench.ts
+++ b/benchmarks/performance/orderBy.bench.ts
@@ -44,3 +44,13 @@ describe('orderBy (property path)', () => {
     orderByLodash(users, ['nested.user', 'age'], orders);
   });
 });
+
+describe('orderBy (custom key function)', () => {
+  bench('es-toolkit/compat/orderBy', () => {
+    orderByToolkitCompat(users, [item => item.user, item => item.age], orders);
+  });
+
+  bench('lodash/orderBy', () => {
+    orderByLodash(users, [item => item.user, item => item.age], orders);
+  });
+});

--- a/src/compat/_internal/getPath.ts
+++ b/src/compat/_internal/getPath.ts
@@ -4,9 +4,10 @@ import { toPath } from './toPath';
 /**
  * Get the `path` (property name) from the `key` (property name or property path).
  *
- * @param {string | string[]} key - The `key` (property name or property path) to convert.
- * @param {object} object - The object to query.
- * @returns {string | string[]} The converted key (only property name).
+ * @template T - The type of the object.
+ * @param {((item: T) => unknown) | string | string[]} key - The `key` (property name or property path or custom key function) to query.
+ * @param {T} object - The object to query.
+ * @returns {((item: T) => unknown) | string | string[]} The converted key (only property name or custom key function).
  */
 export function getPath<T extends object>(
   key: ((item: T) => unknown) | string | string[],
@@ -14,19 +15,19 @@ export function getPath<T extends object>(
 ): ((item: T) => unknown) | string | string[] {
   if (Array.isArray(key)) {
     const path = [];
-    let keyOwner: object = object;
+    let current: object = object;
 
     for (let i = 0; i < key.length; i++) {
       const k = key[i];
 
-      if (isKey(k, keyOwner)) {
-        keyOwner = keyOwner[k as keyof typeof keyOwner];
+      if (isKey(k, current)) {
+        current = current[k as keyof typeof current];
         path.push(k);
       } else {
         const keys = toPath(k);
 
         for (let i = 0; i < keys.length; i++) {
-          keyOwner = keyOwner[keys[i] as keyof typeof keyOwner];
+          current = current[keys[i] as keyof typeof current];
           path.push(keys[i]);
         }
       }
@@ -34,9 +35,10 @@ export function getPath<T extends object>(
 
     return path;
   }
-  if (typeof key === 'function') {
+
+  if (typeof key === 'function' || isKey(key, object)) {
     return key;
   }
 
-  return isKey(key, object) ? key : toPath(key);
+  return toPath(key);
 }

--- a/src/compat/_internal/getPath.ts
+++ b/src/compat/_internal/getPath.ts
@@ -8,27 +8,34 @@ import { toPath } from './toPath';
  * @param {object} object - The object to query.
  * @returns {string | string[]} The converted key (only property name).
  */
-export function getPath(key: string | string[], object: object): string | string[] {
+export function getPath<T extends object>(
+  key: ((item: T) => unknown) | string | string[],
+  object: T
+): ((item: T) => unknown) | string | string[] {
   if (Array.isArray(key)) {
     const path = [];
+    let keyOwner: object = object;
 
     for (let i = 0; i < key.length; i++) {
       const k = key[i];
 
-      if (isKey(k, object)) {
-        object = object[k as keyof typeof object];
+      if (isKey(k, keyOwner)) {
+        keyOwner = keyOwner[k as keyof typeof keyOwner];
         path.push(k);
       } else {
         const keys = toPath(k);
 
         for (let i = 0; i < keys.length; i++) {
-          object = object[keys[i] as keyof typeof object];
+          keyOwner = keyOwner[keys[i] as keyof typeof keyOwner];
           path.push(keys[i]);
         }
       }
     }
 
     return path;
+  }
+  if (typeof key === 'function') {
+    return key;
   }
 
   return isKey(key, object) ? key : toPath(key);

--- a/src/compat/_internal/getPath.ts
+++ b/src/compat/_internal/getPath.ts
@@ -15,19 +15,19 @@ export function getPath<T extends object>(
 ): ((item: T) => unknown) | string | string[] {
   if (Array.isArray(key)) {
     const path = [];
-    let current: object = object;
+    let target: object = object;
 
     for (let i = 0; i < key.length; i++) {
       const k = key[i];
 
-      if (isKey(k, current)) {
-        current = current[k as keyof typeof current];
+      if (isKey(k, target)) {
+        target = target[k as keyof typeof target];
         path.push(k);
       } else {
         const keys = toPath(k);
 
         for (let i = 0; i < keys.length; i++) {
-          current = current[keys[i] as keyof typeof current];
+          target = target[keys[i] as keyof typeof target];
           path.push(keys[i]);
         }
       }

--- a/src/compat/array/orderBy.spec.ts
+++ b/src/compat/array/orderBy.spec.ts
@@ -80,4 +80,13 @@ describe('orderBy', () => {
 
     expect(actual).toEqual(expected);
   });
+
+  it('should work with `keys` specified as functions', () => {
+    expect(orderBy(objects, [item => item.a, item => item.b], ['desc', 'asc'])).toEqual([
+      objects[3],
+      objects[1],
+      objects[2],
+      objects[0],
+    ]);
+  });
 });

--- a/src/compat/array/orderBy.ts
+++ b/src/compat/array/orderBy.ts
@@ -10,7 +10,7 @@ import { getPath } from '../_internal/getPath';
  *
  * @template T - The type of elements in the array.
  * @param {T[] | null} collection - The array of objects to be sorted.
- * @param {string | Array<string | string[]>} keys - An array of keys (property names or property paths) to sort by.
+ * @param {((item: T) => unknown) | string | Array<((item: T) => unknown) | string | string[]>} keys - An array of keys (property names or property paths or custom key functions) to sort by.
  * @param {unknown | unknown[]} orders - An array of order directions ('asc' for ascending or 'desc' for descending).
  * @returns {T[]} - The sorted array.
  *
@@ -22,7 +22,7 @@ import { getPath } from '../_internal/getPath';
  *   { user: 'fred', age: 40 },
  *   { user: 'barney', age: 36 },
  * ];
- * const result = orderBy(users, ['user', 'age'], ['asc', 'desc']);
+ * const result = orderBy(users, ['user', (item) => item.age], ['asc', 'desc']);
  * // result will be:
  * // [
  * //   { user: 'barney', age: 36 },
@@ -32,8 +32,8 @@ import { getPath } from '../_internal/getPath';
  * // ]
  */
 export function orderBy<T extends object>(
-  collection?: T[] | null,
-  keys?: string | Array<string | string[]>,
+  collection: T[] | null | undefined,
+  keys?: ((item: T) => unknown) | string | Array<((item: T) => unknown) | string | string[]>,
   orders?: unknown | unknown[]
 ): T[] {
   if (collection == null) {
@@ -60,7 +60,7 @@ export function orderBy<T extends object>(
     return 0;
   };
 
-  const getValueByPath = (key: string | string[], obj: T) => {
+  const getValueByPath = (key: string | ((item: T) => unknown) | string[], obj: T) => {
     if (Array.isArray(key)) {
       let value: object = obj;
 
@@ -69,6 +69,10 @@ export function orderBy<T extends object>(
       }
 
       return value;
+    }
+
+    if (typeof key === 'function') {
+      return key(obj);
     }
 
     return obj[key as keyof typeof obj];

--- a/src/compat/array/orderBy.ts
+++ b/src/compat/array/orderBy.ts
@@ -60,32 +60,32 @@ export function orderBy<T extends object>(
     return 0;
   };
 
-  const getValueByPath = (key: string | ((item: T) => unknown) | string[], obj: T) => {
-    if (Array.isArray(key)) {
+  const getValueByPath = (path: string | ((item: T) => unknown) | string[], obj: T) => {
+    if (Array.isArray(path)) {
       let value: object = obj;
 
-      for (let i = 0; i < key.length; i++) {
-        value = value[key[i] as keyof typeof value];
+      for (let i = 0; i < path.length; i++) {
+        value = value[path[i] as keyof typeof value];
       }
 
       return value;
     }
 
-    if (typeof key === 'function') {
-      return key(obj);
+    if (typeof path === 'function') {
+      return path(obj);
     }
 
-    return obj[key as keyof typeof obj];
+    return obj[path as keyof typeof obj];
   };
 
   keys = keys.map(key => getPath(key, collection[0]));
 
   return collection.slice().sort((a, b) => {
     for (let i = 0; i < keys.length; i++) {
-      const key = keys[i];
+      const path = keys[i];
 
-      const valueA = getValueByPath(key, a);
-      const valueB = getValueByPath(key, b);
+      const valueA = getValueByPath(path, a);
+      const valueB = getValueByPath(path, b);
       const order = String((orders as unknown[])[i]); // For Object('desc') case
 
       const comparedResult = compareValues(valueA, valueB, order);

--- a/src/compat/array/orderBy.ts
+++ b/src/compat/array/orderBy.ts
@@ -80,8 +80,7 @@ export function orderBy<T extends object>(
 
   keys = keys.map(key => getPath(key, collection[0]));
 
-  const shallowCopiedCollection = collection.slice();
-  const orderedCollection = shallowCopiedCollection.sort((a, b) => {
+  return collection.slice().sort((a, b) => {
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
 
@@ -98,6 +97,4 @@ export function orderBy<T extends object>(
 
     return 0;
   });
-
-  return orderedCollection;
 }


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/f19cdeb9-1807-477f-8cf1-0e867fee26f1)

`lodash/orderBy` has a feature of custom key functions, but `es-toolkit/compat/orderBy` doesn't have it.

I think that it makes confusion, so I added it.

### Benchmarks

![Screenshot 2024-08-16 at 3 38 40 PM](https://github.com/user-attachments/assets/689cbe8a-bddd-4542-ac0e-a231f9645417)

related #383, #361