### PR TITLE
fix(negate): Fix parameter type of `negate`

### DIFF
--- a/src/function/negate.spec.ts
+++ b/src/function/negate.spec.ts
@@ -6,5 +6,10 @@ describe('negate', () => {
     expect(typeof negate(() => true)).toBe('function');
     expect(negate(() => true)()).toBe(false);
     expect(negate(() => false)()).toBe(true);
+
+    function isEven(n: number) {
+      return n % 2 === 0;
+    }
+    expect([1, 2, 3, 4, 5, 6].filter(negate(isEven))).toEqual([1, 3, 5]);
   });
 });

--- a/src/function/negate.ts
+++ b/src/function/negate.ts
@@ -5,6 +5,6 @@
  * @param {F} func - The function to negate.
  * @returns {F} The new negated function, which negates the boolean result of `func`.
  */
-export function negate<F extends (...args: unknown[]) => boolean>(func: F): F {
+export function negate<F extends (...args: any[]) => boolean>(func: F): F {
   return ((...args: any[]) => !func(...args)) as F;
 }


### PR DESCRIPTION
Before the change, I encountered a type error when using the negate function with a function that has parameters.

<img width="1283" alt="스크린샷 2024-08-31 오후 3 04 48" src="https://github.com/user-attachments/assets/84fcf02f-b05e-415a-8153-a41c89fc65ec">

I have updated the parameter type of negate so that it now supports functions with parameters.


