### PR TITLE
feat(sum,sumBy): add a feature handling `bigint` values to original library

### DIFF
--- a/docs/ja/reference/math/sum.md
+++ b/docs/ja/reference/math/sum.md
@@ -4,24 +4,29 @@
 
 この関数は数値配列を受け取り、配列のすべての要素を足し合わせた合計を返します。
 
+配列が空の場合、この関数は `0` を返します。
+
+配列に `bigint` 値が含まれている場合、関数は `bigint` 値を返します。
+
 ## インターフェース
 
 ```typescript
 function sum(nums: number[]): number;
+function sum(nums: bigint[]): bigint;
 ```
 
 ### パラメータ
 
-- `nums` (`number[]`): 合計を計算する数値配列です。
+- `nums` (`number[] | bigint[]`): 合計を計算する数値配列です。
 
 ### 戻り値
 
-(`number`): 配列にあるすべての数値の合計を返します。
+(`number | bigint`): 配列にあるすべての数値の合計を返します。
 
 ## 例
 
 ```typescript
-const numbers = [1, 2, 3, 4, 5];
-const result = sum(numbers);
-// resultは15になります。
+sum([1, 2, 3, 4, 5]); // 15
+sum([1n, 2n, 3n, 4n, 5n]); // 15n
+sum([]); // 0
 ```

--- a/docs/ja/reference/math/sumBy.md
+++ b/docs/ja/reference/math/sumBy.md
@@ -4,24 +4,28 @@
 
 空の配列に対しては `0` を返します。
 
+`getValue` 関数が `bigint` を返す場合、関数は `bigint` 値を返します。ただし、配列が空の場合、この関数は `0` を返します。
+
 ## インターフェース
 
 ```typescript
-export function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint;
 ```
 
 ### パラメータ
 
 - `items` (`T[]`): 合計を計算する数値配列です。
-- `getValue` (`(item: T) => number`): 各要素から数値を選択する関数です。
+- `getValue` (`(item: T) => number | bigint`): 各要素から数値を選択する関数です。
 
 ### 戻り値
 
-(`number`): `getValue` 関数を基準に、配列にあるすべての数値の合計を返します。
+(`number | bigint`): `getValue` 関数を基準に、配列にあるすべての数値の合計を返します。
 
 ## 例
 
 ```typescript
 sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // 6を返します。
 sumBy([], x => x.a); // 0を返します。
+sumBy([{ a: 1n }, { a: 2n }, { a: 3n }], x => x.a); // 6nを返します。
 ```

--- a/docs/ja/reference/math/sumBy.md
+++ b/docs/ja/reference/math/sumBy.md
@@ -10,7 +10,7 @@
 
 ```typescript
 function sumBy<T>(items: T[], getValue: (element: T) => number): number;
-function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint;
+function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint | number;
 ```
 
 ### パラメータ

--- a/docs/ko/reference/math/sum.md
+++ b/docs/ko/reference/math/sum.md
@@ -4,24 +4,29 @@
 
 이 함수는 숫자 배열을 받아서 배열의 모든 요소를 더한 합계를 반환해요.
 
+배열이 비어있으면 이 함수는 `0`을 반환해요.
+
+배열에 `bigint` 값이 포함되어 있으면 함수는 `bigint` 값을 반환해요.
+
 ## 인터페이스
 
 ```typescript
 function sum(nums: number[]): number;
+function sum(nums: bigint[]): bigint;
 ```
 
 ### 파라미터
 
-- `nums` (`number[]`): 합계를 계산할 숫자 배열이에요.
+- `nums` (`readonly number[] | readonly bigint[]`): 합계를 계산할 숫자 배열이에요.
 
 ### 반환 값
 
-(`number`): 배열에 있는 모든 숫자의 합계를 반환해요.
+(`number | bigint`): 배열에 있는 모든 숫자의 합계를 반환해요.
 
 ## 예시
 
 ```typescript
-const numbers = [1, 2, 3, 4, 5];
-const result = sum(numbers);
-// result는 15가 되어요.
+sum([1, 2, 3, 4, 5]); // 15
+sum([1n, 2n, 3n, 4n, 5n]); // 15n
+sum([]); // 0
 ```

--- a/docs/ko/reference/math/sumBy.md
+++ b/docs/ko/reference/math/sumBy.md
@@ -4,24 +4,28 @@
 
 빈 배열에 대해서는 `0`을 반환해요.
 
+만약 `getValue` 함수가 `bigint`를 반환한다면, 함수는 `bigint` 값을 반환해요. 하지만 배열이 비어있다면, 이 함수는 `0`을 반환해요.
+
 ## 인터페이스
 
 ```typescript
-export function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint;
 ```
 
 ### 파라미터
 
 - `items` (`T[]`): 합계를 계산할 숫자 배열이에요.
