### PR TITLE
docs(ary): Update docs for `ary`

### DIFF
--- a/docs/ja/reference/function/ary.md
+++ b/docs/ja/reference/function/ary.md
@@ -26,8 +26,8 @@ function fn(a: number, b: number, c: number) {
   return Array.from(arguments);
 }
 
-expect(ary(fn, 0)(1, 2, 3)).toEqual([]);
-expect(ary(fn, 1)(1, 2, 3)).toEqual([1]);
-expect(ary(fn, 2)(1, 2, 3)).toEqual([1, 2]);
-expect(ary(fn, 3)(1, 2, 3)).toEqual([1, 2, 3]);
+ary(fn, 0)(1, 2, 3) // []
+ary(fn, 1)(1, 2, 3) // [1]
+ary(fn, 2)(1, 2, 3) // [1, 2]
+ary(fn, 3)(1, 2, 3) // [1, 2, 3]
 ```

--- a/docs/ja/reference/function/ary.md
+++ b/docs/ja/reference/function/ary.md
@@ -11,7 +11,7 @@ function ary<F extends (...args: any[]) => any>(func: F, n: number): (...args: a
 ### パラメータ
 
 - `func` (`F`): 引数の受け取りを制限する関数。
-- `n` (`number`, オプション): 受け取る引数の最大数。
+- `n` (`number`): 受け取る引数の最大数。
 
 ### 戻り値
 
@@ -22,13 +22,12 @@ function ary<F extends (...args: any[]) => any>(func: F, n: number): (...args: a
 ```typescript
 import { ary } from 'es-toolkit/function';
 
