### PR TITLE
docs(range): Update docs for `range`

### DIFF
--- a/src/math/range.ts
+++ b/src/math/range.ts
@@ -1,39 +1,21 @@
 /**
- * Returns an array of numbers from `start` to `end`, incrementing by `step`.
+ * Returns an array of numbers from `0` (inclusive) to `end` (exclusive), incrementing by `1`.
  *
- * If `step` is not provided, it defaults to `1`.
- *
- * @param {number} start - The starting number of the range (inclusive).
- * @param {number} [end] - The end number of the range (exclusive).
- * @param {number} [step] - The step value for the range. (default: 1)
- * @returns {number[]} An array of numbers from `start` to `end` with the specified `step`.
+ * @param {number} end - The end number of the range (exclusive).
+ * @returns {number[]} An array of numbers from `0` (inclusive) to `end` (exclusive) with a step of `1`.
  *
  * @example
  * // Returns [0, 1, 2, 3]
  * range(4);
- *
- * @example
- * // Returns [0, 5, 10, 15]
- * range(0, 20, 5);
- *
- * @example
- * // Returns [0, -1, -2, -3]
- * range(0, -4, -1);
- *
- * @example
- * // Throws an error: The step value must be a non-zero integer.
- * range(1, 4, 0);
  */
 export function range(end: number): number[];
 
 /**
- * Returns an array of numbers from `start` to `end`, incrementing by `step`.
- *
- * If `step` is not provided, it defaults to `1`.
+ * Returns an array of numbers from `start` (inclusive) to `end` (exclusive), incrementing by `1`.
  *
  * @param {number} start - The starting number of the range (inclusive).
  * @param {number} end - The end number of the range (exclusive).
- * @returns {number[]} An array of numbers from `start` to `end` with the specified `step`.
+ * @returns {number[]} An array of numbers from `start` (inclusive) to `end` (exclusive) with a step of `1`.
  *
  * @example
  * // Returns [1, 2, 3]
@@ -42,12 +24,12 @@ export function range(end: number): number[];
 export function range(start: number, end: number): number[];
 
 /**
- * Returns an array of numbers from `start` to `end`, incrementing by `step`.
+ * Returns an array of numbers from `start` (inclusive) to `end` (exclusive), incrementing by `step`.
  *
  * @param {number} start - The starting number of the range (inclusive).
  * @param {number} end - The end number of the range (exclusive).
  * @param {number} step - The step value for the range.
- * @returns {number[]} An array of numbers from `start` to `end` with the specified `step`.
+ * @returns {number[]} An array of numbers from `start` (inclusive) to `end` (exclusive) with the specified `step`.
  *
  * @example
  * // Returns [0, 5, 10, 15]
@@ -55,25 +37,6 @@ export function range(start: number, end: number): number[];
  */
 export function range(start: number, end: number, step: number): number[];
 
-/**
- * Returns an array of numbers from `start` to `end`, incrementing by `step`.
- *
- * If only one argument is provided, it returns an array from `0` to `start`.
- *
- * @param {number} start - The starting number of the range (inclusive).
- * @param {number} [end] - The end number of the range (exclusive).
- * @param {number} [step] - The step value for the range. (default: 1)
- * @returns {number[]} An array of numbers from `start` to `end` with the specified `step`.
- * @throws {Error} Throws an error if the step value is not a non-zero integer.
- *
- * @example
- * // Returns [0, 1, 2, 3]
- * range(4);
- *
- * @example
- * // Returns [0, -1, -2, -3]
- * range(0, -4, -1);
- */
 export function range(start: number, end?: number, step?: number): number[] {
   if (end == null) {
     end = start;

--- a/src/math/range.ts
+++ b/src/math/range.ts
@@ -38,24 +38,24 @@ export function range(start: number, end: number): number[];
 export function range(start: number, end: number, step: number): number[];
 
 /**
-  * Returns an array of numbers from `start` to `end`, incrementing by `step`.
-  *
-  * If only one argument is provided, it returns an array from `0` to `start`.
-  *
-  * @param {number} start - The starting number of the range (inclusive).
-  * @param {number} [end] - The end number of the range (exclusive).
-  * @param {number} [step] - The step value for the range. (default: 1)
-  * @returns {number[]} An array of numbers from `start` to `end` with the specified `step`.
-  * @throws {Error} Throws an error if the step value is not a non-zero integer.
-  *
-  * @example
-  * // Returns [0, 1, 2, 3]
-  * range(4);
-  *
-  * @example
-  * // Returns [0, -1, -2, -3]
-  * range(0, -4, -1);
-  */
+ * Returns an array of numbers from `start` to `end`, incrementing by `step`.
+ *
+ * If only one argument is provided, it returns an array from `0` to `start`.
+ *
+ * @param {number} start - The starting number of the range (inclusive).
+ * @param {number} [end] - The end number of the range (exclusive).
+ * @param {number} [step] - The step value for the range. (default: 1)
+ * @returns {number[]} An array of numbers from `start` to `end` with the specified `step`.
+ * @throws {Error} Throws an error if the step value is not a non-zero integer.
+ *
+ * @example
+ * // Returns [0, 1, 2, 3]
+ * range(4);
+ *
+ * @example
+ * // Returns [0, -1, -2, -3]
+ * range(0, -4, -1);
+ */
 export function range(start: number, end?: number, step?: number): number[] {
   if (end == null) {
     end = start;

--- a/src/math/range.ts
+++ b/src/math/range.ts
@@ -38,14 +38,12 @@ export function range(start: number, end: number): number[];
 export function range(start: number, end: number, step: number): number[];
 
 /**
- * Returns an array of numbers from `start` to `end`, incrementing by `step`.
- *
- * If only one argument is provided, it returns an array from `0` to `start`.
+ * Returns an array of numbers from `start` (inclusive) to `end` (exclusive), incrementing by `step`.
  *
  * @param {number} start - The starting number of the range (inclusive).
- * @param {number} [end] - The end number of the range (exclusive).
- * @param {number} [step] - The step value for the range. (default: 1)
- * @returns {number[]} An array of numbers from `start` to `end` with the specified `step`.
+ * @param {number} end - The end number of the range (exclusive).
+ * @param {number} step - The step value for the range.
+ * @returns {number[]} An array of numbers from `start` (inclusive) to `end` (exclusive) with the specified `step`.
  * @throws {Error} Throws an error if the step value is not a non-zero integer.
  *
  * @example

--- a/src/math/range.ts
+++ b/src/math/range.ts
@@ -37,6 +37,25 @@ export function range(start: number, end: number): number[];
  */
 export function range(start: number, end: number, step: number): number[];
 
+/**
+  * Returns an array of numbers from `start` to `end`, incrementing by `step`.
+  *
+  * If only one argument is provided, it returns an array from `0` to `start`.
+  *
+  * @param {number} start - The starting number of the range (inclusive).
+  * @param {number} [end] - The end number of the range (exclusive).
+  * @param {number} [step] - The step value for the range. (default: 1)
+  * @returns {number[]} An array of numbers from `start` to `end` with the specified `step`.
+  * @throws {Error} Throws an error if the step value is not a non-zero integer.
+  *
+  * @example
+  * // Returns [0, 1, 2, 3]
+  * range(4);
+  *
+  * @example
+  * // Returns [0, -1, -2, -3]
+  * range(0, -4, -1);
+  */
 export function range(start: number, end?: number, step?: number): number[] {
   if (end == null) {
     end = start;


### PR DESCRIPTION
I've updated the JSDoc for `range` to describe only the corresponding overloaded function signatures.