### PR TITLE
fix(negate): add missing example

### DIFF
--- a/src/function/negate.ts
+++ b/src/function/negate.ts
@@ -4,6 +4,12 @@
  * @template F - The type of the function to negate.
  * @param {F} func - The function to negate.
  * @returns {F} The new negated function, which negates the boolean result of `func`.
+ *
+ * @example
+ * const array = [1, 2, 3, 4, 5, 6];
+ * const isEven = (n: number) => n % 2 === 0;
+ * const result = array.filter(negate(isEven));
+ * // result will be [1, 3, 5]
  */
 export function negate<F extends (...args: any[]) => boolean>(func: F): F {
   return ((...args: any[]) => !func(...args)) as F;


### PR DESCRIPTION
Added missing example in jsdoc of `negate` function.