### PR TITLE
perf(deburr): improve performance

### DIFF
--- a/src/string/deburr.ts
+++ b/src/string/deburr.ts
@@ -1,34 +1,36 @@
-const deburrMap: Record<string, string> = {
-  Æ: 'Ae',
-  Ð: 'D',
-  Ø: 'O',
-  Þ: 'Th',
-  ß: 'ss',
-  æ: 'ae',
-  ð: 'd',
-  ø: 'o',
-  þ: 'th',
-  Đ: 'D',
-  đ: 'd',
-  Ħ: 'H',
-  ħ: 'h',
-  ı: 'i',
-  Ĳ: 'IJ',
-  ĳ: 'ij',
-  ĸ: 'k',
-  Ŀ: 'L',
-  ŀ: 'l',
-  Ł: 'L',
-  ł: 'l',
-  ŉ: "'n",
-  Ŋ: 'N',
-  ŋ: 'n',
-  Œ: 'Oe',
-  œ: 'oe',
-  Ŧ: 'T',
-  ŧ: 't',
-  ſ: 's',
-};
+const deburrMap = new Map<string, string>(
+  Object.entries({
+    Æ: 'Ae',
+    Ð: 'D',
+    Ø: 'O',
+    Þ: 'Th',
+    ß: 'ss',
+    æ: 'ae',
+    ð: 'd',
+    ø: 'o',
+    þ: 'th',
+    Đ: 'D',
+    đ: 'd',
+    Ħ: 'H',
+    ħ: 'h',
+    ı: 'i',
+    Ĳ: 'IJ',
+    ĳ: 'ij',
+    ĸ: 'k',
+    Ŀ: 'L',
+    ŀ: 'l',
+    Ł: 'L',
+    ł: 'l',
+    ŉ: "'n",
+    Ŋ: 'N',
+    ŋ: 'n',
+    Œ: 'Oe',
+    œ: 'oe',
+    Ŧ: 'T',
+    ŧ: 't',
+    ſ: 's',
+  })
+);
 
 /**
  * Converts a string by replacing special characters and diacritical marks with their ASCII equivalents.
@@ -52,7 +54,7 @@ const deburrMap: Record<string, string> = {
 export function deburr(str: string): string {
   str = str.normalize('NFD');
 
-  const result: string[] = [];
+  let result = '';
 
   for (let i = 0; i < str.length; i++) {
     const char = str[i];
@@ -61,8 +63,8 @@ export function deburr(str: string): string {
       continue;
     }
 
-    result.push(deburrMap[char] ?? char);
+    result += deburrMap.get(char) ?? char;
   }
 
-  return result.join('');
+  return result;
 }


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/3e1a4418-4510-4c68-beac-6951b8aa8caa)
after
![image](https://github.com/user-attachments/assets/736eb8b0-dd96-46ba-a236-87f68cc9b14d)

**However, if the input string does not have any characters that need to be deburr'd, the performance of the lodash implementation improves dramatically in long words case. Is this acceptable?**
![image](https://github.com/user-attachments/assets/372bc22e-d830-454b-b9aa-cd9f8c000456)
