### PR TITLE
feat(includes): add `includes` in `es-toolkit/object`

### DIFF
--- a/benchmarks/performance/includes.bench.ts
+++ b/benchmarks/performance/includes.bench.ts
@@ -1,0 +1,39 @@
+import { bench, describe } from 'vitest';
+import { includes as includesToolkit } from 'es-toolkit';
+import { includes as includesLodash } from 'lodash';
+
+describe('includes', () => {
+  const object = {
+    a: 1,
+    b: 'a',
+    c: NaN,
+    d: undefined,
+    e: null,
+    f: Infinity,
+    g: -0,
+  };
+
+  bench('es-toolkit/includes', () => {
+    includesToolkit(object, 1);
+    includesToolkit(object, 'a');
+    includesToolkit(object, NaN);
+    includesToolkit(object, undefined);
+    includesToolkit(object, null);
+    includesToolkit(object, Infinity);
+    includesToolkit(object, Symbol('sym1'));
+    includesToolkit(object, -0);
+  });
+
+  bench('lodash/includes', () => {
+    includesLodash(object, 1);
+    includesLodash(object, 'a');
+    includesLodash(object, NaN);
+    includesLodash(object, undefined);
+    includesLodash(object, null);
+    includesLodash(object, Infinity);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    includesLodash(object, Symbol('sym1'));
+    includesLodash(object, -0);
+  });
+});

--- a/src/object/includes.spec.ts
+++ b/src/object/includes.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { includes } from './includes';
+
+describe('includes', () => {
+  const symbol1 = Symbol('sym1');
+
+  const object = {
+    a: 1,
+    b: 'a',
+    c: NaN,
+    d: undefined,
+    e: null,
+    f: Infinity,
+    g: -0,
+    h: symbol1,
+  };
+
+  it('should return true if the object includes the target value', () => {
+    expect(includes(object, 1)).toBe(true);
+    expect(includes(object, 'a')).toBe(true);
+    expect(includes(object, NaN)).toBe(true); // SameValueZero
+    expect(includes(object, undefined)).toBe(true);
+    expect(includes(object, null)).toBe(true);
+    expect(includes(object, Infinity)).toBe(true);
+    expect(includes(object, Symbol('sym1'))).toBe(false);
+    expect(includes(object, -0)).toBe(true);
+    expect(includes(object, 0)).toBe(true); // SameValueZero
+    expect(includes(object, symbol1)).toBe(true);
+  });
+
+  it('should return false if the object does not include the target value', () => {
+    expect(includes(object, 2)).toBe(false);
+    expect(includes(object, 'b')).toBe(false);
+    expect(includes(object, Symbol('sym1'))).toBe(false);
+    expect(includes(object, -Infinity)).toBe(false);
+    expect(includes(object, false)).toBe(false);
+    expect(includes(object, true)).toBe(false);
+  });
+
+  const objectWithSymbol = {
+    [Symbol('sym1')]: 1,
+    [Symbol('sy2')]: 'a',
+    [Symbol('sym3')]: NaN,
+    [Symbol('sym4')]: undefined,
+    [Symbol('sym5')]: null,
+    [Symbol('sym6')]: Infinity,
+    [Symbol('sym7')]: -0,
+    [Symbol('sym8')]: symbol1,
+  };
+  it('should return true if the object includes the target value with symbol keys', () => {
+    expect(includes(objectWithSymbol, 'a', { allowSymbolKeyed: true })).toBe(true);
+    expect(includes(objectWithSymbol, 1, { allowSymbolKeyed: true })).toBe(true);
+    expect(includes(objectWithSymbol, NaN, { allowSymbolKeyed: true })).toBe(true); // SameValueZero
+    expect(includes(objectWithSymbol, undefined, { allowSymbolKeyed: true })).toBe(true);
+    expect(includes(objectWithSymbol, null, { allowSymbolKeyed: true })).toBe(true);
+    expect(includes(objectWithSymbol, Infinity, { allowSymbolKeyed: true })).toBe(true);
+    expect(includes(objectWithSymbol, -0, { allowSymbolKeyed: true })).toBe(true);
+    expect(includes(objectWithSymbol, 0, { allowSymbolKeyed: true })).toBe(true); // SameValueZero
+    expect(includes(objectWithSymbol, symbol1, { allowSymbolKeyed: true })).toBe(true);
+  });
+
+  it('should return false if the object does not include the target value with symbol keys', () => {
+    expect(includes(objectWithSymbol, 'b', { allowSymbolKeyed: true })).toBe(false);
+    expect(includes(objectWithSymbol, 2, { allowSymbolKeyed: true })).toBe(false);
+    expect(includes(objectWithSymbol, Symbol('sym1'), { allowSymbolKeyed: true })).toBe(false);
+    expect(includes(objectWithSymbol, -Infinity, { allowSymbolKeyed: true })).toBe(false);
+  });
+
+  class CustomClass {
+    a = 1;
+    b = 'a';
+    c = NaN;
+    d = undefined;
+    e = null;
+    f = Infinity;
+    g = -0;
+    h = symbol1;
+  }
+
+  const instance = new CustomClass();
+
+  it('should return true if the object includes the target value', () => {
+    expect(includes(instance, 1)).toBe(true);
+    expect(includes(instance, 'a')).toBe(true);
+    expect(includes(instance, NaN)).toBe(true); // SameValueZero
+    expect(includes(instance, undefined)).toBe(true);
+    expect(includes(instance, null)).toBe(true);
+    expect(includes(instance, Infinity)).toBe(true);
+    expect(includes(instance, Symbol('sym1'))).toBe(false);
+    expect(includes(instance, -0)).toBe(true);
+    expect(includes(instance, 0)).toBe(true); // SameValueZero
+    expect(includes(instance, symbol1)).toBe(true);
+  });
+
+  it('should return false if the object does not include the target value', () => {
+    expect(includes(instance, 2)).toBe(false);
+    expect(includes(instance, 'b')).toBe(false);
+    expect(includes(instance, Symbol('sym1'))).toBe(false);
+    expect(includes(instance, -Infinity)).toBe(false);
+    expect(includes(instance, false)).toBe(false);
+    expect(includes(instance, true)).toBe(false);
+  });
+});

