### PR TITLE
feat(string): implement `compat/upperCase` and fix types and jsdoc of case methods

### DIFF
--- a/benchmarks/performance/upperCase.bench.ts
+++ b/benchmarks/performance/upperCase.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from 'vitest';
 import { upperCase as upperCaseToolkit } from 'es-toolkit';
+import { upperCase as upperCaseToolkitCompat } from 'es-toolkit/compat';
 import { upperCase as upperCaseLodash } from 'lodash';
 
 describe('upperCase', () => {
@@ -7,6 +8,11 @@ describe('upperCase', () => {
     bench('es-toolkit/upperCase', () => {
       const str = 'camelCase';
       upperCaseToolkit(str);
+    });
+
+    bench('es-toolkit/compat/upperCase', () => {
+      const str = 'camelCase';
+      upperCaseToolkitCompat(str);
     });
 
     bench('lodash/upperCase', () => {
@@ -19,6 +25,10 @@ describe('upperCase', () => {
     const LONG_STR = 'camelCaseLongString'.repeat(1000);
     bench('es-toolkit/upperCase', () => {
       upperCaseToolkit(LONG_STR);
+    });
+
+    bench('es-toolkit/compat/upperCase', () => {
+      upperCaseToolkitCompat(LONG_STR);
     });
 
     bench('lodash/upperCase', () => {

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -93,6 +93,7 @@ export { kebabCase } from './string/kebabCase.ts';
 export { snakeCase } from './string/snakeCase.ts';
 export { startCase } from './string/startCase.ts';
 export { lowerCase } from './string/lowerCase.ts';
+export { upperCase } from './string/upperCase.ts';
 export { startsWith } from './string/startsWith.ts';
 export { endsWith } from './string/endsWith.ts';
 export { padStart } from './string/padStart.ts';

--- a/src/compat/string/camelCase.ts
+++ b/src/compat/string/camelCase.ts
@@ -17,6 +17,6 @@ import { normalizeForCase } from '../_internal/normalizeForCase';
  * const convertedStr4 = camelCase('HTTPRequest') // returns 'httpRequest'
  */
 
-export function camelCase(str: string | object): string {
+export function camelCase(str?: string | object): string {
   return camelCaseToolkit(normalizeForCase(str));
 }

--- a/src/compat/string/kebabCase.ts
+++ b/src/compat/string/kebabCase.ts
@@ -6,7 +6,7 @@ import { normalizeForCase } from '../_internal/normalizeForCase';
  *
  * Kebab case is the naming convention in which each word is written in lowercase and separated by a dash (-) character.
  *
- * @param {string} str - The string that is to be changed to kebab case.
+ * @param {string | object} str - The string that is to be changed to kebab case.
  * @returns {string} - The converted string to kebab case.
  *
  * @example
@@ -15,6 +15,6 @@ import { normalizeForCase } from '../_internal/normalizeForCase';
  * const convertedStr3 = kebabCase('hyphen-text') // returns 'hyphen-text'
  * const convertedStr4 = kebabCase('HTTPRequest') // returns 'http-request'
  */
-export function kebabCase(str: string | object): string {
+export function kebabCase(str?: string | object): string {
   return kebabCaseToolkit(normalizeForCase(str));
 }

--- a/src/compat/string/lowerCase.ts
+++ b/src/compat/string/lowerCase.ts
@@ -6,7 +6,7 @@ import { normalizeForCase } from '../_internal/normalizeForCase';
  *
  * Lower case is the naming convention in which each word is written in lowercase and separated by an space ( ) character.
  *
- * @param {string} str - The string that is to be changed to lower case.
+ * @param {string | object} str - The string that is to be changed to lower case.
  * @returns {string} - The converted string to lower case.
  *
  * @example
@@ -15,6 +15,6 @@ import { normalizeForCase } from '../_internal/normalizeForCase';
  * const convertedStr3 = lowerCase('hyphen-text') // returns 'hyphen text'
  * const convertedStr4 = lowerCase('HTTPRequest') // returns 'http request'
  */
-export function lowerCase(str: string | object): string {
+export function lowerCase(str?: string | object): string {
   return lowerCaseToolkit(normalizeForCase(str));
 }

--- a/src/compat/string/snakeCase.ts
+++ b/src/compat/string/snakeCase.ts
@@ -6,7 +6,7 @@ import { normalizeForCase } from '../_internal/normalizeForCase';
  *
  * Snake case is the naming convention in which each word is written in lowercase and separated by an underscore (_) character.
  *
- * @param {string} str - The string that is to be changed to snake case.
+ * @param {string | object} str - The string that is to be changed to snake case.
  * @returns {string} - The converted string to snake case.
  *
  * @example
@@ -15,6 +15,6 @@ import { normalizeForCase } from '../_internal/normalizeForCase';
  * const convertedStr3 = snakeCase('hyphen-text') // returns 'hyphen_text'
  * const convertedStr4 = snakeCase('HTTPRequest') // returns 'http_request'
  */
-export function snakeCase(str: string | object): string {
+export function snakeCase(str?: string | object): string {
   return snakeCaseToolkit(normalizeForCase(str));
 }

--- a/src/compat/string/startCase.spec.ts
+++ b/src/compat/string/startCase.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { startCase } from './startCase';
 
-describe('case methods', () => {
+describe('startCase', () => {
   const strings = ['foo bar', 'Foo bar', 'foo Bar', 'Foo Bar', 'FOO BAR', 'fooBar', '--foo-bar--', '__foo_bar__'];
 
   it(`should convert \`string\``, () => {

--- a/src/compat/string/startCase.ts
+++ b/src/compat/string/startCase.ts
@@ -5,7 +5,7 @@ import { normalizeForCase } from '../_internal/normalizeForCase';
  * Converts the first character of each word in a string to uppercase and the remaining characters to lowercase.
  *
  * Start case is the naming convention in which each word is written with an initial capital letter.
- * @param {string} str - The string to convert.
+ * @param {string | object} str - The string to convert.
  * @returns {string} The converted string.
  *
  * @example
@@ -14,6 +14,6 @@ import { normalizeForCase } from '../_internal/normalizeForCase';
  * const result3 = startCase('hello-world');  // result will be 'Hello World'
  * const result4 = startCase('hello_world');  // result will be 'Hello World'
  */
-export function startCase(str: string | object): string {
+export function startCase(str?: string | object): string {
   return startCaseToolkit(normalizeForCase(str));
 }

--- a/src/compat/string/upperCase.spec.ts
+++ b/src/compat/string/upperCase.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { upperCase } from './upperCase';
+describe('upperCase', () => {
+  const strings = ['foo bar', 'Foo bar', 'foo Bar', 'Foo Bar', 'FOO BAR', 'fooBar', '--foo-bar--', '__foo_bar__'];
+
+  it(`should convert \`string\``, () => {
+    const actual = strings.map(string => upperCase(string));
+
+    const expected = actual.map(() => 'FOO BAR');
+
+    expect(actual).toEqual(expected);
+  });
+
+  it(`should handle double-converting strings`, () => {
+    const actual = strings.map(string => upperCase(upperCase(string)));
+
+    const expected = actual.map(() => 'FOO BAR');
+
+    expect(actual).toEqual(expected);
+  });
+
+  it(`should remove contraction apostrophes`, () => {
+    const postfixes = ['d', 'll', 'm', 're', 's', 't', 've'];
+
+    ["'", '\u2019'].forEach(apos => {
+      const actual = postfixes.map(postfix => upperCase(`a b${apos}${postfix} c`));
+
+      const expected = postfixes.map(postfix => `A B${postfix.toUpperCase()} C`);
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  it(`should remove Latin mathematical operators`, () => {
+    const actual = ['\xd7', '\xf7'].map(upperCase);
+    expect(actual).toEqual(['', '']);
+  });
+
+  it(`should coerce \`string\` to a string`, () => {
+    const string = 'foo bar';
+    expect(upperCase(Object(string))).toBe('FOO BAR');
+    expect(upperCase({ toString: () => string })).toBe('FOO BAR');
+  });
+  it('should uppercase as space-separated words', () => {
+    expect(upperCase('--foo-bar--')).toBe('FOO BAR');
+    expect(upperCase('fooBar')).toBe('FOO BAR');
+    expect(upperCase('__foo_bar__')).toBe('FOO BAR');
+  });
+});

--- a/src/compat/string/upperCase.ts
+++ b/src/compat/string/upperCase.ts
@@ -1,0 +1,20 @@
+import { upperCase as upperCaseToolkit } from '../../string';
+import { normalizeForCase } from '../_internal/normalizeForCase';
+
+/**
+ * Converts a string to upper case.
+ *
+ * Upper case is the naming convention in which each word is written in uppercase and separated by an space ( ) character.
+ *
+ * @param {string | object} str - The string that is to be changed to upper case.
+ * @returns {string} - The converted string to upper case.
+ *
+ * @example
+ * const convertedStr1 = upperCase('camelCase') // returns 'CAMEL CASE'
+ * const convertedStr2 = upperCase('some whitespace') // returns 'SOME WHITESPACE'
+ * const convertedStr3 = upperCase('hyphen-text') // returns 'HYPHEN TEXT'
+ * const convertedStr4 = upperCase('HTTPRequest') // returns 'HTTP REQUEST'
+ */
+export function upperCase(str?: string | object): string {
+  return upperCaseToolkit(normalizeForCase(str));
+}


### PR DESCRIPTION
# Description

I added a `upperCase` in compat layer.

And I fixed function interface similar with `@types/lodash`.

## Benchmark (`upperCase`)

<img width="586" alt="Screenshot 2024-09-15 at 6 41 20 PM" src="https://github.com/user-attachments/assets/f8433f33-4171-48e6-a36d-8c38853fd7da">
