### PR TITLE
feat(curry): enhance type

### DIFF
--- a/src/function/curry.ts
+++ b/src/function/curry.ts
@@ -2,119 +2,8 @@
  * Curries a function, allowing it to be called with a single argument at a time and returning a new function that takes the next argument.
  * This process continues until all arguments have been provided, at which point the original function is called with all accumulated arguments.
  *
- * @param {() => R} func - The function to curry.
- * @returns {() => R} A curried function.
- *
- * @example
- * function noArgFunc() {
- *   return 42;
- * }
- * const curriedNoArgFunc = curry(noArgFunc);
- * console.log(curriedNoArgFunc()); // 42
- */
-export function curry<R>(func: () => R): () => R;
-
-/**
- * Curries a function, allowing it to be called with a single argument at a time and returning a new function that takes the next argument.
- * This process continues until all arguments have been provided, at which point the original function is called with all accumulated arguments.
- *
- * @param {(p: P) => R} func - The function to curry.
- * @returns {(p: P) => R} A curried function.
- *
- * @example
- * function oneArgFunc(a: number) {
- *   return a * 2;
- * }
- * const curriedOneArgFunc = curry(oneArgFunc);
- * console.log(curriedOneArgFunc(5)); // 10
- */
-export function curry<P, R>(func: (p: P) => R): (p: P) => R;
-
-/**
- * Curries a function, allowing it to be called with a single argument at a time and returning a new function that takes the next argument.
- * This process continues until all arguments have been provided, at which point the original function is called with all accumulated arguments.
- *
- * @param {(p1: P1, p2: P2) => R} func - The function to curry.
- * @returns {(p1: P1) => (p2: P2) => R} A curried function.
- *
- * @example
- * function twoArgFunc(a: number, b: number) {
- *   return a + b;
- * }
- * const curriedTwoArgFunc = curry(twoArgFunc);
- * const add5 = curriedTwoArgFunc(5);
- * console.log(add5(10)); // 15
- */
-export function curry<P1, P2, R>(func: (p1: P1, p2: P2) => R): (p1: P1) => (p2: P2) => R;
-
-/**
- * Curries a function, allowing it to be called with a single argument at a time and returning a new function that takes the next argument.
- * This process continues until all arguments have been provided, at which point the original function is called with all accumulated arguments.
- *
- * @param {(p1: P1, p2: P2, p3: P3, p4: P4) => R} func - The function to curry.
- * @returns {(p1: P1) => (p2: P2) => (p3: P3) => (p4: P4) => R} A curried function.
- *
- * @example
- * function fourArgFunc(a: number, b: number, c: number, d: number) {
- *   return a + b + c + d;
- * }
- * const curriedFourArgFunc = curry(fourArgFunc);
- * const add1 = curriedFourArgFunc(1);
- * const add2 = add1(2);
- * const add3 = add2(3);
- * console.log(add3(4)); // 10
- */
-export function curry<P1, P2, P3, R>(func: (p1: P1, p2: P2, p3: P3) => R): (p1: P1) => (p2: P2) => (p3: P3) => R;
-
-/**
- * Curries a function, allowing it to be called with a single argument at a time and returning a new function that takes the next argument.
- * This process continues until all arguments have been provided, at which point the original function is called with all accumulated arguments.
- *
- * @param {(p1: P1, p2: P2, p3: P3, p4: P4) => R} func - The function to curry.
- * @returns {(p1: P1) => (p2: P2) => (p3: P3) => (p4: P4) => R} A curried function.
- *
- * @example
- * function fourArgFunc(a: number, b: number, c: number, d: number) {
- *   return a + b + c + d;
- * }
- * const curriedFourArgFunc = curry(fourArgFunc);
- * const add1 = curriedFourArgFunc(1);
- * const add2 = add1(2);
- * const add3 = add2(3);
- * console.log(add3(4)); // 10
- */
-export function curry<P1, P2, P3, P4, R>(
-  func: (p1: P1, p2: P2, p3: P3, p4: P4) => R
-): (p1: P1) => (p2: P2) => (p3: P3) => (p4: P4) => R;
-
-/**
- * Curries a function, allowing it to be called with a single argument at a time and returning a new function that takes the next argument.
- * This process continues until all arguments have been provided, at which point the original function is called with all accumulated arguments.
- *
- * @param {(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => R} func - The function to curry.
- * @returns {(p1: P1) => (p2: P2) => (p3: P3) => (p4: P4) => (p5: P5) => R} A curried function.
- *
- * @example
- * function fiveArgFunc(a: number, b: number, c: number, d: number, e: number) {
- *   return a + b + c + d + e;
- * }
- * const curriedFiveArgFunc = curry(fiveArgFunc);
- * const add1 = curriedFiveArgFunc(1);
- * const add2 = add1(2);
- * const add3 = add2(3);
- * const add4 = add3(4);
- * console.log(add4(5)); // 15
- */
-export function curry<P1, P2, P3, P4, P5, R>(
-  func: (p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => R
-): (p1: P1) => (p2: P2) => (p3: P3) => (p4: P4) => (p5: P5) => R;
-
-/**
- * Curries a function, allowing it to be called with a single argument at a time and returning a new function that takes the next argument.
- * This process continues until all arguments have been provided, at which point the original function is called with all accumulated arguments.
- *
- * @param {(...args: any[]) => any} func - The function to curry.
- * @returns {(...args: any[]) => any} A curried function that can be called with a single argument at a time.
+ * @param {(...args: A) => R} func - The function to curry.
+ * @returns {Curried<A, R>} A curried function
  *
  * @example
  * function sum(a: number, b: number, c: number) {
@@ -132,39 +21,22 @@ export function curry<P1, P2, P3, P4, P5, R>(
  * // The parameter `c` should be given the value `5`. The function 'sum' has received all its arguments and will now return a value.
  * const result = sum25(5);
  */
-export function curry(func: (...args: any[]) => any): (...args: any[]) => any;
-
-/**
- * Curries a function, allowing it to be called with a single argument at a time and returning a new function that takes the next argument.
- * This process continues until all arguments have been provided, at which point the original function is called with all accumulated arguments.
- *
- * @param {(...args: any[]) => any} func - The function to curry.
- * @returns {(...args: any[]) => any} A curried function that can be called with a single argument at a time.
- *
- * @example
- * function sum(a: number, b: number, c: number) {
- *   return a + b + c;
- * }
- *
- * const curriedSum = curry(sum);
- *
- * // The parameter `a` should be given the value `10`.
- * const sum10 = curriedSum(10);
- *
- * // The parameter `b` should be given the value `15`.
- * const sum25 = sum10(15);
- *
- * // The parameter `c` should be given the value `5`. The function 'sum' has received all its arguments and will now return a value.
- * const result = sum25(5);
- */
-export function curry(func: (...args: any[]) => any): (...args: any[]) => any {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type Curried<A extends any[], R> = A extends []
+  ? () => R
+  : A extends [infer P]
+    ? (p: P) => R
+    : A extends [infer P, ...infer Rest]
+      ? (p: P) => Curried<Rest, R>
+      : never;
+export function curry<A extends any[], R>(func: (...args: A) => R): Curried<A, R> {
   if (func.length === 0 || func.length === 1) {
-    return func;
+    return func as Curried<A, R>;
   }
 
-  return function (arg: any) {
+  return function (arg) {
     return makeCurry(func, func.length, [arg]);
-  } as any;
+  } as Curried<A, R>;
 }
 
 function makeCurry<F extends (...args: any) => any>(origin: F, argsLength: number, args: any[]) {


### PR DESCRIPTION
I noticed that the type tag of the curry function is enumerated. When the number of parameters exceeds a certain value, the type will be any.

There are three cases for currying function types:

1. no parameter, return `() => R`
2. one parameter, return `(p: P) => R`
3. More than one parameter, return `(p: P) => Curried<Rest, P>`

```ts
type Curried<A extends any[], R> = A extends []
  // If the function parameter length is 0, return () => R
  ? () => R
  : A extends [infer P]
    // If the function parameter length is 1, return (p: P) => R
    ? (p: P) => R
    : A extends [infer P, ...infer Rest]
      // If the function has more than 1 parameter, return (p: P) => Curried<Rest, R>
      ? (p: P) => Curried<Rest, R>
      : never;
export function curry<A extends any[], R>(func: (...args: A) => R): Curried<A, R> {
  if (func.length === 0 || func.length === 1) {
    return func as Curried<A, R>;
  }

  return function (arg) {
    return makeCurry(func, func.length, [arg]);
  } as Curried<A, R>;
}
```