### PR TITLE
fix(before,once): allow accepting arguments for `once` and fix types of `before` and `once`

### DIFF
--- a/docs/ja/reference/function/before.md
+++ b/docs/ja/reference/function/before.md
@@ -5,7 +5,7 @@
 ## インターフェース
 
 ```typescript
-function before<F extends (...args: any[]) => any>(n: number, func: F): F;
+function before<F extends (...args: unkown[]) => any>(n: number, func: F): (...args: Parameters<F>) => ReturnType<F> | undefined;
 ```
 
 ### パラメータ
@@ -17,7 +17,7 @@ function before<F extends (...args: any[]) => any>(n: number, func: F): F;
 
 ### 戻り値
 
-(`F`): 新しい関数を返します。この関数は以下の機能を持ちます：
+(`(...args: Parameters<F>) => ReturnType<F> | undefined`): 新しい関数を返します。この関数は以下の機能を持ちます：
 
 - 呼び出し回数を追跡します。
 - `n-1` 回目の呼び出しまで `func` を呼び出します。

--- a/docs/ja/reference/function/before.md
+++ b/docs/ja/reference/function/before.md
@@ -5,7 +5,7 @@
 ## インターフェース
 
 ```typescript
-function before<F extends (...args: unkown[]) => any>(
+function before<F extends (...args: any[]) => any>(
   n: number,
   func: F
 ): (...args: Parameters<F>) => ReturnType<F> | undefined;

--- a/docs/ja/reference/function/before.md
+++ b/docs/ja/reference/function/before.md
@@ -5,7 +5,10 @@
 ## インターフェース
 
 ```typescript
-function before<F extends (...args: unkown[]) => any>(n: number, func: F): (...args: Parameters<F>) => ReturnType<F> | undefined;
+function before<F extends (...args: unkown[]) => any>(
+  n: number,
+  func: F
+): (...args: Parameters<F>) => ReturnType<F> | undefined;
 ```
 
 ### パラメータ

--- a/docs/ja/reference/function/once.md
+++ b/docs/ja/reference/function/once.md
@@ -6,16 +6,16 @@
 ## インターフェース
 
 ```typescript
-function once<F extends () => any>(func: F): F;
+function once<F extends (...args: unknown[]) => any>(func: F): () => ReturnType<F>;
 ```
 
 ### パラメータ
 
-- `func` (`F extends () => any`): 一度だけ呼び出すように制限する関数です。
+- `func` (`F extends (...args: unknown[]) => any`): 一度だけ呼び出すように制限する関数です。
 
 ### 戻り値
 
-(`F`): `func` が一度呼び出されると結果をキャッシュして返す新しい関数です。
+(`() => ReturnType<F>`): `func` が一度呼び出されると結果をキャッシュして返す新しい関数です。
 
 ## 例
 

--- a/docs/ja/reference/function/once.md
+++ b/docs/ja/reference/function/once.md
@@ -6,16 +6,17 @@
 ## インターフェース
 
 ```typescript
-function once<F extends (...args: any[]) => any>(func: F): (...args: Parameters<F>) => ReturnType<F>;
+function once<F extends () => any>(func: F): F;
+function once<F extends (...args: any[]) => void>(func: F): F;
 ```
 
 ### パラメータ
 
-- `func` (`F extends (...args: any[]) => any`): 一度だけ呼び出すように制限する関数です。
+- `func` (`F extends (() => any) | ((...args: any[]) => void)`): 一度だけ呼び出すように制限する関数です。
 
 ### 戻り値
 
-(`(...args: Parameters<F>) => ReturnType<F>`): `func` が一度呼び出されると結果をキャッシュして返す新しい関数です。
+(`F`): `func` が一度呼び出されると結果をキャッシュして返す新しい関数です。
 
 ## 例
 

--- a/docs/ja/reference/function/once.md
+++ b/docs/ja/reference/function/once.md
@@ -6,12 +6,12 @@
 ## インターフェース
 
 ```typescript
-function once<F extends (...args: unknown[]) => any>(func: F): () => ReturnType<F>;
+function once<F extends (...args: any[]) => any>(func: F): () => ReturnType<F>;
 ```
 
 ### パラメータ
 
-- `func` (`F extends (...args: unknown[]) => any`): 一度だけ呼び出すように制限する関数です。
+- `func` (`F extends (...args: any[]) => any`): 一度だけ呼び出すように制限する関数です。
 
 ### 戻り値
 

--- a/docs/ja/reference/function/once.md
+++ b/docs/ja/reference/function/once.md
@@ -6,7 +6,7 @@
 ## インターフェース
 
 ```typescript
