### PR TITLE
docs: fix typo in `/bundle-size`, `/compatibility`, `/intro`, `/usage`

### DIFF
--- a/docs/ko/bundle-size.md
+++ b/docs/ko/bundle-size.md
@@ -28,7 +28,7 @@ es-toolkit은 현대적인 구현을 가지고 있기 때문에, 다른 라이�
 
 ```tsx
 import { chunk } from 'es-toolkit';
-// or import { chunk } from 'lodash-es';
+// 또는 import { chunk } from 'lodash-es';
 
 console.log(chunk);
 ```

--- a/docs/ko/compatibility.md
+++ b/docs/ko/compatibility.md
@@ -15,7 +15,7 @@ chunk([1, 2, 3, 4], 0);
 
 `es-toolkit/compat`은 실제 `lodash` 테스트 코드를 이용해서 테스트돼요.
 
-`es-toolkit/compat`는 원래 `es-toolkit`에 비해 런타임 퍼포먼스나 번들 크기가 최적은 아닐 수 있어요. 마이그레이션 중에 사용하는 도구로 생각해 주시고, 새로운 기능은 `es-toolkit`로 개발해주세요.
+`es-toolkit/compat`은 원래 `es-toolkit`에 비해 런타임 퍼포먼스나 번들 크기가 최적은 아닐 수 있어요. 마이그레이션 중에 사용하는 도구로 생각해 주시고, 새로운 기능은 `es-toolkit`로 개발해주세요.
 
 ## 설계 원칙
 

--- a/docs/ko/intro.md
+++ b/docs/ko/intro.md
@@ -2,8 +2,7 @@
 
 es-toolkit은 일상적인 개발에서 사용하는 다양한 함수들을 모은 현대적인 JavaScript 유틸리티 라이브러리예요.
 
-[lodash](https://lodash.com/)와 같은 다른 라이브러리와 비교했을 때, es-toolkit은 [같은 함수 기준 최대 97% 작은 번들 사이즈](./bundle-size.md)
-를 제공하며, [2~3배 빠른 속도로](./performance.md) 동작합니다. 최신 JavaScript API를 활용해서 현대적으로 구현한 덕분이죠.
+[lodash](https://lodash.com/)와 같은 다른 라이브러리와 비교했을 때, es-toolkit은 [같은 함수 기준 최대 97% 작은 번들 사이즈](./bundle-size.md)를 제공하며, [2~3배 빠른 속도로](./performance.md) 동작합니다. 최신 JavaScript API를 활용해서 현대적으로 구현한 덕분이죠.
 
 es-toolkit은 견고한 TypeScript 타입을 내장하여 제공하며, 신뢰성을 높일 수 있도록 100% 테스트 커버리지를 목표로 하고 있습니다.
 
@@ -13,7 +12,7 @@ es-toolkit이 제공하는 기능 목록은 다음과 같습니다.
 
 - **배열**: [uniq](./reference/array/uniq.md)나 [difference](./reference/array/difference.md)와 같이 배열을 다루기 위한 다양한 함수를 제공해요.
 - **함수**: [debounce](./reference/function/debounce.md)나 [throttle](./reference/function/throttle.md)처럼 함수 호출을 다루는 도구를 제공해요.
-- **숫자**: [sum](./reference/math/sum.md)이나 [round](./reference/math/round.md) 처럼 숫자를 쉽게 다루는 함수를 제공해요.
+- **숫자**: [sum](./reference/math/sum.md)이나 [round](./reference/math/round.md)처럼 숫자를 쉽게 다루는 함수를 제공해요.
 - **객체**: [pick](./reference/object/pick.md)이나 [omit](./reference/object/omit.md)처럼 JavaScript 객체를 다루는 함수를 제공해요.
 - **타입 가드**: [isNotNil](./reference/predicate/isNotNil.md)처럼 특정한 객체가 어떤 상태인지 검사하는 타입 가드 함수를 제공해요.
 - **Promise**: [delay](./reference/promise/delay.md)와 같은 비동기 유틸리티 함수를 제공해요.

--- a/docs/ko/usage.md
+++ b/docs/ko/usage.md
@@ -12,7 +12,7 @@ next:
 
 Node.js나 Bun을 사용하는 경우, [npm](https://npmjs.com/package/es-toolkit)에서 설치할 수 있어요. Deno에서는 [JSR](https://jsr.io/@es-toolkit/es-toolkit)에서 설치할 수 있어요.
 
-브라우저에서 바로 쓰는 경우, [CDN에서 가져올 수](#브라우저)있어요.
+브라우저에서 바로 쓰는 경우, [CDN에서 가져올 수](#브라우저) 있어요.
 
 ## Node.js
 


### PR DESCRIPTION
- fix typos and incorrect spacing
- fix untranslated comments in codeblock