### PR TITLE
fix(predicate): enhance performance and simplify codes of `isNumber`, `isString`, `isSymbol`, `isRegExp`, `isBoolean`

### DIFF
--- a/benchmarks/performance/isBoolean.bench.ts
+++ b/benchmarks/performance/isBoolean.bench.ts
@@ -10,6 +10,8 @@ describe('isBoolean', () => {
     isBooleanToolkit(undefined);
     isBooleanToolkit('');
     isBooleanToolkit(123);
+    isBooleanToolkit({});
+    isBooleanToolkit(Boolean());
   });
 
   bench('es-toolkit/compat/isBoolean', () => {
@@ -18,6 +20,8 @@ describe('isBoolean', () => {
     isBooleanToolkitCompat(undefined);
     isBooleanToolkitCompat('');
     isBooleanToolkitCompat(123);
+    isBooleanToolkitCompat({});
+    isBooleanToolkitCompat(Boolean());
   });
 
   bench('lodash/isBoolean', () => {
@@ -26,5 +30,7 @@ describe('isBoolean', () => {
     isBooleanLodash(undefined);
     isBooleanLodash('');
     isBooleanLodash(123);
+    isBooleanLodash({});
+    isBooleanLodash(Boolean());
   });
 });

--- a/benchmarks/performance/isBoolean.bench.ts
+++ b/benchmarks/performance/isBoolean.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from 'vitest';
-import { isBoolean as isBooleanToolkit } from 'es-toolkit';
+import { isBoolean as isBooleanToolkit } from 'es-toolkit/predicate';
+import { isBoolean as isBooleanToolkitCompat } from 'es-toolkit/compat';
 import { isBoolean as isBooleanLodash } from 'lodash';
 
 describe('isBoolean', () => {
@@ -9,6 +10,14 @@ describe('isBoolean', () => {
     isBooleanToolkit(undefined);
     isBooleanToolkit('');
     isBooleanToolkit(123);
+  });
+
+  bench('es-toolkit/compat/isBoolean', () => {
+    isBooleanToolkitCompat(true);
+    isBooleanToolkitCompat(false);
+    isBooleanToolkitCompat(undefined);
+    isBooleanToolkitCompat('');
+    isBooleanToolkitCompat(123);
   });
 
   bench('lodash/isBoolean', () => {

--- a/benchmarks/performance/isRegExp.bench.ts
+++ b/benchmarks/performance/isRegExp.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from 'vitest';
-import { isRegExp as isRegExpToolkit } from 'es-toolkit';
+import { isRegExp as isRegExpToolkit } from 'es-toolkit/predicate';
+import { isRegExp as isRegExpToolkitCompat } from 'es-toolkit/compat';
 import { isRegExp as isRegExpLodash } from 'lodash';
 
 describe('isRegExp', () => {
@@ -7,6 +8,12 @@ describe('isRegExp', () => {
     isRegExpToolkit(new RegExp(''));
     isRegExpToolkit(/abc/);
     isRegExpToolkit('/abc/');
+  });
+
+  bench('es-toolkit/compat/isRegExp', () => {
+    isRegExpToolkitCompat(new RegExp(''));
+    isRegExpToolkitCompat(/abc/);
+    isRegExpToolkitCompat('/abc/');
   });
 
   bench('lodash/isRegExp', () => {

--- a/benchmarks/performance/isString.bench.ts
+++ b/benchmarks/performance/isString.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from 'vitest';
-import { isString as isStringToolkit } from 'es-toolkit';
+import { isString as isStringToolkit } from 'es-toolkit/predicate';
+import { isString as isStringToolkitCompat } from 'es-toolkit/compat';
 import { isString as isStringLodash } from 'lodash';
 
 describe('isString', () => {
@@ -8,6 +9,17 @@ describe('isString', () => {
     isStringToolkit(true);
     isStringToolkit(undefined);
     isStringToolkit(123);
+    isStringToolkit(String(''));
+    isStringToolkit(Object(''));
+  });
+
+  bench('es-toolkit/compat/isString', () => {
+    isStringToolkitCompat('');
+    isStringToolkitCompat(true);
+    isStringToolkitCompat(undefined);
+    isStringToolkitCompat(123);
+    isStringToolkitCompat(String(''));
+    isStringToolkitCompat(Object(''));
   });
 
   bench('lodash/isString', () => {
@@ -15,5 +27,7 @@ describe('isString', () => {
     isStringLodash(true);
     isStringLodash(undefined);
     isStringLodash(123);
+    isStringLodash(String(''));
+    isStringLodash(Object(''));
   });
 });

--- a/benchmarks/performance/isSymbol.bench.ts
+++ b/benchmarks/performance/isSymbol.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from 'vitest';
-import { isSymbol as isSymbolToolkit } from 'es-toolkit';
+import { isSymbol as isSymbolToolkit } from 'es-toolkit/predicate';
 import { isSymbol as isSymbolToolkitCompat } from 'es-toolkit/compat';
 import { isSymbol as isSymbolLodash } from 'lodash';
 

--- a/src/compat/predicate/isBoolean.ts
+++ b/src/compat/predicate/isBoolean.ts
@@ -1,5 +1,3 @@
-import { getTag } from '../_internal/getTag.ts';
-
 /**
  * Checks if the given value is boolean.
  *

--- a/src/compat/predicate/isBoolean.ts
+++ b/src/compat/predicate/isBoolean.ts
@@ -6,8 +6,8 @@
  *
  *  This function can also serve as a type predicate in TypeScript, narrowing the type of the argument to `boolean`.
  *
- * @param {unknown} x - The Value to test if it is boolean.
- * @returns {x is boolean} True if the value is boolean, false otherwise.
+ * @param {unknown} value - The Value to test if it is boolean.
+ * @returns {value is boolean} True if the value is boolean, false otherwise.
  *
  * @example
  *
@@ -20,6 +20,6 @@
  * console.log(isBoolean(value3)); // false
  *
  */
-export function isBoolean(x: unknown): x is boolean {
-  return typeof x === 'boolean' || x instanceof Boolean;
+export function isBoolean(value?: unknown): value is boolean {
+  return typeof value === 'boolean' || value instanceof Boolean;
 }

--- a/src/compat/predicate/isBoolean.ts
+++ b/src/compat/predicate/isBoolean.ts
@@ -23,13 +23,5 @@ import { getTag } from '../_internal/getTag.ts';
  *
  */
 export function isBoolean(x: unknown): x is boolean {
-  if (x === true || x === false) {
-    return true;
-  }
-
-  if (typeof x === 'object' && x != null && getTag(x) === '[object Boolean]') {
-    return true;
-  }
-
-  return false;
+  return typeof x === 'boolean' || x instanceof Boolean;
 }

--- a/src/compat/predicate/isNumber.ts
+++ b/src/compat/predicate/isNumber.ts
@@ -18,9 +18,5 @@ import { getTag } from '../_internal/getTag';
  * console.log(isNumber(value3)); // false
  */
 export function isNumber(value?: unknown): value is number {
-  if (typeof value === 'object' && value != null && getTag(value) === '[object Number]') {
-    return true;
-  }
-
-  return typeof value === 'number';
+  return typeof value === 'number' || value instanceof Number;
 }

--- a/src/compat/predicate/isNumber.ts
+++ b/src/compat/predicate/isNumber.ts
@@ -1,5 +1,3 @@
-import { getTag } from '../_internal/getTag';
-
 /**
  * Checks if a given value is a number.
  *

--- a/src/compat/predicate/isRegExp.ts
+++ b/src/compat/predicate/isRegExp.ts
@@ -1,4 +1,4 @@
-import { getTag } from '../_internal/getTag.ts';
+import { isRegExp as isRegExpToolkit } from '../../predicate/isRegExp';
 
 /**
  * Checks if `value` is a RegExp.
@@ -14,5 +14,5 @@ import { getTag } from '../_internal/getTag.ts';
  * console.log(isRegExp(value2)); // false
  */
 export function isRegExp(value?: unknown): value is RegExp {
-  return getTag(value) === '[object RegExp]';
+  return isRegExpToolkit(value);
 }

--- a/src/compat/predicate/isString.ts
+++ b/src/compat/predicate/isString.ts
@@ -16,6 +16,6 @@
  * console.log(isString(value3)); // false
  */
 
-export function isString(value: unknown): value is string {
+export function isString(value?: unknown): value is string {
   return typeof value === 'string' || value instanceof String;
 }

--- a/src/compat/predicate/isString.ts
+++ b/src/compat/predicate/isString.ts
@@ -1,5 +1,3 @@
-import { getTag } from '../_internal/getTag.ts';
-
 /**
  * Checks if a given value is string.
  *
@@ -19,13 +17,5 @@ import { getTag } from '../_internal/getTag.ts';
  */
 
 export function isString(value: unknown): value is string {
-  if (typeof value === 'string') {
-    return true;
-  }
-
-  if (typeof value === 'object' && value != null && getTag(value) === '[object String]') {
-    return true;
-  }
-
-  return false;
+  return typeof value === 'string' || value instanceof String;
 }

--- a/src/compat/predicate/isSymbol.ts
+++ b/src/compat/predicate/isSymbol.ts
@@ -13,5 +13,5 @@
  * // => false
  */
 export function isSymbol(value?: unknown): value is symbol {
-  return typeof value === 'symbol' || (value != null && value instanceof Symbol);
+  return typeof value === 'symbol' || value instanceof Symbol;
 }


### PR DESCRIPTION
# Description

If Class like `String` exists, I think that we don't need to compare with string like`[Object string]`, when checking wrapped value like `Object('str')`.

Additionally, I changed the parameter name of `isBoolean` to value for consistency, and added optional types to both `isBoolean` and `isString` for compatibility with Lodash.

## Benchmarks

### `isNumber`

#### Before
<img width="752" alt="Screenshot 2024-09-21 at 7 59 30 PM" src="https://github.com/user-attachments/assets/6801aef4-ff82-4631-995b-6871e0ca6b79">

#### After

<img width="740" alt="Screenshot 2024-09-21 at 7 59 38 PM" src="https://github.com/user-attachments/assets/63d2a48c-a1b2-4071-9a2d-a921936fc9a8">

---

### `isString`

#### Before

<img width="756" alt="Screenshot 2024-09-21 at 8 00 31 PM" src="https://github.com/user-attachments/assets/03044e49-35cf-4080-b9cb-b1628e055fd3">

#### After

<img width="756" alt="Screenshot 2024-09-21 at 8 00 58 PM" src="https://github.com/user-attachments/assets/893841b2-6348-4b16-81f8-bdf57dd128e6">

---

### `isSymbol`

#### Before

<img width="757" alt="Screenshot 2024-09-21 at 8 01 56 PM" src="https://github.com/user-attachments/assets/b00874f2-c8a6-45f3-9a1f-9f0b96d54dfa">

#### After

<img width="763" alt="Screenshot 2024-09-21 at 8 02 10 PM" src="https://github.com/user-attachments/assets/5dbe6d65-02bc-4ce4-93a0-a19f464bf497">

---

### `isRegExp`

#### Before

<img width="761" alt="Screenshot 2024-09-21 at 8 03 18 PM" src="https://github.com/user-attachments/assets/4a41c7ac-ab4b-4885-add4-a7fd06cff4a3">

#### After

<img width="751" alt="Screenshot 2024-09-21 at 8 04 11 PM" src="https://github.com/user-attachments/assets/9169955c-fc05-429c-b709-41a7cbba23b8">

---

### `isBoolean`

#### Before

<img width="741" alt="Screenshot 2024-09-21 at 8 05 37 PM" src="https://github.com/user-attachments/assets/93619528-04e6-40f6-8cb8-ee7dad671e66">

#### After

<img width="748" alt="Screenshot 2024-09-21 at 8 05 52 PM" src="https://github.com/user-attachments/assets/e66c6eaf-8c81-49af-b171-d0026dc32506">
