### PR TITLE
fix(orderBy/sortBy): fix lodash compatibility

### DIFF
--- a/src/compat/array/orderBy.spec.ts
+++ b/src/compat/array/orderBy.spec.ts
@@ -202,4 +202,20 @@ describe('orderBy', () => {
       [1, 2, 3],
     ]);
   });
+
+  it('should move `NaN`, nullish, and symbol values to the end', () => {
+    const symbol1 = Symbol ? Symbol('a') : null;
+    const symbol2 = Symbol ? Symbol('b') : null;
+    const array = [NaN, undefined, null, 4, symbol1, null, 1, symbol2, undefined, 3, NaN, 2];
+    const expected = [1, 2, 3, 4, symbol1, symbol2, null, null, undefined, undefined, NaN, NaN];
+
+    expect(orderBy(array)).toEqual(expected);
+    expect(orderBy(array, [])).toEqual(expected);
+
+    const array2 = [NaN, undefined, symbol1, null, 'd', null, 'a', symbol2, undefined, 'c', NaN, 'b'];
+    const expected2 = ['a', 'b', 'c', 'd', symbol1, symbol2, null, null, undefined, undefined, NaN, NaN];
+
+    expect(orderBy(array2)).toEqual(expected2);
+    expect(orderBy(array2, [])).toEqual(expected2);
+  });
 });

--- a/src/compat/array/orderBy.ts
+++ b/src/compat/array/orderBy.ts
@@ -11,9 +11,10 @@ export type Criterion<T> = ((item: T) => unknown) | PropertyKey | PropertyKey[] 
  * If values for a key are equal, it moves to the next key to determine the order.
  *
  * @template T - The type of elements in the array.
- * @param { T[] | object | null | undefined} collection - The array of objects to be sorted.
+ * @param {ArrayLike<T> | object | null | undefined} collection - The array of objects to be sorted.
  * @param {Criterion<T> | Array<Criterion<T>>} criteria - An array of criteria (property names or property paths or custom key functions) to sort by.
  * @param {unknown | unknown[]} orders - An array of order directions ('asc' for ascending or 'desc' for descending).
+ * @param {unknown} [guard] Enables use as an iteratee for methods like `_.reduce`.
  * @returns {T[]} - The sorted array.
  *
  * @example
@@ -33,21 +34,27 @@ export type Criterion<T> = ((item: T) => unknown) | PropertyKey | PropertyKey[] 
  * //   { user: 'fred', age: 40 },
  * // ]
  */
