### PR TITLE
fix(compat/cloneDeep): fix lodash compatibiliy

### DIFF
--- a/src/compat/object/cloneDeep.spec.ts
+++ b/src/compat/object/cloneDeep.spec.ts
@@ -268,7 +268,7 @@ describe('cloneDeep', () => {
   it('should not clone function, error objects and weakMap', () => {
     expect(cloneDeep(() => {})).toEqual({});
     expect(cloneDeep(async () => {})).toEqual({});
-    expect(cloneDeep(new Function())).toEqual({});
+    expect(cloneDeep(function* () {})).toEqual({});
     expect(cloneDeep(new Error())).toEqual({});
     expect(cloneDeep(new DOMException())).toEqual({});
     expect(cloneDeep(new WeakMap())).toEqual({});

--- a/src/compat/object/cloneDeep.spec.ts
+++ b/src/compat/object/cloneDeep.spec.ts
@@ -264,4 +264,13 @@ describe('cloneDeep', () => {
 
     expect(actual).toEqual(expected);
   });
+
+  it('should not clone function, error objects and weakMap', () => {
+    expect(cloneDeep(() => {})).toEqual({});
+    expect(cloneDeep(async () => {})).toEqual({});
+    expect(cloneDeep(new Function())).toEqual({});
+    expect(cloneDeep(new Error())).toEqual({});
+    expect(cloneDeep(new DOMException())).toEqual({});
+    expect(cloneDeep(new WeakMap())).toEqual({});
+  });
 });

--- a/src/compat/object/cloneDeep.spec.ts
+++ b/src/compat/object/cloneDeep.spec.ts
@@ -265,12 +265,33 @@ describe('cloneDeep', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should not clone function, error objects and weakMap', () => {
+  it('should not clone function, error objects, weakMap and weakSet', () => {
     expect(cloneDeep(() => {})).toEqual({});
     expect(cloneDeep(async () => {})).toEqual({});
     expect(cloneDeep(function* () {})).toEqual({});
     expect(cloneDeep(new Error())).toEqual({});
     expect(cloneDeep(new DOMException())).toEqual({});
     expect(cloneDeep(new WeakMap())).toEqual({});
+    expect(cloneDeep(new WeakSet())).toEqual({});
+  });
+
+  it('should copy function properties', () => {
+    function Foo() {}
+    Foo.a = 1;
+    Foo.b = function () {};
+    Foo.c = 3;
+    // @ts-expect-error - Symbol
+    Foo[Symbol.for('map')] = new WeakMap();
+    // @ts-expect-error - Symbol
+    Foo[Symbol.for('set')] = new WeakSet();
+
+    const actual = cloneDeep(Foo);
+    expect(actual.a).toBe(1);
+    expect(actual.b).toBe(Foo.b);
+    expect(actual.c).toBe(3);
+    // @ts-expect-error - Symbol
+    expect(actual[Symbol.for('map')]).toBe(Foo[Symbol.for('map')]);
+    // @ts-expect-error - Symbol
+    expect(actual[Symbol.for('set')]).toBe(Foo[Symbol.for('set')]);
   });
 });

--- a/src/compat/object/cloneDeep.ts
+++ b/src/compat/object/cloneDeep.ts
@@ -48,6 +48,9 @@ import { argumentsTag, booleanTag, numberTag, stringTag } from '../_internal/tag
  * console.log(clonedObj === obj); // false
  */
 export function cloneDeep<T>(obj: T): T {
+  if (typeof obj === 'function' || obj instanceof Error) {
+    return {} as any;
+  }
   if (typeof obj !== 'object') {
     return cloneDeepToolkit(obj);
   }

--- a/src/compat/object/cloneDeep.ts
+++ b/src/compat/object/cloneDeep.ts
@@ -48,8 +48,13 @@ import { argumentsTag, booleanTag, numberTag, stringTag } from '../_internal/tag
  * console.log(clonedObj === obj); // false
  */
 export function cloneDeep<T>(obj: T): T {
-  if (typeof obj === 'function' || obj instanceof Error) {
+  if (obj instanceof Error || obj instanceof WeakMap || obj instanceof WeakSet) {
     return {} as any;
+  }
+  if (typeof obj === 'function') {
+    const result = {};
+    copyProperties(result, obj);
+    return result as T;
   }
   if (typeof obj !== 'object') {
     return cloneDeepToolkit(obj);

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -183,7 +183,7 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
     return result as T;
   }
 
-  if (typeof obj === 'object' && obj !== null) {
+  if (typeof obj === 'object' && obj !== null && !(obj instanceof WeakMap) && !(obj instanceof WeakSet)) {
     const result = {};
     stack.set(obj, result);
 


### PR DESCRIPTION
> An empty object is returned for uncloneable values such as error objects, functions, DOM nodes, and WeakMaps.

lodash has the following behaviors:
```ts
// simple object
_.cloneDeep(() => {}) // => {}
_.cloneDeep(new Error()) // => {}
_.cloneDeep(new WeakMap()) // => {}
_.cloneDeep(new WeakSet()) // => {}
```

```ts
// function should copy property
const a = () => {}
a.b = 1;
a.c = () => {};
a.d = new WeakMap();
_.cloneDeep(a).b // =>1;
_.cloneDeep(a).c === a.c // => true
_.cloneDeep(a).d === a.d // => true
```

```ts
// error, weakMap, weakSet shouldn't copy property
const a = new Error(); // same as new WeakMap(), new WeakSet()
a.b = 1;
a.c = () => {};
a.d = new WeakMap();
_.cloneDeep(a) // => {}
```

**However, to achieve this, I changed the behavior of the native cloneDeep:**
```ts
// before
cloneDeep(new WeakMap()) // => {}
cloneDeep({a: new WeakMap()}) // => {a: {}}
// now
cloneDeep(new WeakMap()) // => WeakMap {}   weakMap/weakSet will return just like function
cloneDeep({a: new WeakMap()}) // => { a: WeakMap {} }     weakMap/weakSet will return just like function
```
**Do you think that's acceptable?**