### PR TITLE
feat(orderBy, sortBy): support custom key functions in `orderBy` and integrate `sortBy` with `orderBy`

### DIFF
--- a/benchmarks/performance/orderBy.bench.ts
+++ b/benchmarks/performance/orderBy.bench.ts
@@ -15,14 +15,17 @@ const orders: Array<'asc' | 'desc'> = ['asc', 'desc'];
 describe('orderBy', () => {
   bench('es-toolkit/orderBy', () => {
     orderByToolkit(users, keys, orders);
+    orderByToolkit(users, [user => user.user, user => user.age], orders);
   });
 
   bench('es-toolkit/compat/orderBy', () => {
     orderByToolkitCompat(users, keys, orders);
+    orderByToolkitCompat(users, [user => user.user, user => user.age], orders);
   });
 
   bench('lodash/orderBy', () => {
     orderByLodash(users, keys, orders);
+    orderByLodash(users, [user => user.user, user => user.age], orders);
   });
 });
 
@@ -42,15 +45,5 @@ describe('orderBy (property path)', () => {
   });
   bench('lodash/orderBy', () => {
     orderByLodash(users, ['nested.user', 'age'], orders);
-  });
-});
-
-describe('orderBy (custom key function)', () => {
-  bench('es-toolkit/compat/orderBy', () => {
-    orderByToolkitCompat(users, [item => item.user, item => item.age], orders);
-  });
-
-  bench('lodash/orderBy', () => {
-    orderByLodash(users, [item => item.user, item => item.age], orders);
   });
 });

--- a/docs/ko/reference/array/orderBy.md
+++ b/docs/ko/reference/array/orderBy.md
@@ -2,21 +2,30 @@
 
 여러 속성과 해당 순서 방향에 따라 객체 배열을 정렬해요.
 
-이 함수는 객체 배열, 정렬할 키의 배열, 그리고 정렬 방향의 배열을 받아요.
-각 키에 대해 해당 방향('asc'는 오름차순, 'desc'는 내림차순)에 따라 정렬된 배열을 반환해요.
-키의 값이 동일한 경우 다음 키를 기준으로 정렬 순서를 결정해요.
+주어진 조건 `criteria` 그리고 지정한 순서 방향에 따라서 객체로 이루어진 배열을 정렬해요.
+
+- 조건이 프로퍼티 이름이면, 해당하는 프로퍼티 값에 따라 정렬해요.
+- 조건이 함수이면, 함수가 반환하는 값에 따라 정렬해요.
+
+배열은 지정된 순서에 따라 오름차순(`asc`) 혹은 내림차순(`desc`)으로 정렬돼요.
+조건에 따라 두 요소의 값이 같으면, 다음 조건으로 정렬해요.
+만약에 순서의 개수가 조건의 개수보다 적으면, 나머지는 마지막 순서로 정렬돼요.
 
 ## Signature
 
 ```typescript
-function orderBy<T>(collection: T[], keys: Array<keyof T>, orders: Order[]): T[];
+function orderBy<T extends object>(
+  arr: T[],
+  criteria: Array<((item: T) => unknown) | keyof T>,
+  orders: Array<'asc' | 'desc'>
+): T[];
 ```
 
 ### Parameters
 
-- `collection` (`T[]`): 정렬할 객체 배열.
-- `keys` (`Array<keyof T>`): 정렬할 키(속성) 배열.
-- `orders` (`Order[]`): 각 키에 대한 정렬 방향 배열('asc'는 오름차순, 'desc'는 내림차순).
+- `arr` (`T[]`): 정렬할 객체 배열.
+- `criteria` (`Array<((item: T) => unknown) | keyof T>`): 정렬할 기준. 객체의 프로퍼티 이름이나 함수를 쓸 수 있어요.
+- `orders` (`Array<'asc' | 'desc'>)`): 각 키에 대한 정렬 방향 배열('asc'는 오름차순, 'desc'는 내림차순).
 
 ### Returns
 
