### PR TITLE
fix(clone): Return empty object when cloning function

### DIFF
--- a/src/object/clone.spec.ts
+++ b/src/object/clone.spec.ts
@@ -119,11 +119,11 @@ describe('clone', () => {
     expect(clonedNestedObj.a[2]).toEqual(nestedObj.a[2]);
   });
 
-  it('should return functions as is', () => {
+  it('should return an empty object when cloning a function', () => {
     const func = () => {};
     const clonedFunc = clone(func);
 
-    expect(clonedFunc).toBe(func);
+    expect(clonedFunc).toEqual({});
   });
 
   it('should clone sets', () => {

--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -81,5 +81,9 @@ export function clone<T>(obj: T): T {
     return Object.assign(newObject, obj);
   }
 
+  if (typeof obj === 'function') {
+    return {} as T;
+  }
+
   return obj;
 }


### PR DESCRIPTION
I found that the `clone` function in 'es-toolkit' returns functions as they are, unlike 'lodash', which returns an empty object. I’m curious if this behavior was intended.