-- `getValue` (`(item: T) => number`): 각 요소에서 숫자 값을 선택하는 함수에요.
+- `getValue` (`(item: T) => number | bigint`): 각 요소에서 숫자 값을 선택하는 함수에요.
 
 ### 반환 값
 
-(`number`): `getValue` 함수를 기준으로, 배열에 있는 모든 숫자의 합계를 반환해요.
+(`number | bigint`): `getValue` 함수를 기준으로, 배열에 있는 모든 숫자의 합계를 반환해요.
 
 ## 예시
 
 ```typescript
 sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // 6을 반환해요.
 sumBy([], x => x.a); // 0을 반환해요.
+sumBy([{ a: 1n }, { a: 2n }, { a: 3n }], x => x.a); // 6n을 반환해요.
 ```

--- a/docs/ko/reference/math/sumBy.md
+++ b/docs/ko/reference/math/sumBy.md
@@ -10,7 +10,7 @@
 
 ```typescript
 function sumBy<T>(items: T[], getValue: (element: T) => number): number;
-function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint;
+function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint | number;
 ```
 
 ### 파라미터

--- a/docs/reference/math/sum.md
+++ b/docs/reference/math/sum.md
@@ -4,24 +4,29 @@ Calculates the sum of an array of numbers.
 
 This function takes an array of numbers and returns the sum of all the elements in the array.
 
+If the array is empty, this function returns `0`.
+
+If the array contains `bigint` values, the function returns a `bigint` value.
+
 ## Signature
 
 ```typescript
 function sum(nums: number[]): number;
+function sum(nums: bigint[]): bigint;
 ```
 
 ### Parameters
 
-- `nums` (`number[]`): An array of numbers to be summed.
+- `nums` (`number[] | bigint[]`): An array of numbers to be summed.
 
 ### Returns
 
-(`number`): The sum of all the numbers in the array.
+(`number | bigint`): The sum of all the numbers in the array.
 
 ## Examples
 
 ```typescript
-const numbers = [1, 2, 3, 4, 5];
-const result = sum(numbers);
-// result will be 15
+sum([1, 2, 3, 4, 5]); // 15
+sum([1n, 2n, 3n, 4n, 5n]); // 15n
+sum([]); // 0
 ```

--- a/docs/reference/math/sumBy.md
+++ b/docs/reference/math/sumBy.md
@@ -4,24 +4,28 @@ Calculates the sum of an array of numbers when applying the `getValue` function 
 
 If the array is empty, this function returns `0`.
 
+If the `getValue` function returns a `bigint`, the function returns a `bigint` value. But if the array is empty, this function returns `0`.
+
 ## Signature
 
 ```typescript
-export function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint;
 ```
 
 ### Parameters
 
 - `items` (`T[]`): An array to calculate the sum.
-- `getValue` (`(item: T) => number`): A function that selects a numeric value from each element.
+- `getValue` (`(item: T) => number | bigint`): A function that selects a numeric value from each element.
 
 ### Returns
 
-(`number`): The sum of all the numbers as determined by the `getValue` function.
+(`number | bigint`): The sum of all the numbers as determined by the `getValue` function.
 
 ## Examples
 
 ```typescript
 sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: 6
 sumBy([], x => x.a); // Returns: 0
+sumBy([{ a: 1n }, { a: 2n }, { a: 3n }], x => x.a); // Returns: 6n
 ```

--- a/docs/reference/math/sumBy.md
+++ b/docs/reference/math/sumBy.md
@@ -10,7 +10,7 @@ If the `getValue` function returns a `bigint`, the function returns a `bigint` v
 
 ```typescript
 function sumBy<T>(items: T[], getValue: (element: T) => number): number;
-function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint;
+function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint | number;
 ```
 
 ### Parameters

--- a/docs/zh_hans/reference/math/sum.md
+++ b/docs/zh_hans/reference/math/sum.md
@@ -4,24 +4,29 @@
 
 该函数接受一个数字数组，并返回数组中所有元素的总和。
 
+如果数组为空，则该函数返回 `0`。
+
+如果数组包含 `bigint` 值，则该函数返回一个 `bigint` 值。
+
 ## 签名
 
 ```typescript
 function sum(nums: number[]): number;
+function sum(nums: bigint[]): bigint;
 ```
 
 ### 参数
 
-- `nums` (`number[]`): 要求和的数字数组。
+- `nums` (`number[] | bigint[]`): 要求和的数字数组。
 
 ### 返回值
 
-(`number`): 数组中所有数字的总和。
+(`number | bigint`): 数组中所有数字的总和。
 
 ## 示例
 
 ```typescript
-const numbers = [1, 2, 3, 4, 5];
-const result = sum(numbers);
-// result 将会是 15
+sum([1, 2, 3, 4, 5]); // 15
+sum([1n, 2n, 3n, 4n, 5n]); // 15n
+sum([]); // 0
 ```

