### PR TITLE
docs(isSubset): update isSubset path to /ko in the Korean documentation

### DIFF
--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -83,7 +83,7 @@ function sidebar(): DefaultTheme.Sidebar {
               text: 'intersectionWith',
               link: '/ko/reference/array/intersectionWith',
             },
-            { text: 'isSubset', link: '/reference/array/isSubset' },
+            { text: 'isSubset', link: '/ko/reference/array/isSubset' },
             { text: 'keyBy', link: '/ko/reference/array/keyBy' },
             { text: 'minBy', link: '/ko/reference/array/minBy' },
             { text: 'maxBy', link: '/ko/reference/array/maxBy' },


### PR DESCRIPTION
Hello, I noticed that the isSubset link in the Korean sidebar was pointing to the English documentation. I updated the link to correctly point to the Korean version /ko.