### PR TITLE
fix(sumBy, sum): Remove array allocation from sumBy

### DIFF
--- a/src/math/sum.ts
+++ b/src/math/sum.ts
@@ -1,3 +1,5 @@
+import { sumBy } from './sumBy';
+
 /**
  * Calculates the sum of an array of numbers.
  *
@@ -12,11 +14,5 @@
  * // result will be 15
  */
 export function sum(nums: readonly number[]): number {
-  let result = 0;
-
-  for (let i = 0; i < nums.length; i++) {
-    result += nums[i];
-  }
-
-  return result;
+  return sumBy(nums, x => x);
 }

--- a/src/math/sum.ts
+++ b/src/math/sum.ts
@@ -1,5 +1,3 @@
-import { sumBy } from './sumBy';
-
 /**
  * Calculates the sum of an array of numbers.
  *
@@ -14,5 +12,11 @@ import { sumBy } from './sumBy';
  * // result will be 15
  */
 export function sum(nums: readonly number[]): number {
-  return sumBy(nums, x => x);
+  let result = 0;
+
+  for (let i = 0; i < nums.length; i++) {
+    result += nums[i];
+  }
+
+  return result;
 }

--- a/src/math/sumBy.ts
+++ b/src/math/sumBy.ts
@@ -1,5 +1,3 @@
-import { sum } from './sum.ts';
-
 /**
  * Calculates the sum of an array of numbers when applying
  * the `getValue` function to each element.
@@ -16,7 +14,11 @@ import { sum } from './sum.ts';
  * sumBy([], x => x.a); // Returns: 0
  */
 export function sumBy<T>(items: readonly T[], getValue: (element: T) => number): number {
-  const nums = items.map(x => getValue(x));
+  let result = 0;
 
-  return sum(nums);
+  for (let i = 0; i < items.length; i++) {
+    result += getValue(items[i]);
+  }
+
+  return result;
 }


### PR DESCRIPTION
This changes `sumBy` to avoid allocating an array (from `.map`) - instead the sum is computed with a simple accumulating number. This should be a strict improvement. I also took the opportunity to implement `sum` in terms of `sumBy` to save code size if both are imported, since they're basically the same function.

<img width="969" alt="Screenshot 2024-10-24 at 11 22 19 PM" src="https://github.com/user-attachments/assets/d3072fff-2983-40a8-bd78-aefe521dcfad">

I don't trust these benchmarks at all - this claimed no benefit to my change, and it also claims lodash is 50% faster on the large array case *even if I replace `sumBy`'s implementation with lodash's implementation!* Perhaps vite is adding some overhead.