--- a/docs/zh_hans/reference/math/sumBy.md
+++ b/docs/zh_hans/reference/math/sumBy.md
@@ -10,7 +10,7 @@
 
 ```typescript
 function sumBy<T>(items: T[], getValue: (element: T) => number): number;
-function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint;
+function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint | number;
 ```
 
 ### 参数

--- a/docs/zh_hans/reference/math/sumBy.md
+++ b/docs/zh_hans/reference/math/sumBy.md
@@ -4,24 +4,28 @@
 
 如果数组为空，则此函数返回 `0`。
 
+如果 `getValue` 函数返回一个 `bigint`，则函数返回一个 `bigint` 值。但如果数组为空，则此函数返回 `0`。
+
 ## 签名
 
 ```typescript
-export function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+function sumBy<T>(items: T[], getValue: (element: T) => number): number;
+function sumBy<T>(items: T[], getValue: (element: T) => bigint): bigint;
 ```
 
 ### 参数
 
 - `items` (`T[]`): 要计算总和的数组。
-- `getValue` (`(item: T) => number`): 从每个元素选择数值的函数。
+- `getValue` (`(item: T) => number | bigint`): 从每个元素选择数值的函数。
 
 ### 返回值
 
-(`number`): 根据 `getValue` 函数确定的所有数值的平均值。
+(`number | bigint`): 根据 `getValue` 函数确定的所有数值的平均值。
 
 ## 示例
 
 ```typescript
 sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // 返回: 6
 sumBy([], x => x.a); // 返回: 0
+sumBy([{ a: 1n }, { a: 2n }, { a: 3n }], x => x.a); // 返回: 6n
 ```

--- a/src/math/sum.spec.ts
+++ b/src/math/sum.spec.ts
@@ -16,4 +16,9 @@ describe('sum function', () => {
     const result = sum([-1, -2, -3, 4]);
     expect(result).toBe(-2);
   });
+
+  it('calculates the sum of an array of bigints', () => {
+    const result = sum([1n, 2n, 3n, 4n]);
+    expect(result).toBe(10n);
+  });
 });

--- a/src/math/sum.ts
+++ b/src/math/sum.ts
@@ -2,6 +2,7 @@
  * Calculates the sum of an array of numbers.
  *
  * This function takes an array of numbers and returns the sum of all the elements in the array.
+ * If the array is empty, this function returns `0`.
  *
  * @param {number[]} nums - An array of numbers to be summed.
  * @returns {number} The sum of all the numbers in the array.
@@ -9,12 +10,35 @@
  * @example
  * const numbers = [1, 2, 3, 4, 5];
  * const result = sum(numbers);
- * // result will be 15
+ * // `result` will be 15
+ * sum([1, 2, 3]); // => 6
+ * sum([]); // => 0
  */
