### PR TITLE
fix(throttle): fix types of generic and return value

### DIFF
--- a/docs/ja/reference/function/throttle.md
+++ b/docs/ja/reference/function/throttle.md
@@ -5,7 +5,7 @@
 ## インターフェース
 
 ```typescript
-function function throttle<F extends (...args: Parameters<F>) => ReturnType<F>>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
+function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
 ```
 
 ### パラメータ

--- a/docs/ja/reference/function/throttle.md
+++ b/docs/ja/reference/function/throttle.md
@@ -5,7 +5,7 @@
 ## インターフェース
 
 ```typescript
-function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: number): F;
+function function throttle<F extends (...args: Parameters<F>) => ReturnType<F>>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
 ```
 
 ### パラメータ
@@ -15,7 +15,7 @@ function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: numbe
 
 ### 戻り値
 
-(`F`): 新しいスロットル化された関数。
+(`(...args: Parameters<F>) => void`): 新しいスロットル化された関数。
 
 ## 例
 

--- a/docs/ko/reference/function/throttle.md
+++ b/docs/ko/reference/function/throttle.md
@@ -5,7 +5,7 @@
 ## 인터페이스
 
 ```typescript
-function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: number): F;
+function function throttle<F extends (...args: Parameters<F>) => ReturnType<F>>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
 ```
 
 ### 파라미터
@@ -15,7 +15,7 @@ function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: numbe
 
 ### 반환 값
 
-(`F`): 새로운 throttle된 함수.
+(`(...args: Parameters<F>) => void`): 새로운 throttle된 함수.
 
 ## 예시
 

--- a/docs/ko/reference/function/throttle.md
+++ b/docs/ko/reference/function/throttle.md
@@ -5,7 +5,7 @@
 ## 인터페이스
 
 ```typescript
-function function throttle<F extends (...args: Parameters<F>) => ReturnType<F>>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
+function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
 ```
 
 ### 파라미터

--- a/docs/reference/function/throttle.md
+++ b/docs/reference/function/throttle.md
@@ -7,7 +7,7 @@ within the wait time will not trigger the execution of the original function.
 ## Signature
 
 ```typescript
-function function throttle<F extends (...args: Parameters<F>) => ReturnType<F>>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
+function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
 ```
 
 ### Parameters

--- a/docs/reference/function/throttle.md
+++ b/docs/reference/function/throttle.md
@@ -7,7 +7,7 @@ within the wait time will not trigger the execution of the original function.
 ## Signature
 
 ```typescript
-function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: number): F;
+function function throttle<F extends (...args: Parameters<F>) => ReturnType<F>>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
 ```
 
 ### Parameters
@@ -17,7 +17,7 @@ function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: numbe
 
 ### Returns
 
-(`F`): A new throttled function.
+(`(...args: Parameters<F>) => void`): A new throttled function.
 
 ## Examples
 

--- a/docs/zh_hans/reference/function/throttle.md
+++ b/docs/zh_hans/reference/function/throttle.md
@@ -7,7 +7,7 @@
 ## 签名
 
 ```typescript
-function function throttle<F extends (...args: Parameters<F>) => ReturnType<F>>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
+function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
 ```
 
 ### 参数

--- a/docs/zh_hans/reference/function/throttle.md
+++ b/docs/zh_hans/reference/function/throttle.md
@@ -7,7 +7,7 @@
 ## 签名
 
 ```typescript
-function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: number): F;
+function function throttle<F extends (...args: Parameters<F>) => ReturnType<F>>(func: F, throttleMs: number): (...args: Parameters<F>) => void;
 ```
 
 ### 参数
@@ -17,7 +17,7 @@ function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: numbe
 
 ### 返回值
 
-(`F`): 一个新的节流函数。
+(`(...args: Parameters<F>) => void`): 一个新的节流函数。
 
 ## 示例
 

--- a/src/function/throttle.ts
+++ b/src/function/throttle.ts
@@ -24,7 +24,7 @@
  *   throttledFunction(); // Will log 'Function executed'
  * }, 1000);
  */
-export function throttle<F extends (...args: Parameters<F>) => ReturnType<F>>(
+export function throttle<F extends (...args: any[]) => void>(
   func: F,
   throttleMs: number
 ): (...args: Parameters<F>) => void {

--- a/src/function/throttle.ts
+++ b/src/function/throttle.ts
@@ -6,7 +6,7 @@
  * @template F - The type of function.
  * @param {F} func - The function to throttle.
  * @param {number} throttleMs - The number of milliseconds to throttle executions to.
- * @returns {F} A new throttled function that accepts the same parameters as the original function.
+ * @returns {(...args: Parameters<F>) => void} A new throttled function that accepts the same parameters as the original function.
  *
  * @example
  * const throttledFunction = throttle(() => {
@@ -24,7 +24,10 @@
  *   throttledFunction(); // Will log 'Function executed'
  * }, 1000);
  */
-export function throttle<F extends (...args: any[]) => void>(func: F, throttleMs: number): F {
+export function throttle<F extends (...args: Parameters<F>) => ReturnType<F>>(
+  func: F,
+  throttleMs: number
+): (...args: Parameters<F>) => void {
   let lastCallTime: number | null;
 
   const throttledFunction = function (...args: Parameters<F>) {
@@ -34,7 +37,7 @@ export function throttle<F extends (...args: any[]) => void>(func: F, throttleMs
       lastCallTime = now;
       func(...args);
     }
-  } as F;
+  };
 
   return throttledFunction;
 }


### PR DESCRIPTION
# Description

I changed types like this PR(https://github.com/toss/es-toolkit/pull/406).

I think that `throttle` also have to change its types for same reason.