### PR TITLE
fix(isPlainObject): Fix isPlainObject and perf 3x+

### DIFF
--- a/src/predicate/isPlainObject.spec.ts
+++ b/src/predicate/isPlainObject.spec.ts
@@ -1,38 +1,49 @@
-import { describe, expect, it } from "vitest";
-import { isPlainObject } from "./isPlainObject";
-import { runInNewContext } from "node:vm";
+import { describe, expect, it } from 'vitest';
+import { runInNewContext } from 'node:vm';
+import { isPlainObject } from './isPlainObject';
 
-describe("isPlainObject", () => {
-  it("should return true for plain objects", () => {
-    const str = "key";
+describe('isPlainObject', () => {
+  it('should return true for plain objects', () => {
+    const str = 'key';
 
     expect(isPlainObject({})).toBe(true);
     expect(isPlainObject(Object.create(null))).toBe(true);
-    expect(isPlainObject(new Object({ key: "new_object" }))).toBe(true);
+    expect(isPlainObject(new Object({ key: 'new_object' }))).toBe(true);
     expect(isPlainObject(new Object({ key: new Date() }))).toBe(true);
-    expect(isPlainObject({ 1: "integer_key" })).toBe(true);
-    expect(isPlainObject({ name: "string_key" })).toBe(true);
-    expect(isPlainObject({ [str]: "dynamic_string_key" })).toBe(true);
-    expect(isPlainObject({ [Symbol("tag")]: "value" })).toBe(true);
+    expect(isPlainObject({ 1: 'integer_key' })).toBe(true);
+    expect(isPlainObject({ name: 'string_key' })).toBe(true);
+    expect(isPlainObject({ [str]: 'dynamic_string_key' })).toBe(true);
+    expect(isPlainObject({ [Symbol('tag')]: 'value' })).toBe(true);
     expect(
       isPlainObject({
-        children: [{ key: "deep-children" }],
-        name: "deep-plain",
-      }),
+        children: [{ key: 'deep-children' }],
+        name: 'deep-plain',
+      })
     ).toBe(true);
     expect(
       isPlainObject({
         children: [{ key: new Date() }],
-        name: "deep-with-regular-object",
-      }),
+        name: 'deep-with-regular-object',
+      })
     ).toBe(true);
-    expect(isPlainObject({ constructor: { name: "Object2" } })).toBe(true);
-    expect(isPlainObject(JSON.parse("{}"))).toBe(true);
+    expect(isPlainObject({ constructor: { name: 'Object2' } })).toBe(true);
+    expect(isPlainObject(JSON.parse('{}'))).toBe(true);
     expect(isPlainObject(new Proxy({}, {}))).toBe(true);
-    expect(isPlainObject(new Proxy({ key: "proxied_key" }, {}))).toBe(true);
+    expect(isPlainObject(new Proxy({ key: 'proxied_key' }, {}))).toBe(true);
+    expect(isPlainObject(JSON)).toBe(true);
+    expect(isPlainObject(Math)).toBe(true);
+    expect(isPlainObject(Atomics)).toBe(true);
+    expect(
+      isPlainObject({
+        [Symbol.iterator]: function* () {
+          yield 1;
+        },
+      })
+    ).toBe(true);
+    expect(isPlainObject({ [Symbol.toStringTag]: 'string-tagged' })).toBe(true);
   });
 
-  it("should return false for invalid plain objects", () => {
+  it('should return false for invalid plain objects', () => {
     function fnWithProto(x: number) {
       // @ts-expect-error for the sake of testing
       this.x = x;
@@ -42,59 +53,50 @@ describe("isPlainObject", () => {
 
     ObjectConstructor.prototype.constructor = Object;
 
-    expect(isPlainObject("hello")).toBe(false);
+    expect(isPlainObject('hello')).toBe(false);
     expect(isPlainObject(false)).toBe(false);
     expect(isPlainObject(undefined)).toBe(false);
     expect(isPlainObject(null)).toBe(false);
     expect(isPlainObject(10)).toBe(false);
     expect(isPlainObject([])).toBe(false);
     expect(isPlainObject(Number.NaN)).toBe(false);
-    expect(isPlainObject(() => "cool")).toBe(false);
+    expect(isPlainObject(() => 'cool')).toBe(false);
     expect(isPlainObject(new (class Cls {})())).toBe(false);
-    expect(isPlainObject(new Intl.Locale("en"))).toBe(false);
+    expect(isPlainObject(new Intl.Locale('en'))).toBe(false);
     expect(isPlainObject(new (class extends Object {})())).toBe(false);
     expect(isPlainObject(fnWithProto)).toBe(false);
-    expect(isPlainObject(Symbol("cool"))).toBe(false);
-    expect(isPlainObject({
-      [Symbol.iterator]: function* () {
-        yield 1;
-      },
-    })).toBe(false);
-    expect(isPlainObject({ [Symbol.toStringTag]: "string-tagged" })).toBe(
-      false,
-    );
+    expect(isPlainObject(Symbol('cool'))).toBe(false);
     expect(isPlainObject(globalThis)).toBe(false);
-    expect(isPlainObject(JSON)).toBe(false);
-    expect(isPlainObject(Math)).toBe(false);
-    expect(isPlainObject(Atomics)).toBe(false);
     expect(isPlainObject(new Date())).toBe(false);
     expect(isPlainObject(new Map())).toBe(false);
     expect(isPlainObject(new Error())).toBe(false);
     expect(isPlainObject(new Set())).toBe(false);
-    expect(isPlainObject(new Request("http://localhost"))).toBe(false);
+    expect(isPlainObject(new Request('http://localhost'))).toBe(false);
     expect(isPlainObject(new Promise(() => {}))).toBe(false);
     expect(isPlainObject(Promise.resolve({}))).toBe(false);
-    expect(isPlainObject(Buffer.from("ABC"))).toBe(false);
+    expect(isPlainObject(Buffer.from('ABC'))).toBe(false);
     expect(isPlainObject(new Uint8Array([1, 2, 3]))).toBe(false);
     expect(isPlainObject(Object.create({}))).toBe(false);
     expect(isPlainObject(/(\d+)/)).toBe(false);
-    expect(isPlainObject(new RegExp("/d+/"))).toBe(false);
+    expect(isPlainObject(new RegExp('/d+/'))).toBe(false);
     expect(isPlainObject(/d+/)).toBe(false);
     expect(isPlainObject(`cool`)).toBe(false);
     expect(isPlainObject(String.raw`rawtemplate`)).toBe(false);
     // eslint-disable-next-line
     // @ts-ignore
     expect(isPlainObject(new ObjectConstructor())).toBe(false);
-    expect(isPlainObject(
-      new Proxy(new Date(), {
-        get(target) {
-          return target;
-        },
-      }),
-    )).toBe(false);
+    expect(
+      isPlainObject(
+        new Proxy(new Date(), {
+          get(target) {
+            return target;
+          },
+        })
+      )
+    ).toBe(false);
   });
 
-  it("should return true for cross-realm plain objects", async () => {
-    expect(isPlainObject(runInNewContext("({})"))).toBe(true);
+  it('should return true for cross-realm plain objects', async () => {
+    expect(isPlainObject(runInNewContext('({})'))).toBe(true);
   });
 });

--- a/src/predicate/isPlainObject.spec.ts
+++ b/src/predicate/isPlainObject.spec.ts
@@ -102,4 +102,12 @@ describe('isPlainObject', () => {
   it.each(cases)('when "%s" is given, should return %s', (v, expected) => {
     expect(isPlainObject(v)).toStrictEqual(expected);
   });
+
+  describe('Cross-realms node:vm:runInNewContext support', () => {
+    const isNodeLike = !('window' in globalThis);
+    it.skipIf(!isNodeLike)('should support vm', async () => {
+      const runInNewContext = await import('node:vm').then(mod => mod.runInNewContext);
+      expect(isPlainObject(runInNewContext('({})'))).toBe(true);
+    });
+  });
 });

--- a/src/predicate/isPlainObject.spec.ts
+++ b/src/predicate/isPlainObject.spec.ts
@@ -1,113 +1,100 @@
-import { describe, expect, it } from 'vitest';
-import { isPlainObject } from './isPlainObject';
+import { describe, expect, it } from "vitest";
+import { isPlainObject } from "./isPlainObject";
+import { runInNewContext } from "node:vm";
 
-describe('isPlainObject', () => {
-  const str = 'key';
+describe("isPlainObject", () => {
+  it("should return true for plain objects", () => {
+    const str = "key";
 
-  function fnWithProto(x: number) {
-    // @ts-expect-error for the sake of testing
-    this.x = x;
-  }
+    expect(isPlainObject({})).toBe(true);
+    expect(isPlainObject(Object.create(null))).toBe(true);
+    expect(isPlainObject(new Object({ key: "new_object" }))).toBe(true);
+    expect(isPlainObject(new Object({ key: new Date() }))).toBe(true);
+    expect(isPlainObject({ 1: "integer_key" })).toBe(true);
+    expect(isPlainObject({ name: "string_key" })).toBe(true);
+    expect(isPlainObject({ [str]: "dynamic_string_key" })).toBe(true);
+    expect(isPlainObject({ [Symbol("tag")]: "value" })).toBe(true);
+    expect(
+      isPlainObject({
+        children: [{ key: "deep-children" }],
+        name: "deep-plain",
+      }),
+    ).toBe(true);
+    expect(
+      isPlainObject({
+        children: [{ key: new Date() }],
+        name: "deep-with-regular-object",
+      }),
+    ).toBe(true);
+    expect(isPlainObject({ constructor: { name: "Object2" } })).toBe(true);
+    expect(isPlainObject(JSON.parse("{}"))).toBe(true);
+    expect(isPlainObject(new Proxy({}, {}))).toBe(true);
+    expect(isPlainObject(new Proxy({ key: "proxied_key" }, {}))).toBe(true);
+  });
 
-  function ObjectConstructor() {}
+  it("should return false for invalid plain objects", () => {
+    function fnWithProto(x: number) {
+      // @ts-expect-error for the sake of testing
+      this.x = x;
+    }
 
-  ObjectConstructor.prototype.constructor = Object;
+    function ObjectConstructor() {}
 
-  const validPlainObjects = [
-    [{}, true],
-    [Object.create(null), true],
-    [new Object({ key: 'new_object' }), true],
-    [new Object({ key: new Date() }), true],
-    [{ 1: 'integer_key' }, true],
-    [{ name: 'string_key' }, true],
-    [{ [str]: 'dynamic_string_key' }, true],
-    [{ [Symbol('tag')]: 'value' }, true],
-    [{ children: [{ key: 'deep-children' }], name: 'deep-plain' }, true],
-    [{ children: [{ key: new Date() }], name: 'deep-with-regular-object' }, true],
-    [{ constructor: { name: 'Object2' } }, true],
-    [JSON.parse('{}'), true],
-    [new Proxy({}, {}), true],
-    [new Proxy({ key: 'proxied_key' }, {}), true],
-  ] as const;
+    ObjectConstructor.prototype.constructor = Object;
 
-  const invalidPlainObjects = [
-    ['hello', false],
-    [false, false],
-    [undefined, false],
-    [null, false],
-    [10, false],
-    [[], false],
-    [Number.NaN, false],
-    // functions and objects
-    [() => 'cool', false],
-    [new (class Cls {})(), false],
-    [new Intl.Locale('en'), false],
-    [new (class extends Object {})(), false],
-    [fnWithProto, false],
-    // Symbols
-    [Symbol('cool'), false],
-    [
-      {
-        [Symbol.iterator]: function* () {
-          yield 1;
-        },
+    expect(isPlainObject("hello")).toBe(false);
+    expect(isPlainObject(false)).toBe(false);
+    expect(isPlainObject(undefined)).toBe(false);
+    expect(isPlainObject(null)).toBe(false);
+    expect(isPlainObject(10)).toBe(false);
+    expect(isPlainObject([])).toBe(false);
+    expect(isPlainObject(Number.NaN)).toBe(false);
+    expect(isPlainObject(() => "cool")).toBe(false);
+    expect(isPlainObject(new (class Cls {})())).toBe(false);
+    expect(isPlainObject(new Intl.Locale("en"))).toBe(false);
+    expect(isPlainObject(new (class extends Object {})())).toBe(false);
+    expect(isPlainObject(fnWithProto)).toBe(false);
+    expect(isPlainObject(Symbol("cool"))).toBe(false);
+    expect(isPlainObject({
+      [Symbol.iterator]: function* () {
+        yield 1;
       },
+    })).toBe(false);
+    expect(isPlainObject({ [Symbol.toStringTag]: "string-tagged" })).toBe(
       false,
-    ],
-    [
-      {
-        [Symbol.toStringTag]: 'string-tagged',
-      },
-      false,
-    ],
-    // globalThis
-    [globalThis, false],
-    // Static built-in classes
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON
-    [JSON, false],
-    [Math, false],
-    [Atomics, false],
-    [JSON, false],
-    // Built-in classes
-    [new Date(), false],
-    [new Map(), false],
-    [new Error(), false],
-    [new Set(), false],
-    [new Request('http://localhost'), false],
-    [new Promise(() => {}), false],
-    [Promise.resolve({}), false],
-    [Buffer.from('ABC'), false],
-    [new Uint8Array([1, 2, 3]), false],
-    [Object.create({}), false],
-    [/(\d+)/, false],
-    [new RegExp('/d+/'), false],
-    [/d+/, false],
-    // Template literals
-    [`cool`, false],
-    [String.raw`rawtemplate`, false],
-    // @ts-expect-error to allow testing crafted object
-    [new ObjectConstructor(), false],
-    [
+    );
+    expect(isPlainObject(globalThis)).toBe(false);
+    expect(isPlainObject(JSON)).toBe(false);
+    expect(isPlainObject(Math)).toBe(false);
+    expect(isPlainObject(Atomics)).toBe(false);
+    expect(isPlainObject(new Date())).toBe(false);
+    expect(isPlainObject(new Map())).toBe(false);
+    expect(isPlainObject(new Error())).toBe(false);
+    expect(isPlainObject(new Set())).toBe(false);
+    expect(isPlainObject(new Request("http://localhost"))).toBe(false);
+    expect(isPlainObject(new Promise(() => {}))).toBe(false);
+    expect(isPlainObject(Promise.resolve({}))).toBe(false);
+    expect(isPlainObject(Buffer.from("ABC"))).toBe(false);
+    expect(isPlainObject(new Uint8Array([1, 2, 3]))).toBe(false);
+    expect(isPlainObject(Object.create({}))).toBe(false);
+    expect(isPlainObject(/(\d+)/)).toBe(false);
+    expect(isPlainObject(new RegExp("/d+/"))).toBe(false);
+    expect(isPlainObject(/d+/)).toBe(false);
+    expect(isPlainObject(`cool`)).toBe(false);
+    expect(isPlainObject(String.raw`rawtemplate`)).toBe(false);
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(isPlainObject(new ObjectConstructor())).toBe(false);
+    expect(isPlainObject(
       new Proxy(new Date(), {
         get(target) {
           return target;
         },
       }),
-      false,
-    ],
-  ] as const;
-
-  const cases = [...validPlainObjects, ...invalidPlainObjects] as const;
-
-  it.each(cases)('when "%s" is given, should return %s', (v, expected) => {
-    expect(isPlainObject(v)).toStrictEqual(expected);
+    )).toBe(false);
   });
 
-  describe('Cross-realms node:vm:runInNewContext support', () => {
-    const isNodeLike = !('window' in globalThis);
-    it.skipIf(!isNodeLike)('should support vm', async () => {
-      const runInNewContext = await import('node:vm').then(mod => mod.runInNewContext);
-      expect(isPlainObject(runInNewContext('({})'))).toBe(true);
-    });
+  it("should return true for cross-realm plain objects", async () => {
+    expect(isPlainObject(runInNewContext("({})"))).toBe(true);
   });
 });

--- a/src/predicate/isPlainObject.spec.ts
+++ b/src/predicate/isPlainObject.spec.ts
@@ -2,17 +2,104 @@ import { describe, expect, it } from 'vitest';
 import { isPlainObject } from './isPlainObject';
 
 describe('isPlainObject', () => {
-  it('returns true for plain objects', () => {
-    expect(isPlainObject({})).toBe(true);
-    expect(isPlainObject(Object.create(null))).toBe(true);
-    expect(isPlainObject(new Object())).toBe(true);
-  });
+  const str = 'key';
 
-  it('returns false for non-plain objects', () => {
-    expect(isPlainObject([])).toBe(false);
-    expect(isPlainObject(new Date())).toBe(false);
-    expect(isPlainObject(new Map())).toBe(false);
-    expect(isPlainObject(Buffer.from('123123'))).toBe(false);
-    expect(isPlainObject(new Uint8Array([1, 2, 3]))).toBe(false);
+  function fnWithProto(x: number) {
+    // @ts-expect-error for the sake of testing
+    this.x = x;
+  }
+
+  function ObjectConstructor() {}
+
+  ObjectConstructor.prototype.constructor = Object;
+
+  const validPlainObjects = [
+    [{}, true],
+    [Object.create(null), true],
+    [new Object({ key: 'new_object' }), true],
+    [new Object({ key: new Date() }), true],
+    [{ 1: 'integer_key' }, true],
+    [{ name: 'string_key' }, true],
+    [{ [str]: 'dynamic_string_key' }, true],
+    [{ [Symbol('tag')]: 'value' }, true],
+    [{ children: [{ key: 'deep-children' }], name: 'deep-plain' }, true],
+    [{ children: [{ key: new Date() }], name: 'deep-with-regular-object' }, true],
+    [{ constructor: { name: 'Object2' } }, true],
+    [JSON.parse('{}'), true],
+    [new Proxy({}, {}), true],
+    [new Proxy({ key: 'proxied_key' }, {}), true],
+  ] as const;
+
+  const invalidPlainObjects = [
+    ['hello', false],
+    [false, false],
+    [undefined, false],
+    [null, false],
+    [10, false],
+    [[], false],
+    [Number.NaN, false],
+    // functions and objects
+    [() => 'cool', false],
+    [new (class Cls {})(), false],
+    [new Intl.Locale('en'), false],
+    [new (class extends Object {})(), false],
+    [fnWithProto, false],
+    // Symbols
+    [Symbol('cool'), false],
+    [
+      {
+        [Symbol.iterator]: function* () {
+          yield 1;
+        },
+      },
+      false,
+    ],
+    [
+      {
+        [Symbol.toStringTag]: 'string-tagged',
+      },
+      false,
+    ],
+    // globalThis
+    [globalThis, false],
+    // Static built-in classes
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON
+    [JSON, false],
+    [Math, false],
+    [Atomics, false],
+    [JSON, false],
+    // Built-in classes
+    [new Date(), false],
+    [new Map(), false],
+    [new Error(), false],
+    [new Set(), false],
+    [new Request('http://localhost'), false],
+    [new Promise(() => {}), false],
+    [Promise.resolve({}), false],
+    [Buffer.from('ABC'), false],
+    [new Uint8Array([1, 2, 3]), false],
+    [Object.create({}), false],
+    [/(\d+)/, false],
+    [new RegExp('/d+/'), false],
+    [/d+/, false],
+    // Template literals
+    [`cool`, false],
+    [String.raw`rawtemplate`, false],
+    // @ts-expect-error to allow testing crafted object
+    [new ObjectConstructor(), false],
+    [
+      new Proxy(new Date(), {
+        get(target) {
+          return target;
+        },
+      }),
+      false,
+    ],
+  ] as const;
+
+  const cases = [...validPlainObjects, ...invalidPlainObjects] as const;
+
+  it.each(cases)('when "%s" is given, should return %s', (v, expected) => {
+    expect(isPlainObject(v)).toStrictEqual(expected);
   });
 });

--- a/src/predicate/isPlainObject.ts
+++ b/src/predicate/isPlainObject.ts
@@ -32,7 +32,6 @@
  * isPlainObject('hello');             // ❌
  * isPlainObject([]);                  // ❌
  * isPlainObject(new Date());          // ❌
- * isPlainObject(Math);                // ❌ Static built-in classes
  * isPlainObject(new Uint8Array([1])); // ❌
  * isPlainObject(Buffer.from('ABC'));  // ❌
  * isPlainObject(Promise.resolve({})); // ❌
@@ -47,13 +46,11 @@ export function isPlainObject(value: unknown): value is Record<PropertyKey, any>
   }
 
   const proto = Object.getPrototypeOf(value) as typeof Object.prototype | null;
+
   return (
-    (proto === null ||
-      proto === Object.prototype ||
-      // Required to support node:vm.runInNewContext({})
-      Object.getPrototypeOf(proto) === null) &&
-    // https://stackoverflow.com/a/76387885/5490184
-    !(Symbol.toStringTag in value) &&
-    !(Symbol.iterator in value)
+    proto === null ||
+    proto === Object.prototype ||
+    // Required to support node:vm.runInNewContext({})
+    Object.getPrototypeOf(proto) === null
   );
 }

--- a/src/predicate/isPlainObject.ts
+++ b/src/predicate/isPlainObject.ts
@@ -5,34 +5,55 @@
  * @returns {value is Record<PropertyKey, any>} - True if the value is a plain object, otherwise false.
  *
  * @example
- * console.log(isPlainObject({})); // true
- * console.log(isPlainObject([])); // false
- * console.log(isPlainObject(null)); // false
- * console.log(isPlainObject(Object.create(null))); // true
- * console.log(Buffer.from('hello, world')); // false
+ * ```typescript
+ * // ✅👇 True
+ *
+ * isPlainObject({ });                       // ✅
+ * isPlainObject({ key: 'value' });          // ✅
+ * isPlainObject({ key: new Date() });       // ✅
+ * isPlainObject(new Object());              // ✅
+ * isPlainObject(Object.create(null));       // ✅
+ * isPlainObject({ nested: { key: true} });  // ✅
+ * isPlainObject(new Proxy({}, {}));         // ✅
+ * isPlainObject({ [Symbol('tag')]: 'A' });  // ✅
+ *
+ * // ✅👇 (cross-realms, node context, workers, ...)
+ * const runInNewContext = await import('node:vm').then(
+ *     (mod) => mod.runInNewContext
+ * );
+ * isPlainObject(runInNewContext('({})'));   // ✅
+ *
+ * // ❌👇 False
+ *
+ * class Test { };
+ * isPlainObject(new Test())           // ❌
+ * isPlainObject(10);                  // ❌
+ * isPlainObject(null);                // ❌
+ * isPlainObject('hello');             // ❌
+ * isPlainObject([]);                  // ❌
+ * isPlainObject(new Date());          // ❌
+ * isPlainObject(Math);                // ❌ Static built-in classes
+ * isPlainObject(new Uint8Array([1])); // ❌
+ * isPlainObject(Buffer.from('ABC'));  // ❌
+ * isPlainObject(Promise.resolve({})); // ❌
+ * isPlainObject(Object.create({}));   // ❌
+ * isPlainObject(new (class Cls {}));  // ❌
+ * isPlainObject(globalThis);          // ❌,
+ * ```
  */
 export function isPlainObject(value: unknown): value is Record<PropertyKey, any> {
-  if (typeof value !== 'object') {
+  if (value === null || typeof value !== 'object') {
     return false;
   }
 
-  if (value == null) {
-    return false;
-  }
-
-  if (Object.getPrototypeOf(value) === null) {
-    return true;
-  }
-
-  if (value.toString() !== '[object Object]') {
-    return false;
-  }
-
-  let proto = value;
-
-  while (Object.getPrototypeOf(proto) !== null) {
-    proto = Object.getPrototypeOf(proto);
-  }
-
-  return Object.getPrototypeOf(value) === proto;
+  const proto = Object.getPrototypeOf(value) as typeof Object.prototype | null;
+  return (
+    (proto === null ||
+      proto === Object.prototype ||
+      // Required to support node:vm.runInNewContext({})
+      Object.getPrototypeOf(proto) === null) &&
+    // https://stackoverflow.com/a/76387885/5490184
+    !(Symbol.toStringTag in value) &&
+    !(Symbol.iterator in value)
+  );
 }

--- a/src/predicate/isPlainObject.ts
+++ b/src/predicate/isPlainObject.ts
@@ -42,7 +42,7 @@
  * ```
  */
 export function isPlainObject(value: unknown): value is Record<PropertyKey, any> {
-  if (value === null || typeof value !== 'object') {
+  if (!value || typeof value !== 'object') {
     return false;
   }
 


### PR DESCRIPTION
Hello, I'm really impressed by estoolkit. Great !

I'm porting few more tests and fixes to the isPlainObject implementation. Mostly taken from my own isPlainObject implementation: see https://github.com/belgattitude/httpx/tree/main/packages/plain-object#readme

This fix few bugs that I found. So I've completed the test suite. 

## Fixes

- #694 
- #693 
- #695 


## Performance

### "Realworld" scenario

Should also bring a >3x speedup based on my "real-world" scenarios

![image](https://github.com/user-attachments/assets/7537ea21-f9fe-4d03-8853-4c0d7f401ab5)

https://github.com/belgattitude/httpx/tree/main/packages/plain-object#benchmarks

### estoolkit bench

After the changes
```
 ✓ benchmarks/performance/isPlainObject.bench.ts > isPlainObject 3920ms
     name                                       hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · es-toolkit/isPlainObject         2,519,342.19  0.0004  0.0325  0.0004  0.0004  0.0007  0.0009  0.0017  ±0.06%  1259672
   · es-toolkit/compat/isPlainObject  3,528,357.44  0.0003  0.2412  0.0003  0.0003  0.0005  0.0007  0.0014  ±0.12%  1764179   fastest
   · lodash/isPlainObject               692,780.40  0.0014  0.3287  0.0014  0.0014  0.0021  0.0026  0.0044
```

Before
```
✓ benchmarks/performance/isPlainObject.bench.ts > isPlainObject 3842ms
     name                                       hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · es-toolkit/isPlainObject         2,496,468.28  0.0004  0.0388  0.0004  0.0004  0.0008  0.0010  0.0018  ±0.07%  1248235
   · es-toolkit/compat/isPlainObject  3,137,159.94  0.0003  0.3087  0.0003  0.0003  0.0008  0.0010  0.0019  ±0.20%  1568580   fastest
   · lodash/isPlainObject               702,054.71  0.0013  0.0356  0.0014  0.0014  0.0019  0.0025  0.0044  ±0.09%   351028   slowest
```

## Tasks

- [x] Improve test suite in https://github.com/toss/es-toolkit/pull/692/commits/ab76ab3b71b023e41dcb5a41b63492e1a8350641
- [x] Fix bugs: iterator symbol, anonymous classes, runInNewContext (see fixes below)
- [x] Refactor isPlainObject function

## Notes

> See the updated test suite in: https://github.com/toss/es-toolkit/pull/692/commits/ab76ab3b71b023e41dcb5a41b63492e1a8350641

- [x] If an object has an iterator symbol, it shouldn't be a plain-object (open to discuss ?)

![image](https://github.com/user-attachments/assets/648c22ac-982e-499a-a2eb-50d9019d7bc5)

- [x]  When passing an anonymous class it should not fail with TypeError 

![image](https://github.com/user-attachments/assets/f569e8b7-b026-4102-90a1-3c24492afb23)

- [x] Should support cross realms (node:vm runInNewContext)

![image](https://github.com/user-attachments/assets/063dd85e-9d20-4caa-b71b-d761b1f5d710)

