### PR TITLE
docs(throttle): Update docs

### DIFF
--- a/docs/ja/reference/function/throttle.md
+++ b/docs/ja/reference/function/throttle.md
@@ -119,4 +119,17 @@ const trailingFn = throttle(
 // 'Trailing function executed'をすぐにログに記録します。
 // 続けて呼び出しても、1秒ごとに'Trailing function executed'をログに記録します。
 trailingFn();
+
+// leading: false, trailing: trueオプションの例
+const trailingOnlyFn = throttle(
+  () => {
+    console.log('Trailing-only function executed');
+  },
+  1000,
+  { leading: false, trailing: true }
+);
+
+// 'Trailing-only function executed'は最初にはログに記録されません。
+// 続けて呼び出しても、1秒ごとに'Trailing-only function executed'をログに記録します。
+trailingOnlyFn();
 ```

--- a/docs/ko/reference/function/throttle.md
+++ b/docs/ko/reference/function/throttle.md
@@ -120,4 +120,19 @@ const trailingFn = throttle(
 // 'Trailing function executed'를 바로 로깅해요.
 // 계속 호출하더라도 1초마다 'Trailing function executed'를 로깅해요.
 trailingFn();
+
+// leading: false, trailing: true 옵션 예시
+const trailingOnlyFn = throttle(
+  () => {
+    console.log('Trailing-only function executed');
+  },
+  1000,
+  { leading: false, trailing: true }
+);
+
+// 'Trailing-only function executed'는 처음에는 로깅되지 않아요.
+// 계속 호출하더라도 1초마다 'Trailing-only function executed'를 로깅해요.
+trailingOnlyFn();
 ```
+
+

--- a/docs/reference/function/throttle.md
+++ b/docs/reference/function/throttle.md
@@ -97,7 +97,7 @@ By default, both `leading` and `trailing` are set to `true`, so specifying `{ le
 :::
 
 ```typescript
-// Example with leading option
+// Example with the leading option
 const leadingFn = throttle(
   () => {
     console.log('Leading function executed');
@@ -106,11 +106,11 @@ const leadingFn = throttle(
   { leading: true }
 );
 
-// Logs 'Leading function executed' immediately
-// Logs 'Leading function executed' again every 1 second, even if called continuously
+// Logs 'Leading function executed' immediately.
+// Even if called repeatedly, it logs 'Leading function executed' every 1 second.
 leadingFn();
 
-// Example with trailing option
+// Example with the trailing option
 const trailingFn = throttle(
   () => {
     console.log('Trailing function executed');
@@ -119,7 +119,20 @@ const trailingFn = throttle(
   { trailing: true }
 );
 
-// Logs 'Trailing function executed' immediately
-// Logs 'Trailing function executed' again every 1 second, even if called continuously
+// Logs 'Trailing function executed' immediately.
+// Even if called repeatedly, it logs 'Trailing function executed' every 1 second.
 trailingFn();
+
+// Example with the leading: false, trailing: true option
+const trailingOnlyFn = throttle(
+  () => {
+    console.log('Trailing-only function executed');
+  },
+  1000,
+  { leading: false, trailing: true }
+);
+
+// 'Trailing-only function executed' does not log initially.
+// Even if called repeatedly, it logs 'Trailing-only function executed' every 1 second.
+trailingOnlyFn();
 ```

--- a/docs/zh_hans/reference/function/throttle.md
+++ b/docs/zh_hans/reference/function/throttle.md
@@ -110,16 +110,16 @@ const leadingFn = throttle(
 // 即使连续调用，每1秒记录一次 'Leading function executed'。
 leadingFn();
 
-// trailing 选项示例
-const trailingFn = throttle(
+// leading: false, trailing: true 选项示例
+const trailingOnlyFn = throttle(
   () => {
-    console.log('Trailing function executed');
+    console.log('Trailing-only function executed');
   },
   1000,
-  { trailing: true }
+  { leading: false, trailing: true }
 );
 
-// 立即记录 'Trailing function executed'。
-// 即使连续调用，每1秒记录一次 'Trailing function executed'。
-trailingFn();
+// 最初不会记录 'Trailing-only function executed'。
+// 即使连续调用，每1秒记录一次 'Trailing-only function executed'。
+trailingOnlyFn();
 ```


### PR DESCRIPTION
#668 

I have added documentation for the { leading: false, trailing: true } option in throttle, as it could cause confusion based on how Lodash handles it.