### PR TITLE
fix(cloneDeep): cloneDeep should clone own enumerable symbol property

### DIFF
--- a/src/object/cloneDeep.spec.ts
+++ b/src/object/cloneDeep.spec.ts
@@ -46,7 +46,7 @@ describe('cloneDeep', () => {
   // object
   //-------------------------------------------------------------------------------------
   it('should clone objects', () => {
-    const obj = { a: 1, b: 'es-toolkit', c: [1, 2, 3] };
+    const obj = { a: 1, b: 'es-toolkit', c: [1, 2, 3], [Symbol()]: 2 };
     const clonedObj = cloneDeep(obj);
 
     expect(clonedObj).toEqual(obj);

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -197,7 +197,7 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
 
 // eslint-disable-next-line
 export function copyProperties(target: any, source: any, stack?: Map<any, any>): void {
-  const keys = [...Object.keys(source), ...getSymbols(source)];
+  const keys = Reflect.ownKeys(source);
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -197,7 +197,7 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
 
 // eslint-disable-next-line
 export function copyProperties(target: any, source: any, stack?: Map<any, any>): void {
-  const keys = Reflect.ownKeys(source);
+  const keys = [...Object.keys(source), ...getSymbols(source)];
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -1,3 +1,4 @@
+import { getSymbols } from '../compat/_internal/getSymbols.ts';
 import { isPrimitive } from '../predicate/isPrimitive.ts';
 import { isTypedArray } from '../predicate/isTypedArray.ts';
 
@@ -196,7 +197,7 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
 
 // eslint-disable-next-line
 export function copyProperties(target: any, source: any, stack?: Map<any, any>): void {
-  const keys = Object.keys(source);
+  const keys = [...Object.keys(source), ...getSymbols(source)];
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];


### PR DESCRIPTION
- Fixed `cloneDeep` to properly clone own enumerable symbol properties