### PR TITLE
feat(compat): Add `isObject` function 

### DIFF
--- a/benchmarks/performance/isObject.bench.ts
+++ b/benchmarks/performance/isObject.bench.ts
@@ -1,0 +1,27 @@
+import { bench, describe } from 'vitest';
+import { isObject as isObjectToolkit } from 'es-toolkit/compat';
+import { isObject as isObjectLodash } from 'lodash';
+
+describe('isObject', () => {
+  bench('es-toolkit/isObject', () => {
+    isObjectToolkit([1, 2, 3]);
+    isObjectToolkit(true);
+    isObjectToolkit(new Date());
+    isObjectToolkit(new Error());
+    isObjectToolkit(1);
+    isObjectToolkit(/x/);
+    isObjectToolkit('a');
+    isObjectToolkit(Array.prototype.slice);
+  });
+
+  bench('lodash/isObject', () => {
+    isObjectLodash([1, 2, 3]);
+    isObjectLodash(true);
+    isObjectLodash(new Date());
+    isObjectLodash(new Error());
+    isObjectLodash(1);
+    isObjectLodash(/x/);
+    isObjectLodash('a');
+    isObjectToolkit(Array.prototype.slice);
+  });
+});

--- a/docs/ko/reference/compat/predicate/isObject.md
+++ b/docs/ko/reference/compat/predicate/isObject.md
@@ -1,0 +1,43 @@
+# isObject
+
+::: info
+이 함수는 호환성을 위한 `es-toolkit/compat` 에서만 가져올 수 있어요. 대체할 수 있는 네이티브 JavaScript API가 있거나, 아직 충분히 최적화되지 않았기 때문이에요.
+
+`es-toolkit/compat`에서 이 함수를 가져오면, [lodash와 완전히 똑같이 동작](../../../compatibility.md)해요.
+:::
+
+주어진 값이 객체([language type](https://262.ecma-international.org/7.0/#sec-ecmascript-language-types) of Object)인지 확인해요.
+
+객체란, `typeof` 연산의 결과가 `object`, `function` 이고 `null`이 아닌 값을 말해요.
+
+TypeScript의 타입 가드로 사용할 수 있어요. 파라미터로 주어진 값의 타입을 객체 값으로 좁혀요.
+
+## 인터페이스
+
+```typescript
+function isObject(value: unknown): value is object | Function;
+```
+
+### 파라미터
+
+- `value` (`unknown`): 객체인지 확인할 값이에요.
+
+### 반환 값
+
+(`value is object | Function`): 주어진 값이 객체 이면 `true`, 아니면 `false`를 반환해요.
+
+## 예시
+
+```typescript
+import { isObject } from 'es-toolkit/predicate';
+
+const value1 = {};
+const value2 = [1, 2, 3];
+const value3 = () => {};
+const value4 = null;
+
+console.log(isArray(value1)); // true
+console.log(isArray(value2)); // true
+console.log(isArray(value3)); // true
+console.log(isArray(value4)); // false
+```

--- a/docs/ko/reference/compat/predicate/isObject.md
+++ b/docs/ko/reference/compat/predicate/isObject.md
@@ -15,7 +15,7 @@ TypeScript의 타입 가드로 사용할 수 있어요. 파라미터로 주어�
 ## 인터페이스
 
 ```typescript
-function isObject(value: unknown): value is object | ((...args: any[]) => unknown);
+function isObject(value: unknown): value is object;
 ```
 
 ### 파라미터
@@ -24,7 +24,7 @@ function isObject(value: unknown): value is object | ((...args: any[]) => unknow
 
 ### 반환 값
 
-(`value is object | (...args: any[]) => unknown`): 주어진 값이 객체 이면 `true`, 아니면 `false`를 반환해요.
+(`value is object`): 주어진 값이 객체 이면 `true`, 아니면 `false`를 반환해요.
 
 ## 예시
 

--- a/docs/ko/reference/compat/predicate/isObject.md
+++ b/docs/ko/reference/compat/predicate/isObject.md
@@ -15,7 +15,7 @@ TypeScript의 타입 가드로 사용할 수 있어요. 파라미터로 주어�
 ## 인터페이스
 
 ```typescript
-function isObject(value: unknown): value is object | Function;
+function isObject(value: unknown): value is object | ((...args: any[]) => unknown);
 ```
 
 ### 파라미터
@@ -24,7 +24,7 @@ function isObject(value: unknown): value is object | Function;
 
 ### 반환 값
 
-(`value is object | Function`): 주어진 값이 객체 이면 `true`, 아니면 `false`를 반환해요.
+(`value is object | (...args: any[]) => unknown`): 주어진 값이 객체 이면 `true`, 아니면 `false`를 반환해요.
 
 ## 예시
 

--- a/docs/reference/compat/predicate/isObject.md
+++ b/docs/reference/compat/predicate/isObject.md
@@ -15,7 +15,7 @@ This function can also serve as a type predicate in TypeScript, narrowing the ty
 ## Signature
 
 ```typescript
-function isObject(value: unknown): value is object | ((...args: any[]) => unknown);
+function isObject(value: unknown): value is object;
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ function isObject(value: unknown): value is object | ((...args: any[]) => unknow
 
 ### Returns
 
-(`value is object | (...args: any[]) => unknown`): Returns `true` if the value is an object, `false` otherwise.
+(`value is object`): Returns `true` if the value is an object, `false` otherwise.
 
 ## Examples
 

--- a/docs/reference/compat/predicate/isObject.md
+++ b/docs/reference/compat/predicate/isObject.md
@@ -15,7 +15,7 @@ This function can also serve as a type predicate in TypeScript, narrowing the ty
 ## Signature
 
 ```typescript
-function isObject(value: unknown): value is object | Function;
+function isObject(value: unknown): value is object | ((...args: any[]) => unknown);
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ function isObject(value: unknown): value is object | Function;
 
 ### Returns
 
-(`value is object | Function`): Returns `true` if the value is an object, `false` otherwise.
+(`value is object | (...args: any[]) => unknown`): Returns `true` if the value is an object, `false` otherwise.
 
 ## Examples
 

--- a/docs/reference/compat/predicate/isObject.md
+++ b/docs/reference/compat/predicate/isObject.md
@@ -1,0 +1,43 @@
+# isObject
+
+::: info
+This function is only available in `es-toolkit/compat` for compatibility reasons. It either has alternative native JavaScript APIs or isn’t fully optimized yet.
+
+When imported from `es-toolkit/compat`, it behaves exactly like lodash and provides the same functionalities, as detailed [here](../../../compatibility.md).
+:::
+
+Check if a value is is the language type of Object. (e.g. arrays, functions, objects, regexes, new Number(0), and new String('')).
+
+A value is an object if its type is object, function and it is not null.
+
+This function can also serve as a type predicate in TypeScript, narrowing the type of the argument to an object value.
+
+## Signature
+
+```typescript
+function isObject(value: unknown): value is object | Function;
+```
+
+### Parameters
+
+- `value` (`unknown`): The value to check if it is an object.
+
+### Returns
+
+(`value is object | Function`): Returns `true` if the value is an object, `false` otherwise.
+
+## Examples
+
+```typescript
+import { isObject } from 'es-toolkit/predicate';
+
+const value1 = {};
+const value2 = [1, 2, 3];
+const value3 = () => {};
+const value4 = null;
+
+console.log(isArray(value1)); // true
+console.log(isArray(value2)); // true
+console.log(isArray(value3)); // true
+console.log(isArray(value4)); // false
+```

--- a/docs/reference/compat/predicate/isObject.md
+++ b/docs/reference/compat/predicate/isObject.md
@@ -6,7 +6,7 @@ This function is only available in `es-toolkit/compat` for compatibility reasons
 When imported from `es-toolkit/compat`, it behaves exactly like lodash and provides the same functionalities, as detailed [here](../../../compatibility.md).
 :::
 
-Check if a value is is the language type of Object. (e.g. arrays, functions, objects, regexes, new Number(0), and new String('')).
+Check if a value is is [the language type](https://262.ecma-international.org/7.0/#sec-ecmascript-language-types) of Object. (e.g. arrays, functions, objects, regexes, new Number(0), and new String('')).
 
 A value is an object if its type is object, function and it is not null.
 

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -63,6 +63,7 @@ export { isArray } from './predicate/isArray.ts';
 export { isArguments } from './predicate/isArguments.ts';
 export { isArrayLike } from './predicate/isArrayLike.ts';
 export { isSymbol } from './predicate/isSymbol.ts';
+export { isObject } from './predicate/isObject.ts';
 export { isObjectLike } from './predicate/isObjectLike.ts';
 export { isBoolean } from './predicate/isBoolean.ts';
 export { isTypedArray } from './predicate/isTypedArray.ts';

--- a/src/compat/predicate/isObject.spec.ts
+++ b/src/compat/predicate/isObject.spec.ts
@@ -16,10 +16,10 @@ describe('isObject', () => {
     expect(isObject(new Date())).toBe(true);
     expect(isObject(new Error())).toBe(true);
     expect(isObject({ a: 1 })).toBe(true);
-    expect(isObject(Object(0))).toBe(true);
+    expect(isObject(new Number(0))).toBe(true);
     expect(isObject(slice)).toBe(true);
     expect(isObject(/x/)).toBe(true);
-    expect(isObject(Object('a'))).toBe(true);
+    expect(isObject(new String(''))).toBe(true);
   });
 
   it('should return `false` for non-objects', () => {

--- a/src/compat/predicate/isObject.spec.ts
+++ b/src/compat/predicate/isObject.spec.ts
@@ -10,6 +10,7 @@ describe('isObject', () => {
   it('should return `true` if value is an object', () => {
     expect(isObject(args)).toBe(true);
     expect(isObject({})).toBe(true);
+    expect(isObject(() => { })).toBe(true);
     expect(isObject([1, 2, 3])).toBe(true);
     expect(isObject(Object(false))).toBe(true);
     expect(isObject(new Date())).toBe(true);

--- a/src/compat/predicate/isObject.spec.ts
+++ b/src/compat/predicate/isObject.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { isObject } from './isObject';
+import { args } from '../_internal/args';
+import { falsey } from '../_internal/falsey';
+import { symbol } from '../_internal/symbol';
+import { slice } from '../_internal/slice';
+import { stubFalse } from '../_internal/stubFalse';
+
+describe('isObject', () => {
+  it('should return `true` if value is an object', () => {
+    expect(isObject(args)).toBe(true);
+    expect(isObject({})).toBe(true);
+    expect(isObject([1, 2, 3])).toBe(true);
+    expect(isObject(Object(false))).toBe(true);
+    expect(isObject(new Date())).toBe(true);
+    expect(isObject(new Error())).toBe(true);
+    expect(isObject({ a: 1 })).toBe(true);
+    expect(isObject(Object(0))).toBe(true);
+    expect(isObject(slice)).toBe(true);
+    expect(isObject(/x/)).toBe(true);
+    expect(isObject(Object('a'))).toBe(true);
+  });
+
+  it('should return `false` for non-objects', () => {
+    const values = falsey.concat(true, 1, 'a', symbol);
+    const expected = values.map(stubFalse);
+    const actual = values.map(isObject);
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/compat/predicate/isObject.ts
+++ b/src/compat/predicate/isObject.ts
@@ -1,0 +1,29 @@
+/**
+ * Checks if the given value is the language type of Object.
+ * https://262.ecma-international.org/7.0/#sec-ecmascript-language-types
+ *
+ * This function tests whether the provided value is an object or not.
+ * It returns `true` if the value is an object, and `false` otherwise.
+ *
+ * This function can also serve as a type predicate in TypeScript, narrowing the type of the argument to an object value.
+ *
+ * @param {unknown} value - The value to check if it is an object.
+ * @returns {value is object | Function} `true` if the value is the language type of Object, `false` otherwise.
+ *
+ * @example
+ * const value1 = {};
+ * const value2 = [1, 2, 3];
+ * const value3 = () => {};
+ * const value4 = null;
+ *
+ * console.log(isArray(value1)); // true
+ * console.log(isArray(value2)); // true
+ * console.log(isArray(value3)); // true
+ * console.log(isArray(value4)); // false
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export function isObject(value: unknown): value is object | Function {
+  const type = typeof value;
+  return value !== null && (type === 'object' || type === 'function');
+}

--- a/src/compat/predicate/isObject.ts
+++ b/src/compat/predicate/isObject.ts
@@ -8,7 +8,7 @@
  * This function can also serve as a type predicate in TypeScript, narrowing the type of the argument to an object value.
  *
  * @param {unknown} value - The value to check if it is an object.
- * @returns {value is object | Function} `true` if the value is the language type of Object, `false` otherwise.
+ * @returns {value is object} `true` if the value is the language type of Object, `false` otherwise.
  *
  * @example
  * const value1 = {};
@@ -22,7 +22,7 @@
  * console.log(isArray(value4)); // false
  */
 
-export function isObject(value: unknown): value is object | ((...args: any[]) => unknown) {
+export function isObject(value: unknown): value is object {
   const type = typeof value;
   return value !== null && (type === 'object' || type === 'function');
 }

--- a/src/compat/predicate/isObject.ts
+++ b/src/compat/predicate/isObject.ts
@@ -22,8 +22,7 @@
  * console.log(isArray(value4)); // false
  */
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-export function isObject(value: unknown): value is object | Function {
+export function isObject(value: unknown): value is object | ((...args: any[]) => unknown) {
   const type = typeof value;
   return value !== null && (type === 'object' || type === 'function');
 }


### PR DESCRIPTION
benchmark

<img width="953" alt="image" src="https://github.com/user-attachments/assets/355b79a5-b89f-4392-9a18-75a7ca9f6e9c">


There is an isObjectLike function, but not an isObject, so I implemented it.

I would appreciate any feedback and reviews.