### PR TITLE
perf(compat/array): Improve performance of various array functions in `compat`

### DIFF
--- a/src/compat/_internal/ensureIsArray.ts
+++ b/src/compat/_internal/ensureIsArray.ts
@@ -1,0 +1,3 @@
+export function ensureIsArray<T>(value: ArrayLike<T>): T[] {
+  return Array.isArray(value) ? value : Array.from(value);
+}

--- a/src/compat/_internal/toArray.ts
+++ b/src/compat/_internal/toArray.ts
@@ -1,3 +1,3 @@
-export function ensureIsArray<T>(value: ArrayLike<T>): T[] {
+export function toArray<T>(value: ArrayLike<T>): T[] {
   return Array.isArray(value) ? value : Array.from(value);
 }

--- a/src/compat/array/chunk.ts
+++ b/src/compat/array/chunk.ts
@@ -1,4 +1,5 @@
 import { chunk as chunkToolkit } from '../../array/chunk.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -30,5 +31,5 @@ export function chunk<T>(arr: ArrayLike<T> | null | undefined, size = 1): T[][] 
     return [];
   }
 
-  return chunkToolkit(Array.from(arr), size);
+  return chunkToolkit(ensureIsArray(arr), size);
 }

--- a/src/compat/array/chunk.ts
+++ b/src/compat/array/chunk.ts
@@ -1,5 +1,5 @@
 import { chunk as chunkToolkit } from '../../array/chunk.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -31,5 +31,5 @@ export function chunk<T>(arr: ArrayLike<T> | null | undefined, size = 1): T[][] 
     return [];
   }
 
-  return chunkToolkit(ensureIsArray(arr), size);
+  return chunkToolkit(toArray(arr), size);
 }

