### PR TITLE
refactor(range): Enhance type safety in the implementation

### DIFF
--- a/src/math/range.ts
+++ b/src/math/range.ts
@@ -69,7 +69,7 @@ export function range(start: number, end?: number, step?: number): number[] {
   }
 
   const length = Math.max(Math.ceil((end - start) / step), 0);
-  const result = new Array(length);
+  const result = new Array<number>(length);
 
   for (let i = 0; i < length; i++) {
     result[i] = start + i * step;


### PR DESCRIPTION
`range` was returning `any[]`. Updated it to explicitly return `number[]` by using `new Array<number>(length)` for better type safety. `range` should always return an array of numbers.

#### AS-IS
<img width="367" alt="스크린샷 2024-10-02 오후 1 58 46" src="https://github.com/user-attachments/assets/ee08c063-3888-4858-a509-7c764c5cd18c">

#### TO-BE
<img width="368" alt="스크린샷 2024-10-02 오후 1 59 07" src="https://github.com/user-attachments/assets/d02fafa2-4005-42ba-8971-e428ec7b0e5e">

