### PR TITLE
feat(iteratee): add `iteratee` to compat layer

### DIFF
--- a/benchmarks/performance/iteratee.bench.ts
+++ b/benchmarks/performance/iteratee.bench.ts
@@ -1,0 +1,22 @@
+import { bench, describe } from 'vitest';
+import { iteratee as iterateeToolkit_ } from 'es-toolkit/compat';
+import { iteratee as iterateeLodash_ } from 'lodash';
+
+const iterateeToolkit = iterateeToolkit_;
+const iterateeLodash = iterateeLodash_;
+
+describe('iteratee', () => {
+  bench('es-toolkit/compat/iteratee', () => {
+    iterateeToolkit(1);
+    iterateeToolkit([1, 2]);
+    iterateeToolkit({ a: 1 });
+    iterateeToolkit(() => {});
+  });
+
+  bench('lodash/compat/iteratee', () => {
+    iterateeLodash(1);
+    iterateeLodash([1, 2]);
+    iterateeLodash({ a: 1 });
+    iterateeLodash(() => {});
+  });
+});

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -161,6 +161,7 @@ export { trimStart } from './string/trimStart.ts';
 export { constant } from './util/constant.ts';
 export { defaultTo } from './util/defaultTo.ts';
 export { eq } from './util/eq.ts';
+export { iteratee } from './util/iteratee.ts';
 export { times } from './util/times.ts';
 export { toFinite } from './util/toFinite.ts';
 export { toInteger } from './util/toInteger.ts';

