### PR TITLE
fix(matchesProperty): Add boolean type guard 

### DIFF
--- a/src/compat/predicate/matchesProperty.spec.ts
+++ b/src/compat/predicate/matchesProperty.spec.ts
@@ -8,6 +8,13 @@ import { numberProto } from '../_internal/numberProto';
 import { cloneDeep } from '../object/cloneDeep';
 
 describe('matchesProperty', () => {
+  it('should return true when the property value matches the boolean source', () => {
+    const object = { a: false };
+    const matches = matchesProperty('a', false);
+
+    expect(matches(object)).toBe(true);
+  });
+
   it('should create a function that performs a deep comparison between a property value and `srcValue`', () => {
     let object: any = { a: 1, b: 2, c: 3 };
     let matches = matchesProperty('a', 1);

--- a/src/compat/predicate/matchesProperty.ts
+++ b/src/compat/predicate/matchesProperty.ts
@@ -55,6 +55,10 @@ export function matchesProperty(
       return has(target, property as PropertyKey | PropertyKey[]);
     }
 
+    if (typeof source === 'boolean') {
+      return result === source;
+    }
+
     if (source === undefined) {
       return result === undefined;
     }


### PR DESCRIPTION
Hello, I hope you're having a great weekend. 😊

I found that I needed to add a type guard for boolean types in the `matchesProperty` function. In a previous PR ([#610](https://github.com/toss/es-toolkit/pull/610)), I noticed a problem where, when using a tuple as a predicate in the `filter` function, the test case didn’t pass if the value was boolean.

So, I added new logic to fix this, and I also added a test case for matchesProperty to make sure the test coverage is 100%. I checked, and there’s almost no performance difference.

Could you check if this logic is really necessary? Thank you!

#### The failing cases in the filter function
```typescript
const users = [
  { user: 'barney', age: 36, active: true },
  { user: 'fred', age: 40, active: false },
];

it(`should filter objects based on the specified key and value pair`, () => {
  expect(filter(users, ['active', false])).toEqual([{ user: 'fred', age: 40, active: false }]);
});
```