### PR TITLE
fix(timeout): Add missing export for `timeout`

### DIFF
--- a/src/promise/index.ts
+++ b/src/promise/index.ts
@@ -1,2 +1,3 @@
 export { delay } from './delay.ts';
 export { withTimeout } from './withTimeout.ts';
+export { timeout } from './timeout.ts';


### PR DESCRIPTION
Looks like the `timeout` function was mistakenly omitted from index.ts.