### PR TITLE
fix(includes): Ignore inherited value when searching object

### DIFF
--- a/src/compat/array/includes.spec.ts
+++ b/src/compat/array/includes.spec.ts
@@ -7,6 +7,11 @@ import { args } from '../_internal/args';
 import { falsey } from '../_internal/falsey';
 
 describe('includes', () => {
+  it('should ignore inherited value', () => {
+    const obj = Object.create({ inherited: 'value' });
+    expect(includes(obj, 'value')).toBe(false);
+  });
+
   Object.entries({
     'an `arguments` object': toArgs([1, 2, 3, 4]),
     'an array': [1, 2, 3, 4],

--- a/src/compat/array/includes.ts
+++ b/src/compat/array/includes.ts
@@ -121,7 +121,9 @@ export function includes(
 
   // Not using `Object.keys` because it can't access inherited properties.
   for (const key in source) {
-    keys.push(key);
+    if (Object.hasOwn(source, key)) {
+      keys.push(key);
+    }
   }
 
   if (fromIndex < 0) {

--- a/src/compat/array/includes.ts
+++ b/src/compat/array/includes.ts
@@ -117,14 +117,7 @@ export function includes(
     return source.includes(target, fromIndex);
   }
 
-  const keys = [];
-
-  // Not using `Object.keys` because it can't access inherited properties.
-  for (const key in source) {
-    if (Object.hasOwn(source, key)) {
-      keys.push(key);
-    }
-  }
+  const keys = Object.keys(source);
 
   if (fromIndex < 0) {
     fromIndex = Math.max(0, keys.length + fromIndex);


### PR DESCRIPTION
Fixed `includes` to ignore the inherited value.