### PR TITLE
feat(uniqueId): add `uniqueId` in compat layer

### DIFF
--- a/benchmarks/performance/uniqueId.bench.ts
+++ b/benchmarks/performance/uniqueId.bench.ts
@@ -1,0 +1,16 @@
+import { bench, describe } from 'vitest';
+import { uniqueId as uniqueIdToolkitCompat_ } from 'es-toolkit/compat';
+import { uniqueId as uniqueIdLodash_ } from 'lodash';
+
+const uniqueIdToolkitCompat = uniqueIdToolkitCompat_;
+const uniqueIdLodash = uniqueIdLodash_;
+
+describe('uniqueId', () => {
+  bench('es-toolkit/compat/uniqueId', () => {
+    uniqueIdToolkitCompat('321');
+  });
+
+  bench('lodash/uniqueId', () => {
+    uniqueIdLodash('321');
+  });
+});

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -150,11 +150,10 @@ export { repeat } from './string/repeat.ts';
 export { snakeCase } from './string/snakeCase.ts';
 export { startCase } from './string/startCase.ts';
 export { startsWith } from './string/startsWith.ts';
-export { upperCase } from './string/upperCase.ts';
-
 export { trim } from './string/trim.ts';
 export { trimEnd } from './string/trimEnd.ts';
 export { trimStart } from './string/trimStart.ts';
+export { upperCase } from './string/upperCase.ts';
 
 export { constant } from './util/constant.ts';
 export { defaultTo } from './util/defaultTo.ts';
@@ -167,3 +166,4 @@ export { toNumber } from './util/toNumber.ts';
 export { toPath } from './util/toPath.ts';
 export { toSafeInteger } from './util/toSafeInteger.ts';
 export { toString } from './util/toString.ts';
+export { uniqueId } from './util/uniqueId.ts';

--- a/src/compat/util/uniqueId.spec.ts
+++ b/src/compat/util/uniqueId.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { uniqueId } from './uniqueId';
+import * as esToolkit from '../index';
+
+describe('uniqueId', () => {
+  it('should generate unique ids', () => {
+    const actual = esToolkit.times(1000, () => uniqueId());
+
+    expect(esToolkit.uniq(actual).length).toBe(actual.length);
+  });
+
+  it('should return a string value when not providing a `prefix`', () => {
+    expect(typeof uniqueId()).toBe('string');
+  });
+
+  it('should coerce the prefix argument to a string', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    const actual = [uniqueId(3), uniqueId(2), uniqueId(1)];
+
+    expect(/3\d+,2\d+,1\d+/.test(String(actual))).toBe(true);
+  });
+});

--- a/src/compat/util/uniqueId.ts
+++ b/src/compat/util/uniqueId.ts
@@ -1,0 +1,18 @@
+import { toString } from './toString.ts';
+
+let counter = 0;
+
+/**
+ * Generates a unique ID. If a `prefix` is provided, the ID is appended to it.
+ *
+ * @param {string} [prefix=''] - The value to prefix the unique ID with.
+ * @returns {string} - Returns the unique ID.
+ *
+ * @example
+ * uniqueId('contact_'); // => 'contact_1'
+ *
+ * uniqueId(); // => '2'
+ */
+export function uniqueId(prefix = ''): string {
+  return `${toString(prefix)}${++counter}`;
+}


### PR DESCRIPTION
# Description

I added `uniqueId` in compat layer.

As far as I know, the documentation is automated, so I haven’t been writing it manually until now. Do I still need to write it myself?

## Benchmark

<img width="810" alt="Screenshot 2024-10-20 at 12 01 45 AM" src="https://github.com/user-attachments/assets/804b61d4-7549-495d-a637-758ee8557837">