--- a/src/object/includes.spec.ts
+++ b/src/object/includes.spec.ts
@@ -37,35 +37,6 @@ describe('includes', () => {
     expect(includes(object, true)).toBe(false);
   });
 
-  const objectWithSymbol = {
-    [Symbol('sym1')]: 1,
-    [Symbol('sy2')]: 'a',
-    [Symbol('sym3')]: NaN,
-    [Symbol('sym4')]: undefined,
-    [Symbol('sym5')]: null,
-    [Symbol('sym6')]: Infinity,
-    [Symbol('sym7')]: -0,
-    [Symbol('sym8')]: symbol1,
-  };
-  it('should return true if the object includes the target value with symbol keys', () => {
-    expect(includes(objectWithSymbol, 'a', { allowSymbolKeyed: true })).toBe(true);
-    expect(includes(objectWithSymbol, 1, { allowSymbolKeyed: true })).toBe(true);
-    expect(includes(objectWithSymbol, NaN, { allowSymbolKeyed: true })).toBe(true); // SameValueZero
-    expect(includes(objectWithSymbol, undefined, { allowSymbolKeyed: true })).toBe(true);
-    expect(includes(objectWithSymbol, null, { allowSymbolKeyed: true })).toBe(true);
-    expect(includes(objectWithSymbol, Infinity, { allowSymbolKeyed: true })).toBe(true);
-    expect(includes(objectWithSymbol, -0, { allowSymbolKeyed: true })).toBe(true);
-    expect(includes(objectWithSymbol, 0, { allowSymbolKeyed: true })).toBe(true); // SameValueZero
-    expect(includes(objectWithSymbol, symbol1, { allowSymbolKeyed: true })).toBe(true);
-  });
-
-  it('should return false if the object does not include the target value with symbol keys', () => {
-    expect(includes(objectWithSymbol, 'b', { allowSymbolKeyed: true })).toBe(false);
-    expect(includes(objectWithSymbol, 2, { allowSymbolKeyed: true })).toBe(false);
-    expect(includes(objectWithSymbol, Symbol('sym1'), { allowSymbolKeyed: true })).toBe(false);
-    expect(includes(objectWithSymbol, -Infinity, { allowSymbolKeyed: true })).toBe(false);
-  });
-
   class CustomClass {
     a = 1;
     b = 'a';

--- a/src/object/includes.ts
+++ b/src/object/includes.ts
@@ -1,30 +1,21 @@
 /**
  * Check if the object includes the target value using SameValueZero comparison.
  *
- * It only checks the given object's own enumerable string-keyed property values by default.
- * But, if `options.allowSymbolKeyed` is set to `true`, it will also check the object's own symbol-keyed property values excluding inherited ones.
+ * It only checks the given object's own enumerable string-keyed property values.
  *
  * @template T - The object type.
  * @param {T extends unknown[] ? never : T} object - The object to check. (Array is not allowed)
  * @param {unknown} target - The target value to check.
- * @param {{ allowSymbolKeyed: boolean }} [options] - The options object.
- * @param {boolean} [options.allowSymbolKeyed] - Whether to include symbol-keyed property values in the check. Default is `false`.
  * @returns {boolean} `true` if the object includes the target value, `false` otherwise.
  *
  * @example
  * includes({ a: 1, b: 'a', c: NaN }, 1); // true
  * includes({ a: 1, b: 'a', c: NaN }, 'a'); // true
  * includes({ a: 1, b: 'a', c: NaN }, NaN); // true
- *
  * includes({ [Symbol('sym1')]: 1 }, 1); // false
- * includes({ [Symbol('sym1')]: 1 }, 1, { allowSymbolKeyed: true }); // true
  */
-export function includes<T extends object>(
-  object: T extends unknown[] ? never : T,
-  target: unknown,
-  options = { allowSymbolKeyed: false }
-): boolean {
-  const keys = options.allowSymbolKeyed ? Reflect.ownKeys(object) : Object.keys(object);
+export function includes<T extends object>(object: T extends unknown[] ? never : T, target: unknown): boolean {
+  const keys = Object.keys(object);
 
   // Not using `Object.values` because it always creates an array of all values.
   for (let i = 0; i < keys.length; i++) {

--- a/src/object/includes.ts
+++ b/src/object/includes.ts
@@ -2,7 +2,7 @@
  * Check if the object includes the target value using SameValueZero comparison.
  *
  * It only checks the given object's own enumerable string-keyed property values.
- * But, if `options.allowSymbolKeys` is set to `true`, it will also check the object's own enumerable symbol-keyed property values.
+ * But, if `options.allowSymbolKeyed` is set to `true`, it will also check the object's own enumerable symbol-keyed property values.
  *
  * @template T - The object type.
  * @param {T extends unknown[] ? never : T} object - The object to check. (Array is not allowed)

--- a/src/object/includes.ts
+++ b/src/object/includes.ts
@@ -1,8 +1,8 @@
 /**
  * Check if the object includes the target value using SameValueZero comparison.
  *
- * It only checks the given object's own enumerable string-keyed property values.
- * But, if `options.allowSymbolKeyed` is set to `true`, it will also check the object's own enumerable symbol-keyed property values.
+ * It only checks the given object's own enumerable string-keyed property values by default.
+ * But, if `options.allowSymbolKeyed` is set to `true`, it will also check the object's own symbol-keyed property values excluding inherited ones.
  *
  * @template T - The object type.
  * @param {T extends unknown[] ? never : T} object - The object to check. (Array is not allowed)

--- a/src/object/includes.ts
+++ b/src/object/includes.ts
@@ -1,0 +1,39 @@
+/**
+ * Check if the object includes the target value using SameValueZero comparison.
+ *
+ * It only checks the given object's own enumerable string-keyed property values.
+ * But, if `options.allowSymbolKeys` is set to `true`, it will also check the object's own enumerable symbol-keyed property values.
+ *
+ * @template T - The object type.
+ * @param {T extends unknown[] ? never : T} object - The object to check. (Array is not allowed)
+ * @param {unknown} target - The target value to check.
+ * @param {{ allowSymbolKeyed: boolean }} [options] - The options object.
+ * @param {boolean} [options.allowSymbolKeyed] - Whether to include symbol-keyed property values in the check. Default is `false`.
+ * @returns {boolean} `true` if the object includes the target value, `false` otherwise.
+ *
+ * @example
+ * includes({ a: 1, b: 'a', c: NaN }, 1); // true
+ * includes({ a: 1, b: 'a', c: NaN }, 'a'); // true
+ * includes({ a: 1, b: 'a', c: NaN }, NaN); // true
+ *
+ * includes({ [Symbol('sym1')]: 1 }, 1); // false
+ * includes({ [Symbol('sym1')]: 1 }, 1, { allowSymbolKeyed: true }); // true
+ */
+export function includes<T extends object>(
+  object: T extends unknown[] ? never : T,
+  target: unknown,
+  options = { allowSymbolKeyed: false }
+): boolean {
+  const keys = options.allowSymbolKeyed ? Reflect.ownKeys(object) : Object.keys(object);
+
+  for (let i = 0; i < keys.length; i++) {
+    const value = Reflect.get(object, keys[i]);
+
+    // SameValueZero comparison for early return
+    if (value === target || (Number.isNaN(value) && Number.isNaN(target))) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/object/includes.ts
+++ b/src/object/includes.ts
@@ -26,10 +26,11 @@ export function includes<T extends object>(
 ): boolean {
   const keys = options.allowSymbolKeyed ? Reflect.ownKeys(object) : Object.keys(object);
 
+  // Not using `Object.values` because it always creates an array of all values.
   for (let i = 0; i < keys.length; i++) {
     const value = Reflect.get(object, keys[i]);
 
-    // SameValueZero comparison for early return
+    // This condition is the SameValueZero comparison.
     if (value === target || (Number.isNaN(value) && Number.isNaN(target))) {
       return true;
     }

--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -3,6 +3,7 @@ export { omitBy } from './omitBy.ts';
 export { pick } from './pick.ts';
 export { pickBy } from './pickBy.ts';
 export { invert } from './invert.ts';
+export { includes } from './includes.ts';
 export { clone } from './clone.ts';
 export { flattenObject } from './flattenObject.ts';
 export { mapKeys } from './mapKeys.ts';


### PR DESCRIPTION
# Description

I have added an `includes` method for `Object`. Unlike lodash, it doesn't allow `Array` and `String` value. This is because both `String` and `Array` already have native `includes` methods like `Array.prototype.includes`.

My implementation uses the `SameValueZero` comparison algorithm, similar to `Array.prototype.includes`.

## Main Concerns During Implementation

### 1. Not Using `Object.values`

<img width="676" alt="Screenshot 2024-09-24 at 6 56 20 PM" src="https://github.com/user-attachments/assets/052efe3f-9443-4594-98a5-0cd15464b2a3">

Implementing it like `Object.values(obj).includes(value)` forces access to both all of keys and all of values as shown as a image above(under the hood of Object.values). This approach is less efficient.

Therefore, I chose not to use `Object.values` and `Array.prototype.includes`. Instead, I implemented the function using `Object.keys` and manually implemented the `SameValueZero` comparison. This allows early return upon finding the value, improving performance.

<img width="727" alt="Screenshot 2024-09-24 at 6 42 47 PM" src="https://github.com/user-attachments/assets/c6356f67-57a7-4a3f-aae3-e808a3ef1786">

> In the above image, `include` is implemented using `Object.keys`, and `include2` using `Object.values`.

### ~~2. Symbol-keyed property~~

~~By default, `Object.keys` only returns `enumerable string-keyed properties`. However, users may want to check `symbol-keyed properties`, both enumerable and non-enumerable. To address this, I added an option `options.allowSymbolKeyed`. If enabled, the function will check symbol-keyed properties using `Reflect.ownKeys()`.~~

~~Since `Reflect.ownKeys()` has some performance overhead, this feature is optional. I’d like feedback on whether this interface design is user-friendly or if improvements are needed.~~

In my opinion, there's no need to implement this all the way from the initial interface. I removed that option because other includes methods only support enumerable string keyed. Additionally, since this case is likely to be very minor, I removed it to adhere to the principle of simplicity.

## Benchmark

<img width="756" alt="Screenshot 2024-09-24 at 6 48 15 PM" src="https://github.com/user-attachments/assets/06e9f0da-af50-4c6f-8dfd-93d3f7401587">
