### PR TITLE
refactor: replace direct expressions with `eq` function calls

### DIFF
--- a/src/compat/array/includes.ts
+++ b/src/compat/array/includes.ts
@@ -1,4 +1,5 @@
 import { isString } from '../predicate/isString.ts';
+import { eq } from '../util/eq.ts';
 import { toInteger } from '../util/toInteger.ts';
 
 /**
@@ -77,6 +78,7 @@ export function includes<T>(
  * @param {T[] | Record<string, any> | string} source - The source to search in. It can be an array, an object, or a string.
  * @param {T} [target] - The value to search for in the source.
  * @param {number} [fromIndex=0] - The index to start searching from. If negative, it is treated as an offset from the end of the source.
+ * @param guard
  * @returns {boolean} `true` if the value is found in the source, `false` otherwise.
  *
  * @example
@@ -126,8 +128,7 @@ export function includes(
   for (let i = fromIndex; i < keys.length; i++) {
     const value = Reflect.get(source, keys[i]);
 
-    // This condition is the SameValueZero comparison.
-    if (value === target || (Number.isNaN(value) && Number.isNaN(target))) {
+    if (eq(value, target)) {
       return true;
     }
   }

--- a/src/compat/predicate/isMatch.ts
+++ b/src/compat/predicate/isMatch.ts
@@ -1,5 +1,6 @@
 import { isObject } from './isObject.ts';
 import { isPrimitive } from '../../predicate/isPrimitive.ts';
+import { eq } from '../util/eq.ts';
 
 /**
  * Checks if the target matches the source by comparing their structures and values.
@@ -118,7 +119,7 @@ export function isMatch(target: any, source: any): boolean {
     }
     default: {
       if (!isObject(target)) {
-        return target === source || (Number.isNaN(target) && Number.isNaN(source));
+        return eq(target, source);
       }
 
       return !source;

--- a/src/predicate/isEqualWith.ts
+++ b/src/predicate/isEqualWith.ts
@@ -29,6 +29,7 @@ import {
   uint16ArrayTag,
   uint32ArrayTag,
 } from '../compat/_internal/tags.ts';
+import { eq } from '../compat/index.ts';
 
 declare let Buffer:
   | {
@@ -172,7 +173,7 @@ function areObjectsEqual(
       const x = a.valueOf();
       const y = b.valueOf();
 
-      return x === y || (Number.isNaN(x) && Number.isNaN(y));
+      return eq(x, y);
     }
 
     case booleanTag:


### PR DESCRIPTION
# Description

This refactor updates the code by replacing direct expressions with calls to the `eq` function. It makes the code slightly slower but enhances consistency and readability across the codebase.

I also was going to modify `defaults`, but you’ve already taken care of it, so thank you! Also, thank you for removing `eq` inside `_internal`!
