### PR TITLE
fix(clone): `SharedArrayBuffer` could be `undefined`

### DIFF
--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -34,7 +34,12 @@ export function clone<T>(obj: T): T {
     return obj;
   }
 
-  if (Array.isArray(obj) || isTypedArray(obj) || obj instanceof ArrayBuffer || obj instanceof SharedArrayBuffer) {
+  if (
+    Array.isArray(obj) ||
+    isTypedArray(obj) ||
+    obj instanceof ArrayBuffer ||
+    (typeof SharedArrayBuffer !== 'undefined' && obj instanceof SharedArrayBuffer)
+  ) {
     return obj.slice(0) as T;
   }
 


### PR DESCRIPTION
# Description

It is related this [comment](https://github.com/toss/es-toolkit/pull/312#issuecomment-2357611703)