-export function orderBy<T>(
-  collection: readonly T[] | object | number | null | undefined,
+export function orderBy<T = any>(
+  collection: ArrayLike<T> | object | null | undefined,
   criteria?: Criterion<T> | Array<Criterion<T>>,
-  orders?: unknown | unknown[]
+  orders?: unknown | unknown[],
+  guard?: unknown
 ): T[] {
-  if (collection == null || typeof collection === 'number') {
+  if (collection == null) {
     return [];
   }
 
-  if (typeof collection === 'object' && !Array.isArray(collection)) {
+  orders = guard ? undefined : orders;
+
+  if (!Array.isArray(collection)) {
     collection = Object.values(collection);
   }
 
   if (!Array.isArray(criteria)) {
     criteria = criteria == null ? [null] : [criteria];
+  }
+  if (criteria.length === 0) {
+    criteria = [null];
   }
 
   if (!Array.isArray(orders)) {

--- a/src/compat/array/sortBy.spec.ts
+++ b/src/compat/array/sortBy.spec.ts
@@ -50,6 +50,7 @@ describe('sortBy', () => {
   it(`should sort multiple properties in ascending order`, () => {
     const actual = sortBy(objects, ['a', 'b']);
     expect(actual).toEqual([objects[2], objects[0], objects[3], objects[1]]);
+    expect(sortBy(objects, 'a', 'b')).toEqual([objects[2], objects[0], objects[3], objects[1]]);
   });
 
   it(`should support iteratees`, () => {
@@ -60,11 +61,14 @@ describe('sortBy', () => {
       },
     ]);
     expect(actual).toEqual([objects[2], objects[0], objects[3], objects[1]]);
+    expect(sortBy(objects, 'a', object => object.b)).toEqual([objects[2], objects[0], objects[3], objects[1]]);
   });
 
   it(`should perform a stable sort (test in IE > 8 and V8)`, () => {
     expect(sortBy(stableArray, ['a', 'c'])).toEqual(stableArray);
+    expect(sortBy(stableArray, 'a', 'c')).toEqual(stableArray);
     expect(sortBy(stableObject, ['a', 'c'])).toEqual(stableArray);
+    expect(sortBy(stableObject, 'a', 'c')).toEqual(stableArray);
   });
 
   it(`should not error on nullish elements`, () => {
@@ -76,6 +80,14 @@ describe('sortBy', () => {
     }
 
     expect(actual).toEqual([objects[2], objects[0], objects[3], objects[1], null, undefined]);
+    expect(sortBy([...objects, null, undefined], 'a', 'b')).toEqual([
+      objects[2],
+      objects[0],
+      objects[3],
+      objects[1],
+      null,
+      undefined,
+    ]);
   });
 
   it(`should work as an iteratee for methods like \`_.reduce\``, () => {
@@ -126,15 +138,17 @@ describe('sortBy', () => {
     const expected = [1, 2, 3, 4, symbol1, symbol2, null, null, undefined, undefined, NaN, NaN];
 
     expect(sortBy(array)).toEqual(expected);
+    expect(sortBy(array, [])).toEqual(expected);
 
     const array2 = [NaN, undefined, symbol1, null, 'd', null, 'a', symbol2, undefined, 'c', NaN, 'b'];
     const expected2 = ['a', 'b', 'c', 'd', symbol1, symbol2, null, null, undefined, undefined, NaN, NaN];
 
     expect(sortBy(array2)).toEqual(expected2);
+    expect(sortBy(array2, [])).toEqual(expected2);
   });
 
   it('should treat number values for `collection` as empty', () => {
-    expect(sortBy(1)).toEqual([]);
+    expect(sortBy(1 as any)).toEqual([]);
   });
 
   it('should coerce arrays returned from `iteratee`', () => {

--- a/src/compat/array/sortBy.ts
+++ b/src/compat/array/sortBy.ts
@@ -1,4 +1,6 @@
 import { Criterion, orderBy } from './orderBy.ts';
+import { flatten } from '../../array/flatten.ts';
+import { isIterateeCall } from '../_internal/isIterateeCall.ts';
 
 /**
  * Sorts an array of objects based on multiple properties and their corresponding order directions.
@@ -8,8 +10,8 @@ import { Criterion, orderBy } from './orderBy.ts';
  * If values for a key are equal, it moves to the next key to determine the order.
  *
  * @template T - The type of elements in the array.
- * @param { T[] | object | null | undefined} collection - The array of objects to be sorted.
- * @param {Criterion<T> | Array<Criterion<T>>} criteria - An array of criteria (property names or property paths or custom key functions) to sort by.
+ * @param {ArrayLike<T> | object | null | undefined} collection - The array of objects to be sorted.
+ * @param {Array<Array<Criterion<T> | Criterion<T>>>} criteria - An array of criteria (property names or property paths or custom key functions) to sort by.
  * @returns {T[]} - The ascending sorted array.
  *
  * @example
@@ -29,9 +31,16 @@ import { Criterion, orderBy } from './orderBy.ts';
  * //   { user: 'fred', age: 48 },
  * // ]
  */
-export function sortBy<T>(
-  collection: readonly T[] | object | number | null | undefined,
-  criteria?: Criterion<T> | Array<Criterion<T>>
+export function sortBy<T = any>(
+  collection: ArrayLike<T> | object | null | undefined,
+  ...criteria: Array<Criterion<T> | Array<Criterion<T>>>
 ): T[] {
-  return orderBy(collection, criteria, ['asc']);
+  const length = criteria.length;
+  // Enables use as an iteratee for methods like `_.reduce` and `_.map`.
+  if (length > 1 && isIterateeCall(collection, criteria[0], criteria[1])) {
+    criteria = [];
+  } else if (length > 2 && isIterateeCall(criteria[0], criteria[1], criteria[2])) {
+    criteria = [criteria[0]];
+  }
+  return orderBy(collection, flatten(criteria), ['asc']);
 }


### PR DESCRIPTION
- `orderBy` should support `ArrayLike`
- `orderBy criteria` should treat `[]` as `undefined`
- `sortBy` should support `ArrayLike`
- `sortBy` should support rest criteria