### PR TITLE
fix(countBy): add missing example in jsdoc

### DIFF
--- a/src/array/countBy.ts
+++ b/src/array/countBy.ts
@@ -14,6 +14,16 @@
  * @param {(item: T) => K} mapper - The transformation function that maps each item to a key.
  * @returns {Record<K, number>} An object containing the transformed items as keys and the
  * counts as values.
+ *
+ * @example
+ * const array = ['a', 'b', 'c', 'a', 'b', 'a'];
+ * const result = countBy(array, String);
+ * // result will be { a: 3, b: 2, c: 1 }
+ *
+ * @example
+ * const array = [1, 2, 3, 4, 5];
+ * const result = countBy(array, item => item % 2 === 0 ? 'even' : 'odd');
+ * // result will be { odd: 3, even: 2 }
  */
 export function countBy<T, K extends PropertyKey>(arr: readonly T[], mapper: (item: T) => K): Record<K, number> {
   const result = {} as Record<K, number>;

--- a/src/array/countBy.ts
+++ b/src/array/countBy.ts
@@ -17,7 +17,7 @@
  *
  * @example
  * const array = ['a', 'b', 'c', 'a', 'b', 'a'];
- * const result = countBy(array, String);
+ * const result = countBy(array, x => x);
  * // result will be { a: 3, b: 2, c: 1 }
  *
  * @example


### PR DESCRIPTION
Added missing example in jsdoc of `countBy` function.