### PR TITLE
chore(lint): Add `prefer-object-has-own` eslint rule and fix lint error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -113,6 +113,7 @@ export default [
       'jsdoc/no-defaults': 'off',
       'jsdoc/require-jsdoc': 'off',
       'vue/multi-word-component-names': 'off',
+      'prefer-object-has-own': 'error',
     },
   },
 ];

--- a/src/compat/array/dropWhile.spec.ts
+++ b/src/compat/array/dropWhile.spec.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { dropWhile } from './dropWhile';
 import { slice } from '../_internal/slice';
-import { range } from '../../math/range';
-import { LARGE_ARRAY_SIZE } from '../_internal/LARGE_ARRAY_SIZE';
 
 /**
  * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/dropWhile.spec.js
@@ -28,6 +26,7 @@ describe('dropWhile', () => {
     let args;
 
     dropWhile(array, function () {
+      // eslint-disable-next-line prefer-rest-params
       args = slice.call(arguments);
     });
 

--- a/src/compat/array/every.spec.ts
+++ b/src/compat/array/every.spec.ts
@@ -62,7 +62,9 @@ describe('every', () => {
     const actual = empties.map(value => {
       try {
         return every(value, identity);
-      } catch (e) {}
+      } catch (e) {
+        /* empty */
+      }
     });
 
     expect(actual).toEqual(expected);
@@ -86,6 +88,7 @@ describe('every', () => {
   });
 
   it('should use `_.identity` when `predicate` is nullish', () => {
+    // eslint-disable-next-line no-sparse-arrays
     const values = [, null, undefined];
     let expected = values.map(stubFalse);
 

--- a/src/compat/object/has.ts
+++ b/src/compat/object/has.ts
@@ -84,7 +84,7 @@ export function has(object: any, path: PropertyKey | readonly PropertyKey[]): bo
     const key = resolvedPath[i];
 
     // Check if the current key is a direct property of the current object
-    if (current == null || !Object.prototype.hasOwnProperty.call(current, key)) {
+    if (current == null || !Object.hasOwn(current, key)) {
       const isSparseIndex = (Array.isArray(current) || isArguments(current)) && isIndex(key) && key < current.length;
 
       if (!isSparseIndex) {

--- a/src/compat/object/pick.ts
+++ b/src/compat/object/pick.ts
@@ -116,7 +116,7 @@ export function pick<
     for (const key of keys) {
       const value = get(obj, key);
 
-      if (typeof key === 'string' && Object.prototype.hasOwnProperty.call(obj, key)) {
+      if (typeof key === 'string' && Object.hasOwn(obj, key)) {
         result[key] = value;
       } else {
         set(result, key, value);

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -69,12 +69,12 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
     }
 
     // For RegExpArrays
-    if (Object.prototype.hasOwnProperty.call(obj, 'index')) {
+    if (Object.hasOwn(obj, 'index')) {
       // eslint-disable-next-line
       // @ts-ignore
       result.index = obj.index;
     }
-    if (Object.prototype.hasOwnProperty.call(obj, 'input')) {
+    if (Object.hasOwn(obj, 'input')) {
       // eslint-disable-next-line
       // @ts-ignore
       result.input = obj.input;

--- a/src/object/pick.ts
+++ b/src/object/pick.ts
@@ -21,7 +21,7 @@ export function pick<T extends Record<string, any>, K extends keyof T>(obj: T, k
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
 
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+    if (Object.hasOwn(obj, key)) {
       result[key] = obj[key];
     }
   }

--- a/src/predicate/isEqual.ts
+++ b/src/predicate/isEqual.ts
@@ -241,7 +241,7 @@ function areObjectsEqual(a: any, b: any, stack?: Map<any, any>) {
           const propKey = aKeys[i];
           const aProp = (a as any)[propKey];
 
-          if (!Object.prototype.hasOwnProperty.call(b, propKey)) {
+          if (!Object.hasOwn(b, propKey)) {
             return false;
           }
 


### PR DESCRIPTION
# Description

`Object.hasOwn` behaves the same as `Object.prototype.hasOwnProperty.call`, but with more explicit syntax. For the sake of consistency and better maintainability, I am submitting this PR.