--- a/src/compat/array/difference.ts
+++ b/src/compat/array/difference.ts
@@ -1,4 +1,5 @@
 import { difference as differenceToolkit } from '../../array/difference.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 
 /**
@@ -31,7 +32,7 @@ export function difference<T>(arr: ArrayLike<T> | undefined | null, ...values: A
     return [];
   }
 
-  const arr1 = Array.from(arr);
+  const arr1 = ensureIsArray(arr);
   const arr2 = [];
 
   for (let i = 0; i < values.length; i++) {

--- a/src/compat/array/difference.ts
+++ b/src/compat/array/difference.ts
@@ -1,5 +1,5 @@
 import { difference as differenceToolkit } from '../../array/difference.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 
 /**
@@ -32,7 +32,7 @@ export function difference<T>(arr: ArrayLike<T> | undefined | null, ...values: A
     return [];
   }
 
-  const arr1 = ensureIsArray(arr);
+  const arr1 = toArray(arr);
   const arr2 = [];
 
   for (let i = 0; i < values.length; i++) {

--- a/src/compat/array/drop.ts
+++ b/src/compat/array/drop.ts
@@ -1,5 +1,5 @@
 import { drop as dropToolkit } from '../../array/drop.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
@@ -26,5 +26,5 @@ export function drop<T>(collection: ArrayLike<T> | null | undefined, itemsCount:
   }
   itemsCount = guard ? 1 : toInteger(itemsCount);
 
-  return dropToolkit(ensureIsArray(collection), itemsCount);
+  return dropToolkit(toArray(collection), itemsCount);
 }

--- a/src/compat/array/drop.ts
+++ b/src/compat/array/drop.ts
@@ -1,4 +1,5 @@
 import { drop as dropToolkit } from '../../array/drop.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
@@ -25,5 +26,5 @@ export function drop<T>(collection: ArrayLike<T> | null | undefined, itemsCount:
   }
   itemsCount = guard ? 1 : toInteger(itemsCount);
 
-  return dropToolkit(Array.from(collection), itemsCount);
+  return dropToolkit(ensureIsArray(collection), itemsCount);
 }

--- a/src/compat/array/dropRight.ts
+++ b/src/compat/array/dropRight.ts
@@ -1,5 +1,5 @@
 import { dropRight as dropRightToolkit } from '../../array/dropRight.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
@@ -30,5 +30,5 @@ export function dropRight<T>(
   }
   itemsCount = guard ? 1 : toInteger(itemsCount);
 
-  return dropRightToolkit(ensureIsArray(collection), itemsCount);
+  return dropRightToolkit(toArray(collection), itemsCount);
 }

--- a/src/compat/array/dropRight.ts
+++ b/src/compat/array/dropRight.ts
@@ -1,4 +1,5 @@
 import { dropRight as dropRightToolkit } from '../../array/dropRight.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
@@ -29,5 +30,5 @@ export function dropRight<T>(
   }
   itemsCount = guard ? 1 : toInteger(itemsCount);
 
-  return dropRightToolkit(Array.from(collection), itemsCount);
+  return dropRightToolkit(ensureIsArray(collection), itemsCount);
 }

--- a/src/compat/array/dropWhile.ts
+++ b/src/compat/array/dropWhile.ts
@@ -1,5 +1,5 @@
 import { dropWhile as dropWhileToolkit } from '../../array/dropWhile.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { property } from '../object/property.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { matches } from '../predicate/matches.ts';
@@ -96,7 +96,7 @@ export function dropWhile<T>(
     return [];
   }
 
-  return dropWhileImpl(ensureIsArray(arr), predicate);
+  return dropWhileImpl(toArray(arr), predicate);
 }
 
 function dropWhileImpl<T>(

--- a/src/compat/array/dropWhile.ts
+++ b/src/compat/array/dropWhile.ts
@@ -1,4 +1,5 @@
 import { dropWhile as dropWhileToolkit } from '../../array/dropWhile.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { property } from '../object/property.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { matches } from '../predicate/matches.ts';
@@ -95,7 +96,7 @@ export function dropWhile<T>(
     return [];
   }
 
-  return dropWhileImpl(Array.from(arr), predicate);
+  return dropWhileImpl(ensureIsArray(arr), predicate);
 }
 
 function dropWhileImpl<T>(

--- a/src/compat/array/findLastIndex.ts
+++ b/src/compat/array/findLastIndex.ts
@@ -1,4 +1,4 @@
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { property } from '../object/property.ts';
 import { matches } from '../predicate/matches.ts';
 import { matchesProperty } from '../predicate/matchesProperty.ts';
@@ -116,7 +116,7 @@ export function findLastIndex<T>(
     fromIndex = Math.min(fromIndex, arr.length - 1);
   }
 
-  const subArray = ensureIsArray(arr).slice(0, fromIndex + 1);
+  const subArray = toArray(arr).slice(0, fromIndex + 1);
 
   switch (typeof doesMatch) {
     case 'function': {

--- a/src/compat/array/findLastIndex.ts
+++ b/src/compat/array/findLastIndex.ts
@@ -1,3 +1,4 @@
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { property } from '../object/property.ts';
 import { matches } from '../predicate/matches.ts';
 import { matchesProperty } from '../predicate/matchesProperty.ts';
@@ -115,7 +116,7 @@ export function findLastIndex<T>(
     fromIndex = Math.min(fromIndex, arr.length - 1);
   }
 
-  const subArray = Array.from(arr).slice(0, fromIndex + 1);
+  const subArray = ensureIsArray(arr).slice(0, fromIndex + 1);
 
   switch (typeof doesMatch) {
     case 'function': {

--- a/src/compat/array/head.ts
+++ b/src/compat/array/head.ts
@@ -1,5 +1,5 @@
 import { head as headToolkit } from '../../array/head.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -21,5 +21,5 @@ export function head<T>(arr: ArrayLike<T> | undefined | null): T | undefined {
   if (!isArrayLike(arr)) {
     return undefined;
   }
-  return headToolkit(ensureIsArray(arr));
+  return headToolkit(toArray(arr));
 }

--- a/src/compat/array/head.ts
+++ b/src/compat/array/head.ts
@@ -1,4 +1,5 @@
 import { head as headToolkit } from '../../array/head.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -20,5 +21,5 @@ export function head<T>(arr: ArrayLike<T> | undefined | null): T | undefined {
   if (!isArrayLike(arr)) {
     return undefined;
   }
-  return headToolkit(Array.from(arr));
+  return headToolkit(ensureIsArray(arr));
 }

--- a/src/compat/array/last.ts
+++ b/src/compat/array/last.ts
@@ -1,5 +1,5 @@
 import { last as lastToolkit } from '../../array/last.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -28,5 +28,5 @@ export function last<T>(array: ArrayLike<T> | null | undefined): T | undefined {
   if (!isArrayLike(array)) {
     return undefined;
   }
-  return lastToolkit(ensureIsArray(array));
+  return lastToolkit(toArray(array));
 }

--- a/src/compat/array/last.ts
+++ b/src/compat/array/last.ts
@@ -1,4 +1,5 @@
 import { last as lastToolkit } from '../../array/last.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -27,5 +28,5 @@ export function last<T>(array: ArrayLike<T> | null | undefined): T | undefined {
   if (!isArrayLike(array)) {
     return undefined;
   }
-  return lastToolkit(Array.from(array));
+  return lastToolkit(ensureIsArray(array));
 }

--- a/src/compat/array/sample.ts
+++ b/src/compat/array/sample.ts
@@ -1,5 +1,5 @@
 import { sample as sampleToolkit } from '../../array/sample.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -101,7 +101,7 @@ export function sample<T>(collection: ArrayLike<T> | Record<string, T>): T | str
   }
 
   if (isArrayLike(collection)) {
-    return sampleToolkit(ensureIsArray(collection));
+    return sampleToolkit(toArray(collection));
   }
 
   return sampleToolkit(Object.values(collection));

--- a/src/compat/array/sample.ts
+++ b/src/compat/array/sample.ts
@@ -1,4 +1,5 @@
 import { sample as sampleToolkit } from '../../array/sample.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -100,7 +101,7 @@ export function sample<T>(collection: ArrayLike<T> | Record<string, T>): T | str
   }
 
   if (isArrayLike(collection)) {
-    return sampleToolkit(Array.from(collection));
+    return sampleToolkit(ensureIsArray(collection));
   }
 
   return sampleToolkit(Object.values(collection));

--- a/src/compat/array/tail.ts
+++ b/src/compat/array/tail.ts
@@ -1,5 +1,5 @@
 import { tail as tailToolkit } from '../../array/tail.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -30,5 +30,5 @@ export function tail<T>(arr: ArrayLike<T> | null | undefined): T[] {
   if (!isArrayLike(arr)) {
     return [];
   }
-  return tailToolkit(ensureIsArray(arr));
+  return tailToolkit(toArray(arr));
 }

--- a/src/compat/array/tail.ts
+++ b/src/compat/array/tail.ts
@@ -1,4 +1,5 @@
 import { tail as tailToolkit } from '../../array/tail.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -29,5 +30,5 @@ export function tail<T>(arr: ArrayLike<T> | null | undefined): T[] {
   if (!isArrayLike(arr)) {
     return [];
   }
-  return tailToolkit(Array.from(arr));
+  return tailToolkit(ensureIsArray(arr));
 }

--- a/src/compat/array/take.ts
+++ b/src/compat/array/take.ts
@@ -1,4 +1,5 @@
 import { take as takeToolkit } from '../../array/take.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
@@ -31,5 +32,5 @@ export function take<T>(arr: ArrayLike<T> | null | undefined, count: number = 1,
     return [];
   }
 
-  return takeToolkit(Array.from(arr), count);
+  return takeToolkit(ensureIsArray(arr), count);
 }

--- a/src/compat/array/take.ts
+++ b/src/compat/array/take.ts
@@ -1,5 +1,5 @@
 import { take as takeToolkit } from '../../array/take.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
@@ -32,5 +32,5 @@ export function take<T>(arr: ArrayLike<T> | null | undefined, count: number = 1,
     return [];
   }
 
-  return takeToolkit(ensureIsArray(arr), count);
+  return takeToolkit(toArray(arr), count);
 }

--- a/src/compat/array/takeRight.ts
+++ b/src/compat/array/takeRight.ts
@@ -1,5 +1,5 @@
 import { takeRight as takeRightToolkit } from '../../array/takeRight.ts';
-import { ensureIsArray } from '../_internal/ensureIsArray.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
@@ -31,5 +31,5 @@ export function takeRight<T>(arr: ArrayLike<T> | null | undefined, count: number
     return [];
   }
 
-  return takeRightToolkit(ensureIsArray(arr), count);
+  return takeRightToolkit(toArray(arr), count);
 }

--- a/src/compat/array/takeRight.ts
+++ b/src/compat/array/takeRight.ts
@@ -1,4 +1,5 @@
 import { takeRight as takeRightToolkit } from '../../array/takeRight.ts';
+import { ensureIsArray } from '../_internal/ensureIsArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
@@ -30,5 +31,5 @@ export function takeRight<T>(arr: ArrayLike<T> | null | undefined, count: number
     return [];
   }
 
-  return takeRightToolkit(Array.from(arr), count);
+  return takeRightToolkit(ensureIsArray(arr), count);
 }


### PR DESCRIPTION
Various compatibility array functions are slow when handling large arrays, which is largely caused by unnecessary `Array.from()` calls. This PR adds a check, so `Array.from()` is only called when necessary.

Below are performance improvements for the `head` function. Results for other methods are similar.

Before:
![Before](https://github.com/user-attachments/assets/26535387-4efe-4413-b626-dfa400b7aab4)

---

After:
![After](https://github.com/user-attachments/assets/6ed468c5-226b-4776-8adf-42b7b6cd1194)