### PR TITLE
docs(isEqual): Correct result of special case

### DIFF
--- a/docs/ja/reference/predicate/isEqual.md
+++ b/docs/ja/reference/predicate/isEqual.md
@@ -34,7 +34,7 @@ isEqual(true, false); // false
 
 ```javascript
 isEqual(NaN, NaN); // true
-isEqual(+0, -0); // false
+isEqual(+0, -0); // true
 ```
 
 ### 例3: Dateオブジェクトの比較

--- a/docs/ko/reference/predicate/isEqual.md
+++ b/docs/ko/reference/predicate/isEqual.md
@@ -34,7 +34,7 @@ isEqual(true, false); // false
 
 ```javascript
 isEqual(NaN, NaN); // true
-isEqual(+0, -0); // false
+isEqual(+0, -0); // true
 ```
 
 ### 예시 3: 날짜 객체 비교

--- a/docs/reference/predicate/isEqual.md
+++ b/docs/reference/predicate/isEqual.md
@@ -34,7 +34,7 @@ isEqual(true, false); // false
 
 ```javascript
 isEqual(NaN, NaN); // true
-isEqual(+0, -0); // false
+isEqual(+0, -0); // true
 ```
 
 ### Example 3: Comparing Date Objects

--- a/docs/zh_hans/reference/predicate/isEqual.md
+++ b/docs/zh_hans/reference/predicate/isEqual.md
@@ -34,7 +34,7 @@ isEqual(true, false); // false
 
 ```javascript
 isEqual(NaN, NaN); // true
-isEqual(+0, -0); // false
+isEqual(+0, -0); // true
 ```
 
 ### 示例 3: 比较日期对象


### PR DESCRIPTION
Since in es-toolkit and lodash, `isEqual` returns `true` when comparing`+0` and `-0`, i updated document.