### PR TITLE
refactor(without): improved by reusing the difference function in the without function

### DIFF
--- a/src/array/without.ts
+++ b/src/array/without.ts
@@ -1,3 +1,5 @@
+import { difference } from './difference.ts';
+
 /**
  * Creates an array that excludes all specified values.
  *
@@ -19,6 +21,5 @@
  * // Returns: ['b', 'c']
  */
 export function without<T>(array: readonly T[], ...values: T[]): T[] {
-  const valuesSet = new Set(values);
-  return array.filter(item => !valuesSet.has(item));
+  return difference(array, values);
 }


### PR DESCRIPTION
This can be implemented simply by reusing the `difference` function for the `without` function!! 🤗

```ts
// as-is
export function without<T>(array: readonly T[], ...values: T[]): T[] {
  const valuesSet = new Set(values);
  return array.filter(item => !valuesSet.has(item));
}

export function difference<T>(firstArr: readonly T[], secondArr: readonly T[]): T[] {
  const secondSet = new Set(secondArr);
  return firstArr.filter(item => !secondSet.has(item));
}
```
```ts
// to-be
export function without<T>(array: readonly T[], ...values: T[]): T[] {
  return difference(array, values);
}
```

Despite the differences in the interface of the two functions, the internal logic is the same, so they can be reused 👍