### PR TITLE
fix(countBy): Support nemeric and symbol keys in `countBy`

### DIFF
--- a/docs/ko/reference/array/countBy.md
+++ b/docs/ko/reference/array/countBy.md
@@ -5,17 +5,17 @@
 ## 인터페이스
 
 ```typescript
-function countBy<T>(arr: T[], mapper: (item: T) => string): Record<string, number>;
+function countBy<T, K extends PropertyKey>(arr: T[], mapper: (item: T) => K): Record<K, number>;
 ```
 
 ### 파라미터
 
 - `arr` (`T[]`): 요소의 갯수를 세고자 하는 배열.
-- `mapper` (`(item: T) => string`): 요소를 분류할 기준이 되는 값을 반환하는 함수.
+- `mapper` (`(item: T) => K`): 요소를 분류할 기준이 되는 값을 반환하는 함수.
 
 ### 반환 값
 
-(`Record<string, number>`) 각 요소가 분류별로 몇 개 있는지를 계산한 객체.
+(`Record<K, number>`) 각 요소가 분류별로 몇 개 있는지를 계산한 객체.
 
 ## 예시
 

--- a/docs/reference/array/countBy.md
+++ b/docs/reference/array/countBy.md
@@ -5,17 +5,17 @@ Count the occurrences of each item in an array based on a `mapper` function.
 ## Signature
 
 ```typescript
-function countBy<T>(arr: T[], mapper: (item: T) => string): Record<string, number>;
+function countBy<T, K extends PropertyKey>(arr: T[], mapper: (item: T) => K): Record<K, number>;
 ```
 
 ### Parameters
 
 - `arr` (`T[]`): The input array to count occurrences.
-- `mapper` (`(item: T) => string`): The transformation function that maps each item to a string key.
+- `mapper` (`(item: T) => K`): The transformation function that maps each item to a key.
 
 ### Returns
 
-(`Record<string, number>`) An object containing the count of each item based on the transformation function.
+(`Record<K, number>`) An object containing the count of each item based on the transformation function.
 
 ## Examples
 

--- a/docs/zh_hans/reference/array/countBy.md
+++ b/docs/zh_hans/reference/array/countBy.md
@@ -5,17 +5,17 @@
 ## 签名
 
 ```typescript
-function countBy<T>(arr: T[], mapper: (item: T) => string): Record<string, number>;
+function countBy<T, K extends PropertyKey>(arr: T[], mapper: (item: T) => K): Record<K, number>;
 ```
 
 ### 参数
 
 - `arr` (`T[]`): 输入数组，用于统计每个项目的出现次数。
-- `mapper` (`(item: T) => string`): 将每个项目映射到字符串键的转换函数。
+- `mapper` (`(item: T) => K`): 将每个项目映射到字符串键的转换函数。
 
 ### 返回值
 
-(`Record<string, number>`) 包含基于转换函数的每个项目计数的对象。
+(`Record<K, number>`) 包含基于转换函数的每个项目计数的对象。
 
 ## 示例
 

--- a/src/array/countBy.ts
+++ b/src/array/countBy.ts
@@ -3,20 +3,20 @@
  * based on a transformation function.
  *
  * This function takes an array and a transformation function
- * that converts each item in the array to a string. It then
+ * that converts each item in the array to a key. It then
  * counts the occurrences of each transformed item and returns
  * an object with the transformed items as keys and the counts
  * as values.
  *
  * @template T - The type of the items in the input array.
- *
+ * @template K - The type of keys.
  * @param {T[]} arr - The input array to count occurrences.
- * @param {(item: T) => string} mapper - The transformation function that maps each item to a string key.
- * @returns {Record<string, number>} An object containing the transformed items as keys and the
+ * @param {(item: T) => K} mapper - The transformation function that maps each item to a key.
+ * @returns {Record<K, number>} An object containing the transformed items as keys and the
  * counts as values.
  */
-export function countBy<T>(arr: readonly T[], mapper: (item: T) => string): Record<string, number> {
-  const result: Record<string, number> = {};
+export function countBy<T, K extends PropertyKey>(arr: readonly T[], mapper: (item: T) => K): Record<K, number> {
+  const result = {} as Record<K, number>;
 
   for (const item of arr) {
     const key = mapper(item);

--- a/src/array/countBy.ts
+++ b/src/array/countBy.ts
@@ -15,7 +15,7 @@
  * @returns {Record<string, number>} An object containing the transformed items as keys and the
  * counts as values.
  */
-export function countBy<T>(arr: T[], mapper: (item: T) => string): Record<string, number> {
+export function countBy<T>(arr: readonly T[], mapper: (item: T) => string): Record<string, number> {
   const result: Record<string, number> = {};
 
   for (const item of arr) {


### PR DESCRIPTION
For consistency, the countBy function should support readonly arrays and non-string keys, like `groupBy`, so I made the change.