### PR TITLE
fix(throttle): not throttling after initial throttleMs

### DIFF
--- a/src/function/throttle.spec.ts
+++ b/src/function/throttle.spec.ts
@@ -28,19 +28,19 @@ describe('throttle', () => {
     throttledFunc(); // should be ignored
     expect(func).toHaveBeenCalledTimes(1);
 
-    await delay(throttleMs / 2);
+    await delay(throttleMs / 2 + 1);
     expect(func).toHaveBeenCalledTimes(1);
 
     throttledFunc(); // should be excuted
     expect(func).toHaveBeenCalledTimes(2);
 
-    await delay(throttleMs / 2);
+    await delay(throttleMs / 2 - 1);
     expect(func).toHaveBeenCalledTimes(2);
 
     throttledFunc(); // should be ignored
     expect(func).toHaveBeenCalledTimes(2);
 
-    await delay(throttleMs / 2);
+    await delay(throttleMs / 2 + 1);
     expect(func).toHaveBeenCalledTimes(2);
 
     throttledFunc(); // should be executed

--- a/src/function/throttle.spec.ts
+++ b/src/function/throttle.spec.ts
@@ -19,19 +19,32 @@ describe('throttle', () => {
     const throttleMs = 500;
     const throttledFunc = throttle(func, throttleMs);
 
-    throttledFunc();
+    throttledFunc(); // should be excuted
+    expect(func).toHaveBeenCalledTimes(1);
+
     await delay(throttleMs / 2);
-
-    throttledFunc();
     expect(func).toHaveBeenCalledTimes(1);
 
-    await delay(throttleMs / 2 + 1);
-
+    throttledFunc(); // should be ignored
     expect(func).toHaveBeenCalledTimes(1);
 
-    throttledFunc();
+    await delay(throttleMs / 2);
+    expect(func).toHaveBeenCalledTimes(1);
 
+    throttledFunc(); // should be excuted
     expect(func).toHaveBeenCalledTimes(2);
+
+    await delay(throttleMs / 2);
+    expect(func).toHaveBeenCalledTimes(2);
+
+    throttledFunc(); // should be ignored
+    expect(func).toHaveBeenCalledTimes(2);
+
+    await delay(throttleMs / 2);
+    expect(func).toHaveBeenCalledTimes(2);
+
+    throttledFunc(); // should be executed
+    expect(func).toHaveBeenCalledTimes(3);
   });
 
   it('should call the function with correct arguments', () => {

--- a/src/function/throttle.ts
+++ b/src/function/throttle.ts
@@ -59,6 +59,7 @@ export function throttle<F extends (...args: any[]) => void>(
       pendingAt = Date.now();
     } else {
       if (Date.now() - pendingAt >= throttleMs) {
+        pendingAt = Date.now();
         debounced.cancel();
         debounced(...args);
       }


### PR DESCRIPTION
## Description

- `throttle` fails to throttle its callback function after initial `throttleMs` delay. 
- Fixed the issue by updating the `pendingAt` timestamp when the callback function is executed. 

```ts
import { throttle } from "es-toolkit";

const startedAt = Date.now();
const throttledFunc = throttle(() => console.log(Date.now() - startedAt), 1_000);
setInterval(throttledFunc, 100);

// AS-IS: 100, 1102, 1202, 1301, ...
// TO-BE: 100, 1102, 2104, 3108, ...
```