### PR TITLE
feat(before): add `before` in compat layer

### DIFF
--- a/benchmarks/performance/before.bench.ts
+++ b/benchmarks/performance/before.bench.ts
@@ -1,28 +1,57 @@
 import { bench, describe } from 'vitest';
 import { before as beforeToolkit_ } from 'es-toolkit';
+import { before as beforeToolkitCompat_ } from 'es-toolkit/compat';
 import { before as beforeLodash_ } from 'lodash';
 
 const beforeToolkit = beforeToolkit_;
+const beforeToolkitCompat = beforeToolkitCompat_;
 const beforeLodash = beforeLodash_;
 
 describe('before', () => {
-  bench('es-toolkit/before', () => {
-    const add = (a: number, b: number) => a + b;
-    const n = 10;
-    const beforeFn = beforeToolkit(10, add);
+  bench(
+    'es-toolkit/before',
+    () => {
+      const add = (a: number, b: number) => a + b;
+      const n = 10;
+      const beforeFn = beforeToolkit(10, add);
 
-    for (let i = 0; i < n; i++) {
-      beforeFn(1, 2);
+      for (let i = 0; i < n; i++) {
+        beforeFn(1, 2);
+      }
+    },
+    {
+      time: 100,
     }
-  });
+  );
+  bench(
+    'es-toolkit/compat/before',
+    () => {
+      const add = (a: number, b: number) => a + b;
+      const n = 10;
+      const beforeFn = beforeToolkitCompat(10, add);
 
-  bench('lodash/before', () => {
-    const add = (a: number, b: number) => a + b;
-    const n = 10;
-    const beforeFn = beforeLodash(10, add);
-
-    for (let i = 0; i < n; i++) {
-      beforeFn(1, 2);
+      for (let i = 0; i < n; i++) {
+        beforeFn(1, 2);
+      }
+    },
+    {
+      time: 100,
     }
-  });
+  );
+
+  bench(
+    'lodash/before',
+    () => {
+      const add = (a: number, b: number) => a + b;
+      const n = 10;
+      const beforeFn = beforeLodash(10, add);
+
+      for (let i = 0; i < n; i++) {
+        beforeFn(1, 2);
+      }
+    },
+    {
+      time: 100,
+    }
+  );
 });

--- a/src/compat/function/before.spec.ts
+++ b/src/compat/function/before.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { before } from './before';
+
+describe('before', () => {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  function _before(n: number, times: number) {
+    let count = 0;
+    const innerBefore = before(n, () => {
+      count++;
+    });
+
+    for (let i = 0; i < times; i++) {
+      innerBefore();
+    }
+
+    return count;
+  }
+
+  it('should create a function that invokes `func` after `n` calls', () => {
+    expect(_before(5, 4), 'before(n) should invoke `func` before being called `n` times').toBe(4);
+    expect(_before(5, 6), 'before(n) should not invoke `func` after being called `n - 1` times').toBe(4);
+    expect(_before(0, 0), 'before(0) should not invoke `func` immediately').toBe(0);
+    expect(_before(0, 1), 'before(0) should not invoke `func` when called').toBe(0);
+  });
+
+  it('should coerce `n` values of `NaN` to `0`', () => {
+    expect(_before(NaN, 1)).toBe(0);
+  });
+
+  it('should use `this` binding of function', () => {
+    const _before = before(2, function () {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      return ++this.count;
+    });
+    const object = { before: _before, count: 0 };
+
+    object.before();
+    expect(object.before()).toBe(1);
+    expect(object.count).toBe(1);
+  });
+
+  it('should throw an error if `func` is not a function', () => {
+    expect(() => before(1, 1 as any)).toThrow(TypeError);
+  });
+});

--- a/src/compat/function/before.ts
+++ b/src/compat/function/before.ts
@@ -24,7 +24,7 @@ import { toInteger } from '../util/toInteger';
  * before3(); // => 3
  * before3(); // => 3
  */
-export function before<F extends (...args: unknown[]) => any>(
+export function before<F extends (...args: any[]) => any>(
   n: number,
   func: F
 ): (...args: Parameters<F>) => ReturnType<F> {

--- a/src/compat/function/before.ts
+++ b/src/compat/function/before.ts
@@ -1,0 +1,50 @@
+import { toInteger } from '../util/toInteger';
+
+/**
+ * Creates a function that invokes `func`, with the `this` binding and arguments
+ * of the created function, while it's called less than `n` times. Subsequent
+ * calls to the created function return the result of the last `func` invocation.
+ *
+ * @template F - The type of the function to be invoked.
+ * @param {number} n - The number of times the returned function is allowed to call `func` before stopping.
+ * - If `n` is 0, `func` will never be called.
+ * - If `n` is a positive integer, `func` will be called up to `n-1` times.
+ * @param {F} func - The function to be called with the limit applied.
+ * @returns {(...args: Parameters<F>) => ReturnType<F> } - A new function that:
+ * - Tracks the number of calls.
+ * - Invokes `func` until the `n-1`-th call.
+ * - Returns last result of `func`, if `n` is reached.
+ * @throws {TypeError} - If `func` is not a function.
+ * @example
+ * let count = 0;
+ * const before3 = before(3, () => ++count);
+ *
+ * before3(); // => 1
+ * before3(); // => 2
+ * before3(); // => 3
+ * before3(); // => 3
+ */
+export function before<F extends (...args: unknown[]) => any>(
+  n: number,
+  func: F
+): (...args: Parameters<F>) => ReturnType<F> {
+  if (typeof func !== 'function') {
+    throw new TypeError('Expected a function');
+  }
+
+  let result: ReturnType<F>;
+  n = toInteger(n);
+
+  return function (this: unknown, ...args: Parameters<F>) {
+    if (--n > 0) {
+      result = func.apply(this, args);
+    }
+
+    if (n <= 1 && func) {
+      // for garbage collection
+      func = undefined as any;
+    }
+
+    return result;
+  };
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -51,6 +51,7 @@ export { head as first } from '../array/head.ts';
 
 export { ary } from './function/ary.ts';
 export { bind } from './function/bind.ts';
+export { before } from './function/before.ts';
 export { bindKey } from './function/bindKey.ts';
 export { defer } from './function/defer.ts';
 export { rest } from './function/rest.ts';


### PR DESCRIPTION
# Descritpiton

Our implementation of `before` returns `undefined` after the `n-1` call, while Lodash's implementation returns the result of the `n-1` call. Therefore, I couldn't use our function, so I re-implemented.

## Benchmarks

<img width="788" alt="Screenshot 2024-10-03 at 2 28 53 PM" src="https://github.com/user-attachments/assets/45e59872-483c-4370-a148-e4ab6e817408">

The issue arises due to the overhead involved when importing the module, which is causing this result. If we resolve the part where `toInteger` is imported, the output will be the same as Lodash.

