### PR TITLE
fix(startCase): add missing tests and separate logic for `es-toolkit` and `es-toolkit/compat`

### DIFF
--- a/src/compat/string/camelCase.spec.ts
+++ b/src/compat/string/camelCase.spec.ts
@@ -31,13 +31,13 @@ describe('camelCase', () => {
 
   it('should convert string to camel case', () => {
     const actual = strings.map(camelCase);
-    const expected = actual.map(() => 'fooBar');
+    const expected = strings.map(() => 'fooBar');
     expect(actual).toEqual(expected);
   });
 
   it('should handle double-converting strings', () => {
     const actual = strings.map(str => camelCase(camelCase(str)));
-    const expected = actual.map(() => 'fooBar');
+    const expected = strings.map(() => 'fooBar');
     expect(actual).toEqual(expected);
   });
 

--- a/src/compat/string/kebabCase.spec.ts
+++ b/src/compat/string/kebabCase.spec.ts
@@ -7,7 +7,7 @@ describe('kebabCase', () => {
   it(`should convert \`string\``, () => {
     const actual = strings.map(string => kebabCase(string));
 
-    const expected = actual.map(() => 'foo-bar');
+    const expected = strings.map(() => 'foo-bar');
 
     expect(actual).toEqual(expected);
   });
@@ -15,7 +15,7 @@ describe('kebabCase', () => {
   it(`should handle double-converting strings`, () => {
     const actual = strings.map(string => kebabCase(kebabCase(string)));
 
-    const expected = actual.map(() => 'foo-bar');
+    const expected = strings.map(() => 'foo-bar');
 
     expect(actual).toEqual(expected);
   });

--- a/src/compat/string/lowerCase.spec.ts
+++ b/src/compat/string/lowerCase.spec.ts
@@ -7,7 +7,7 @@ describe('lowerCase', () => {
   it(`should convert \`string\``, () => {
     const actual = strings.map(string => lowerCase(string));
 
-    const expected = actual.map(() => 'foo bar');
+    const expected = strings.map(() => 'foo bar');
 
     expect(actual).toEqual(expected);
   });
@@ -15,7 +15,7 @@ describe('lowerCase', () => {
   it(`should handle double-converting strings`, () => {
     const actual = strings.map(string => lowerCase(lowerCase(string)));
 
-    const expected = actual.map(() => 'foo bar');
+    const expected = strings.map(() => 'foo bar');
 
     expect(actual).toEqual(expected);
   });

--- a/src/compat/string/snakeCase.spec.ts
+++ b/src/compat/string/snakeCase.spec.ts
@@ -7,7 +7,7 @@ describe('snakeCase', () => {
   it(`should convert \`string\``, () => {
     const actual = strings.map(string => snakeCase(string));
 
-    const expected = actual.map(() => 'foo_bar');
+    const expected = strings.map(() => 'foo_bar');
 
     expect(actual).toEqual(expected);
   });
@@ -15,7 +15,7 @@ describe('snakeCase', () => {
   it(`should handle double-converting strings`, () => {
     const actual = strings.map(string => snakeCase(snakeCase(string)));
 
-    const expected = actual.map(() => 'foo_bar');
+    const expected = strings.map(() => 'foo_bar');
 
     expect(actual).toEqual(expected);
   });

--- a/src/compat/string/startCase.spec.ts
+++ b/src/compat/string/startCase.spec.ts
@@ -7,7 +7,7 @@ describe('startCase', () => {
   it(`should convert \`string\``, () => {
     const actual = strings.map(string => startCase(string));
 
-    const expected = actual.map(string => (string === 'FOO BAR' ? 'FOO BAR' : 'Foo Bar'));
+    const expected = strings.map(string => (string === 'FOO BAR' ? 'FOO BAR' : 'Foo Bar'));
 
     expect(actual).toEqual(expected);
   });
@@ -15,7 +15,7 @@ describe('startCase', () => {
   it(`should handle double-converting strings`, () => {
     const actual = strings.map(string => startCase(startCase(string)));
 
-    const expected = actual.map(string => (string === 'FOO BAR' ? 'FOO BAR' : 'Foo Bar'));
+    const expected = strings.map(string => (string === 'FOO BAR' ? 'FOO BAR' : 'Foo Bar'));
 
     expect(actual).toEqual(expected);
   });
@@ -41,5 +41,11 @@ describe('startCase', () => {
     const string = 'foo bar';
     expect(startCase(Object(string))).toBe('Foo Bar');
     expect(startCase({ toString: () => string })).toBe('Foo Bar');
+  });
+
+  it('should uppercase only the first character of each word', () => {
+    expect(startCase('--foo-bar--')).toBe('Foo Bar');
+    expect(startCase('fooBar')).toBe('Foo Bar');
+    expect(startCase('__FOO_BAR__')).toBe('FOO BAR');
   });
 });

--- a/src/compat/string/startCase.ts
+++ b/src/compat/string/startCase.ts
@@ -1,4 +1,4 @@
-import { startCase as startCaseToolkit } from '../../string/startCase.ts';
+import { getWords } from '../../string/_internal/getWords.ts';
 import { normalizeForCase } from '../_internal/normalizeForCase.ts';
 
 /**
@@ -15,5 +15,23 @@ import { normalizeForCase } from '../_internal/normalizeForCase.ts';
  * const result4 = startCase('hello_world');  // result will be 'Hello World'
  */
 export function startCase(str?: string | object): string {
-  return startCaseToolkit(normalizeForCase(str));
+  const words = getWords(normalizeForCase(str).trim());
+
+  let result = '';
+
+  for (let i = 0; i < words.length; i++) {
+    const word = words[i];
+
+    if (result) {
+      result += ' ';
+    }
+
+    if (word === word.toUpperCase()) {
+      result += word;
+    } else {
+      result += word[0].toUpperCase() + word.slice(1).toLowerCase();
+    }
+  }
+
+  return result;
 }

--- a/src/compat/string/upperCase.spec.ts
+++ b/src/compat/string/upperCase.spec.ts
@@ -6,7 +6,7 @@ describe('upperCase', () => {
   it(`should convert \`string\``, () => {
     const actual = strings.map(string => upperCase(string));
 
-    const expected = actual.map(() => 'FOO BAR');
+    const expected = strings.map(() => 'FOO BAR');
 
     expect(actual).toEqual(expected);
   });
@@ -14,7 +14,7 @@ describe('upperCase', () => {
   it(`should handle double-converting strings`, () => {
     const actual = strings.map(string => upperCase(upperCase(string)));
 
-    const expected = actual.map(() => 'FOO BAR');
+    const expected = strings.map(() => 'FOO BAR');
 
     expect(actual).toEqual(expected);
   });


### PR DESCRIPTION
Due to [the change](https://github.com/toss/es-toolkit/pull/591) in the behavior of `startCase` in `es-toolkit`, the tests for `startCase` in `es-toolkit/compat` should have failed, but they did not. Upon investigation, I found that some test cases were either incorrect or missing.

I have added the missing test cases and separated the code according to the differences in behavior.