### PR TITLE
chore(script): enhance transforming lodash test codes script

### DIFF
--- a/.scripts/tests/_internal/formatter/brokenSyntax.ts
+++ b/.scripts/tests/_internal/formatter/brokenSyntax.ts
@@ -1,6 +1,7 @@
 export function formatBrokenSyntax(source: string): string {
   // Fix broken syntax
-  const brokenMatched = source.match(/(?<=,)[\s\d\w?]+\[.+\).toEqual\((?!\[).+\]\);/g);
+  const brokenMatched = source.match(/(?<=expect\(.+)[[{][^{[]+\)\.toEqual\([^\]}]+[\]}]\);/g);
+
   if (brokenMatched != null) {
     for (const match of brokenMatched) {
       const splited = match.split(').toEqual(');

--- a/.scripts/tests/_internal/transform/assert.ts
+++ b/.scripts/tests/_internal/transform/assert.ts
@@ -16,14 +16,36 @@ export function transformAssert(root: Collection, jscodeshift: JSCodeshift): voi
     })
     .replaceWith(({ node }) => {
       if (node.callee.type === 'MemberExpression' && node.callee.property.type === 'Identifier') {
-        if (node.callee.property.name === 'deepStrictEqual') {
-          const expectArguments =
-            node.arguments.length === 3 ? [node.arguments[0], node.arguments[2]] : [node.arguments[0]];
+        const expectArguments =
+          node.arguments.length === 3 ? [node.arguments[0], node.arguments[2]] : [node.arguments[0]];
+        const expect = jscodeshift.callExpression(jscodeshift.identifier('expect'), expectArguments);
 
-          return jscodeshift.memberExpression(
-            jscodeshift.callExpression(jscodeshift.identifier('expect'), expectArguments),
-            jscodeshift.callExpression(jscodeshift.identifier('toEqual'), [node.arguments[1]])
-          );
+        switch (node.callee.property.name) {
+          case 'deepStrictEqual':
+            return jscodeshift.memberExpression(
+              expect,
+              jscodeshift.callExpression(jscodeshift.identifier('toEqual'), [node.arguments[1]])
+            );
+          case 'deepEqual':
+            return jscodeshift.memberExpression(
+              expect,
+              jscodeshift.callExpression(jscodeshift.identifier('toEqual'), [node.arguments[1]])
+            );
+          case 'strictEqual':
+            return jscodeshift.memberExpression(
+              expect,
+              jscodeshift.callExpression(jscodeshift.identifier('toBe'), [node.arguments[1]])
+            );
+          case 'notEqual':
+            return jscodeshift.memberExpression(
+              expect,
+              jscodeshift.callExpression(jscodeshift.identifier('not.toBe'), [node.arguments[1]])
+            );
+          case 'notStrictEqual':
+            return jscodeshift.memberExpression(
+              expect,
+              jscodeshift.callExpression(jscodeshift.identifier('not.toBe'), [node.arguments[1]])
+            );
         }
       }
       return node;

--- a/.scripts/tests/_internal/transform/assert.ts
+++ b/.scripts/tests/_internal/transform/assert.ts
@@ -1,0 +1,31 @@
+import type { Collection, JSCodeshift } from 'jscodeshift';
+
+export function transformAssert(root: Collection, jscodeshift: JSCodeshift): void {
+  // Change `assert.deepStrictEqual(a, b, c)` to `expect(a, c).toEqual(b)`
+  root
+    .find(jscodeshift.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: {
+          name: 'assert',
+        },
+        property: {
+          type: 'Identifier',
+        },
+      },
+    })
+    .replaceWith(({ node }) => {
+      if (node.callee.type === 'MemberExpression' && node.callee.property.type === 'Identifier') {
+        if (node.callee.property.name === 'deepStrictEqual') {
+          const expectArguments =
+            node.arguments.length === 3 ? [node.arguments[0], node.arguments[2]] : [node.arguments[0]];
+
+          return jscodeshift.memberExpression(
+            jscodeshift.callExpression(jscodeshift.identifier('expect'), expectArguments),
+            jscodeshift.callExpression(jscodeshift.identifier('toEqual'), [node.arguments[1]])
+          );
+        }
+      }
+      return node;
+    });
+}

--- a/.scripts/tests/_internal/transform/import.ts
+++ b/.scripts/tests/_internal/transform/import.ts
@@ -35,15 +35,44 @@ export function transformImport(root: Collection, jscodeshift: JSCodeshift): voi
     .remove();
 
   // Add import { describe, it, expect } from 'vitest';
-  const vitestImport = jscodeshift.importDeclaration(
-    [
-      jscodeshift.importSpecifier(jscodeshift.identifier('describe')),
-      jscodeshift.importSpecifier(jscodeshift.identifier('it')),
-      jscodeshift.importSpecifier(jscodeshift.identifier('expect')),
+  const vitestImport = root.find(jscodeshift.ImportDeclaration, {
+    source: {
+      value: 'vitest',
+    },
+    specifiers: [
+      {
+        type: 'ImportSpecifier',
+        imported: {
+          name: 'describe',
+        },
+      },
+      {
+        type: 'ImportSpecifier',
+        imported: {
+          name: 'it',
+        },
+      },
+      {
+        type: 'ImportSpecifier',
+        imported: {
+          name: 'expect',
+        },
+      },
     ],
-    jscodeshift.literal('vitest')
-  );
-  astPath.value.program.body.unshift(vitestImport);
+  });
+
+  if (!vitestImport.length) {
+    astPath.value.program.body.unshift(
+      jscodeshift.importDeclaration(
+        [
+          jscodeshift.importSpecifier(jscodeshift.identifier('describe')),
+          jscodeshift.importSpecifier(jscodeshift.identifier('it')),
+          jscodeshift.importSpecifier(jscodeshift.identifier('expect')),
+        ],
+        jscodeshift.literal('vitest')
+      )
+    );
+  }
 
   // Remove import from 'lodash'
   root

--- a/.scripts/tests/_internal/transform/import.ts
+++ b/.scripts/tests/_internal/transform/import.ts
@@ -69,10 +69,12 @@ export function transformImport(root: Collection, jscodeshift: JSCodeshift): voi
     })
     .remove();
 
-  const methodImport = jscodeshift.importDeclaration(
-    Array.from(methodSet).map(method => jscodeshift.importSpecifier(jscodeshift.identifier(method))),
-    jscodeshift.literal('../index')
-  );
+  if (methodSet.size) {
+    const methodImport = jscodeshift.importDeclaration(
+      Array.from(methodSet).map(method => jscodeshift.importSpecifier(jscodeshift.identifier(method))),
+      jscodeshift.literal('../index')
+    );
 
-  astPath.value.program.body.unshift(methodImport);
+    astPath.value.program.body.unshift(methodImport);
+  }
 }

