### PR TITLE
refactor(cloneDeep): Refactoring cloneDeep

### DIFF
--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -100,7 +100,7 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
     const result = new Map();
     stack.set(obj, result);
 
-    for (const [key, value] of obj.entries()) {
+    for (const [key, value] of obj) {
       result.set(key, cloneDeepImpl(value, stack));
     }
 
@@ -111,7 +111,7 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
     const result = new Set();
     stack.set(obj, result);
 
-    for (const value of obj.values()) {
+    for (const value of obj) {
       result.add(cloneDeepImpl(value, stack));
     }
 


### PR DESCRIPTION
`Map` in a `for...of` statement basically behaves the same as `entries()`.

`Set` in a `for...of` statement basically behaves the same as `values()`.

Therefore, we can write even simpler. Is there a reason we're writing this explicitly? 