-function fn(a, b, c) {
-  console.log(arguments);
+function fn(a: number, b: number, c: number) {
+  return Array.from(arguments);
 }
 
-ary(fn, 2)(1, 2, 3); // [Arguments] { '0': 1, '1': 2 }
-ary(fn); // [Arguments] { '0': 1, '1': 2, '2': 3 }
-ary(fn, -1); // [Arguments] {}
-ary(fn, 1.5); // [Arguments] { '0': 1 }
-ary(fn, 2, {}); // [Arguments] { '0': 1, '1': 2, '2': 3 }
+expect(ary(fn, 0)(1, 2, 3)).toEqual([]);
+expect(ary(fn, 1)(1, 2, 3)).toEqual([1]);
+expect(ary(fn, 2)(1, 2, 3)).toEqual([1, 2]);
+expect(ary(fn, 3)(1, 2, 3)).toEqual([1, 2, 3]);
 ```

--- a/docs/ko/reference/function/ary.md
+++ b/docs/ko/reference/function/ary.md
@@ -26,8 +26,8 @@ function fn(a: number, b: number, c: number) {
   return Array.from(arguments);
 }
 
-expect(ary(fn, 0)(1, 2, 3)).toEqual([]);
-expect(ary(fn, 1)(1, 2, 3)).toEqual([1]);
-expect(ary(fn, 2)(1, 2, 3)).toEqual([1, 2]);
-expect(ary(fn, 3)(1, 2, 3)).toEqual([1, 2, 3]);
+ary(fn, 0)(1, 2, 3) // []
+ary(fn, 1)(1, 2, 3) // [1]
+ary(fn, 2)(1, 2, 3) // [1, 2]
+ary(fn, 3)(1, 2, 3) // [1, 2, 3]
 ```

--- a/docs/ko/reference/function/ary.md
+++ b/docs/ko/reference/function/ary.md
@@ -11,7 +11,7 @@ function ary<F extends (...args: any[]) => any>(func: F, n: number): (...args: a
 ### 파라미터
 
 - `func` (`F`): 인자를 받는 것을 제한할 함수.
-- `n` (`number`, 선택): 최대로 받을 인자의 숫자.
+- `n` (`number`): 최대로 받을 인자의 숫자.
 
 ### 반환 값
 
@@ -22,13 +22,12 @@ function ary<F extends (...args: any[]) => any>(func: F, n: number): (...args: a
 ```typescript
 import { ary } from 'es-toolkit/function';
 
-function fn(a, b, c) {
-  console.log(arguments);
+function fn(a: number, b: number, c: number) {
+  return Array.from(arguments);
 }
 
-ary(fn, 2)(1, 2, 3); // [Arguments] { '0': 1, '1': 2 }
-ary(fn); // [Arguments] { '0': 1, '1': 2, '2': 3 }
-ary(fn, -1); // [Arguments] {}
-ary(fn, 1.5); // [Arguments] { '0': 1 }
-ary(fn, 2, {}); // [Arguments] { '0': 1, '1': 2, '2': 3 }
+expect(ary(fn, 0)(1, 2, 3)).toEqual([]);
+expect(ary(fn, 1)(1, 2, 3)).toEqual([1]);
+expect(ary(fn, 2)(1, 2, 3)).toEqual([1, 2]);
+expect(ary(fn, 3)(1, 2, 3)).toEqual([1, 2, 3]);
 ```

--- a/docs/reference/function/ary.md
+++ b/docs/reference/function/ary.md
@@ -11,7 +11,7 @@ function ary<F extends (...args: any[]) => any>(func: F, n: number): (...args: a
 ### Parameters
 
 - `func` (`F`): The function to cap arguments for.
-- `n` (`number`, optional): The arity cap, defaulting to the number of parameters of `func`.
+- `n` (`number`): The arity cap.
 
 ### Returns
 
@@ -22,13 +22,12 @@ function ary<F extends (...args: any[]) => any>(func: F, n: number): (...args: a
 ```typescript
 import { ary } from 'es-toolkit/function';
 
-function fn(a, b, c) {
-  console.log(arguments);
+function fn(a: number, b: number, c: number) {
+  return Array.from(arguments);
 }
 
-ary(fn, 2)(1, 2, 3); // [Arguments] { '0': 1, '1': 2 }
-ary(fn); // [Arguments] { '0': 1, '1': 2, '2': 3 }
-ary(fn, -1); // [Arguments] {}
-ary(fn, 1.5); // [Arguments] { '0': 1 }
-ary(fn, 2, {}); // [Arguments] { '0': 1, '1': 2, '2': 3 }
+expect(ary(fn, 0)(1, 2, 3)).toEqual([]);
+expect(ary(fn, 1)(1, 2, 3)).toEqual([1]);
+expect(ary(fn, 2)(1, 2, 3)).toEqual([1, 2]);
+expect(ary(fn, 3)(1, 2, 3)).toEqual([1, 2, 3]);
 ```

--- a/docs/reference/function/ary.md
+++ b/docs/reference/function/ary.md
@@ -26,8 +26,8 @@ function fn(a: number, b: number, c: number) {
   return Array.from(arguments);
 }
 
-expect(ary(fn, 0)(1, 2, 3)).toEqual([]);
-expect(ary(fn, 1)(1, 2, 3)).toEqual([1]);
-expect(ary(fn, 2)(1, 2, 3)).toEqual([1, 2]);
-expect(ary(fn, 3)(1, 2, 3)).toEqual([1, 2, 3]);
+ary(fn, 0)(1, 2, 3) // []
+ary(fn, 1)(1, 2, 3) // [1]
+ary(fn, 2)(1, 2, 3) // [1, 2]
+ary(fn, 3)(1, 2, 3) // [1, 2, 3]
 ```

--- a/docs/zh_hans/reference/function/ary.md
+++ b/docs/zh_hans/reference/function/ary.md
@@ -26,8 +26,8 @@ function fn(a: number, b: number, c: number) {
   return Array.from(arguments);
 }
 
-expect(ary(fn, 0)(1, 2, 3)).toEqual([]);
-expect(ary(fn, 1)(1, 2, 3)).toEqual([1]);
-expect(ary(fn, 2)(1, 2, 3)).toEqual([1, 2]);
-expect(ary(fn, 3)(1, 2, 3)).toEqual([1, 2, 3]);
+ary(fn, 0)(1, 2, 3) // []
+ary(fn, 1)(1, 2, 3) // [1]
+ary(fn, 2)(1, 2, 3) // [1, 2]
+ary(fn, 3)(1, 2, 3) // [1, 2, 3]
 ```

--- a/docs/zh_hans/reference/function/ary.md
+++ b/docs/zh_hans/reference/function/ary.md
@@ -11,7 +11,7 @@ function ary<F extends (...args: any[]) => any>(func: F, n: number): (...args: a
 ### 参数
 
 - `func` (`F`): 要限制参数数量的函数。
-- `n` (`number`, 可选): 参数数量上限，默认为 `func` 的参数个数。
+- `n` (`number`): 参数数量上限。
 
 ### 返回值
 
@@ -22,13 +22,12 @@ function ary<F extends (...args: any[]) => any>(func: F, n: number): (...args: a
 ```typescript
 import { ary } from 'es-toolkit/function';
 
-function fn(a, b, c) {
-  console.log(arguments);
+function fn(a: number, b: number, c: number) {
+  return Array.from(arguments);
 }
 
-ary(fn, 2)(1, 2, 3); // [Arguments] { '0': 1, '1': 2 }
-ary(fn); // [Arguments] { '0': 1, '1': 2, '2': 3 }
-ary(fn, -1); // [Arguments] {}
-ary(fn, 1.5); // [Arguments] { '0': 1 }
-ary(fn, 2, {}); // [Arguments] { '0': 1, '1': 2, '2': 3 }
+expect(ary(fn, 0)(1, 2, 3)).toEqual([]);
+expect(ary(fn, 1)(1, 2, 3)).toEqual([1]);
+expect(ary(fn, 2)(1, 2, 3)).toEqual([1, 2]);
+expect(ary(fn, 3)(1, 2, 3)).toEqual([1, 2, 3]);
 ```

--- a/src/function/ary.ts
+++ b/src/function/ary.ts
@@ -11,10 +11,10 @@
  *   return Array.from(arguments);
  * }
  *
- * expect(ary(fn, 0)(1, 2, 3)).toEqual([]);
- * expect(ary(fn, 1)(1, 2, 3)).toEqual([1]);
- * expect(ary(fn, 2)(1, 2, 3)).toEqual([1, 2]);
- * expect(ary(fn, 3)(1, 2, 3)).toEqual([1, 2, 3]);
+ * ary(fn, 0)(1, 2, 3) // []
+ * ary(fn, 1)(1, 2, 3) // [1]
+ * ary(fn, 2)(1, 2, 3) // [1, 2]
+ * ary(fn, 3)(1, 2, 3) // [1, 2, 3]
  */
 export function ary<F extends (...args: any[]) => any>(func: F, n: number): (...args: any[]) => ReturnType<F> {
   return function (this: any, ...args: Parameters<F>) {

--- a/src/function/ary.ts
+++ b/src/function/ary.ts
@@ -5,6 +5,16 @@
  * @param {F} func - The function to cap arguments for.
  * @param {number} n - The arity cap.
  * @returns {(...args: any[]) => ReturnType<F>} Returns the new capped function.
+ *
+ * @example
+ * function fn(a: number, b: number, c: number) {
+ *   return Array.from(arguments);
+ * }
+ *
+ * expect(ary(fn, 0)(1, 2, 3)).toEqual([]);
+ * expect(ary(fn, 1)(1, 2, 3)).toEqual([1]);
+ * expect(ary(fn, 2)(1, 2, 3)).toEqual([1, 2]);
+ * expect(ary(fn, 3)(1, 2, 3)).toEqual([1, 2, 3]);
  */
 export function ary<F extends (...args: any[]) => any>(func: F, n: number): (...args: any[]) => ReturnType<F> {
   return function (this: any, ...args: Parameters<F>) {


### PR DESCRIPTION
Previous docs of `ary` had this following problems.

```typescript
import { ary } from 'es-toolkit/function';

function fn(a, b, c) {
  console.log(arguments);
}

ary(fn, 2)(1, 2, 3); // [Arguments] { '0': 1, '1': 2 }
ary(fn); // [Arguments] { '0': 1, '1': 2, '2': 3 }
ary(fn, -1); // [Arguments] {}
ary(fn, 1.5); // [Arguments] { '0': 1 }
ary(fn, 2, {}); // [Arguments] { '0': 1, '1': 2, '2': 3 }
```

- Arguments were not provided.
- The number of arguments is mandatory, but it was not provided; the documentation incorrectly states that it is optional.
- The ary function is supposed to receive 2 arguments, but an example with 3 arguments is included.
- Since arguments are internally sliced, providing negative integers results in outcomes different from the examples.

Not only did I fix this issue, but I also simplified the example for clarity.
