### PR TITLE
chore: fix test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
   "scripts": {
     "prepack": "yarn build",
     "build": "rollup -c rollup.config.mjs && ./.scripts/postbuild.sh",
-    "test": "vitest run --coverage --typecheck",
+    "test": "vitest --coverage --typecheck",
     "bench": "vitest bench",
     "lint": "eslint --config eslint.config.mjs",
     "format": "prettier --write .",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -10,5 +10,6 @@ export default defineConfig({
       include: ['src/**/*'],
       exclude: ['src/compat/_internal/**/*'],
     },
+    watch: false,
   },
 });


### PR DESCRIPTION
`vitest run` implied non-development environment, disabling features like watching. So, now you can e.g.:

```
yarn test cloneDeep --watch
```

and work on your utility in peace.

At the same time, added `watch: false` to `vitest.config.mts` ensures the expected behavior of all test related commands won't change.