@@ -25,6 +34,7 @@ function orderBy<T>(collection: T[], keys: Array<keyof T>, orders: Order[]): T[]
 ## Examples
 
 ```typescript
+// Sort an array of objects by 'user' in ascending order and 'age' in descending order.
 const users = [
   { user: 'fred', age: 48 },
   { user: 'barney', age: 34 },
@@ -32,7 +42,7 @@ const users = [
   { user: 'barney', age: 36 },
 ];
 
-const result = orderBy(users, ['user', 'age'], ['asc', 'desc']);
+const result = orderBy(users, [obj => obj.user, 'age'], ['asc', 'desc']);
 // result will be:
 // [
 //   { user: 'barney', age: 36 },

--- a/docs/reference/array/orderBy.md
+++ b/docs/reference/array/orderBy.md
@@ -1,23 +1,29 @@
 # orderBy
 
-Sorts an array of objects based on multiple properties and their corresponding order directions.
+Sorts an array of objects based on the given `criteria` and their corresponding order directions.
 
-This function takes an array of objects, an array of keys to sort by, and an array of order directions.
-It returns the sorted array, ordering by each key according to its corresponding direction
-('asc' for ascending or 'desc' for descending). If values for a key are equal,
-it moves to the next key to determine the order.
+- If you provide keys, it sorts the objects by the values of those keys.
+- If you provide functions, it sorts based on the values returned by those functions.
+
+The function returns the array of objects sorted in corresponding order directions.
+If two objects have the same value for the current criterion, it uses the next criterion to determine their order.
+If the number of orders is less than the number of criteria, it uses the last order for the remaining criteria.
 
 ## Signature
 
 ```typescript
-function orderBy<T>(collection: T[], keys: Array<keyof T>, orders: Order[]): T[];
+function orderBy<T extends object>(
+  arr: T[],
+  criteria: Array<((item: T) => unknown) | keyof T>,
+  orders: Array<'asc' | 'desc'>
+): T[];
 ```
 
 ### Parameters
 
-- `collection` (`T[]`): The array of objects to be sorted.
-- `keys` (`Array<keyof T>`): An array of keys (properties) by which to sort.
-- `orders` (`Order[]`): An array of order directions ('asc' for ascending or 'desc' for descending).
+- `arr` (`T[]`): The array of objects to be sorted.
+- `criteria` (`Array<keyof T | ((item: T) => unknown)>`): The criteria for sorting. This can be an array of object keys or functions that return values used for sorting.
+- `orders` (`Array<'asc' | 'desc'>)`): An array of order directions ('asc' for ascending or 'desc' for descending).
 
 ### Returns
 
@@ -26,6 +32,7 @@ function orderBy<T>(collection: T[], keys: Array<keyof T>, orders: Order[]): T[]
 ## Examples
 
 ```typescript
