### PR TITLE
fix(delay): Ensure event listener is removed after timeout

### DIFF
--- a/src/promise/delay.spec.ts
+++ b/src/promise/delay.spec.ts
@@ -46,4 +46,15 @@ describe('delay', () => {
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
   });
+
+  it('should clear event listener if timeout completes', async () => {
+    const controller = new AbortController();
+    const { signal } = controller;
+    const spy = vi.spyOn(signal, 'removeEventListener');
+
+    await delay(100, { signal });
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
 });

--- a/src/promise/delay.ts
+++ b/src/promise/delay.ts
@@ -51,7 +51,10 @@ export function delay(ms: number, { signal }: DelayOptions = {}): Promise<void> 
       return abortError();
     }
 
-    const timeoutId = setTimeout(resolve, ms);
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener('abort', abortHandler);
+      resolve();
+    }, ms);
 
     signal?.addEventListener('abort', abortHandler, { once: true });
   });


### PR DESCRIPTION
Currently, if a signal is passed but not aborted, the event listener will not be removed, since the event listener with the [once](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#once) option is only automatically removed when it is invoked.

Therefore, I have updated the code to explicitly remove the event listener when a timeout occurs.