### PR TITLE
perf(zip): Optimize performance of `zip`

### DIFF
--- a/src/array/zip.ts
+++ b/src/array/zip.ts
@@ -111,19 +111,16 @@ export function zip<T, U, V, W>(
  * // result will be [[1, 'a', true], [2, 'b', false], [3, 'c', undefined]]
  */
 export function zip<T>(...arrs: Array<readonly T[]>): T[][] {
-  const result: T[][] = [];
+  const rowCount = Math.max(...arrs.map(x => x.length));
+  const columnCount = arrs.length;
+  const result = Array(rowCount);
 
-  const maxIndex = Math.max(...arrs.map(x => x.length));
-
-  for (let i = 0; i < maxIndex; i++) {
-    const element: T[] = [];
-
-    for (const arr of arrs) {
-      element.push(arr[i]);
+  for (let i = 0; i < rowCount; ++i) {
+    const row = Array(columnCount);
+    for (let j = 0; j < columnCount; ++j) {
+      row[j] = arrs[j][i];
     }
-
-    result.push(element);
+    result[i] = row;
   }
-
   return result;
 }


### PR DESCRIPTION
I've improved the performance of `zip` by defining the array size. The updated code is 1.41x faster than the previous version.


<img width="557" alt="스크린샷 2024-09-15 오후 8 36 11" src="https://github.com/user-attachments/assets/8b52fac5-ffad-4255-baa1-a39f8d983d03">
