### PR TITLE
fix : wrong docs in isObject docs

### DIFF
--- a/docs/ja/reference/compat/predicate/isObject.md
+++ b/docs/ja/reference/compat/predicate/isObject.md
@@ -35,8 +35,8 @@ const value2 = [1, 2, 3];
 const value3 = () => {};
 const value4 = null;
 
-console.log(isArray(value1)); // true
-console.log(isArray(value2)); // true
-console.log(isArray(value3)); // true
-console.log(isArray(value4)); // false
+console.log(isObject(value1)); // true
+console.log(isObject(value2)); // true
+console.log(isObject(value3)); // true
+console.log(isObject(value4)); // false
 ```

--- a/docs/ko/reference/compat/predicate/isObject.md
+++ b/docs/ko/reference/compat/predicate/isObject.md
@@ -36,8 +36,8 @@ const value2 = [1, 2, 3];
 const value3 = () => {};
 const value4 = null;
 
-console.log(isArray(value1)); // true
-console.log(isArray(value2)); // true
-console.log(isArray(value3)); // true
-console.log(isArray(value4)); // false
+console.log(isObject(value1)); // true
+console.log(isObject(value2)); // true
+console.log(isObject(value3)); // true
+console.log(isObject(value4)); // false
 ```

--- a/docs/reference/compat/predicate/isObject.md
+++ b/docs/reference/compat/predicate/isObject.md
@@ -37,8 +37,8 @@ const value2 = [1, 2, 3];
 const value3 = () => {};
 const value4 = null;
 
-console.log(isArray(value1)); // true
-console.log(isArray(value2)); // true
-console.log(isArray(value3)); // true
-console.log(isArray(value4)); // false
+console.log(isObject(value1)); // true
+console.log(isObject(value2)); // true
+console.log(isObject(value3)); // true
+console.log(isObject(value4)); // false
 ```

--- a/docs/zh_hans/reference/compat/predicate/isObject.md
+++ b/docs/zh_hans/reference/compat/predicate/isObject.md
@@ -34,8 +34,8 @@ const value2 = [1, 2, 3];
 const value3 = () => {};
 const value4 = null;
 
-console.log(isArray(value1)); // true
-console.log(isArray(value2)); // true
-console.log(isArray(value3)); // true
-console.log(isArray(value4)); // false
+console.log(isObject(value1)); // true
+console.log(isObject(value2)); // true
+console.log(isObject(value3)); // true
+console.log(isObject(value4)); // false
 ```

--- a/src/compat/predicate/isObject.ts
+++ b/src/compat/predicate/isObject.ts
@@ -16,10 +16,10 @@
  * const value3 = () => {};
  * const value4 = null;
  *
- * console.log(isArray(value1)); // true
- * console.log(isArray(value2)); // true
- * console.log(isArray(value3)); // true
- * console.log(isArray(value4)); // false
+ * console.log(isObject(value1)); // true
+ * console.log(isObject(value2)); // true
+ * console.log(isObject(value3)); // true
+ * console.log(isObject(value4)); // false
  */
 
 export function isObject(value: unknown): value is object {


### PR DESCRIPTION
All example code that should have been written as `isObject` has been modified to be written as `isArray`.