### PR TITLE
fix(merge): improved merge function types

### DIFF
--- a/src/object/merge.ts
+++ b/src/object/merge.ts
@@ -44,7 +44,7 @@ export function merge<T extends Record<PropertyKey, any>, S extends Record<Prope
   target: T,
   source: S
 ): T & S {
-  const sourceKeys = Object.keys(source) as (keyof S)[];
+  const sourceKeys = Object.keys(source) as Array<keyof S>;
 
   for (let i = 0; i < sourceKeys.length; i++) {
     const key = sourceKeys[i];

--- a/src/object/merge.ts
+++ b/src/object/merge.ts
@@ -40,49 +40,11 @@ import { isPlainObject } from '../predicate/isPlainObject.ts';
  * console.log(result);
  * // Output: { a: [1, 2, 3] }
  */
-export function merge<T, S>(target: T, source: S): T & S;
-/**
- * Merges the properties of the source object into the target object.
- *
- * This function performs a deep merge, meaning nested objects and arrays are merged recursively.
- * If a property in the source object is an array or an object and the corresponding property in the target object is also an array or object, they will be merged.
- * If a property in the source object is undefined, it will not overwrite a defined property in the target object.
- *
- * Note that this function mutates the target object.
- *
- * @param {T} target - The target object into which the source object properties will be merged. This object is modified in place.
- * @param {S} source - The source object whose properties will be merged into the target object.
- * @returns {T & S} The updated target object with properties from the source object merged in.
- *
- * @template T - Type of the target object.
- * @template S - Type of the source object.
- *
- * @example
- * const target = { a: 1, b: { x: 1, y: 2 } };
- * const source = { b: { y: 3, z: 4 }, c: 5 };
- *
- * const result = merge(target, source);
- * console.log(result);
- * // Output: { a: 1, b: { x: 1, y: 3, z: 4 }, c: 5 }
- *
- * @example
- * const target = { a: [1, 2], b: { x: 1 } };
- * const source = { a: [3], b: { y: 2 } };
- *
- * const result = merge(target, source);
- * console.log(result);
- * // Output: { a: [3, 2], b: { x: 1, y: 2 } }
- *
- * @example
- * const target = { a: null };
- * const source = { a: [1, 2, 3] };
- *
- * const result = merge(target, source);
- * console.log(result);
- * // Output: { a: [1, 2, 3] }
- */
-export function merge(target: any, source: any) {
-  const sourceKeys = Object.keys(source);
+export function merge<T extends Record<PropertyKey, any>, S extends Record<PropertyKey, any>>(
+  target: T,
+  source: S
+): T & S {
+  const sourceKeys = Object.keys(source) as (keyof S)[];
 
   for (let i = 0; i < sourceKeys.length; i++) {
     const key = sourceKeys[i];


### PR DESCRIPTION
Is there a reason not to define the types of arguments to the `merge` function more narrowly? 

Given the purpose of the `merge` function and most use cases, I think it's appropriate to narrow the type of the source and destination to `Object`.

What do you think? 

Currently, the following cases are allowed 
Do we really need to allow this? 🤔
```ts
// as-is
merge(1, 2); // type pass
```