### PR TITLE
perf(zipWith): Optimize performance of `zipWith`

### DIFF
--- a/src/array/zipWith.ts
+++ b/src/array/zipWith.ts
@@ -105,12 +105,12 @@ export function zipWith<T, R>(arr1: readonly T[], ...rest: any[]): R[] {
   const arrs = [arr1, ...rest.slice(0, -1)];
   const combine = rest[rest.length - 1] as (...items: T[]) => R;
 
-  const result: R[] = [];
   const maxIndex = Math.max(...arrs.map(arr => arr.length));
+  const result: R[] = Array(maxIndex);
 
   for (let i = 0; i < maxIndex; i++) {
     const elements: T[] = arrs.map(arr => arr[i]);
-    result.push(combine(...elements));
+    result[i] = combine(...elements);
   }
 
   return result;


### PR DESCRIPTION
I've optimized performance of `zipWith`

<img width="624" alt="스크린샷 2024-09-15 오후 9 11 04" src="https://github.com/user-attachments/assets/5baa6efa-9e50-4ae3-80a3-8a7c7d634c0d">
