### PR TITLE
fix(startCase): convert the non-first char to lowercase

### DIFF
--- a/docs/ja/reference/string/startCase.md
+++ b/docs/ja/reference/string/startCase.md
@@ -25,8 +25,8 @@ import { startCase } from 'es-toolkit/string';
 
 startCase('--foo-bar--'); // 'Foo Bar' を返します
 startCase('fooBar'); // 'Foo Bar' を返します
-startCase('__FOO_BAR__'); // 'FOO BAR' を返します
-startCase('XMLHttpRequest'); // 'XML Http Request' を返します
+startCase('__FOO_BAR__'); // 'Foo Bar' を返します
+startCase('XMLHttpRequest'); // 'Xml Http Request' を返します
 startCase('_abc_123_def'); // 'Abc 123 Def' を返します
 startCase('__abc__123__def__'); // 'Abc 123 Def' を返します
 startCase('_-_-_-_'); // '' を返します

--- a/docs/ko/reference/string/startCase.md
+++ b/docs/ko/reference/string/startCase.md
@@ -25,8 +25,8 @@ import { startCase } from 'es-toolkit/string';
 
 startCase('--foo-bar--'); // returns 'Foo Bar'
 startCase('fooBar'); // returns 'Foo Bar'
-startCase('__FOO_BAR__'); // returns 'FOO BAR'
-startCase('XMLHttpRequest'); // returns 'XML Http Request'
+startCase('__FOO_BAR__'); // returns 'Foo Bar'
+startCase('XMLHttpRequest'); // returns 'Xml Http Request'
 startCase('_abc_123_def'); // returns 'Abc 123 Def'
 startCase('__abc__123__def__'); // returns 'Abc 123 Def'
 startCase('_-_-_-_'); // returns ''

--- a/docs/reference/string/startCase.md
+++ b/docs/reference/string/startCase.md
@@ -25,8 +25,8 @@ import { startCase } from 'es-toolkit/string';
 
 startCase('--foo-bar--'); // returns 'Foo Bar'
 startCase('fooBar'); // returns 'Foo Bar'
-startCase('__FOO_BAR__'); // returns 'FOO BAR'
-startCase('XMLHttpRequest'); // returns 'XML Http Request'
+startCase('__FOO_BAR__'); // returns 'Foo Bar'
+startCase('XMLHttpRequest'); // returns 'Xml Http Request'
 startCase('_abc_123_def'); // returns 'Abc 123 Def'
 startCase('__abc__123__def__'); // returns 'Abc 123 Def'
 startCase('_-_-_-_'); // returns ''

--- a/docs/zh_hans/reference/string/startCase.md
+++ b/docs/zh_hans/reference/string/startCase.md
@@ -25,8 +25,8 @@ import { startCase } from 'es-toolkit/string';
 
 startCase('--foo-bar--'); // returns 'Foo Bar'
 startCase('fooBar'); // returns 'Foo Bar'
-startCase('__FOO_BAR__'); // returns 'FOO BAR'
-startCase('XMLHttpRequest'); // returns 'XML Http Request'
+startCase('__FOO_BAR__'); // returns 'Foo Bar'
+startCase('XMLHttpRequest'); // returns 'Xml Http Request'
 startCase('_abc_123_def'); // returns 'Abc 123 Def'
 startCase('__abc__123__def__'); // returns 'Abc 123 Def'
 startCase('_-_-_-_'); // returns ''