-function once<F extends (...args: any[]) => any>(func: F): () => ReturnType<F>;
+function once<F extends (...args: any[]) => any>(func: F): (...args: Parameters<F>) => ReturnType<F>;
 ```
 
 ### パラメータ
@@ -15,7 +15,7 @@ function once<F extends (...args: any[]) => any>(func: F): () => ReturnType<F>;
 
 ### 戻り値
 
-(`() => ReturnType<F>`): `func` が一度呼び出されると結果をキャッシュして返す新しい関数です。
+(`(...args: Parameters<F>) => ReturnType<F>`): `func` が一度呼び出されると結果をキャッシュして返す新しい関数です。
 
 ## 例
 

--- a/docs/ko/reference/function/before.md
+++ b/docs/ko/reference/function/before.md
@@ -5,7 +5,7 @@
 ## 인터페이스
 
 ```typescript
-function before<F extends (...args: any[]) => any>(n: number, func: F): F;
+function before<F extends (...args: unknown[]) => any>(n: number, func: F): (...args: Parameters<F>) => ReturnType<F> | undefined;
 ```
 
 ### 파라미터
@@ -17,7 +17,7 @@ function before<F extends (...args: any[]) => any>(n: number, func: F): F;
 
 ### 반환 값
 
-(`F`): 새로운 함수를 반환해요. 이 함수는 다음과 같은 기능을 가져요.
+(`(...args: Parameters<F>) => ReturnType<F> | undefined`): 새로운 함수를 반환해요. 이 함수는 다음과 같은 기능을 가져요.
 
 - 호출 횟수를 추적해요.
 - `n-1`번째 호출까지 `func`를 호출해요.

--- a/docs/ko/reference/function/before.md
+++ b/docs/ko/reference/function/before.md
@@ -5,7 +5,10 @@
 ## 인터페이스
 
 ```typescript
-function before<F extends (...args: unknown[]) => any>(n: number, func: F): (...args: Parameters<F>) => ReturnType<F> | undefined;
+function before<F extends (...args: unknown[]) => any>(
+  n: number,
+  func: F
+): (...args: Parameters<F>) => ReturnType<F> | undefined;
 ```
 
 ### 파라미터

--- a/docs/ko/reference/function/before.md
+++ b/docs/ko/reference/function/before.md
@@ -5,7 +5,7 @@
 ## 인터페이스
 
 ```typescript