--- a/.scripts/tests/transform-lodash-test.ts
+++ b/.scripts/tests/transform-lodash-test.ts
@@ -7,7 +7,6 @@ import { transformAssert } from './_internal/transform/assert';
 export default function transform(file: FileInfo, { jscodeshift }: API) {
   try {
     const root = jscodeshift(formatBrokenSyntax(file.source));
-
     transformLodashStable(root, jscodeshift);
     transformImport(root, jscodeshift);
     transformAssert(root, jscodeshift);
@@ -15,6 +14,7 @@ export default function transform(file: FileInfo, { jscodeshift }: API) {
     return root.toSource();
   } catch (error) {
     if (error instanceof Error) {
+      console.error(`File Path: ${file.path}`);
       console.error(`Error Messaging: ${error.message}`);
       console.error('Please resolve the error before continuing.');
       console.error('If you need help, please open an issue on GitHub.');

--- a/.scripts/tests/transform-lodash-test.ts
+++ b/.scripts/tests/transform-lodash-test.ts
@@ -7,8 +7,8 @@ export default function transform(file: FileInfo, { jscodeshift }: API) {
   try {
     const root = jscodeshift(formatBrokenSyntax(file.source));
 
-    transformImport(root, jscodeshift);
     transformLodashStable(root, jscodeshift);
+    transformImport(root, jscodeshift);
 
     return root.toSource();
   } catch (error) {

--- a/.scripts/tests/transform-lodash-test.ts
+++ b/.scripts/tests/transform-lodash-test.ts
@@ -2,6 +2,7 @@ import type { API, FileInfo } from 'jscodeshift';
 import { formatBrokenSyntax } from './_internal/formatter/brokenSyntax';
 import { transformImport } from './_internal/transform/import';
 import { transformLodashStable } from './_internal/transform/lodashStable';
+import { transformAssert } from './_internal/transform/assert';
 
 export default function transform(file: FileInfo, { jscodeshift }: API) {
   try {
@@ -9,6 +10,7 @@ export default function transform(file: FileInfo, { jscodeshift }: API) {
 
     transformLodashStable(root, jscodeshift);
     transformImport(root, jscodeshift);
+    transformAssert(root, jscodeshift);
 
     return root.toSource();
   } catch (error) {


### PR DESCRIPTION
# Description

I improved transforming lodash test codes script:

1. Change `delete localVariable` to comment, Because this expression is not allowed in js strict mode.
2. Enhance fixing a broken syntax like `expect(a, [1, 2).toEqual(3])`.
  a. Now, we can handle cases like `expect(func()`, `expect({a: {b: [1,2]}`, etc...
3. Change `assert.methods(a,b,c)` to `expect(a,c).toMethods(b)`.
  b. e.g. `assert.strictEqual(a,b,c)` to `expect(a, c).toBe(b)`
4. Change `lodashStable.methods` to `esToolit.methods`
5. Change `import method from '../src/method'` to `import { method } from '../index'`

## Test results

<img width="176" alt="Screenshot 2024-09-18 at 1 17 46 PM" src="https://github.com/user-attachments/assets/1b01d22c-da26-4c55-86da-23033803e1ba">

At now, We can transform all of the lodash testcode except 2 files.

I have automated the transformation of all lodash test codes as much as possible, but there are cases where the test code itself is inaccurate. Therefore, we shouldn’t rely on the tool too much. It would be better if it is only used as an auxiliary tool.