### PR TITLE
bench: import `lodash` as inlined modules

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -10,6 +10,11 @@ export default defineConfig({
       include: ['src/**/*'],
       exclude: ['src/compat/_internal/**/*'],
     },
+    server: {
+      deps: {
+        inline: ['lodash'],
+      },
+    },
     watch: false,
   },
 });


### PR DESCRIPTION
# Description 

| Before |  After |
| - | - |
|<img width="812" alt="Screenshot 2024-10-04 at 4 59 49 PM" src="https://github.com/user-attachments/assets/6f30701a-4470-4afd-8d7e-fcb1a8e703ab">|<img width="846" alt="Screenshot 2024-10-04 at 4 59 24 PM" src="https://github.com/user-attachments/assets/82fa129f-2007-41ea-b6c8-36ad22cc1f17">|

I thought there was overhead when importing external packages, so I switched to an inline approach, and I was able to achieve the same performance without needing to reassign.

If it is merged with  [PR](https://github.com/toss/es-toolkit/pull/661 ), it seems that reassignment will no longer be necessary.