### PR TITLE
feat(clone): enhance clone function to handle various data types 

### DIFF
--- a/src/object/clone.spec.ts
+++ b/src/object/clone.spec.ts
@@ -160,6 +160,10 @@ describe('clone', () => {
   });
 
   it('should clone File', () => {
+    if (typeof File === 'undefined') {
+      return;
+    }
+
     const file = new File(['Hello'], 'file.txt', { type: 'text/plain' });
     const clonedFile = clone(file);
 

--- a/src/object/clone.spec.ts
+++ b/src/object/clone.spec.ts
@@ -29,6 +29,32 @@ describe('clone', () => {
     expect(clonedBuffer).toEqual(buffer);
     expect(clonedBuffer).not.toBe(buffer);
     expect(clonedBuffer).toBeInstanceOf(ArrayBuffer);
+
+    expect(clonedBuffer.byteLength).toBe(buffer.byteLength);
+    expect(new Uint8Array(clonedBuffer)).toEqual(new Uint8Array(buffer));
+  });
+
+  it('should clone buffers', () => {
+    const buffer = Buffer.from([1, 2, 3]);
+    const clonedBuffer = clone(buffer);
+
+    expect(clonedBuffer).toEqual(buffer);
+    expect(clonedBuffer).not.toBe(buffer);
+    expect(clonedBuffer).toBeInstanceOf(Buffer);
+
+    expect(clonedBuffer.length).toBe(buffer.length);
+  });
+
+  it('should clone SharedArrayBuffer', () => {
+    const buffer = new SharedArrayBuffer(8);
+    const clonedBuffer = clone(buffer);
+
+    expect(clonedBuffer).toEqual(buffer);
+    expect(clonedBuffer).not.toBe(buffer);
+    expect(clonedBuffer).toBeInstanceOf(SharedArrayBuffer);
+
+    expect(clonedBuffer.byteLength).toBe(buffer.byteLength);
+    expect(new Uint8Array(clonedBuffer)).toEqual(new Uint8Array(buffer));
   });
 
   it('should clone objects', () => {
@@ -150,15 +176,6 @@ describe('clone', () => {
     expect(clonedDataView).toBeInstanceOf(DataView);
   });
 
-  it('should clone Promises', () => {
-    const promise = Promise.resolve('Hello');
-    const clonedPromise = clone(promise);
-
-    expect(clonedPromise).toEqual(promise);
-    expect(clonedPromise).not.toBe(promise);
-    expect(clonedPromise).toBeInstanceOf(Promise);
-  });
-
   it('should clone File', () => {
     if (typeof File === 'undefined') {
       return;
@@ -190,7 +207,7 @@ describe('clone', () => {
   });
 
   it('should clone Error', () => {
-    const error = new Error('Something went wrong');
+    const error = new Error('Something went wrong', { cause: 'Unknown' });
     const clonedError = clone(error);
 
     expect(clonedError).toEqual(error);
@@ -198,6 +215,9 @@ describe('clone', () => {
     expect(clonedError).toBeInstanceOf(Error);
 
     expect(clonedError.message).toBe(error.message);
+    expect(clonedError.stack).toBe(error.stack);
+    expect(clonedError.name).toBe(error.name);
+    expect(clonedError.cause).toBe(error.cause);
   });
 
   it('should clone Custom Error', () => {

--- a/src/object/clone.spec.ts
+++ b/src/object/clone.spec.ts
@@ -11,6 +11,7 @@ describe('clone', () => {
     expect(clone(true)).toBe(true);
     expect(clone(null)).toBe(null);
     expect(clone(undefined)).toBe(undefined);
+    expect(clone(42n)).toBe(42n);
   });
 
   it('should clone arrays', () => {
@@ -65,14 +66,21 @@ describe('clone', () => {
 
     expect(clonedDate).toEqual(date);
     expect(clonedDate).not.toBe(date);
+    expect(clonedDate).toBeInstanceOf(Date);
   });
 
   it('should clone regular expressions', () => {
-    const regex = /abc/g;
+    const regex = /abc/gsu;
+    regex.lastIndex = 10;
     const clonedRegex = clone(regex);
 
     expect(clonedRegex).toEqual(regex);
     expect(clonedRegex).not.toBe(regex);
+    expect(clonedRegex).toBeInstanceOf(RegExp);
+
+    expect(clonedRegex.source).toBe(regex.source);
+    expect(clonedRegex.flags).toBe(regex.flags);
+    expect(clonedRegex.lastIndex).toBe(regex.lastIndex);
   });
 
   it('should shallow clone nested objects', () => {
@@ -98,6 +106,7 @@ describe('clone', () => {
 
     expect(clonedSet).toEqual(set);
     expect(clonedSet).not.toBe(set);
+    expect(clonedSet).toBeInstanceOf(Set);
   });
 
   it('should clone maps', () => {
@@ -110,5 +119,99 @@ describe('clone', () => {
 
     expect(clonedMap).toEqual(map);
     expect(clonedMap).not.toBe(map);
+    expect(clonedMap).toBeInstanceOf(Map);
+  });
+
+  it('should clone typed arrays', () => {
+    const typedArray = new Uint8Array([1, 2, 3]);
+    const clonedTypedArray = clone(typedArray);
+
+    expect(clonedTypedArray).toEqual(typedArray);
+    expect(clonedTypedArray).not.toBe(typedArray);
+    expect(clonedTypedArray).toBeInstanceOf(Uint8Array);
+  });
+
+  it('should clone BigInt64Array', () => {
+    const bigIntArray = new BigInt64Array([1n, 2n, 3n]);
+    const clonedBigIntArray = clone(bigIntArray);
+
+    expect(clonedBigIntArray).toEqual(bigIntArray);
+    expect(clonedBigIntArray).not.toBe(bigIntArray);
+    expect(clonedBigIntArray).toBeInstanceOf(BigInt64Array);
+  });
+
+  it('should clone Data views', () => {
+    const buffer = new ArrayBuffer(8);
+    const dataView = new DataView(buffer);
+    const clonedDataView = clone(dataView);
+
+    expect(clonedDataView).toEqual(dataView);
+    expect(clonedDataView).not.toBe(dataView);
+    expect(clonedDataView).toBeInstanceOf(DataView);
+  });
+
+  it('should clone Promises', () => {
+    const promise = Promise.resolve('Hello');
+    const clonedPromise = clone(promise);
+
+    expect(clonedPromise).toEqual(promise);
+    expect(clonedPromise).not.toBe(promise);
+    expect(clonedPromise).toBeInstanceOf(Promise);
+  });
+
+  it('should clone File', () => {
+    const file = new File(['Hello'], 'file.txt', { type: 'text/plain' });
+    const clonedFile = clone(file);
+
+    expect(clonedFile).toEqual(file);
+    expect(clonedFile).not.toBe(file);
+    expect(clonedFile).toBeInstanceOf(File);
+
+    expect(clonedFile.size).toBe(file.size);
+    expect(clonedFile.type).toBe(file.type);
+    expect(clonedFile.text()).resolves.toBe('Hello');
+  });
+
+  it('should clone Blob', () => {
+    const blob = new Blob(['Hello'], { type: 'text/plain' });
+    const clonedBlob = clone(blob);
+
+    expect(clonedBlob).toEqual(blob);
+    expect(clonedBlob).not.toBe(blob);
+    expect(clonedBlob).toBeInstanceOf(Blob);
+
+    expect(clonedBlob.size).toBe(blob.size);
+    expect(clonedBlob.type).toBe(blob.type);
+    expect(clonedBlob.text()).resolves.toBe('Hello');
+  });
+
+  it('should clone Error', () => {
+    const error = new Error('Something went wrong');
+    const clonedError = clone(error);
+
+    expect(clonedError).toEqual(error);
+    expect(clonedError).not.toBe(error);
+    expect(clonedError).toBeInstanceOf(Error);
+
+    expect(clonedError.message).toBe(error.message);
+  });
+
+  it('should clone Custom Error', () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'CustomError';
+      }
+    }
+
+    const error = new CustomError('Something went wrong');
+    const clonedError = clone(error);
+
+    expect(clonedError).toEqual(error);
+    expect(clonedError).not.toBe(error);
+    expect(clonedError).toBeInstanceOf(CustomError);
+
+    expect(clonedError.message).toBe(error.message);
+    expect(clonedError.name).toBe(error.name);
   });
 });

--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -38,7 +38,6 @@ export function clone<T>(obj: T): T {
     return obj.slice() as T;
   }
 
-  // Handle objects
   const prototype = Object.getPrototypeOf(obj);
   const Constructor = prototype.constructor;
 

--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -37,7 +37,7 @@ export function clone<T>(obj: T): T {
   if (Array.isArray(obj) || isTypedArray(obj)) {
     return obj.slice() as T;
   }
-  g;
+
   // Handle objects
   const prototype = Object.getPrototypeOf(obj);
   const Constructor = prototype.constructor;

--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -1,3 +1,6 @@
+import { isTypedArray } from '../predicate';
+import { isPrimitive } from '../predicate/isPrimitive';
+
 /**
  * Creates a shallow clone of the given object.
  *
@@ -31,44 +34,37 @@ export function clone<T>(obj: T): T {
     return obj;
   }
 
-  if (Array.isArray(obj)) {
+  if (Array.isArray(obj) || isTypedArray(obj)) {
     return obj.slice() as T;
   }
+  g;
+  // Handle objects
+  const prototype = Object.getPrototypeOf(obj);
+  const Constructor = prototype.constructor;
 
-  if (obj instanceof Date) {
-    return new Date(obj.getTime()) as T;
+  if (obj instanceof Date || obj instanceof Map || obj instanceof Set) {
+    return new Constructor(obj);
   }
 
   if (obj instanceof RegExp) {
-    return new RegExp(obj.source, obj.flags) as T;
+    const result = new Constructor(obj);
+    result.lastIndex = obj.lastIndex;
+
+    return result;
   }
 
-  if (obj instanceof Map) {
-    const result = new Map();
-    for (const [key, value] of obj) {
-      result.set(key, value);
-    }
-    return result as T;
+  if (obj instanceof DataView) {
+    return new Constructor(obj.buffer.slice(0));
   }
 
-  if (obj instanceof Set) {
-    const result = new Set();
-    for (const value of obj) {
-      result.add(value);
-    }
-    return result as T;
+  if (obj instanceof Error) {
+    return new Constructor(obj.message);
   }
 
   if (typeof obj === 'object') {
-    const prototype = Object.getPrototypeOf(obj);
-    const result = Object.create(prototype);
-    return Object.assign(result, obj);
+    const newObject = Object.create(prototype);
+    return Object.assign(newObject, obj);
   }
+
   return obj;
-}
-
-type Primitive = null | undefined | string | number | boolean | symbol | bigint;
-
-function isPrimitive(value: unknown): value is Primitive {
-  return value == null || (typeof value !== 'object' && typeof value !== 'function');
 }


### PR DESCRIPTION
# Description 

Changes:

- It supports `DataView`, `Error`, `TypedArray`, `File`, `ArrayBuffer`, `Blob`, `Buffer`, `SharedArrayBuffer`.
- I simplified the codes
  - Using `prototype.constructor()` instead of specified constructors  like `new Date()`(Also it's good for the exteneded Error instance.)
  - Using `obj` instead of property value like `obj.gettime()`, `obj.source`
  - Removing `isPrimitive()` that is a duplicated function.
- I fixed that we forget to copy `lastIndex` property in a `RegExp` object.

## Benchmark

<img width="732" alt="Screenshot 2024-09-10 at 1 17 47 PM" src="https://github.com/user-attachments/assets/677c7853-e74b-48ec-9069-78424d5000dc">