-export function sum(nums: readonly number[]): number {
-  let result = 0;
+export function sum(nums: readonly number[]): number;
 
-  for (let i = 0; i < nums.length; i++) {
+/**
+ * Calculates the sum of an array of bigints.
+ *
+ * This function takes an array of bigints and returns the sum of all the elements in the array.
+ *
+ * @param {bigint[]} nums - An array of bigints to be summed.
+ * @returns {bigint} The sum of all the bigints in the array.
+ *
+ * @example
+ * const bigints = [1n, 2n, 3n, 4n, 5n];
+ * const result = sum(bigints);
+ * // `result` will be 15n
+ */
+export function sum(nums: readonly bigint[]): bigint;
+
+export function sum(nums: readonly number[] | readonly bigint[]): number | bigint {
+  if (!nums || nums.length === 0) {
+    return 0;
+  }
+
+  let result: any = nums[0];
+
+  for (let i = 1; i < nums.length; i++) {
     result += nums[i];
   }
 

--- a/src/math/sumBy.spec.ts
+++ b/src/math/sumBy.spec.ts
@@ -8,9 +8,15 @@ describe('sumBy function', () => {
   });
 
   it('returns 0 for empty arrays', () => {
-    type Person = { name: string; age: number };
+    type Person = { name: string; age: number; id: bigint };
     const people: Person[] = [];
 
     expect(sumBy(people, x => x.age)).toEqual(0);
+    expect(sumBy(people, x => x.id)).toEqual(0);
+  });
+
+  it('calculates the sum of bigints extracted from objects', () => {
+    const result = sumBy([{ a: 1n }, { a: 2n }, { a: 3n }], x => x.a);
+    expect(result).toBe(6n);
   });
 });

--- a/src/math/sumBy.ts
+++ b/src/math/sumBy.ts
@@ -26,8 +26,11 @@ export function sumBy<T>(items: readonly T[], getValue: (element: T) => number):
  *
  * @example
  * sumBy([{ a: 1n }, { a: 2n }, { a: 3n }], x => x.a); // Returns: 6n
+ *
+ * const people: { name: string; age: number; id: bigint }[] = [];
+ * sumBy(people, x => x.age); // Returns: 0
  */
-export function sumBy<T>(items: readonly T[], getValue: (element: T) => bigint): bigint;
+export function sumBy<T>(items: readonly T[], getValue: (element: T) => bigint): bigint | number;
 
 export function sumBy<T>(items: readonly T[], getValue: (element: T) => number | bigint): number | bigint {
   if (!items || items.length === 0) {

--- a/src/math/sumBy.ts
+++ b/src/math/sumBy.ts
@@ -22,7 +22,7 @@ export function sumBy<T>(items: readonly T[], getValue: (element: T) => number):
  * @template T - The type of elements in the array.
  * @param {T[]} items An array to calculate the sum.
  * @param {(element: T) => bigint} getValue A function that selects a bigint value from each element.
- * @returns {bigint} The sum of all the bigints as determined by the `getValue` function.
+ * @returns {bigint | number} The sum of all the bigints as determined by the `getValue` function. If `items` is empty, this function returns `0` as a `number`.
  *
  * @example
  * sumBy([{ a: 1n }, { a: 2n }, { a: 3n }], x => x.a); // Returns: 6n

--- a/src/math/sumBy.ts
+++ b/src/math/sumBy.ts
@@ -32,6 +32,22 @@ export function sumBy<T>(items: readonly T[], getValue: (element: T) => number):
  */
 export function sumBy<T>(items: readonly T[], getValue: (element: T) => bigint): bigint | number;
 
+/**
+ * Calculates the sum of an array of numbers or bigints when applying
+ * the `getValue` function to each element.
+ *
+ * If the array is empty, this function returns `0`.
+ *
+ * @template T - The type of elements in the array.
+ * @param {T[]} items - An array to calculate the sum.
+ * @param {(element: T) => number | bigint} getValue - A function that selects a numeric value from each element.
+ * @returns {number | bigint} The sum of all the numbers as determined by the `getValue` function.
+ *
+ * @example
+ * sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: 6
+ * sumBy([{ a: 1n }, { a: 2n }, { a: 3n }], x => x.a); // Returns: 6n
+ * sumBy([], x => x.a); // Returns: 0
+ */
 export function sumBy<T>(items: readonly T[], getValue: (element: T) => number | bigint): number | bigint {
   if (!items || items.length === 0) {
     return 0;

--- a/src/math/sumBy.ts
+++ b/src/math/sumBy.ts
@@ -13,10 +13,30 @@
  * sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: 6
  * sumBy([], x => x.a); // Returns: 0
  */
-export function sumBy<T>(items: readonly T[], getValue: (element: T) => number): number {
-  let result = 0;
+export function sumBy<T>(items: readonly T[], getValue: (element: T) => number): number;
 
-  for (let i = 0; i < items.length; i++) {
+/**
+ * Calculates the sum of an array of bigints when applying
+ * the `getValue` function to each element.
+ *
+ * @template T - The type of elements in the array.
+ * @param {T[]} items An array to calculate the sum.
+ * @param {(element: T) => bigint} getValue A function that selects a bigint value from each element.
+ * @returns {bigint} The sum of all the bigints as determined by the `getValue` function.
+ *
+ * @example
+ * sumBy([{ a: 1n }, { a: 2n }, { a: 3n }], x => x.a); // Returns: 6n
+ */
+export function sumBy<T>(items: readonly T[], getValue: (element: T) => bigint): bigint;
+
+export function sumBy<T>(items: readonly T[], getValue: (element: T) => number | bigint): number | bigint {
+  if (!items || items.length === 0) {
+    return 0;
+  }
+
+  let result: any = getValue(items[0]);
+
+  for (let i = 1; i < items.length; i++) {
     result += getValue(items[i]);
   }
 

--- a/src/math/sumBy.ts
+++ b/src/math/sumBy.ts
@@ -28,7 +28,7 @@ export function sumBy<T>(items: readonly T[], getValue: (element: T) => number):
  * sumBy([{ a: 1n }, { a: 2n }, { a: 3n }], x => x.a); // Returns: 6n
  *
  * const people: { name: string; age: number; id: bigint }[] = [];
- * sumBy(people, x => x.age); // Returns: 0
+ * sumBy(people, x => x.id); // Returns: 0
  */
 export function sumBy<T>(items: readonly T[], getValue: (element: T) => bigint): bigint | number;
 


### PR DESCRIPTION
# Overview

I added the feature to original library.

If the array is empty, it is impossible to distinguish between `bigint` and `number`, so I implemented it to always return `0` when the array is empty.

Therefore, in the overloading signature of `sumBy`, it is specified that if the return type of `getValue` is `bigint`, the function may return either a `bigint` or a `number`.

close #742 