### PR TITLE
refac(unionBy): simplify unionBy implementation logic

### DIFF
--- a/src/array/unionBy.ts
+++ b/src/array/unionBy.ts
@@ -1,3 +1,5 @@
+import { uniqBy } from './uniqBy';
+
 /**
  * Creates an array of unique values, in order, from all given arrays using a provided mapping function to determine equality.
  *
@@ -21,17 +23,5 @@
  * // Returns [{ id: 1 }, { id: 2 }, { id: 3 }]
  */
 export function unionBy<T, U>(arr1: readonly T[], arr2: readonly T[], mapper: (item: T) => U): T[] {
-  const map = new Map<U, T>();
-
-  const items = [...arr1, ...arr2];
-  for (let i = 0; i < items.length; i++) {
-    const item = items[i];
-    const key = mapper(item);
-
-    if (!map.has(key)) {
-      map.set(key, item);
-    }
-  }
-
-  return Array.from(map.values());
+  return uniqBy(arr1.concat(arr2), mapper);
 }


### PR DESCRIPTION
By utilizing `uniqBy`, we can implement unionBy a little more simply.

In the case of `union`, it is implemented as follows 

```ts
export function union<T>(arr1: readonly T[], arr2: readonly T[]): T[] {
  return uniq(arr1.concat(arr2));
}
```