### PR TITLE
feat(groupConsecutiveBy): Implement a new function on array to chunk consecutive elements with same key into groups

### DIFF
--- a/docs/reference/array/groupConsecutiveBy.md
+++ b/docs/reference/array/groupConsecutiveBy.md
@@ -1,0 +1,51 @@
+# groupConsecutiveBy
+
+Groups the consecutive elements (like discriminated unions, but not limit only discriminated unions)
+of an array based on a provided key-generating function.
+
+This function takes an array and a function that generates a key from each element. It returns
+a array where the keys are the generated keys and the values are arrays of elements that share
+the same key.
+
+## Signature
+
+```typescript
+function groupConsecutiveBy<T, K extends PropertyKey>(arr: T[], getKeyFromItem: (item: T) => K): T[][];
+```
+
+### Parameters
+
+- `arr` (`T[]`): The array to group.
+- `getKeyFromItem` (`(item: T) => K`): A function that generates a key from an element.
+
+### Returns
+
+(`T[][]`) A array where sub element is an array of elements that
+share that key and are consecutive neighbors in the original array (also order preserved).
+
+## Examples
+
+```typescript
+const array = [
+  { category: 'fruit', name: 'apple' },
+  { category: 'fruit', name: 'banana' },
+  { category: 'vegetable', name: 'carrot' }
+  { category: 'vegetable', name: 'tomato' }
+  { category: 'fruit', name: 'orange' }
+];
+const result = groupConsecutiveBy(array, item => item.category);
+// result will be:
+// [
+//   [
+//     { category: 'fruit', name: 'apple' },
+//     { category: 'fruit', name: 'banana' }
+//   ],
+//   [
+//     { category: 'vegetable', name: 'carrot' }
+//     { category: 'vegetable', name: 'tomato' }
+//   ],
+//   [
+//     { category: 'fruit', name: 'orange' }
+//   ]
+// ]
+```

--- a/src/array/groupConsecutiveBy.spec.ts
+++ b/src/array/groupConsecutiveBy.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { groupConsecutiveBy } from './groupConsecutiveBy';
+
+describe('groupConsecutiveBy', () => {
+  it('should group elements by a given key', () => {
+    const array = [
+      { category: 'fruit', name: 'apple' },
+      { category: 'fruit', name: 'banana' },
+      { category: 'vegetable', name: 'carrot' },
+      { category: 'fruit', name: 'pear' },
+      { category: 'vegetable', name: 'broccoli' },
+      { category: 'vegetable', name: 'tomato' },
+    ];
+
+    const result = groupConsecutiveBy(array, item => item.category);
+
+    expect(result).toEqual([
+      [
+        { category: 'fruit', name: 'apple' },
+        { category: 'fruit', name: 'banana' },
+      ],
+      [{ category: 'vegetable', name: 'carrot' }],
+      [{ category: 'fruit', name: 'pear' }],
+      [
+        { category: 'vegetable', name: 'broccoli' },
+        { category: 'vegetable', name: 'tomato' },
+      ],
+    ]);
+  });
+
+  it('should handle an empty array', () => {
+    const array: Array<{ category: string; name: string }> = [];
+
+    const result = groupConsecutiveBy(array, item => item.category);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle an array with one element', () => {
+    const array = [{ category: 'fruit', name: 'apple' }];
+
+    const result = groupConsecutiveBy(array, item => item.category);
+
+    expect(result).toEqual([[{ category: 'fruit', name: 'apple' }]]);
+  });
+
+  it('should group elements by a numeric key', () => {
+    const array = [
+      { score: 1, name: 'John' },
+      { score: 2, name: 'Jane' },
+      { score: 1, name: 'Joe' },
+      { score: 3, name: 'Jade' },
+      { score: 3, name: 'Jordan' },
+    ];
+
+    const result = groupConsecutiveBy(array, item => item.score);
+
+    expect(result).toEqual([
+      [{ score: 1, name: 'John' }],
+      [{ score: 2, name: 'Jane' }],
+      [{ score: 1, name: 'Joe' }],
+      [
+        { score: 3, name: 'Jade' },
+        { score: 3, name: 'Jordan' },
+      ],
+    ]);
+  });
+
+  it('should group elements by a symbol key', () => {
+    const TYPE_A = Symbol();
+    const TYPE_B = Symbol();
+    const array = [
+      { type: TYPE_A, score: 1, name: 'John' },
+      { type: TYPE_A, score: 2, name: 'Jane' },
+      { type: TYPE_B, score: 1, name: 'Joe' },
+      { type: TYPE_A, score: 4, name: 'Jordan' },
+      { type: TYPE_A, score: 9, name: 'Jade' },
+    ];
+
+    const result = groupConsecutiveBy(array, item => item.type);
+
+    expect(result).toEqual([
+      [
+        { type: TYPE_A, score: 1, name: 'John' },
+        { type: TYPE_A, score: 2, name: 'Jane' },
+      ],
+      [{ type: TYPE_B, score: 1, name: 'Joe' }],
+      [
+        { type: TYPE_A, score: 4, name: 'Jordan' },
+        { type: TYPE_A, score: 9, name: 'Jade' },
+      ],
+    ]);
+  });
+
+  it('should handle duplicate keys correctly', () => {
+    const array = [
+      { category: 'fruit', name: 'apple' },
+      { category: 'fruit', name: 'apple' },
+    ];
+
+    const result = groupConsecutiveBy(array, item => item.category);
+
+    expect(result).toEqual([
+      [
+        { category: 'fruit', name: 'apple' },
+        { category: 'fruit', name: 'apple' },
+      ],
+    ]);
+  });
+});

