### PR TITLE
docs(isMap, isNaN, isRegExp, isSet, toInteger, parseInt, floor): correct translation errors

### DIFF
--- a/docs/ja/reference/compat/math/floor.md
+++ b/docs/ja/reference/compat/math/floor.md
@@ -21,7 +21,7 @@ function floor(number: number | string, precision: number | string): number;
 
 ### 戻り値
 
-(`number`): 切り捨てられた数値。
+(`number`): 切り捨てられた数値。デフォルトは0です。
 
 ## 例
 

--- a/docs/ja/reference/compat/math/floor.md
+++ b/docs/ja/reference/compat/math/floor.md
@@ -21,7 +21,7 @@ function floor(number: number | string, precision: number | string): number;
 
 ### 戻り値
 
-(`number`): 切り捨てられた数値。デフォルトは0です。
+(`number`): 切り捨てられた数値。デフォルトは`0`です。
 
 ## 例
 

--- a/docs/ja/reference/compat/math/parseInt.md
+++ b/docs/ja/reference/compat/math/parseInt.md
@@ -24,7 +24,7 @@ function parseInt(string: string, radix: number, guard?: unknown): number;
 
 ### 戻り値
 
-(`number`): 変換された整数を返しますます。
+(`number`): 変換された整数を返します。
 
 ## 例
 

--- a/docs/ja/reference/compat/predicate/isNaN.md
+++ b/docs/ja/reference/compat/predicate/isNaN.md
@@ -16,7 +16,7 @@ function isNaN(value: unknown): value is typeof NaN;
 
 ### パラメータ
 
-- `value` (`unknown`): 確認する値。
+- `value` (`unknown`): `NaN`かどうか確認する値。
 
 ### 戻り値
 

--- a/docs/ja/reference/compat/util/toInteger.md
+++ b/docs/ja/reference/compat/util/toInteger.md
@@ -20,7 +20,7 @@ function toInteger(value?: unknown): number;
 
 ### 戻り値
 
-(`number`): 整数。
+(`number`): 変換された整数。
 
 ## 例
 

--- a/docs/ja/reference/predicate/isMap.md
+++ b/docs/ja/reference/predicate/isMap.md
@@ -15,7 +15,7 @@ function isMap(value: unknown): value is Map<any, any>;
 
 ### パラメータ
 
-- `value` (`unknown`): テストする値。
+- `value` (`unknown`): `Map`かどうか確認する値。
 
 ### 戻り値
 

--- a/docs/ja/reference/predicate/isRegExp.md
+++ b/docs/ja/reference/predicate/isRegExp.md
@@ -12,7 +12,7 @@ function isRegExp(value: unknown): value is RegExp;
 
 ### パラメータ
 
-- `value` (`unknown`) チェックする値ます。
+- `value` (`unknown`): RegExpかどうかテストする値。
 
 ### 戻り値
 

--- a/docs/ja/reference/predicate/isSet.md
+++ b/docs/ja/reference/predicate/isSet.md
@@ -15,7 +15,7 @@ function isSet(value: unknown): value is Set<any>;
 
 ### パラメータ
 
-- `value` (`unknown`): テストする値。
+- `value` (`unknown`): `Set`かどうか確認する値。
 
 ### 戻り値
 


### PR DESCRIPTION
close #743