### PR TITLE
feat(replace): add `replace` to compat layer

### DIFF
--- a/benchmarks/performance/replace.bench.ts
+++ b/benchmarks/performance/replace.bench.ts
@@ -1,0 +1,22 @@
+import { bench, describe } from 'vitest';
+import { replace as replaceToolkitCompat_ } from 'es-toolkit/compat';
+import { replace as replaceLodash_ } from 'lodash';
+
+const replaceToolkitCompat = replaceToolkitCompat_;
+const replaceLodash = replaceLodash_;
+
+describe('replace', () => {
+  bench('es-toolkit/compat/replace', () => {
+    replaceToolkitCompat('abc', 'de', '123');
+    replaceToolkitCompat('abc', /[bd]/g, '-');
+    replaceToolkitCompat('abc', 'de', substring => substring.toUpperCase());
+    replaceToolkitCompat('abc', /[bd]/g, substring => substring.toUpperCase());
+  });
+
+  bench('lodash/replace', () => {
+    replaceLodash('abc', 'de', '123');
+    replaceLodash('abc', /[bd]/g, '-');
+    replaceLodash('abc', 'de', substring => substring.toUpperCase());
+    replaceLodash('abc', /[bd]/g, substring => substring.toUpperCase());
+  });
+});

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -148,15 +148,15 @@ export { pad } from './string/pad.ts';
 export { padEnd } from './string/padEnd.ts';
 export { padStart } from './string/padStart.ts';
 export { repeat } from './string/repeat.ts';
+export { replace } from './string/replace.ts';
 export { snakeCase } from './string/snakeCase.ts';
 export { startCase } from './string/startCase.ts';
 export { startsWith } from './string/startsWith.ts';
-export { upperCase } from './string/upperCase.ts';
-
 export { template, templateSettings } from './string/template.ts';
 export { trim } from './string/trim.ts';
 export { trimEnd } from './string/trimEnd.ts';
 export { trimStart } from './string/trimStart.ts';
+export { upperCase } from './string/upperCase.ts';
 
 export { constant } from './util/constant.ts';
 export { defaultTo } from './util/defaultTo.ts';

--- a/src/compat/string/replace.spec.ts
+++ b/src/compat/string/replace.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { replace } from './replace';
+
+describe('replace', () => {
+  it('should replace the matched pattern', () => {
+    const string = 'abcde';
+    expect(replace(string, 'de', '123')).toBe('abc123');
+    expect(replace(string, /[bd]/g, '-')).toBe('a-c-e');
+  });
+
+  it('should replace the matched pattern with a function', () => {
+    const string = 'abcde';
+    expect(replace(string, 'de', substring => substring.toUpperCase())).toBe('abcDE');
+    expect(replace(string, /[bd]/g, substring => substring.toUpperCase())).toBe('aBcDe');
+  });
+
+  it('should return empty string if the arguments are not provided', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(replace()).toBe('');
+  });
+});

--- a/src/compat/string/replace.ts
+++ b/src/compat/string/replace.ts
@@ -1,0 +1,23 @@
+import { toString } from '../util/toString.ts';
+
+/**
+ * Replaces the matched pattern with the replacement string.
+ *
+ * @param {string} target - The target string.
+ * @param {string | RegExp} pattern - The pattern to match.
+ * @param {string | ((substring: string, ...args: any[]) => string)} replacement - The replacement string or a function that returns the replacement string.
+ * @returns {string} The new string with the matched pattern replaced.
+ *
+ * @example
+ * replace('abcde', 'de', '123'); // 'abc123'
+ * replace('abcde', /[bd]/g, '-'); // 'a-c-e'
+ * replace('abcde', 'de', substring => substring.toUpperCase()); // 'abcDE'
+ * replace('abcde', /[bd]/g, substring => substring.toUpperCase()); // 'aBcDe'
+ */
+export function replace(
+  target = '',
+  pattern: string | RegExp,
+  replacement: string | ((substring: string, ...args: any[]) => string)
+): string {
+  return toString(target).replace(pattern, replacement as any);
+}


### PR DESCRIPTION
# Description

I added `replace` to compat layer.

It utilizes `String.prototype.replace`, resulting in minimal performance difference compared to Lodash. Additionally, I decided not to include it in the original es-toolkit as it seemed unnecessary.

Furthermore, using a union type in the replacement part causes an error. To circumvent this, I temporarily asserted it as `any`.

> related [Issue](https://github.com/microsoft/TypeScript/issues/22378)

## Benchmark
<img width="783" alt="Screenshot 2024-10-25 at 5 04 52 PM" src="https://github.com/user-attachments/assets/614102fe-aaa1-4f70-bb7a-ae36367045d6">
