### PR TITLE
docs(timeout): Update docs for `timeout`

### DIFF
--- a/docs/zh_hans/reference/promise/timeout.md
+++ b/docs/zh_hans/reference/promise/timeout.md
@@ -5,7 +5,7 @@
 ## 签名
 
 ```typescript
-function timeout(ms: number): Promise<void>;
+function timeout(ms: number): Promise<never>;
 ```
 
 ### 参数

--- a/src/promise/timeout.ts
+++ b/src/promise/timeout.ts
@@ -5,7 +5,7 @@ import { TimeoutError } from '../error/TimeoutError.ts';
  * Returns a promise that rejects with a `TimeoutError` after a specified delay.
  *
  * @param {number} ms - The delay duration in milliseconds.
- * @returns {Promise<void>} A promise that rejects with a `TimeoutError` after the specified delay.
+ * @returns {Promise<never>} A promise that rejects with a `TimeoutError` after the specified delay.
  * @throws {TimeoutError} Throws a `TimeoutError` after the specified delay.
  */
 export async function timeout(ms: number): Promise<never> {


### PR DESCRIPTION
I've corrected the docs for the `timeout` function.