### PR TITLE
fix(replace): Handle cases with less than 3 arguments

### DIFF
--- a/src/compat/string/replace.spec.ts
+++ b/src/compat/string/replace.spec.ts
@@ -19,4 +19,14 @@ describe('replace', () => {
     // @ts-expect-error
     expect(replace()).toBe('');
   });
+
+  it('should return the original string if arguments length is less than 3', () => {
+    const string = 'abcde';
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(replace(string)).toBe(string);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(replace(string, 'de')).toBe(string);
+  });
 });

--- a/src/compat/string/replace.ts
+++ b/src/compat/string/replace.ts
@@ -19,5 +19,9 @@ export function replace(
   pattern: string | RegExp,
   replacement: string | ((substring: string, ...args: any[]) => string)
 ): string {
+  if (arguments.length < 3) {
+    return toString(target);
+  }
+
   return toString(target).replace(pattern, replacement as any);
 }


### PR DESCRIPTION
I added an [edge case for the argument length of less than 3](https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L14540) to ensure compatibility with Lodash.