--- a/src/array/groupConsecutiveBy.ts
+++ b/src/array/groupConsecutiveBy.ts
@@ -1,0 +1,63 @@
+import { last } from './last'
+
+export type DistArray<T> = T extends any ? T[] : never;
+export type NonDistArray<T> = [T] extends [any] ? T[] : never;
+
+/**
+ * Groups the consecutive elements (like discriminated unions, but not limit only discriminated unions)
+ * of an array based on a provided key-generating function.
+ *
+ * This function takes an array and a function that generates a key from each element. It returns
+ * a array where the keys are the generated keys and the values are arrays of elements that share
+ * the same key.
+ *
+ * @template T - The type of elements in the array.
+ * @template K - The type of keys.
+ * @param {T[]} arr - The array to group.
+ * @param {(item: T) => K} getKeyFromItem - A function that generates a key from an element.
+ * @returns {T[][]} An object where each key is associated with an array of elements that
+ * share that key.
+ *
+ * @example
+ * const array = [
+ *   { category: 'fruit', name: 'apple' },
+ *   { category: 'fruit', name: 'banana' },
+ *   { category: 'vegetable', name: 'carrot' }
+ *   { category: 'vegetable', name: 'tomato' }
+ *   { category: 'fruit', name: 'orange' }
+ * ];
+ * const result = groupConsecutiveBy(array, item => item.category);
+ * // result will be:
+ * // [
+ * //   [
+ * //     { category: 'fruit', name: 'apple' },
+ * //     { category: 'fruit', name: 'banana' }
+ * //   ],
+ * //   [
+ * //     { category: 'vegetable', name: 'carrot' }
+ * //     { category: 'vegetable', name: 'tomato' }
+ * //   ],
+ * //   [
+ * //     { category: 'fruit', name: 'orange' }
+ * //   ]
+ * // ]
+ */
+export const groupConsecutiveBy = <T, K extends PropertyKey>(arr: NonDistArray<T>, getKeyFromItem: (item: T) => K): DistArray<T>[] => {
+  const result = [] as DistArray<T>[];
+
+  for (const item of arr) {
+    const key = getKeyFromItem(item);
+    const lastGroup = last(result);
+    const lastItem = last(lastGroup ?? []);
+    const lastKey = lastItem ? getKeyFromItem(lastItem) : undefined;
+    const newGroup = lastKey && key !== lastKey;
+
+    if (result.length === 0 || newGroup) {
+      result.push([item] as DistArray<T>);
+    } else {
+      result[result.length - 1].push(item);
+    }
+  }
+
+  return result;
+};

--- a/src/array/index.ts
+++ b/src/array/index.ts
@@ -14,6 +14,7 @@ export { flatten } from './flatten.ts';
 export { flattenDeep } from './flattenDeep.ts';
 export { forEachRight } from './forEachRight.ts';
 export { groupBy } from './groupBy.ts';
+export { groupConsecutiveBy } from './groupConsecutiveBy.ts';
 export { intersection } from './intersection.ts';
 export { intersectionBy } from './intersectionBy.ts';
 export { intersectionWith } from './intersectionWith.ts';


### PR DESCRIPTION
Hi there,

Thanks for such amazing lib. I'm trying to transform consecutive discriminated union elements have the same key in an array into a new array with grouped unions, but I only found `groupBy` function.

Hence, here I want to propose a new function on array toolkits to transform things I described above.

```typescript
const array = [
  { category: 'fruit', name: 'apple' },
  { category: 'fruit', name: 'banana' },
  { category: 'vegetable', name: 'carrot' }
  { category: 'vegetable', name: 'tomato' }
  { category: 'fruit', name: 'orange' }
];
const result = groupConsecutiveBy(array, item => item.category);
// result will be:
// [
//   [
//     { category: 'fruit', name: 'apple' },
//     { category: 'fruit', name: 'banana' }
//   ],
//   [
//     { category: 'vegetable', name: 'carrot' }
//     { category: 'vegetable', name: 'tomato' }
//   ],
//   [
//     { category: 'fruit', name: 'orange' }
//   ]
// ]
```

You could see the details in src changes. And there are some notable comments

- [x] test cases added and passed. Exported in `index.ts`
- [x] en docs added
- [ ] ko docs
- [ ] zh-hans docs
- [ ] I'm not very sure the function name `groupConsecutiveBy` is enough concise and short. The function name could be changed if we have a better one.
- [ ] type hints are implemented as [Distributive Conditional Types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types). 
  - The type signature in docs is a simpler version, because it obviously not only works for discriminated union but has more general cases.
  - The problem is I don't know how to write type hints in the more generic shapes. Want helps. Of course, current type signature probably is usable for most cases?

It will be greatly appreciated if anyone provide suggestions to improve it!

Regards