--- a/src/string/startCase.spec.ts
+++ b/src/string/startCase.spec.ts
@@ -5,20 +5,20 @@ describe('startCase', function () {
   it('should capitalize each word', function () {
     expect(startCase('--foo-bar--')).toBe('Foo Bar');
     expect(startCase('fooBar')).toBe('Foo Bar');
-    expect(startCase('__FOO_BAR__')).toBe('FOO BAR');
+    expect(startCase('__FOO_BAR__')).toBe('Foo Bar');
   });
 
   it('should handle compound words', function () {
     expect(startCase('createElement')).toBe('Create Element');
     expect(startCase('iPhone')).toBe('I Phone');
-    expect(startCase('XMLHttpRequest')).toBe('XML Http Request');
+    expect(startCase('XMLHttpRequest')).toBe('Xml Http Request');
   });
 
   it('should handle various delimiters', function () {
     expect(startCase('_abc_123_def')).toBe('Abc 123 Def');
     expect(startCase('__abc__123__def__')).toBe('Abc 123 Def');
-    expect(startCase('ABC-DEF')).toBe('ABC DEF');
-    expect(startCase('ABC DEF')).toBe('ABC DEF');
+    expect(startCase('ABC-DEF')).toBe('Abc Def');
+    expect(startCase('ABC DEF')).toBe('Abc Def');
   });
 
   it('should handle empty strings', function () {
@@ -30,16 +30,16 @@ describe('startCase', function () {
   });
 
   it('should work with numbers', function () {
-    expect(startCase('12abc 12ABC')).toBe('12 Abc 12 ABC');
+    expect(startCase('12abc 12ABC')).toBe('12 Abc 12 Abc');
   });
 
   it('should handle consecutive uppercase letters', function () {
-    expect(startCase('ABC')).toBe('ABC');
-    expect(startCase('ABCdef')).toBe('AB Cdef');
+    expect(startCase('ABC')).toBe('Abc');
+    expect(startCase('ABCdef')).toBe('Ab Cdef');
   });
 
   it('should handle combinations of numbers and letters', function () {
-    expect(startCase('123ABC')).toBe('123 ABC');
+    expect(startCase('123ABC')).toBe('123 Abc');
     expect(startCase('a1B2c3')).toBe('A 1 B 2 C 3');
   });
 
@@ -57,5 +57,10 @@ describe('startCase', function () {
   it('should handle whitespace characters', function () {
     expect(startCase('  foo  bar  ')).toBe('Foo Bar');
     expect(startCase('\tfoo\nbar')).toBe('Foo Bar');
+  });
+
+  it('should convert the non-first characters to lowercase', function () {
+    expect(startCase('FOO BAR')).toBe('Foo Bar');
+    expect(startCase('FOO BAR BAZ')).toBe('Foo Bar Baz');
   });
 });

--- a/src/string/startCase.ts
+++ b/src/string/startCase.ts
@@ -9,7 +9,7 @@ import { getWords } from './_internal/getWords.ts';
  *
  * @example
  * const result1 = startCase('hello world');  // result will be 'Hello World'
- * const result2 = startCase('HELLO WORLD');  // result will be 'HELLO WORLD'
+ * const result2 = startCase('HELLO WORLD');  // result will be 'Hello World'
  * const result3 = startCase('hello-world');  // result will be 'Hello World'
  * const result4 = startCase('hello_world');  // result will be 'Hello World'
  */
@@ -20,11 +20,8 @@ export function startCase(str: string): string {
     if (result) {
       result += ' ';
     }
-    if (word === word.toUpperCase()) {
-      result += word;
-    } else {
-      result += word[0].toUpperCase() + word.slice(1).toLowerCase();
-    }
+
+    result += word[0].toUpperCase() + word.slice(1).toLowerCase();
   }
   return result;
 }


### PR DESCRIPTION
Hi there 👍 

I saw some [strange behavior at startCase](https://github.com/toss/es-toolkit/issues/580)

so I handle this issue at original path's startCase (non-compat)

> I did not handle compat's startCase, but if you think it's necessary, I'll apply it! 
> Please feel free to talk about it 😄 

## benchmark

![스크린샷 2024-09-24 오전 12 28 06](https://github.com/user-attachments/assets/8de17596-1b75-4bd9-9612-3267549a09d5)

fix #580 

## related pr

- #517 
- #313
- #203 
