### PR TITLE
refactor(isSubsetWith): improved by reusing the differenceWith in the isSubsetWith

### DIFF
--- a/src/array/isSubsetWith.ts
+++ b/src/array/isSubsetWith.ts
@@ -1,3 +1,5 @@
+import { differenceWith } from './differenceWith.ts';
+
 /**
  * Checks if the `subset` array is entirely contained within the `superset` array based on a custom equality function.
  *
@@ -33,7 +35,5 @@ export function isSubsetWith<T>(
   subset: readonly T[],
   areItemsEqual: (x: T, y: T) => boolean
 ): boolean {
-  return subset.every(subsetItem => {
-    return superset.some(supersetItem => areItemsEqual(supersetItem, subsetItem));
-  });
+  return differenceWith(subset, superset, areItemsEqual).length === 0;
 }


### PR DESCRIPTION
Related Pull Request: https://github.com/toss/es-toolkit/pull/783
The `isSubset` function is simply implemented by reusing the `difference` function.

```ts
export function isSubset<T>(superset: readonly T[], subset: readonly T[]): boolean {
  return difference(subset, superset).length === 0;
}
```

I think the same is true for the `isSubsetWith` function. It can be implemented simply by reusing `differenceWith`.

cc. @kaehehehe 