### PR TITLE
fix(clone): `clone` should clone function correctly

### DIFF
--- a/src/object/clone.spec.ts
+++ b/src/object/clone.spec.ts
@@ -119,11 +119,24 @@ describe('clone', () => {
     expect(clonedNestedObj.a[2]).toEqual(nestedObj.a[2]);
   });
 
-  it('should return functions as is', () => {
+  it('should clone function', () => {
     const func = () => {};
     const clonedFunc = clone(func);
 
-    expect(clonedFunc).toBe(func);
+    expect(clonedFunc).toEqual({});
+  });
+
+  it('should clone function with property', () => {
+    function Foo() {}
+    const a = (value: number) => value > 1;
+    const sym = Symbol();
+
+    Foo.a = a;
+    Foo[sym] = 1;
+
+    const clonedFoo = clone(Foo);
+
+    expect(clonedFoo).toEqual({ a, [sym]: 1 });
   });
 
   it('should clone sets', () => {

--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -1,3 +1,4 @@
+import { getSymbols } from '../compat/_internal/getSymbols.ts';
 import { isPrimitive } from '../predicate/isPrimitive.ts';
 import { isTypedArray } from '../predicate/isTypedArray.ts';
 
@@ -79,6 +80,19 @@ export function clone<T>(obj: T): T {
   if (typeof obj === 'object') {
     const newObject = Object.create(prototype);
     return Object.assign(newObject, obj);
+  }
+
+  if (typeof obj === 'function') {
+    const result: Record<PropertyKey, unknown> = {};
+    const keys = [...Object.keys(obj), ...getSymbols(obj)];
+
+    for (let i = 0; i < keys.length; ++i) {
+      const key = keys[i];
+
+      result[key] = obj[key as keyof typeof obj];
+    }
+
+    return result as T;
   }
 
   return obj;


### PR DESCRIPTION
Unlike Lodash, the `clone` function in 'es-toolkit' returns functions as they are. So I fixed it to behave the same as Lodash.
I’m curious if this was intentional?