### PR TITLE
feat(pad): add `pad` function

### DIFF
--- a/benchmarks/performance/pad.bench.ts
+++ b/benchmarks/performance/pad.bench.ts
@@ -1,0 +1,15 @@
+import { bench, describe } from 'vitest';
+import { pad as padStartToolkit } from 'es-toolkit';
+import { pad as padStartLodash } from 'lodash';
+
+describe('pad', () => {
+  bench('es-toolkit/pad', () => {
+    const str = 'abc';
+    padStartToolkit(str, 6, '_-');
+  });
+
+  bench('lodash/pad', () => {
+    const str = 'abc';
+    padStartLodash(str, 6, '_-');
+  });
+});

--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -225,6 +225,7 @@ function sidebar(): DefaultTheme.Sidebar {
             { text: 'padStart (compat)', link: '/reference/compat/string/padStart' },
             { text: 'padEnd (compat)', link: '/reference/compat/string/padEnd' },
             { text: 'deburr', link: '/reference/string/deburr' },
+            { text: 'pad', link: '/reference/string/pad' },
           ],
         },
         {

--- a/docs/reference/string/pad.md
+++ b/docs/reference/string/pad.md
@@ -1,0 +1,34 @@
+# pad
+
+Pads string on the left and right sides if it's shorter than length. Padding characters are truncated if they can't be evenly divided by length.
+
+If the length is less than or equal to the original string's length, or if the padding character is an empty string, the original string is returned unchanged.
+
+## Signature
+
+```typescript
+function pad(str: string, length = 0, chars = ' '): string;
+```
+
+## Parameters
+
+- `str` (`string`): The string to pad.
+- `length` (`number`): The length of the resulting string. Defaults to `0`.
+- `char` (`string`): The character to pad the string with. Defaults to `' '`.
+
+## Returns
+
+Returns the padded string.
+
+## Example
+
+```javascript
+pad('abc', 8);
+// => '  abc   '
+
+pad('abc', 8, '_-');
+// => '_-abc_-_'
+
+pad('abc', 3);
+// => 'abc'
+```

--- a/src/string/index.ts
+++ b/src/string/index.ts
@@ -8,3 +8,4 @@ export { pascalCase } from './pascalCase.ts';
 export { upperFirst } from './upperFirst.ts';
 export { lowerFirst } from './lowerFirst.ts';
 export { deburr } from './deburr.ts';
+export { pad } from './pad.ts';

--- a/src/string/pad.spec.ts
+++ b/src/string/pad.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { pad } from './pad';
+
+describe('pad', () => {
+  it('should return the original string if no length and char is provided', () => {
+    expect(pad('abc')).toBe('abc');
+  });
+
+  it('should pad a string on the left and right sides if it is shorter than the length', () => {
+    expect(pad('abc', 8)).toBe('  abc   ');
+  });
+
+  it('should pad a string on the left and right sides with custom characters', () => {
+    expect(pad('abc', 8, '_-')).toBe('_-abc_-_');
+  });
+
+  it('should not pad a string if it has the same length', () => {
+    expect(pad('abc', 3)).toBe('abc');
+  });
+
+  it('should not pad a string if the length is less than the string length', () => {
+    expect(pad('abc', 2)).toBe('abc');
+  });
+
+  it('should not pad a string if the length is not a number', () => {
+    expect(pad('abc', NaN)).toBe('abc');
+  });
+
+  it('should not pad a string if the length is not an integer', () => {
+    expect(pad('abc', 3.5)).toBe('abc');
+  });
+
+  it('should not pad a string if the length is negative', () => {
+    expect(pad('abc', -3)).toBe('abc');
+  });
+});

--- a/src/string/pad.ts
+++ b/src/string/pad.ts
@@ -1,0 +1,21 @@
+/**
+ * Pads string on the left and right sides if it's shorter than length. Padding characters are truncated if they can't be evenly divided by length.
+ * If the length is less than or equal to the original string's length, or if the padding character is an empty string, the original string is returned unchanged.
+ *
+ *
+ *
+ * @param {string} str - The string to pad.
+ * @param {number} [length] - The length of the resulting string once padded.
+ * @param {string} [chars] - The character(s) to use for padding.
+ * @returns {string} - The padded string, or the original string if padding is not required.
+ *
+ * @example
+ * const result1 = pad('abc', 8);         // result will be '  abc   '
+ * const result2 = pad('abc', 8, '_-');   // result will be '_-abc_-_'
+ * const result3 = pad('abc', 3);         // result will be 'abc'
+ * const result4 = pad('abc', 2);         // result will be 'abc'
+ *
+ */
+export const pad = (str: string, length = 0, chars = ' '): string => {
+  return str.padStart(Math.floor((length - str.length) / 2) + str.length, chars).padEnd(length, chars);
+};


### PR DESCRIPTION
### Solution

This pull request introduces a [pad](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) function that pads a string on both the left and right sides if it is shorter than the specified length. The padding characters are truncated if they cannot be evenly divided by the length.

### Benchmark

<img width="860" alt="Screenshot 2024-09-01 at 21 21 44" src="https://github.com/user-attachments/assets/74a2a980-15a0-4177-b937-a88c071bb343">

Resolves #386