### PR TITLE
feat(isDate): add `isDate` function

### DIFF
--- a/benchmarks/performance/isDate.bench.ts
+++ b/benchmarks/performance/isDate.bench.ts
@@ -1,0 +1,17 @@
+import { bench, describe } from 'vitest';
+import { isDate as isDateToolkit } from 'es-toolkit';
+import { isDate as isDateLodash } from 'lodash';
+
+describe('isDate', () => {
+  bench('es-toolkit/isDate', () => {
+    isDateToolkit(new Date());
+    isDateToolkit('2024-01-01');
+    isDateToolkit({ year: 2024, month: 1, day: 1 });
+  });
+
+  bench('lodash/isDate', () => {
+    isDateLodash(new Date());
+    isDateLodash('2024-01-01');
+    isDateLodash({ year: 2024, month: 1, day: 1 });
+  });
+});

--- a/docs/ja/reference/predicate/isDate.md
+++ b/docs/ja/reference/predicate/isDate.md
@@ -1,0 +1,27 @@
+# isDate
+
+`value`がDateオブジェクトであるかどうかを確認します。
+
+## インターフェース
+
+```typescript
+function isDate(value: unknown): value is Date;
+```
+
+### パラメータ
+
+- `value` (`unknown`): 確認する値です。
+
+### 戻り値
+
+(`value is Date`): `value`がDateオブジェクトであれば`true`を、それ以外の場合は`false`を返します。
+
+## 例
+
+```typescript
+const value1 = new Date();
+const value2 = '2024-01-01';
+
+console.log(isDate(value1)); // true
+console.log(isDate(value2)); // false
+```

--- a/docs/ko/reference/predicate/isDate.md
+++ b/docs/ko/reference/predicate/isDate.md
@@ -1,0 +1,29 @@
+# isDate
+
+주어진 값이 Date 객체인지 확인해요.
+
+TypeScript의 타입 가드로 사용할 수 있어요. 파라미터로 주어진 값의 타입을 `Date`로 좁혀요.
+
+## 인터페이스
+
+```typescript
+function isDate(value: unknown): value is Date;
+```
+
+### 파라미터
+
+- `value`(`unknown`): Date 객체인지 테스트할 값.
+
+### 반환 값
+
+(`value is Date`): 값이 Date 객체이면 `true`, 아니면 `false`.
+
+## 예시
+
+```typescript
+const value1 = new Date();
+const value2 = '2024-01-01';
+
+console.log(isDate(value1)); // true
+console.log(isDate(value2)); // false
+```

--- a/docs/reference/predicate/isDate.md
+++ b/docs/reference/predicate/isDate.md
@@ -1,0 +1,29 @@
+# isDate
+
+Check if the given value is a Date object.
+
+This function can also serve as a type predicate in TypeScript, narrowing the type of the argument to Date.
+
+## Signature
+
+```typescript
+function isDate(value: unknown): value is Date;
+```
+
+### Parameters
+
+- `value`(`unknown`): The value to test if it is a Date object.
+
+### Returns
+
+(`value is Date`): True if the value is a Date object, otherwise false.
+
+## Examples
+
+```typescript
+const value1 = new Date();
+const value2 = '2024-01-01';
+
+console.log(isDate(value1)); // true
+console.log(isDate(value2)); // false
+```

--- a/docs/zh_hans/reference/predicate/isDate.md
+++ b/docs/zh_hans/reference/predicate/isDate.md
@@ -1,0 +1,27 @@
+# isDate
+
+检查 `value` 是否是 Date 对象。
+
+## 签名
+
+```typescript
+function isDate(value: unknown): value is Date;
+```
+
+### 参数
+
+- `value` (`unknown`): 要检查的值。
+
+### 返回值
+
+(`value is Date`): 如果 `value` 是 Date 对象，则返回 `true`，否则返回 `false`。
+
+## 示例
+
+```typescript
+const value1 = new Date();
+const value2 = '2024-01-01';
+
+console.log(isDate(value1)); // true
+console.log(isDate(value2)); // false
+```

--- a/src/predicate/index.ts
+++ b/src/predicate/index.ts
@@ -1,3 +1,4 @@
+export { isDate } from './isDate.ts';
 export { isEqual } from './isEqual.ts';
 export { isNil } from './isNil.ts';
 export { isNotNil } from './isNotNil.ts';

--- a/src/predicate/isDate.spec.ts
+++ b/src/predicate/isDate.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { isDate } from './isDate';
+
+describe('isDate', () => {
+  it('should return `true` for dates', () => {
+    expect(isDate(new Date())).toBe(true);
+  });
+
+  it('should return `false` for non-dates', () => {
+    expect(isDate('2024-01-01')).toBe(false);
+    expect(isDate(2024)).toBe(false);
+    expect(isDate({ year: 2024, month: 1, day: 1 })).toBe(false);
+    expect(isDate([2024, 1, 1])).toBe(false);
+    expect(isDate(new Error())).toBe(false);
+    expect(isDate(/a/)).toBe(false);
+    expect(isDate(Symbol('2024'))).toBe(false);
+    expect(isDate(null)).toBe(false);
+    expect(isDate(undefined)).toBe(false);
+  });
+
+  it('should work on date within object', () => {
+    const obj = {
+      date: new Date(),
+    };
+    expect(isDate(obj.date)).toBe(true);
+  });
+});

--- a/src/predicate/isDate.ts
+++ b/src/predicate/isDate.ts
@@ -1,0 +1,16 @@
+/**
+ * Checks if `value` is a Date object.
+ *
+ * @param {unknown} value The value to check.
+ * @returns {value is Date} Returns `true` if `value` is a Date object, `false` otherwise.
+ *
+ * @example
+ * const value1 = new Date();
+ * const value2 = '2024-01-01';
+ *
+ * console.log(isDate(value1)); // true
+ * console.log(isDate(value2)); // false
+ */
+export function isDate(value: unknown): value is Date {
+  return value instanceof Date;
+}


### PR DESCRIPTION
Hi there. I'm inspired by your work. Thanks for the awesome contribution! 👍 

implements [isDate](https://lodash.com/docs/4.17.15#isDate) at predicate

<img width="874" alt="image" src="https://github.com/user-attachments/assets/2354dfe5-15b2-4a34-85bd-ba7d80e8acc8">