-function before<F extends (...args: unknown[]) => any>(
+function before<F extends (...args: any[]) => any>(
   n: number,
   func: F
 ): (...args: Parameters<F>) => ReturnType<F> | undefined;

--- a/docs/ko/reference/function/once.md
+++ b/docs/ko/reference/function/once.md
@@ -6,7 +6,7 @@
 ## 인터페이스
 
 ```typescript
-function once<F extends (...args: any[]) => any>(func: F): () => ReturnType<F>;
+function once<F extends (...args: any[]) => any>(func: F): (...args: Parameters<F>) => ReturnType<F>;
 ```
 
 ### 파라미터
@@ -15,7 +15,7 @@ function once<F extends (...args: any[]) => any>(func: F): () => ReturnType<F>;
 
 ### 반환 값
 
-(`() => ReturnType<F>`): `func`가 한 번 호출되면 결과를 캐시하고 반환할 새로운 함수예요.
+(`(...args: Parameters<F>) => ReturnType<F>`): `func`가 한 번 호출되면 결과를 캐시하고 반환할 새로운 함수예요.
 
 ## 예시
 

--- a/docs/ko/reference/function/once.md
+++ b/docs/ko/reference/function/once.md
@@ -6,7 +6,7 @@
 ## 인터페이스
 
 ```typescript
-function once<F extends (...args: unknown[]) => any>(func: F): () => ReturnType<F>;
+function once<F extends (...args: any[]) => any>(func: F): () => ReturnType<F>;
 ```
 
 ### 파라미터

--- a/docs/ko/reference/function/once.md
+++ b/docs/ko/reference/function/once.md
@@ -6,16 +6,17 @@
 ## 인터페이스
 
 ```typescript
-function once<F extends (...args: any[]) => any>(func: F): (...args: Parameters<F>) => ReturnType<F>;
+function once<F extends () => any>(func: F): F;
+function once<F extends (...args: any[]) => void>(func: F): F;
 ```
 
 ### 파라미터
 
-- `func` (`F extends (...args: unknown[]) => any`): 한 번만 호출하도록 제한할 함수예요.
+- `func` (`F extends (() => any) | ((...args: any[]) => void)`): 한 번만 호출하도록 제한할 함수예요.
 
 ### 반환 값
 
-(`(...args: Parameters<F>) => ReturnType<F>`): `func`가 한 번 호출되면 결과를 캐시하고 반환할 새로운 함수예요.
+(`F`): `func`가 한 번 호출되면 결과를 캐시하고 반환할 새로운 함수예요.
 
 ## 예시
 

--- a/docs/ko/reference/function/once.md
+++ b/docs/ko/reference/function/once.md
@@ -6,16 +6,16 @@
 ## 인터페이스
 
 ```typescript
-function once<F extends () => any>(func: F): F;
+function once<F extends (...args: unknown[]) => any>(func: F): () => ReturnType<F>;
 ```
 
 ### 파라미터
 
-- `func` (`F extends () => any`): 한 번만 호출하도록 제한할 함수예요.
+- `func` (`F extends (...args: unknown[]) => any`): 한 번만 호출하도록 제한할 함수예요.
 
 ### 반환 값
 
-(`F`): `func`가 한 번 호출되면 결과를 캐시하고 반환할 새로운 함수예요.
+(`() => ReturnType<F>`): `func`가 한 번 호출되면 결과를 캐시하고 반환할 새로운 함수예요.
 
 ## 예시
 

--- a/docs/reference/function/before.md
+++ b/docs/reference/function/before.md
@@ -5,7 +5,7 @@ Creates a new function that limits the number of times the given function (`func
 ## Signature
 
 ```typescript
-function before<F extends (...args: unkown[]) => any>(
+function before<F extends (...args: any[]) => any>(
   n: number,
   func: F
 ): (...args: Parameters<F>) => ReturnType<F> | undefined;

--- a/docs/reference/function/before.md
+++ b/docs/reference/function/before.md
@@ -5,7 +5,10 @@ Creates a new function that limits the number of times the given function (`func
 ## Signature
 
 ```typescript
-function before<F extends (...args: unkown[]) => any>(n: number, func: F): (...args: Parameters<F>) => ReturnType<F> | undefined;
+function before<F extends (...args: unkown[]) => any>(
+  n: number,
+  func: F
+): (...args: Parameters<F>) => ReturnType<F> | undefined;
 ```
 
 ### Parameters

--- a/docs/reference/function/before.md
+++ b/docs/reference/function/before.md
@@ -5,7 +5,7 @@ Creates a new function that limits the number of times the given function (`func
 ## Signature
 
 ```typescript
-function before<F extends (...args: any[]) => any>(n: number, func: F): F;
+function before<F extends (...args: unkown[]) => any>(n: number, func: F): (...args: Parameters<F>) => ReturnType<F> | undefined;
 ```
 
 ### Parameters
@@ -17,7 +17,7 @@ function before<F extends (...args: any[]) => any>(n: number, func: F): F;
 
 ### Returns
 
-(`F`): A new function that:
+(`(...args: Parameters<F>) => ReturnType<F> | undefined`): A new function that:
 
 - Tracks the number of calls.
 - Invokes `func` until the `n-1`-th call.

--- a/docs/reference/function/once.md
+++ b/docs/reference/function/once.md
@@ -6,12 +6,12 @@ Repeated calls to the function will return the value from the first invocation.
 ## Signature
 
 ```typescript
-function once<F extends (...args: unknown[]) => any>(func: F): () => ReturnType<F>;
+function once<F extends () => any>(func: F): () => ReturnType<F>;
 ```
 
 ### Parameters
 
-- `func` (`F extends (...args:unknown[]) => any`): The function to restrict.
+- `func` (`F extends () => any`): The function to restrict.
 
 ### Returns
 

--- a/docs/reference/function/once.md
+++ b/docs/reference/function/once.md
@@ -6,16 +6,16 @@ Repeated calls to the function will return the value from the first invocation.
 ## Signature
 
 ```typescript
-function once<F extends () => any>(func: F): F;
+function once<F extends (...args: unknown[]) => any>(func: F): () => ReturnType<F>;
 ```
 
 ### Parameters
 
-- `func` (`F extends () => any`): The function to restrict.
+- `func` (`F extends (...args:unknown[]) => any`): The function to restrict.
 
 ### Returns
 
-(`F`): A new function that invokes `func` once and caches the result.
+(`() => ReturnType<F>`): A new function that invokes `func` once and caches the result.
 
 ## Examples
 

--- a/docs/reference/function/once.md
+++ b/docs/reference/function/once.md
@@ -6,16 +6,16 @@ Repeated calls to the function will return the value from the first invocation.
 ## Signature
 
 ```typescript
-function once<F extends () => any>(func: F): () => ReturnType<F>;
+function once<F extends (...args: any[]) => any>(func: F): (...args: Parameters<F>) => ReturnType<F>;
 ```
 
 ### Parameters
 
-- `func` (`F extends () => any`): The function to restrict.
+- `func` (`F extends (...args: any[]) => any`): The function to restrict.
 
 ### Returns
 
-(`() => ReturnType<F>`): A new function that invokes `func` once and caches the result.
+(`(...args: Parameters<F>) => ReturnType<F>`): A new function that invokes `func` once and caches the result.
 
 ## Examples
 

--- a/docs/reference/function/once.md
+++ b/docs/reference/function/once.md
@@ -6,16 +6,17 @@ Repeated calls to the function will return the value from the first invocation.
 ## Signature
 
 ```typescript
-function once<F extends (...args: any[]) => any>(func: F): (...args: Parameters<F>) => ReturnType<F>;
+function once<F extends () => any>(func: F): F;
+function once<F extends (...args: any[]) => void>(func: F): F;
 ```
 
 ### Parameters
 
-- `func` (`F extends (...args: any[]) => any`): The function to restrict.
+- `func` (`F extends (() => any) | ((...args: any[]) => void)`): The function to restrict.
 
 ### Returns
 
-(`(...args: Parameters<F>) => ReturnType<F>`): A new function that invokes `func` once and caches the result.
+(`F`): A new function that invokes `func` once and caches the result.
 
 ## Examples
 

--- a/docs/zh_hans/reference/function/before.md
+++ b/docs/zh_hans/reference/function/before.md
@@ -5,7 +5,7 @@
 ## 签名
 
 ```typescript
-function before<F extends (...args: any[]) => any>(n: number, func: F): F;
+function before<F extends (...args: unkown[]) => any>(n: number, func: F): (...args: Parameters<F>) => ReturnType<F> | undefined;
 ```
 
 ### 参数
@@ -17,7 +17,7 @@ function before<F extends (...args: any[]) => any>(n: number, func: F): F;
 
 ### 返回值
 
-(`F`): 一个新函数，该函数：
+(`(...args: Parameters<F>) => ReturnType<F> | undefined`): 一个新函数，该函数：
 
 - 追踪调用次数。
 - 在调用次数达到 `n-1` 次之前调用 `func`。

--- a/docs/zh_hans/reference/function/before.md
+++ b/docs/zh_hans/reference/function/before.md
@@ -5,7 +5,7 @@
 ## 签名
 
 ```typescript
-function before<F extends (...args: unkown[]) => any>(
+function before<F extends (...args: any[]) => any>(
   n: number,
   func: F
 ): (...args: Parameters<F>) => ReturnType<F> | undefined;

--- a/docs/zh_hans/reference/function/before.md
+++ b/docs/zh_hans/reference/function/before.md
@@ -5,7 +5,10 @@
 ## 签名
 
 ```typescript
-function before<F extends (...args: unkown[]) => any>(n: number, func: F): (...args: Parameters<F>) => ReturnType<F> | undefined;
+function before<F extends (...args: unkown[]) => any>(
+  n: number,
+  func: F
+): (...args: Parameters<F>) => ReturnType<F> | undefined;
 ```
 
 ### 参数

--- a/docs/zh_hans/reference/function/once.md
+++ b/docs/zh_hans/reference/function/once.md
@@ -7,16 +7,16 @@
 ## 签名
 
 ```typescript
-function once<F extends () => any>(func: F): F;
+function once<F extends (...args: unknown[]) => any>(func: F): () => ReturnType<F>;
 ```
 
 ### 参数
 
-- `func` (`F extends () => any`): 要限制的函数。
+- `func` (`F extends (...args: unknown[]) => any`): 要限制的函数。
 
 ### 返回值
 
-(`F`): 调用 `func` 一次并缓存结果的新函数。
+(`() => ReturnType<F>`): 调用 `func` 一次并缓存结果的新函数。
 
 ## 示例
 

--- a/docs/zh_hans/reference/function/once.md
+++ b/docs/zh_hans/reference/function/once.md
@@ -7,16 +7,16 @@
 ## 签名
 
 ```typescript
-function once<F extends (...args: unknown[]) => any>(func: F): () => ReturnType<F>;
+function once<F extends (...args: any[]) => any>(func: F): (...args: Parameters<F>) => ReturnType<F>;
 ```
 
 ### 参数
 
-- `func` (`F extends (...args: unknown[]) => any`): 要限制的函数。
+- `func` (`F extends (...args: any[]) => any`): 要限制的函数。
 
 ### 返回值
 
-(`() => ReturnType<F>`): 调用 `func` 一次并缓存结果的新函数。
+(`(...args: Parameters<F>) => ReturnType<F>`): 调用 `func` 一次并缓存结果的新函数。
 
 ## 示例
 

--- a/docs/zh_hans/reference/function/once.md
+++ b/docs/zh_hans/reference/function/once.md
@@ -7,16 +7,17 @@
 ## 签名
 
 ```typescript
-function once<F extends (...args: any[]) => any>(func: F): (...args: Parameters<F>) => ReturnType<F>;
+function once<F extends () => any>(func: F): F;
+function once<F extends (...args: any[]) => void>(func: F): F;
 ```
 
 ### 参数
 
-- `func` (`F extends (...args: any[]) => any`): 要限制的函数。
+- `func` (`F extends (() => any) | ((...args: any[]) => void)`): 要限制的函数。
 
 ### 返回值
 
-(`(...args: Parameters<F>) => ReturnType<F>`): 调用 `func` 一次并缓存结果的新函数。
+(`F`): 调用 `func` 一次并缓存结果的新函数。
 
 ## 示例
 

--- a/src/function/before.ts
+++ b/src/function/before.ts
@@ -27,7 +27,7 @@
  * beforeFn();
  */
 
-export function before<F extends (...args: unknown[]) => any>(
+export function before<F extends (...args: any[]) => any>(
   n: number,
   func: F
 ): (...args: Parameters<F>) => ReturnType<F> | undefined {

--- a/src/function/before.ts
+++ b/src/function/before.ts
@@ -6,7 +6,7 @@
  * - If `n` is 0, `func` will never be called.
  * - If `n` is a positive integer, `func` will be called up to `n-1` times.
  * @param {F} func - The function to be called with the limit applied.
- * @returns {F} - A new function that:
+ * @returns {(...args: Parameters<F>) => ReturnType<F> | undefined} - A new function that:
  * - Tracks the number of calls.
  * - Invokes `func` until the `n-1`-th call.
  * - Returns `undefined` if the number of calls reaches or exceeds `n`, stopping further calls.
@@ -27,16 +27,21 @@
  * beforeFn();
  */
 
-export function before<F extends (...args: any[]) => any>(n: number, func: F): F {
+export function before<F extends (...args: unknown[]) => any>(
+  n: number,
+  func: F
+): (...args: Parameters<F>) => ReturnType<F> | undefined {
   if (!Number.isInteger(n) || n < 0) {
     throw new Error('n must be a non-negative integer.');
   }
 
   let counter = 0;
-  return ((...args: Parameters<F>) => {
+
+  return (...args: Parameters<F>) => {
     if (++counter < n) {
       return func(...args);
     }
+
     return undefined;
-  }) as F;
+  };
 }

--- a/src/function/once.ts
+++ b/src/function/once.ts
@@ -4,7 +4,7 @@
  *
  * @template F - The type of function.
  * @param {F} func - The function to restrict.
- * @returns {() => ReturnType<F>} A new function that invokes `func` once and caches the result.
+ * @returns {(...args: Parameters<F>) => ReturnType<F>} A new function that invokes `func` once and caches the result.
  *
  * @example
  * const initialize = once(() => {
@@ -15,14 +15,14 @@
  * initialize(); // Logs: 'Initialized!' and returns true
  * initialize(); // Returns true without logging
  */
-export function once<F extends (...args: unknown[]) => any>(func: F): () => ReturnType<F> {
+export function once<F extends (...args: any[]) => any>(func: F): (...args: Parameters<F>) => ReturnType<F> {
   let called = false;
   let cache: ReturnType<F>;
 
-  return function () {
+  return function (...args: Parameters<F>): ReturnType<F> {
     if (!called) {
       called = true;
-      cache = func();
+      cache = func(...args);
     }
 
     return cache;

--- a/src/function/once.ts
+++ b/src/function/once.ts
@@ -3,6 +3,39 @@
  * Repeated calls to the function will return the value from the first invocation.
  *
  * @template F - The type of function.
+ * @param {F extends () => any} func - The function to restrict.
+ * @returns {F} A new function that invokes `func` once and caches the result.
+ *
+ * @example
+ * const initialize = once(() => {
+ *   console.log('Initialized!');
+ *   return true;
+ * });
+ *
+ * initialize(); // Logs: 'Initialized!' and returns true
+ * initialize(); // Returns true without logging
+ */
+export function once<F extends () => any>(func: F): F;
+/**
+ * Creates a function that is restricted to invoking the provided function `func` once.
+ * Repeated calls to the function will return the value from the first invocation.
+ *
+ * @template F - The type of function.
+ * @param {F extends (...args: any[]) => void} func - The function to restrict with arguments.
+ * @returns {F} A new function that invokes `func` once.
+ *
+ * @example
+ * const log = once(console.log);
+ *
+ * log('Hello, world!'); // prints 'Hello, world!' and doesn't return anything
+ * log('Hello, world!'); // doesn't print anything and doesn't return anything
+ */
+export function once<F extends (...args: any[]) => void>(func: F): F;
+/**
+ * Creates a function that is restricted to invoking the provided function `func` once.
+ * Repeated calls to the function will return the value from the first invocation.
+ *
+ * @template F - The type of function.
  * @param {F} func - The function to restrict.
  * @returns {(...args: Parameters<F>) => ReturnType<F>} A new function that invokes `func` once and caches the result.
  *
@@ -15,7 +48,7 @@
  * initialize(); // Logs: 'Initialized!' and returns true
  * initialize(); // Returns true without logging
  */
-export function once<F extends (...args: any[]) => any>(func: F): (...args: Parameters<F>) => ReturnType<F> {
+export function once<F extends (() => any) | ((...args: any[]) => void)>(func: F): F {
   let called = false;
   let cache: ReturnType<F>;
 
@@ -26,5 +59,5 @@ export function once<F extends (...args: any[]) => any>(func: F): (...args: Para
     }
 
     return cache;
-  };
+  } as F;
 }

--- a/src/function/once.ts
+++ b/src/function/once.ts
@@ -4,7 +4,7 @@
  *
  * @template F - The type of function.
  * @param {F} func - The function to restrict.
- * @returns {F} A new function that invokes `func` once and caches the result.
+ * @returns {() => ReturnType<F>} A new function that invokes `func` once and caches the result.
  *
  * @example
  * const initialize = once(() => {
@@ -15,20 +15,16 @@
  * initialize(); // Logs: 'Initialized!' and returns true
  * initialize(); // Returns true without logging
  */
-export function once<F extends () => any>(func: F): F {
+export function once<F extends (...args: unknown[]) => any>(func: F): () => ReturnType<F> {
   let called = false;
-  let cache: ReturnType<F> | undefined;
+  let cache: ReturnType<F>;
 
   return function () {
-    if (called) {
-      return cache;
+    if (!called) {
+      called = true;
+      cache = func();
     }
 
-    const result = func();
-
-    called = true;
-    cache = result;
-
-    return result;
-  } as F;
+    return cache;
+  };
 }


### PR DESCRIPTION
# Description

- `before`
  - I corrected the part where the return type was defined as the assigned function, even though it returns a new function.
- `once`:
  - Previously, the function was designed to only accept functions without arguments, but we needs to accept functions with arguments. So I added this feature.
  - I simplified the code a bit.