### PR TITLE
feat(throttle): add promise based feature

### DIFF
--- a/src/function/throttle.spec.ts
+++ b/src/function/throttle.spec.ts
@@ -40,4 +40,17 @@ describe('throttle', () => {
     expect(func).toHaveBeenCalledTimes(1);
     expect(func).toHaveBeenCalledWith('test', 123);
   });
+
+  it('should work correctly if the throttled function is Promise-based and throttleMs is not provided', async () => {
+    const func = vi.fn(() => delay(1000));
+    const throttledFunc = throttle(func);
+
+    throttledFunc();
+    await delay(500);
+    throttledFunc();
+    await delay(500);
+    throttledFunc();
+
+    expect(func).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/function/throttle.ts
+++ b/src/function/throttle.ts
@@ -5,8 +5,8 @@
  *
  * @template F - The type of function.
  * @param {F} func - The function to throttle.
- * @param {number} throttleMs - The number of milliseconds to throttle executions to.
- * @returns {F} A new throttled function that accepts the same parameters as the original function.
+ * @param {number | undefined} throttleMs - The number of milliseconds to throttle executions to, but if not provided and `func` returns a Promise, the function creates a Promise-based throttled function.
+ * @returns {(...args: Parameters<F>) => void} A new throttled function that accepts the same parameters as the original function.
  *
  * @example
  * const throttledFunction = throttle(() => {
@@ -24,6 +24,13 @@
  *   throttledFunction(); // Will log 'Function executed'
  * }, 1000);
  */
+export function throttle<F extends (...args: Parameters<F>) => void>(
+  func: F,
+  throttleMs: number
+): (...args: Parameters<F>) => void;
+export function throttle<F extends (...args: Parameters<F>) => Promise<unknown>>(
+  func: F
+): (...args: Parameters<F>) => void;
 export function throttle<F extends (...args: Parameters<F>) => void | Promise<unknown>>(
   func: F,
   throttleMs?: number

--- a/src/function/throttle.ts
+++ b/src/function/throttle.ts
@@ -38,7 +38,7 @@ export function throttle<F extends (...args: Parameters<F>) => void | Promise<un
   let lastCallTime: number | null = null;
 
   if (throttleMs == null) {
-    // If `throttleMs` is not provided and the function returns a Promise, create a Promise-based throttled function
+    // If `throttleMs` is not provided, create a Promise-based throttled function
     return function (...args: Parameters<F>) {
       if (lastCallTime == null) {
         lastCallTime = Number.MAX_SAFE_INTEGER;

--- a/src/function/throttle.ts
+++ b/src/function/throttle.ts
@@ -24,17 +24,27 @@
  *   throttledFunction(); // Will log 'Function executed'
  * }, 1000);
  */
-export function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: number): F {
-  let lastCallTime: number | null;
+export function throttle<F extends (...args: Parameters<F>) => void | Promise<unknown>>(
+  func: F,
+  throttleMs?: number
+): (...args: Parameters<F>) => void {
+  let lastCallTime: number | null = null;
 
   const throttledFunction = function (...args: Parameters<F>) {
     const now = Date.now();
 
-    if (lastCallTime == null || now - lastCallTime >= throttleMs) {
+    if (throttleMs == null && lastCallTime == null) {
+      lastCallTime = Number.MAX_SAFE_INTEGER;
+      func(...args)?.finally(() => {
+        lastCallTime = null;
+      });
+    }
+
+    if (typeof throttleMs === 'number' && (lastCallTime == null || now - lastCallTime >= throttleMs)) {
       lastCallTime = now;
       func(...args);
     }
-  } as F;
+  };
 
   return throttledFunction;
 }

--- a/src/function/throttle.ts
+++ b/src/function/throttle.ts
@@ -37,21 +37,24 @@ export function throttle<F extends (...args: Parameters<F>) => void | Promise<un
 ): (...args: Parameters<F>) => void {
   let lastCallTime: number | null = null;
 
-  const throttledFunction = function (...args: Parameters<F>) {
-    const now = Date.now();
-
-    if (throttleMs == null && lastCallTime == null) {
-      lastCallTime = Number.MAX_SAFE_INTEGER;
-      func(...args)?.finally(() => {
-        lastCallTime = null;
-      });
-    }
-
-    if (typeof throttleMs === 'number' && (lastCallTime == null || now - lastCallTime >= throttleMs)) {
-      lastCallTime = now;
-      func(...args);
-    }
-  };
-
-  return throttledFunction;
+  if (throttleMs == null) {
+    // If `throttleMs` is not provided and the function returns a Promise, create a Promise-based throttled function
+    return function (...args: Parameters<F>) {
+      if (lastCallTime == null) {
+        lastCallTime = Number.MAX_SAFE_INTEGER;
+        func(...args)?.finally(() => {
+          lastCallTime = null;
+        });
+      }
+    };
+  } else {
+    // Create a time-based throttled function
+    return function (...args: Parameters<F>) {
+      const now = Date.now();
+      if (lastCallTime == null || now - lastCallTime >= throttleMs) {
+        lastCallTime = now;
+        func(...args);
+      }
+    };
+  }
 }


### PR DESCRIPTION
# Description

At now, `es-toolkit/throttle` has only a time based feature.

But if we also support promise based feature, we can do this:

``` typescript
const throttledFetch = throttle(fetch);

throttledFetch('https://es.toolkit/api/login') // Start the first fetching 
throttledFetch('https://es.toolkit/api/login') // Ignored
// End the first fetching
throttledFetch('https://es.toolkit/api/login') // Start the second fetching
// End the second fetching
```

> Currently, if the `throttleMs` parameter is not provided, then It works promise based.


I think that this feature is also good for preventing double(or nth)-clicked.

I'm not sure this feature is good for `es-toolkit`, so I stop working. But this approach is acceptable, then I am going to improve interface and change docs.