### PR TITLE
fix(merge): Handle edge-case for `merge`

### DIFF
--- a/src/object/merge.spec.ts
+++ b/src/object/merge.spec.ts
@@ -60,8 +60,9 @@ describe('merge', () => {
   });
 
   it('should handle merging arrays into non-array target values', () => {
-    const target = { a: 1, b: {} };
     const numbers = [1, 2, 3];
+    
+    const target = { a: 1, b: {} };
     const source = { b: numbers, c: 4 };
     const result = merge(target, source);
 
@@ -71,6 +72,7 @@ describe('merge', () => {
 
   it('should create new plain object when merged', () => {
     const plainObject = { b: 2 } as const;
+    
     const target = {};
     const source = { a: plainObject };
     const result = merge(target, source);

--- a/src/object/merge.spec.ts
+++ b/src/object/merge.spec.ts
@@ -59,6 +59,14 @@ describe('merge', () => {
     expect(result).toEqual({ a: [1, 2, 3] });
   });
 
+  it('should handle merging arrays into non-array target values', () => {
+    const target = { a: 1, b: {} };
+    const source = { b: [1], c: 4 };
+    const result = merge(target, source);
+
+    expect(result).toEqual({ a: 1, b: [1], c: 4 });
+  });
+
   it('should not overwrite existing values with undefined from source', () => {
     const target = { a: 1, b: 2 };
     const source = { b: undefined, c: 3 };

--- a/src/object/merge.spec.ts
+++ b/src/object/merge.spec.ts
@@ -69,6 +69,16 @@ describe('merge', () => {
     expect(result.b).not.toBe(numbers);
   });
 
+  it('should create new plain object when merged', () => {
+    const plainObject = { b: 2 } as const;
+    const target = {};
+    const source = { a: plainObject };
+    const result = merge(target, source);
+
+    expect(result).toEqual({ a: plainObject });
+    expect(result.a).not.toBe(plainObject);
+  });
+
   it('should not overwrite existing values with undefined from source', () => {
     const target = { a: 1, b: 2 };
     const source = { b: undefined, c: 3 };

--- a/src/object/merge.spec.ts
+++ b/src/object/merge.spec.ts
@@ -61,10 +61,12 @@ describe('merge', () => {
 
   it('should handle merging arrays into non-array target values', () => {
     const target = { a: 1, b: {} };
-    const source = { b: [1], c: 4 };
+    const numbers = [1, 2, 3];
+    const source = { b: numbers, c: 4 };
     const result = merge(target, source);
 
-    expect(result).toEqual({ a: 1, b: [1], c: 4 });
+    expect(result).toEqual({ a: 1, b: numbers, c: 4 });
+    expect(result.b).not.toBe(numbers);
   });
 
   it('should not overwrite existing values with undefined from source', () => {

--- a/src/object/merge.spec.ts
+++ b/src/object/merge.spec.ts
@@ -79,6 +79,17 @@ describe('merge', () => {
     expect(result.a).not.toBe(plainObject);
   });
 
+  it('should handle merging values that are neither arrays nor plain objects', () => {
+    const date = new Date();
+    const target = {};
+    const source = { a: date };
+    const result = merge(target, source);
+
+    expect(result).toEqual({ a: date });
+    // unlike arrays and plain objects, the original value is used.
+    expect(result.a).toBe(date);
+  });
+
   it('should not overwrite existing values with undefined from source', () => {
     const target = { a: 1, b: 2 };
     const source = { b: undefined, c: 3 };

--- a/src/object/merge.ts
+++ b/src/object/merge.ts
@@ -92,8 +92,8 @@ export function merge(target: any, source: any) {
 
     if (Array.isArray(sourceValue)) {
       target[key] = merge(Array.isArray(targetValue) ? targetValue : [], sourceValue);
-    } else if (isObjectLike(targetValue) && isObjectLike(sourceValue)) {
-      target[key] = merge(targetValue ?? {}, sourceValue);
+    } else if (isObjectLike(sourceValue)) {
+      target[key] = merge(isObjectLike(targetValue) ? targetValue : {}, sourceValue);
     } else if (targetValue === undefined || sourceValue !== undefined) {
       target[key] = sourceValue;
     }

--- a/src/object/merge.ts
+++ b/src/object/merge.ts
@@ -91,9 +91,17 @@ export function merge(target: any, source: any) {
     const targetValue = target[key];
 
     if (Array.isArray(sourceValue)) {
-      target[key] = merge(Array.isArray(targetValue) ? targetValue : [], sourceValue);
+      if (Array.isArray(targetValue)) {
+        target[key] = merge(targetValue, sourceValue);
+      } else {
+        target[key] = [...sourceValue];
+      }
     } else if (isPlainObject(sourceValue)) {
-      target[key] = merge(isPlainObject(targetValue) ? targetValue : {}, sourceValue);
+      if (isPlainObject(targetValue)) {
+        target[key] = merge(targetValue, sourceValue);
+      } else {
+        target[key] = { ...sourceValue };
+      }
     } else if (targetValue === undefined || sourceValue !== undefined) {
       target[key] = sourceValue;
     }

--- a/src/object/merge.ts
+++ b/src/object/merge.ts
@@ -91,7 +91,11 @@ export function merge(target: any, source: any) {
     const targetValue = target[key];
 
     if (Array.isArray(sourceValue)) {
-      target[key] = merge(targetValue ?? [], sourceValue);
+      if (Array.isArray(targetValue)) {
+        target[key] = merge(targetValue, sourceValue);
+      } else {
+        target[key] = sourceValue;
+      }
     } else if (isObjectLike(targetValue) && isObjectLike(sourceValue)) {
       target[key] = merge(targetValue ?? {}, sourceValue);
     } else if (targetValue === undefined || sourceValue !== undefined) {

--- a/src/object/merge.ts
+++ b/src/object/merge.ts
@@ -91,11 +91,7 @@ export function merge(target: any, source: any) {
     const targetValue = target[key];
 
     if (Array.isArray(sourceValue)) {
-      if (Array.isArray(targetValue)) {
-        target[key] = merge(targetValue, sourceValue);
-      } else {
-        target[key] = sourceValue;
-      }
+      target[key] = merge(Array.isArray(targetValue) ? targetValue : [], sourceValue);
     } else if (isObjectLike(targetValue) && isObjectLike(sourceValue)) {
       target[key] = merge(targetValue ?? {}, sourceValue);
     } else if (targetValue === undefined || sourceValue !== undefined) {

--- a/src/object/merge.ts
+++ b/src/object/merge.ts
@@ -1,4 +1,4 @@
-import { isObjectLike } from '../compat/predicate/isObjectLike.ts';
+import { isPlainObject } from '../predicate/isPlainObject.ts';
 
 /**
  * Merges the properties of the source object into the target object.
@@ -92,8 +92,8 @@ export function merge(target: any, source: any) {
 
     if (Array.isArray(sourceValue)) {
       target[key] = merge(Array.isArray(targetValue) ? targetValue : [], sourceValue);
-    } else if (isObjectLike(sourceValue)) {
-      target[key] = merge(isObjectLike(targetValue) ? targetValue : {}, sourceValue);
+    } else if (isPlainObject(sourceValue)) {
+      target[key] = merge(isPlainObject(targetValue) ? targetValue : {}, sourceValue);
     } else if (targetValue === undefined || sourceValue !== undefined) {
       target[key] = sourceValue;
     }


### PR DESCRIPTION
I understood how the `merge` function works by testing Lodash's `merge` function. I then realized there was a difference between the two.

Although this is not `compat/merge`, the behavior should be consistent. Please let me know if the current behavior is intended.