### PR TITLE
docs: replace `pnpm install` with `pnpm add`

### DIFF
--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -25,7 +25,7 @@ npm install es-toolkit
 ```
 
 ```sh [pnpm]
-pnpm install es-toolkit
+pnpm add es-toolkit
 ```
 
 ```sh [yarn]

--- a/docs/ko/usage.md
+++ b/docs/ko/usage.md
@@ -25,7 +25,7 @@ npm install es-toolkit
 ```
 
 ```sh [pnpm]
-pnpm install es-toolkit
+pnpm add es-toolkit
 ```
 
 ```sh [yarn]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,7 @@ npm install es-toolkit
 ```
 
 ```sh [pnpm]
-pnpm install es-toolkit
+pnpm add es-toolkit
 ```
 
 ```sh [yarn]

--- a/docs/zh_hans/usage.md
+++ b/docs/zh_hans/usage.md
@@ -25,7 +25,7 @@ npm install es-toolkit
 ```
 
 ```sh [pnpm]
-pnpm install es-toolkit
+pnpm add es-toolkit
 ```
 
 ```sh [yarn]


### PR DESCRIPTION
The pnpm official documentation recommends using the `add` command instead of `install` when installing new packages as follows:

- https://pnpm.io/cli/add
- https://pnpm.io/cli/install

Currently it works the same without any differences, but the document clearly distinguishes these two commands.

This means that you have the flexibility to adapt to changes, such as changing or removing commands in future versions.