+// Sort an array of objects by 'user' in ascending order and 'age' in descending order.
 const users = [
   { user: 'fred', age: 48 },
   { user: 'barney', age: 34 },
@@ -33,7 +40,7 @@ const users = [
   { user: 'barney', age: 36 },
 ];
 
-const result = orderBy(users, ['user', 'age'], ['asc', 'desc']);
+const result = orderBy(users, [obj => obj.user, 'age'], ['asc', 'desc']);
 // result will be:
 // [
 //   { user: 'barney', age: 36 },

--- a/src/array/orderBy.spec.ts
+++ b/src/array/orderBy.spec.ts
@@ -2,17 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { orderBy } from './orderBy';
 
 describe('orderBy', () => {
+  const users = [
+    { user: 'fred', age: 48 },
+    { user: 'barney', age: 34 },
+    { user: 'fred', age: 40 },
+    { user: 'barney', age: 36 },
+  ];
+
   it('should order objects by a single property in ascending order', () => {
-    const users = [
-      { user: 'fred', age: 48 },
-      { user: 'barney', age: 34 },
-      { user: 'fred', age: 40 },
-      { user: 'barney', age: 36 },
-    ];
-
-    const result = orderBy(users, ['user'], ['asc']);
-
-    expect(result).toEqual([
+    expect(orderBy(users, ['user'], ['asc'])).toEqual([
       { user: 'barney', age: 34 },
       { user: 'barney', age: 36 },
       { user: 'fred', age: 48 },
@@ -21,16 +19,7 @@ describe('orderBy', () => {
   });
 
   it('should order objects by a single property in descending order', () => {
-    const users = [
-      { user: 'fred', age: 48 },
-      { user: 'barney', age: 34 },
-      { user: 'fred', age: 40 },
-      { user: 'barney', age: 36 },
-    ];
-
-    const result = orderBy(users, ['user'], ['desc']);
-
-    expect(result).toEqual([
+    expect(orderBy(users, ['user'], ['desc'])).toEqual([
       { user: 'fred', age: 48 },
       { user: 'fred', age: 40 },
       { user: 'barney', age: 34 },
@@ -39,16 +28,7 @@ describe('orderBy', () => {
   });
 
   it('should order objects by multiple properties', () => {
-    const users = [
-      { user: 'fred', age: 48 },
-      { user: 'barney', age: 34 },
-      { user: 'fred', age: 40 },
-      { user: 'barney', age: 36 },
-    ];
-
-    const result = orderBy(users, ['user', 'age'], ['asc', 'desc']);
-
-    expect(result).toEqual([
+    expect(orderBy(users, ['user', 'age'], ['asc', 'desc'])).toEqual([
       { user: 'barney', age: 36 },
       { user: 'barney', age: 34 },
       { user: 'fred', age: 48 },
@@ -56,17 +36,24 @@ describe('orderBy', () => {
     ]);
   });
 
+  const users2 = [
+    { user: 'fred', age: 48 },
+    { user: 'barney', age: 36 },
+    { user: 'fred', age: 40 },
+    { user: 'barney', age: 34 },
+  ];
+
   it('should extend orders if orders length is less than keys length', () => {
-    const users = [
-      { user: 'fred', age: 48 },
+    expect(orderBy(users2, ['user', 'age'], ['asc'])).toEqual([
+      { user: 'barney', age: 34 },
       { user: 'barney', age: 36 },
       { user: 'fred', age: 40 },
-      { user: 'barney', age: 34 },
-    ];
+      { user: 'fred', age: 48 },
+    ]);
+  });
 
-    const result = orderBy(users, ['user', 'age'], ['asc']);
-
-    expect(result).toEqual([
+  it('should order objects by criteria functions', () => {
+    expect(orderBy(users2, [obj => obj.user, obj => obj.age], ['asc'])).toEqual([
       { user: 'barney', age: 34 },
       { user: 'barney', age: 36 },
       { user: 'fred', age: 40 },

--- a/src/array/orderBy.ts
+++ b/src/array/orderBy.ts
@@ -1,19 +1,19 @@
 import { compareValues } from '../_internal/compareValues';
 
-type Order = 'asc' | 'desc';
-
 /**
- * Sorts an array of objects based on multiple properties and their corresponding order directions.
+ * Sorts an array of objects based on the given `criteria` and their corresponding order directions.
  *
- * This function takes an array of objects, an array of keys to sort by, and an array of order directions.
- * It returns the sorted array, ordering by each key according to its corresponding direction
- * ('asc' for ascending or 'desc' for descending). If values for a key are equal,
- * it moves to the next key to determine the order.
+ * - If you provide keys, it sorts the objects by the values of those keys.
+ * - If you provide functions, it sorts based on the values returned by those functions.
+ *
+ * The function returns the array of objects sorted in corresponding order directions.
+ * If two objects have the same value for the current criterion, it uses the next criterion to determine their order.
+ * If the number of orders is less than the number of criteria, it uses the last order for the rest of the criteria.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} collection - The array of objects to be sorted.
- * @param {Array<keyof T>} keys - An array of keys (properties) by which to sort.
- * @param {Order[]} orders - An array of order directions ('asc' for ascending or 'desc' for descending).
+ * @param {T[]} arr - The array of objects to be sorted.
+ * @param {Array<((item: T) => unknown) | keyof T>} criteria  - The criteria for sorting. This can be an array of object keys or functions that return values used for sorting.
+ * @param {Array<'asc' | 'desc'>} orders - An array of order directions ('asc' for ascending or 'desc' for descending).
  * @returns {T[]} - The sorted array.
  *
  * @example
@@ -24,7 +24,8 @@ type Order = 'asc' | 'desc';
  *   { user: 'fred', age: 40 },
  *   { user: 'barney', age: 36 },
  * ];
- * const result = orderBy(users, ['user', 'age'], ['asc', 'desc']);
+ *
+ * const result = orderBy(users, [obj => obj.user, 'age'], ['asc', 'desc']);
  * // result will be:
  * // [
  * //   { user: 'barney', age: 36 },
@@ -33,18 +34,29 @@ type Order = 'asc' | 'desc';
  * //   { user: 'fred', age: 40 },
  * // ]
  */
-export function orderBy<T>(collection: T[], keys: Array<keyof T>, orders: Order[]): T[] {
-  const effectiveOrders = keys.map((_, index) => orders[index] || orders[orders.length - 1]);
+export function orderBy<T extends object>(
+  arr: T[],
+  criteria: Array<((item: T) => unknown) | keyof T>,
+  orders: Array<'asc' | 'desc'>
+): T[] {
+  return arr.slice().sort((a, b) => {
+    const ordersLength = orders.length;
 
-  return collection.slice().sort((a, b) => {
-    for (let i = 0; i < keys.length; i++) {
-      const key = keys[i];
-      const order = effectiveOrders[i];
-      const result = compareValues(a[key], b[key], order);
+    for (let i = 0; i < criteria.length; i++) {
+      const order = ordersLength > i ? orders[i] : orders[ordersLength - 1];
+      const criterion = criteria[i];
+      const criterionIsFunction = typeof criterion === 'function';
+
+      const valueA = criterionIsFunction ? criterion(a) : a[criterion];
+      const valueB = criterionIsFunction ? criterion(b) : b[criterion];
+
+      const result = compareValues(valueA, valueB, order);
+
       if (result !== 0) {
         return result;
       }
     }
+
     return 0;
   });
 }

--- a/src/array/sortBy.ts
+++ b/src/array/sortBy.ts
@@ -1,4 +1,4 @@
-import { compareValues } from '../_internal/compareValues';
+import { orderBy } from './orderBy';
 
 /**
  * Sorts an array of objects based on the given `criteria`.
@@ -33,21 +33,9 @@ import { compareValues } from '../_internal/compareValues';
  * // ]
  */
 export function sortBy<T extends object>(arr: T[], criteria: Array<((item: T) => unknown) | keyof T>): T[] {
-  return arr.slice().sort((a, b) => {
-    for (let i = 0; i < criteria.length; i++) {
-      const iteratee = criteria[i];
-      const iterateeIsFunction = typeof iteratee === 'function';
-
-      const valueA = iterateeIsFunction ? iteratee(a) : a[iteratee];
-      const valueB = iterateeIsFunction ? iteratee(b) : b[iteratee];
-
-      const result = compareValues(valueA, valueB, 'asc');
-
-      if (result !== 0) {
-        return result;
-      }
-    }
-
-    return 0;
-  });
+  return orderBy(
+    arr,
+    criteria,
+    criteria.map(() => 'asc')
+  );
 }

--- a/src/array/sortBy.ts
+++ b/src/array/sortBy.ts
@@ -33,9 +33,5 @@ import { orderBy } from './orderBy';
  * // ]
  */
 export function sortBy<T extends object>(arr: T[], criteria: Array<((item: T) => unknown) | keyof T>): T[] {
-  return orderBy(
-    arr,
-    criteria,
-    criteria.map(() => 'asc')
-  );
+  return orderBy(arr, criteria, ['asc']);
 }


### PR DESCRIPTION
# Description

## `orderBy`

1. I add a feature of custom key functions in `orderBy`.
2. I changed handling a case that the number of orders is less than the number of criteria, for performance.
3. And I also integrate signature and docs based on `sortBy`.

## `sortBy`

Two functions are very similar, so I integrate `sortBy` with `orderBy`.

## Benchmarks

<img width="682" alt="Screenshot 2024-08-19 at 11 00 43 AM" src="https://github.com/user-attachments/assets/6acbc7be-a3e6-4c92-bdfe-1d097678c18e">

related #383