### PR TITLE
fix(drop): support array-like args

### DIFF
--- a/benchmarks/performance/dropRight.bench.ts
+++ b/benchmarks/performance/dropRight.bench.ts
@@ -1,13 +1,19 @@
 import { bench, describe } from 'vitest';
 import { dropRight as dropRightToolkit_ } from 'es-toolkit';
+import { dropRight as dropRightToolkitCompat_ } from 'es-toolkit/compat';
 import { dropRight as dropRightLodash_ } from 'lodash';
 
 const dropRightToolkit = dropRightToolkit_;
+const dropRightToolkitCompat = dropRightToolkitCompat_;
 const dropRightLodash = dropRightLodash_;
 
 describe('dropRight', () => {
   bench('es-toolkit/dropRight', () => {
     dropRightToolkit([1, 2, 3, 4, 5, 6], 3);
+  });
+
+  bench('es-toolkit/compat/dropRight', () => {
+    dropRightToolkitCompat([1, 2, 3, 4, 5, 6], 3);
   });
 
   bench('lodash/dropRight', () => {
@@ -20,6 +26,10 @@ describe('dropRight/largeArray', () => {
 
   bench('es-toolkit/dropRight', () => {
     dropRightToolkit(largeArray, 5000);
+  });
+
+  bench('es-toolkit/compat/dropRight', () => {
+    dropRightToolkitCompat(largeArray, 5000);
   });
 
   bench('lodash/dropRight', () => {

--- a/docs/ja/reference/array/dropRightWhile.md
+++ b/docs/ja/reference/array/dropRightWhile.md
@@ -41,10 +41,10 @@ const result = dropRightWhile(array, x => x > 3);
 ### インターフェース
 
 ```typescript
-function dropRightWhile<T>(arr: T[], canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropRightWhile<T>(arr: T[], objectToDrop: Partial<T>): T[];
-function dropRightWhile<T>(arr: T[], propertyToDrop: [keyof T, unknown]): T[];
-function dropRightWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
 ```
 
 ### 例

--- a/docs/ja/reference/array/dropRightWhile.md
+++ b/docs/ja/reference/array/dropRightWhile.md
@@ -41,10 +41,13 @@ const result = dropRightWhile(array, x => x > 3);
 ### インターフェース
 
 ```typescript
-function dropRightWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
+function dropRightWhile<T>(
+  arr: ArrayLike<T> | null | undefined,
+  canContinueDropping: (item: T, index: number, arr: T[]) => unknown
+): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, objectToDrop: Partial<T>): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: [keyof T, unknown]): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: string): T[];
 ```
 
 ### 例

--- a/docs/ja/reference/array/dropWhile.md
+++ b/docs/ja/reference/array/dropWhile.md
@@ -41,10 +41,10 @@ const result = dropWhile(array, x => x < 3);
 ### インターフェース
 
 ```typescript
-function dropWhile<T>(arr: T[], canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropWhile<T>(arr: T[], objectToDrop: Partial<T>): T[];
-function dropWhile<T>(arr: T[], propertyToDrop: [keyof T, unknown]): T[];
-function dropWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
+function dropWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
+function dropWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
+function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
+function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
 ```
 
 ### 例

--- a/docs/ja/reference/array/dropWhile.md
+++ b/docs/ja/reference/array/dropWhile.md
@@ -41,10 +41,13 @@ const result = dropWhile(array, x => x < 3);
 ### インターフェース
 
 ```typescript
-function dropWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
-function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
-function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
+function dropWhile<T>(
+  arr: ArrayLike<T> | null | undefined,
+  canContinueDropping: (item: T, index: number, arr: T[]) => unknown
+): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, objectToDrop: Partial<T>): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: [keyof T, unknown]): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: string): T[];
 ```
 
 ### 例

--- a/docs/ko/reference/array/dropRightWhile.md
+++ b/docs/ko/reference/array/dropRightWhile.md
@@ -42,10 +42,10 @@ const result = dropRightWhile(array, x => x > 3);
 ### 인터페이스
 
 ```typescript
-function dropRightWhile<T>(arr: T[], canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropRightWhile<T>(arr: T[], objectToDrop: Partial<T>): T[];
-function dropRightWhile<T>(arr: T[], propertyToDrop: [keyof T, unknown]): T[];
-function dropRightWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
 ```
 
 ### 예시

--- a/docs/ko/reference/array/dropRightWhile.md
+++ b/docs/ko/reference/array/dropRightWhile.md
@@ -42,10 +42,13 @@ const result = dropRightWhile(array, x => x > 3);
 ### 인터페이스
 
 ```typescript
-function dropRightWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
+function dropRightWhile<T>(
+  arr: ArrayLike<T> | null | undefined,
+  canContinueDropping: (item: T, index: number, arr: T[]) => unknown
+): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, objectToDrop: Partial<T>): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: [keyof T, unknown]): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: string): T[];
 ```
 
 ### 예시

--- a/docs/ko/reference/array/dropWhile.md
+++ b/docs/ko/reference/array/dropWhile.md
@@ -42,10 +42,13 @@ const result = dropWhile(array, x => x < 3);
 ### 인터페이스
 
 ```typescript
-function dropWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
-function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
-function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
+function dropWhile<T>(
+  arr: ArrayLike<T> | null | undefined,
+  canContinueDropping: (item: T, index: number, arr: T[]) => unknown
+): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, objectToDrop: Partial<T>): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: [keyof T, unknown]): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: string): T[];
 ```
 
 ### 예시

--- a/docs/ko/reference/array/dropWhile.md
+++ b/docs/ko/reference/array/dropWhile.md
@@ -42,10 +42,10 @@ const result = dropWhile(array, x => x < 3);
 ### 인터페이스
 
 ```typescript
-function dropWhile<T>(arr: T[], canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropWhile<T>(arr: T[], objectToDrop: Partial<T>): T[];
-function dropWhile<T>(arr: T[], propertyToDrop: [keyof T, unknown]): T[];
-function dropWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
+function dropWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
+function dropWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
+function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
+function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
 ```
 
 ### 예시

--- a/docs/reference/array/dropRightWhile.md
+++ b/docs/reference/array/dropRightWhile.md
@@ -42,10 +42,13 @@ You can specify the condition for dropping elements, and the array will remove i
 ### Signature
 
 ```typescript
-function dropRightWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
+function dropRightWhile<T>(
+  arr: ArrayLike<T> | null | undefined,
+  canContinueDropping: (item: T, index: number, arr: T[]) => unknown
+): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, objectToDrop: Partial<T>): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: [keyof T, unknown]): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: string): T[];
 ```
 
 ### Examples

--- a/docs/reference/array/dropRightWhile.md
+++ b/docs/reference/array/dropRightWhile.md
@@ -42,10 +42,10 @@ You can specify the condition for dropping elements, and the array will remove i
 ### Signature
 
 ```typescript
-function dropRightWhile<T>(arr: T[], canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropRightWhile<T>(arr: T[], objectToDrop: Partial<T>): T[];
-function dropRightWhile<T>(arr: T[], propertyToDrop: [keyof T, unknown]): T[];
-function dropRightWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
 ```
 
 ### Examples

--- a/docs/reference/array/dropWhile.md
+++ b/docs/reference/array/dropWhile.md
@@ -42,10 +42,10 @@ You can specify the condition for dropping elements, and the array will remove i
 ### Signature
 
 ```typescript
-function dropWhile<T>(arr: T[], canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropWhile<T>(arr: T[], objectToDrop: Partial<T>): T[];
-function dropWhile<T>(arr: T[], propertyToDrop: [keyof T, unknown]): T[];
-function dropWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
+function dropWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
+function dropWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
+function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
+function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
 ```
 
 ### Examples

--- a/docs/reference/array/dropWhile.md
+++ b/docs/reference/array/dropWhile.md
@@ -42,10 +42,13 @@ You can specify the condition for dropping elements, and the array will remove i
 ### Signature
 
 ```typescript
-function dropWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
-function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
-function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
+function dropWhile<T>(
+  arr: ArrayLike<T> | null | undefined,
+  canContinueDropping: (item: T, index: number, arr: T[]) => unknown
+): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, objectToDrop: Partial<T>): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: [keyof T, unknown]): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: string): T[];
 ```
 
 ### Examples

--- a/docs/zh_hans/reference/array/dropRightWhile.md
+++ b/docs/zh_hans/reference/array/dropRightWhile.md
@@ -41,10 +41,10 @@ const result = dropRightWhile(array, x => x > 3);
 ### 签名
 
 ```typescript
-function dropRightWhile<T>(arr: T[], canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropRightWhile<T>(arr: T[], objectToDrop: Partial<T>): T[];
-function dropRightWhile<T>(arr: T[], propertyToDrop: [keyof T, unknown]): T[];
-function dropRightWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
+function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
 ```
 
 ### 示例

--- a/docs/zh_hans/reference/array/dropRightWhile.md
+++ b/docs/zh_hans/reference/array/dropRightWhile.md
@@ -41,10 +41,13 @@ const result = dropRightWhile(array, x => x > 3);
 ### 签名
 
 ```typescript
-function dropRightWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, objectToDrop: Partial<T>): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
-function dropRightWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
+function dropRightWhile<T>(
+  arr: ArrayLike<T> | null | undefined,
+  canContinueDropping: (item: T, index: number, arr: T[]) => unknown
+): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, objectToDrop: Partial<T>): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: [keyof T, unknown]): T[];
+function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: string): T[];
 ```
 
 ### 示例

--- a/docs/zh_hans/reference/array/dropWhile.md
+++ b/docs/zh_hans/reference/array/dropWhile.md
@@ -41,10 +41,10 @@ const result = dropWhile(array, x => x < 3);
 ### 签名
 
 ```typescript
-function dropWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropWhile<T>(arr: ArrayLike<T> objectToDrop: Partial<T>): T[];
-function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
-function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined objectToDrop: Partial<T>): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: [keyof T, unknown]): T[];
+function dropWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: string): T[];
 ```
 
 ### 示例

--- a/docs/zh_hans/reference/array/dropWhile.md
+++ b/docs/zh_hans/reference/array/dropWhile.md
@@ -41,10 +41,10 @@ const result = dropWhile(array, x => x < 3);
 ### 签名
 
 ```typescript
-function dropWhile<T>(arr: T[], canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
-function dropWhile<T>(arr: T[], objectToDrop: Partial<T>): T[];
-function dropWhile<T>(arr: T[], propertyToDrop: [keyof T, unknown]): T[];
-function dropWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
+function dropWhile<T>(arr: ArrayLike<T>, canContinueDropping: (item: T, index: number, arr: T[]) => unknown): T[];
+function dropWhile<T>(arr: ArrayLike<T> objectToDrop: Partial<T>): T[];
+function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: [keyof T, unknown]): T[];
+function dropWhile<T>(arr: ArrayLike<T>, propertyToDrop: string): T[];
 ```
 
 ### 示例

--- a/src/compat/array/drop.spec.ts
+++ b/src/compat/array/drop.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { drop } from './drop';
+import { args } from '../_internal/args';
 
 /**
  * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/drop.spec.js#L1
@@ -29,5 +30,18 @@ describe('drop', () => {
 
   it('should return an empty array when the collection is null or undefined', () => {
     expect(drop(null, 2)).toEqual([]);
+  });
+
+  it('should return an empty array when the collection is not array-like', () => {
+    // @ts-expect-error - invalid argument
+    expect(drop(1, 2)).toEqual([]);
+    // @ts-expect-error - invalid argument
+    expect(drop(true, 2)).toEqual([]);
+  });
+
+  it('should support array-like', () => {
+    expect(drop({ 0: 1, 1: 2, length: 2 }, 1)).toEqual([2]);
+    expect(drop('123', 2)).toEqual(['3']);
+    expect(drop(args, 1)).toEqual([2, 3]);
   });
 });

--- a/src/compat/array/drop.ts
+++ b/src/compat/array/drop.ts
@@ -1,3 +1,6 @@
+import { drop as dropToolkit } from '../../array/drop.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
+
 /**
  * Removes a specified number of elements from the beginning of an array and returns the rest.
  *
@@ -5,7 +8,7 @@
  * of elements removed from the start.
  *
  * @template T - The type of elements in the array.
- * @param { T[] |  null | undefined} collection - - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} collection - The array from which to drop elements.
  * @param {number} itemsCount - The number of elements to drop from the beginning of the array.
  * @returns {T[]} A new array with the specified number of elements removed from the start.
  *
@@ -14,12 +17,10 @@
  * const result = drop(array, 2);
  * result will be [3, 4, 5] since the first two elements are dropped.
  */
-export function drop<T>(collection: readonly T[] | null | undefined, itemsCount: number): T[] {
-  if (collection === null || collection === undefined) {
+export function drop<T>(collection: ArrayLike<T> | null | undefined, itemsCount: number): T[] {
+  if (!isArrayLike(collection)) {
     return [];
   }
 
-  itemsCount = Math.max(itemsCount, 0);
-
-  return collection.slice(itemsCount);
+  return dropToolkit(Array.from(collection), itemsCount);
 }

--- a/src/compat/array/dropRight.spec.ts
+++ b/src/compat/array/dropRight.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { dropRight } from '../../array/dropRight';
+import { dropRight } from './dropRight';
+import { args } from '../_internal/args';
 
 /**
  * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/dropRight.spec.js#L1
@@ -25,5 +26,22 @@ describe('dropRight', () => {
 
   it('should coerce `n` to an integer', () => {
     expect(dropRight(array, 1.6)).toEqual([1, 2]);
+  });
+
+  it('should return an empty array when the collection is null or undefined', () => {
+    expect(dropRight(null, 2)).toEqual([]);
+  });
+
+  it('should return an empty array when the collection is not array-like', () => {
+    // @ts-expect-error - invalid argument
+    expect(dropRight(1, 2)).toEqual([]);
+    // @ts-expect-error - invalid argument
+    expect(dropRight(true, 2)).toEqual([]);
+  });
+
+  it('should support array-like', () => {
+    expect(dropRight({ 0: 1, 1: 2, length: 2 }, 1)).toEqual([1]);
+    expect(dropRight('123', 2)).toEqual(['1']);
+    expect(dropRight(args, 1)).toEqual([1, 2]);
   });
 });

--- a/src/compat/array/dropRight.ts
+++ b/src/compat/array/dropRight.ts
@@ -1,0 +1,26 @@
+import { dropRight as dropRightToolkit } from '../../array/dropRight.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
+
+/**
+ * Removes a specified number of elements from the end of an array and returns the rest.
+ *
+ * This function takes an array and a number, and returns a new array with the specified number
+ * of elements removed from the end.
+ *
+ * @template T - The type of elements in the array.
+ * @param {ArrayLike<T> | null | undefined} collection - The array from which to drop elements.
+ * @param {number} itemsCount - The number of elements to drop from the end of the array.
+ * @returns {T[]} A new array with the specified number of elements removed from the end.
+ *
+ * @example
+ * const array = [1, 2, 3, 4, 5];
+ * const result = dropRight(array, 2);
+ * // result will be [1, 2, 3] since the last two elements are dropped.
+ */
+export function dropRight<T>(collection: ArrayLike<T> | null | undefined, itemsCount: number): T[] {
+  if (!isArrayLike(collection)) {
+    return [];
+  }
+
+  return dropRightToolkit(Array.from(collection), itemsCount);
+}

--- a/src/compat/array/dropRightWhile.spec.ts
+++ b/src/compat/array/dropRightWhile.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { dropRightWhile } from './dropRightWhile';
+import { args } from '../_internal/args';
 import { slice } from '../_internal/slice';
 
 /**
@@ -43,5 +44,23 @@ describe('dropRightWhile', () => {
 
   it('should work with `_.property` shorthands', function () {
     expect(dropRightWhile(objects, 'b')).toEqual(objects.slice(0, 1));
+  });
+
+  it('should return an empty array when the collection is null or undefined', () => {
+    expect(dropRightWhile(null, () => true)).toEqual([]);
+    expect(dropRightWhile(undefined, () => true)).toEqual([]);
+  });
+
+  it('should return an empty array when the collection is not array-like', () => {
+    // @ts-expect-error - invalid argument
+    expect(dropRightWhile(1, () => true)).toEqual([]);
+    // @ts-expect-error - invalid argument
+    expect(dropRightWhile(true, () => true)).toEqual([]);
+  });
+
+  it('should support array-like', () => {
+    expect(dropRightWhile({ 0: 1, 1: 2, 2: 3, length: 3 }, i => i > 1)).toEqual([1]);
+    expect(dropRightWhile('123', i => Number(i) > 1)).toEqual(['1']);
+    expect(dropRightWhile(args, i => i > 1)).toEqual([1]);
   });
 });

--- a/src/compat/array/dropRightWhile.ts
+++ b/src/compat/array/dropRightWhile.ts
@@ -94,23 +94,30 @@ export function dropRightWhile<T>(
   if (!isArrayLike(arr)) {
     return [];
   }
-  arr = Array.from(arr);
+
+  return dropRightWhileImpl(Array.from(arr), predicate);
+}
+
+function dropRightWhileImpl<T>(
+  arr: readonly T[],
+  predicate: ((item: T, index: number, arr: readonly T[]) => unknown) | Partial<T> | [keyof T, unknown] | string
+): T[] {
   switch (typeof predicate) {
     case 'function': {
-      return dropRightWhileToolkit(arr as T[], (item, index, arr) => Boolean(predicate(item, index, arr)));
+      return dropRightWhileToolkit(arr, (item, index, arr) => Boolean(predicate(item, index, arr)));
     }
     case 'object': {
       if (Array.isArray(predicate) && predicate.length === 2) {
         const key = predicate[0];
         const value = predicate[1];
 
-        return dropRightWhileToolkit(arr as T[], matchesProperty(key, value));
+        return dropRightWhileToolkit(arr, matchesProperty(key, value));
       } else {
-        return dropRightWhileToolkit(arr as T[], matches(predicate));
+        return dropRightWhileToolkit(arr, matches(predicate));
       }
     }
     case 'string': {
-      return dropRightWhileToolkit(arr as T[], property(predicate));
+      return dropRightWhileToolkit(arr, property(predicate));
     }
   }
 }

--- a/src/compat/array/dropRightWhile.ts
+++ b/src/compat/array/dropRightWhile.ts
@@ -1,5 +1,6 @@
 import { dropRightWhile as dropRightWhileToolkit } from '../../array/dropRightWhile.ts';
 import { property } from '../object/property.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { matches } from '../predicate/matches.ts';
 import { matchesProperty } from '../predicate/matchesProperty.ts';
 
@@ -7,7 +8,7 @@ import { matchesProperty } from '../predicate/matchesProperty.ts';
  * Drops elements from the end of an array while the predicate function returns truthy.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} arr - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} arr - The array from which to drop elements.
  * @param {(item: T, index: number, arr: T[]) => unknown} canContinueDropping - A predicate function that determines
  * whether to continue dropping elements. The function is called with each element, index, and array, and dropping
  * continues as long as it returns true.
@@ -19,7 +20,7 @@ import { matchesProperty } from '../predicate/matchesProperty.ts';
  * result will be [5, 4, 3] since elements less than 3 are dropped.
  */
 export function dropRightWhile<T>(
-  arr: readonly T[],
+  arr: ArrayLike<T> | null | undefined,
   canContinueDropping: (item: T, index: number, arr: readonly T[]) => unknown
 ): T[];
 
@@ -27,7 +28,7 @@ export function dropRightWhile<T>(
  * Drops elements from the end of an array while the specified object properties match.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} arr - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} arr - The array from which to drop elements.
  * @param {Partial<T>} objectToDrop - An object specifying the properties to match for dropping elements.
  * @returns {T[]} A new array with the elements remaining after the predicate returns false.
  *
@@ -36,13 +37,13 @@ export function dropRightWhile<T>(
  * const result = dropRightWhile(array, { a: 3 });
  * result will be [{ a: 1 }, { a: 2 }] since the last object matches the properties of the provided object.
  */
-export function dropRightWhile<T>(arr: readonly T[], objectToDrop: Partial<T>): T[];
+export function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, objectToDrop: Partial<T>): T[];
 
 /**
  * Drops elements from the end of an array while the specified property matches a given value.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} arr - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} arr - The array from which to drop elements.
  * @param {[keyof T, unknown]} propertyToDrop - A tuple containing the property key and the value to match for dropping elements.
  * @returns {T[]} A new array with the elements remaining after the predicate returns false.
  *
@@ -51,13 +52,13 @@ export function dropRightWhile<T>(arr: readonly T[], objectToDrop: Partial<T>): 
  * const result = dropRightWhile(array, ['id', 3]);
  * result will be [{ id: 1 }, { id: 2 }] since the last object has the id property matching the value 3.
  */
-export function dropRightWhile<T>(arr: readonly T[], propertyToDrop: [keyof T, unknown]): T[];
+export function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: [keyof T, unknown]): T[];
 
 /**
  * Drops elements from the end of an array while the specified property name matches.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} arr - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} arr - The array from which to drop elements.
  * @param {string} propertyToDrop - The name of the property to match for dropping elements.
  * @returns {T[]} A new array with the elements remaining after the predicate returns false.
  *
@@ -66,7 +67,7 @@ export function dropRightWhile<T>(arr: readonly T[], propertyToDrop: [keyof T, u
  * const result = dropRightWhile(array, 'isActive');
  * result will be [{ isActive: false }] since it drops elements until it finds one with a falsy isActive property.
  */
-export function dropRightWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
+export function dropRightWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: string): T[];
 
 /**
  * Removes elements from the end of an array until the predicate returns false.
@@ -75,7 +76,7 @@ export function dropRightWhile<T>(arr: readonly T[], propertyToDrop: string): T[
  * predicate function returns false. It then returns a new array with the remaining elements.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} arr - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} arr - The array from which to drop elements.
  * @param {(item: T, index: number, arr: T[]) => unknown} predicate - A predicate function that determines
  * whether to continue dropping elements. The function is called with each element, index, and array, and dropping
  * continues as long as it returns true.
@@ -87,25 +88,29 @@ export function dropRightWhile<T>(arr: readonly T[], propertyToDrop: string): T[
  * // Returns: [3]
  */
 export function dropRightWhile<T>(
-  arr: readonly T[],
+  arr: ArrayLike<T> | null | undefined,
   predicate: ((item: T, index: number, arr: readonly T[]) => unknown) | Partial<T> | [keyof T, unknown] | string
 ): T[] {
+  if (!isArrayLike(arr)) {
+    return [];
+  }
+  arr = Array.from(arr);
   switch (typeof predicate) {
     case 'function': {
-      return dropRightWhileToolkit(arr, (item, index, arr) => Boolean(predicate(item, index, arr)));
+      return dropRightWhileToolkit(arr as T[], (item, index, arr) => Boolean(predicate(item, index, arr)));
     }
     case 'object': {
       if (Array.isArray(predicate) && predicate.length === 2) {
         const key = predicate[0];
         const value = predicate[1];
 
-        return dropRightWhileToolkit(arr, matchesProperty(key, value));
+        return dropRightWhileToolkit(arr as T[], matchesProperty(key, value));
       } else {
-        return dropRightWhileToolkit(arr, matches(predicate));
+        return dropRightWhileToolkit(arr as T[], matches(predicate));
       }
     }
     case 'string': {
-      return dropRightWhileToolkit(arr, property(predicate));
+      return dropRightWhileToolkit(arr as T[], property(predicate));
     }
   }
 }

--- a/src/compat/array/dropWhile.spec.ts
+++ b/src/compat/array/dropWhile.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { dropWhile } from './dropWhile';
+import { args } from '../_internal/args';
 import { slice } from '../_internal/slice';
 
 /**
@@ -43,5 +44,23 @@ describe('dropWhile', () => {
 
   it('should work with `_.property` shorthands', function () {
     expect(dropWhile(objects, 'b')).toEqual(objects.slice(2));
+  });
+
+  it('should return an empty array when the collection is null or undefined', () => {
+    expect(dropWhile(null, () => true)).toEqual([]);
+    expect(dropWhile(undefined, () => true)).toEqual([]);
+  });
+
+  it('should return an empty array when the collection is not array-like', () => {
+    // @ts-expect-error - invalid argument
+    expect(dropWhile(1, () => true)).toEqual([]);
+    // @ts-expect-error - invalid argument
+    expect(dropWhile(true, () => true)).toEqual([]);
+  });
+
+  it('should support array-like', () => {
+    expect(dropWhile({ 0: 1, 1: 2, 2: 3, length: 3 }, n => n < 3)).toEqual([3]);
+    expect(dropWhile('123', n => Number(n) < 3)).toEqual(['3']);
+    expect(dropWhile(args, n => n < 3)).toEqual([3]);
   });
 });

--- a/src/compat/array/dropWhile.ts
+++ b/src/compat/array/dropWhile.ts
@@ -94,23 +94,30 @@ export function dropWhile<T>(
   if (!isArrayLike(arr)) {
     return [];
   }
-  arr = Array.from(arr);
+
+  return dropWhileImpl(Array.from(arr), predicate);
+}
+
+function dropWhileImpl<T>(
+  arr: readonly T[],
+  predicate: ((item: T, index: number, arr: readonly T[]) => unknown) | Partial<T> | [keyof T, unknown] | string
+): T[] {
   switch (typeof predicate) {
     case 'function': {
-      return dropWhileToolkit(arr as T[], (item, index, arr) => Boolean(predicate(item, index, arr)));
+      return dropWhileToolkit(arr, (item, index, arr) => Boolean(predicate(item, index, arr)));
     }
     case 'object': {
       if (Array.isArray(predicate) && predicate.length === 2) {
         const key = predicate[0];
         const value = predicate[1];
 
-        return dropWhileToolkit(arr as T[], matchesProperty(key, value));
+        return dropWhileToolkit(arr, matchesProperty(key, value));
       } else {
-        return dropWhileToolkit(arr as T[], matches(predicate));
+        return dropWhileToolkit(arr, matches(predicate));
       }
     }
     case 'string': {
-      return dropWhileToolkit(arr as T[], property(predicate));
+      return dropWhileToolkit(arr, property(predicate));
     }
   }
 }

--- a/src/compat/array/dropWhile.ts
+++ b/src/compat/array/dropWhile.ts
@@ -1,5 +1,6 @@
 import { dropWhile as dropWhileToolkit } from '../../array/dropWhile.ts';
 import { property } from '../object/property.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { matches } from '../predicate/matches.ts';
 import { matchesProperty } from '../predicate/matchesProperty.ts';
 
@@ -7,7 +8,7 @@ import { matchesProperty } from '../predicate/matchesProperty.ts';
  * Drops elements from the beginning of an array while the predicate function returns truthy.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} arr - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} arr - The array from which to drop elements.
  * @param {(item: T, index: number, arr: T[]) => unknown} canContinueDropping - A predicate function that determines
  * whether to continue dropping elements. The function is called with each element, index, and array, and dropping
  * continues as long as it returns true.
@@ -19,7 +20,7 @@ import { matchesProperty } from '../predicate/matchesProperty.ts';
  * result will be [3, 4, 5] since elements less than 3 are dropped.
  */
 export function dropWhile<T>(
-  arr: readonly T[],
+  arr: ArrayLike<T> | null | undefined,
   canContinueDropping: (item: T, index: number, arr: readonly T[]) => unknown
 ): T[];
 
@@ -27,7 +28,7 @@ export function dropWhile<T>(
  * Drops elements from the beginning of an array while the specified object properties match.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} arr - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} arr - The array from which to drop elements.
  * @param {Partial<T>} objectToDrop - An object specifying the properties to match for dropping elements.
  * @returns {T[]} A new array with the elements remaining after the predicate returns false.
  *
@@ -36,13 +37,13 @@ export function dropWhile<T>(
  * const result = dropWhile(array, { a: 1 });
  * result will be [{ a: 2 }, { a: 3 }] since the first object matches the properties of the provided object.
  */
-export function dropWhile<T>(arr: readonly T[], objectToDrop: Partial<T>): T[];
+export function dropWhile<T>(arr: ArrayLike<T> | null | undefined, objectToDrop: Partial<T>): T[];
 
 /**
  * Drops elements from the beginning of an array while the specified property matches a given value.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} arr - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} arr - The array from which to drop elements.
  * @param {[keyof T, unknown]} propertyToDrop - A tuple containing the property key and the value to match for dropping elements.
  * @returns {T[]} A new array with the elements remaining after the predicate returns false.
  *
@@ -51,13 +52,13 @@ export function dropWhile<T>(arr: readonly T[], objectToDrop: Partial<T>): T[];
  * const result = dropWhile(array, ['id', 1]);
  * result will be [{ id: 2 }, { id: 3 }] since the first object has the id property matching the value 1.
  */
-export function dropWhile<T>(arr: readonly T[], propertyToDrop: [keyof T, unknown]): T[];
+export function dropWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: [keyof T, unknown]): T[];
 
 /**
  * Drops elements from the beginning of an array while the specified property name matches.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} arr - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} arr - The array from which to drop elements.
  * @param {string} propertyToDrop - The name of the property to match for dropping elements.
  * @returns {T[]} A new array with the elements remaining after the predicate returns false.
  *
@@ -66,7 +67,7 @@ export function dropWhile<T>(arr: readonly T[], propertyToDrop: [keyof T, unknow
  * const result = dropWhile(array, 'isActive');
  * result will be [{ isActive: false }] since it drops elements until it finds one with a falsy isActive property.
  */
-export function dropWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
+export function dropWhile<T>(arr: ArrayLike<T> | null | undefined, propertyToDrop: string): T[];
 
 /**
  * Removes elements from the beginning of an array until the predicate returns false.
@@ -75,7 +76,7 @@ export function dropWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
  * predicate function returns false. It then returns a new array with the remaining elements.
  *
  * @template T - The type of elements in the array.
- * @param {T[]} arr - The array from which to drop elements.
+ * @param {ArrayLike<T> | null | undefined} arr - The array from which to drop elements.
  * @param {(item: T, index: number, arr: T[]) => unknown} predicate - A predicate function that determines
  * whether to continue dropping elements. The function is called with each element, index, and array, and dropping
  * continues as long as it returns true.
@@ -87,25 +88,29 @@ export function dropWhile<T>(arr: readonly T[], propertyToDrop: string): T[];
  * // Returns: [3]
  */
 export function dropWhile<T>(
-  arr: readonly T[],
+  arr: ArrayLike<T> | null | undefined,
   predicate: ((item: T, index: number, arr: readonly T[]) => unknown) | Partial<T> | [keyof T, unknown] | string
 ): T[] {
+  if (!isArrayLike(arr)) {
+    return [];
+  }
+  arr = Array.from(arr);
   switch (typeof predicate) {
     case 'function': {
-      return dropWhileToolkit(arr, (item, index, arr) => Boolean(predicate(item, index, arr)));
+      return dropWhileToolkit(arr as T[], (item, index, arr) => Boolean(predicate(item, index, arr)));
     }
     case 'object': {
       if (Array.isArray(predicate) && predicate.length === 2) {
         const key = predicate[0];
         const value = predicate[1];
 
-        return dropWhileToolkit(arr, matchesProperty(key, value));
+        return dropWhileToolkit(arr as T[], matchesProperty(key, value));
       } else {
-        return dropWhileToolkit(arr, matches(predicate));
+        return dropWhileToolkit(arr as T[], matches(predicate));
       }
     }
     case 'string': {
-      return dropWhileToolkit(arr, property(predicate));
+      return dropWhileToolkit(arr as T[], property(predicate));
     }
   }
 }

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -30,6 +30,7 @@ export { chunk } from './array/chunk.ts';
 export { concat } from './array/concat.ts';
 export { difference } from './array/difference.ts';
 export { drop } from './array/drop.ts';
+export { dropRight } from './array/dropRight.ts';
 export { dropRightWhile } from './array/dropRightWhile.ts';
 export { dropWhile } from './array/dropWhile.ts';
 export { every } from './array/every.ts';


### PR DESCRIPTION
After this PR, dropWhile and dropRightWhile are still a bit different from lodash:
lodash: 
```ts
function dropWhile<T>(
  arr: ArrayLike<T> | null | undefined,
  canContinueDropping: (item: T, index: number, arr: ArrayLike<T>) => unknown
): T[];
```
es-toolkit: 
```ts
function dropWhile<T>(
  arr: ArrayLike<T> | null | undefined,
  canContinueDropping: (item: T, index: number, arr: T[]) => unknown
): T[];
```
The third argument to `canContinueDropping` in lodash is the same as `arr`, but the third argument to `canContinueDropping` in es-toolkit is `Array.from(arr)`.
If we want to modify it, we can't use `dropWhileToolkit`/`dropRightWhileToolkit` in the compat layer, because it doesn't support ArrayLike.