### PR TITLE
feat(drop): Added compatibility for `drop`

### DIFF
--- a/src/compat/array/drop.spec.ts
+++ b/src/compat/array/drop.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { drop } from '../../array/drop';
+import { drop } from './drop';
 
 /**
  * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/drop.spec.js#L1
@@ -25,5 +25,9 @@ describe('drop', () => {
 
   it('should coerce `n` to an integer', () => {
     expect(drop(array, 1.6)).toEqual([2, 3]);
+  });
+
+  it('should return an empty array when the collection is null or undefined', () => {
+    expect(drop(null, 2)).toEqual([]);
   });
 });

--- a/src/compat/array/drop.ts
+++ b/src/compat/array/drop.ts
@@ -1,0 +1,25 @@
+/**
+ * Removes a specified number of elements from the beginning of an array and returns the rest.
+ *
+ * This function takes an array and a number, and returns a new array with the specified number
+ * of elements removed from the start.
+ *
+ * @template T - The type of elements in the array.
+ * @param { T[] |  null | undefined} collection - - The array from which to drop elements.
+ * @param {number} itemsCount - The number of elements to drop from the beginning of the array.
+ * @returns {T[]} A new array with the specified number of elements removed from the start.
+ *
+ * @example
+ * const array = [1, 2, 3, 4, 5];
+ * const result = drop(array, 2);
+ * result will be [3, 4, 5] since the first two elements are dropped.
+ */
+export function drop<T>(collection: readonly T[] | null | undefined, itemsCount: number): T[] {
+  if (collection === null || collection === undefined) {
+    return [];
+  }
+
+  itemsCount = Math.max(itemsCount, 0);
+
+  return collection.slice(itemsCount);
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -28,6 +28,7 @@ export { castArray } from './array/castArray.ts';
 export { chunk } from './array/chunk.ts';
 export { concat } from './array/concat.ts';
 export { difference } from './array/difference.ts';
+export { drop } from './array/drop.ts';
 export { fill } from './array/fill.ts';
 export { find } from './array/find.ts';
 export { findIndex } from './array/findIndex.ts';


### PR DESCRIPTION
|`drop.spec.ts`|
|---------------|
|<img src="https://github.com/user-attachments/assets/b3fefae7-81bd-4d90-84e1-17d8d3020258" width=720 height=240/>|


As mentioned in  Issue #531, which I opened, I wrote code to add compatibility to `drop.ts`. I also wrote additional test code and uploaded screenshots showing that it works properly.