--- a/src/compat/util/iteratee.spec.ts
+++ b/src/compat/util/iteratee.spec.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import { iteratee } from './iteratee';
+import { slice } from '../_internal/slice';
+import { stubFalse } from '../_internal/stubFalse';
+import { partial, partialRight } from '../index';
+import * as esToolkit from '../index';
+
+describe('iteratee', () => {
+  it('should provide arguments to `func`', () => {
+    const fn = function () {
+      // eslint-disable-next-line prefer-rest-params
+      return slice.call(arguments);
+    };
+    const iterateeFn = iteratee(fn);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    const actual = iterateeFn('a', 'b', 'c', 'd', 'e', 'f');
+
+    expect(actual).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
+  });
+
+  it('should return `_.identity` when `func` is nullish', () => {
+    const object = {};
+    // eslint-disable-next-line no-sparse-arrays
+    const values = [, null, undefined];
+    const expected = values.map(esToolkit.constant(object));
+
+    const actual = values.map((value, index) => {
+      const identity = index ? iteratee(value) : iteratee();
+      return identity(object);
+    });
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return an iteratee created by `_.matches` when `func` is an object', () => {
+    const matches = iteratee({ a: 1, b: 2 });
+    expect(matches({ a: 1, b: 2, c: 3 })).toBe(true);
+    expect(matches({ b: 2 })).toBe(false);
+  });
+
+  it('should not change `_.matches` behavior if `source` is modified', () => {
+    const sources: any[] = [{ a: { b: 2, c: 3 } }, { a: 1, b: 2 }, { a: 1 }];
+
+    sources.forEach((source, index) => {
+      const object = esToolkit.cloneDeep(source);
+      const matches = iteratee(source);
+
+      expect(matches(object)).toBe(true);
+
+      if (index) {
+        source.a = 2;
+        source.b = 1;
+        source.c = 3;
+      } else {
+        source.a.b = 1;
+        source.a.c = 2;
+        source.a.d = 3;
+      }
+      expect(matches(object)).toBe(true);
+      expect(matches(source)).toBe(false);
+    });
+  });
+
+  it('should return an iteratee created by `_.matchesProperty` when `func` is an array', () => {
+    const array = ['a', undefined];
+    let matches = iteratee([0, 'a']);
+
+    expect(matches(array)).toBe(true);
+
+    matches = iteratee(['0', 'a']);
+    expect(matches(array)).toBe(true);
+
+    matches = iteratee([1, undefined]);
+    expect(matches(array)).toBe(true);
+  });
+
+  it('should support deep paths for `_.matchesProperty` shorthands', () => {
+    const object = { a: { b: { c: 1, d: 2 } } };
+    const matches = iteratee(['a.b', { c: 1 }]);
+
+    expect(matches(object)).toBe(true);
+  });
+
+  it('should not change `_.matchesProperty` behavior if `source` is modified', () => {
+    const sources: any[] = [{ a: { b: 2, c: 3 } }, { a: 1, b: 2 }, { a: 1 }];
+
+    sources.forEach((source, index) => {
+      const object = { a: esToolkit.cloneDeep(source) };
+      const matches = iteratee(['a', source]);
+
+      expect(matches(object)).toBe(true);
+
+      if (index) {
+        source.a = 2;
+        source.b = 1;
+        source.c = 3;
+      } else {
+        source.a.b = 1;
+        source.a.c = 2;
+        source.a.d = 3;
+      }
+      expect(matches(object)).toBe(true);
+      expect(matches({ a: source })).toBe(false);
+    });
+  });
+
+  it('should return an iteratee created by `_.property` when `func` is a number or string', () => {
+    const array = ['a'];
+    let prop = iteratee(0);
+
+    expect(prop(array)).toBe('a');
+
+    prop = iteratee('0');
+    expect(prop(array)).toBe('a');
+  });
+
+  it('should support deep paths for `_.property` shorthands', () => {
+    const object = { a: { b: 2 } };
+    const prop = iteratee('a.b');
+
+    expect(prop(object)).toBe(2);
+  });
+
+  it('should work with functions created by `_.partial` and `_.partialRight`', () => {
+    const fn = function (this: any) {
+      const result = [this.a];
+      // eslint-disable-next-line prefer-rest-params
+      Array.prototype.push.apply(result, arguments as any);
+      return result;
+    };
+
+    const expected = [1, 2, 3];
+    const object = { a: 1, iteratee: iteratee(partial(fn, 2)) };
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(object.iteratee(3)).toEqual(expected);
+
+    object.iteratee = iteratee(partialRight(fn, 3));
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(object.iteratee(2)).toEqual(expected);
+  });
+
+  // it('should use internal `iteratee` if external is unavailable', () => {
+  //   const iteratee = _.iteratee;
+  //   delete _.iteratee;
+
+  //   expect(map([{ a: 1 }], 'a')).toEqual([1]);
+
+  //   _.iteratee = iteratee;
+  // });
+
+  it('should work as an iteratee for methods like `_.map`', () => {
+    const fn = function (this: any) {
+      return this instanceof Number;
+    };
+    const array = [fn, fn, fn];
+    const iteratees = array.map(iteratee);
+    const expected = array.map(stubFalse);
+
+    const actual = iteratees.map(iteratee => iteratee());
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/compat/util/iteratee.ts
+++ b/src/compat/util/iteratee.ts
@@ -1,0 +1,72 @@
+import { property } from '../object/property.ts';
+import { matches } from '../predicate/matches.ts';
+import { matchesProperty } from '../predicate/matchesProperty.ts';
+
+/**
+ * Returns a `identity` function when `value` is `null` or `undefined`.
+ *
+ * @param {null} [value] - The value to convert to an iteratee.
+ * @returns {(value: unknown) => unknown} - Returns a `identity` function.
+ *
+ * @example
+ * const func = iteratee();
+ *
+ * [{ a: 1 }, { a: 2 }, { a: 3 }].map(func) // => [{ a: 1 }, { a: 2 }, { a: 3 }]
+ */
+export function iteratee(value?: null): (value: unknown) => unknown;
+
+/**
+ * Returns a given `func` function when `value` is a `function`.
+ *
+ * @template {(...args: any[]) => unknown} F - The function type.
+ * @param {F} func - The function to return.
+ * @returns {F} - Returns the given function.
+ *
+ * @example
+ * const func = iteratee((object) => object.a);
+ *
+ * [{ a: 1 }, { a: 2 }, { a: 3 }].map(func) // => [1, 2, 3]
+ */
+export function iteratee<F extends (...args: any[]) => unknown>(func: F): F;
+
+/**
+ * Creates a function that invokes `value` with the arguments of the created function.
+ *
+ * The created function returns the property value for a given element.
+ *
+ * @param {symbol | number | string | object} value - The value to convert to an iteratee.
+ * @returns {(...args: any[]) => unknown} - Returns the new iteratee function.
+ *
+ * @example
+ * const func = iteratee('a');
+ *
+ * [{ a: 1 }, { a: 2 }, { a: 3 }].map(func) // => [1, 2, 3]
+ */
+export function iteratee(value: symbol | number | string | object): (...args: any[]) => unknown;
+
+/**
+ * Creates a function that invokes `value` with the arguments of the created function.
+ *
+ * - If `value` is a property name, the created function returns the property value for a given element.
+ * - If `value` is an array or object, the created function returns `true` for elements that contain the equivalent source properties, otherwise `false`.
+ *
+ * @param {symbol | number | string | object | null | ((...args: any[]) => unknown)} value - The value to convert to an iteratee.
+ * @returns {(...args: any[]) => unknown} - Returns the new iteratee function.
+ */
+export function iteratee(
+  value?: symbol | number | string | object | null | ((...args: any[]) => unknown)
+): (...args: any[]) => unknown {
+  if (value == null) {
+    return (value: unknown) => value;
+  }
+
+  switch (typeof value) {
+    case 'function': {
+      return value as any;
+    }
+    case 'object': {
+      return Array.isArray(value) ? matchesProperty(value[0], value[1]) : matches(value);
+    }
+  }
+  return property(value);
+}

--- a/src/compat/util/iteratee.ts
+++ b/src/compat/util/iteratee.ts
@@ -52,6 +52,18 @@ export function iteratee(value: symbol | number | string | object): (...args: an
  *
  * @param {symbol | number | string | object | null | ((...args: any[]) => unknown)} value - The value to convert to an iteratee.
  * @returns {(...args: any[]) => unknown} - Returns the new iteratee function.
+ * @example
+ * const func = iteratee();
+ *
+ * [{ a: 1 }, { a: 2 }, { a: 3 }].map(func) // => [{ a: 1 }, { a: 2 }, { a: 3 }]
+ * @example
+ * const func = iteratee((object) => object.a);
+ *
+ * [{ a: 1 }, { a: 2 }, { a: 3 }].map(func) // => [1, 2, 3]
+ * @example
+ * const func = iteratee('a');
+ *
+ * [{ a: 1 }, { a: 2 }, { a: 3 }].map(func) // => [1, 2, 3]
  */
 export function iteratee(
   value?: symbol | number | string | object | null | ((...args: any[]) => unknown)


### PR DESCRIPTION
# Description

I added `iteratee` to compat layer.

```typescript
  it('should use internal `iteratee` if external is unavailable', () => {
    const iteratee = _.iteratee;
    delete _.iteratee;

    expect(map([{ a: 1 }], 'a')).toEqual([1]);

    _.iteratee = iteratee;
  });
```

The above test case has been commented out because it needs to be implemented in the `map`.

## Benchmark

<img width="798" alt="Screenshot 2024-10-26 at 4 45 38 PM" src="https://github.com/user-attachments/assets/900afd71-e98a-48c8-9d92-89c55d15c4a1">

block #759
close #760 