### PR TITLE
perf: Improve performance of `toPath`, `get`, `set`, `unset`, `has`, `orderBy`.

### DIFF
--- a/src/compat/util/toPath.ts
+++ b/src/compat/util/toPath.ts
@@ -15,11 +15,11 @@
  * toPath('') // Returns []
  * toPath('.a[b].c.d[e]["f.g"].h') // Returns ['', 'a', 'b', 'c', 'd', 'e', 'f.g', 'h']
  */
-export function toPath( deepKey: string ): string[] {
+export function toPath(deepKey: string): string[] {
   const result: string[] = [];
   const length = deepKey.length;
 
-  if ( length === 0 ) return result;
+  if (length === 0) return result;
 
   let index = 0;
   let key = '';
@@ -27,48 +27,48 @@ export function toPath( deepKey: string ): string[] {
   let bracket = false;
 
   // Leading dot
-  if ( deepKey.charCodeAt( 0 ) === 46 ) {
-    result.push( '' );
+  if (deepKey.charCodeAt(0) === 46) {
+    result.push('');
     index++;
   }
 
-  while ( index < length ) {
-    const char = deepKey[ index ];
+  while (index < length) {
+    const char = deepKey[index];
 
-    if ( quoteChar ) {
-      if ( char === '\\' && index + 1 < length ) {
+    if (quoteChar) {
+      if (char === '\\' && index + 1 < length) {
         // Escape character
         index++;
-        key += deepKey[ index ];
-      } else if ( char === quoteChar ) {
+        key += deepKey[index];
+      } else if (char === quoteChar) {
         // End of quote
         quoteChar = '';
       } else {
         key += char;
       }
-    } else if ( bracket ) {
-      if ( char === '"' || char === "'" ) {
+    } else if (bracket) {
+      if (char === '"' || char === "'") {
         // Start of quoted string inside brackets
         quoteChar = char;
-      } else if ( char === ']' ) {
+      } else if (char === ']') {
         // End of bracketed segment
         bracket = false;
-        result.push( key );
+        result.push(key);
         key = '';
       } else {
         key += char;
       }
     } else {
-      if ( char === '[' ) {
+      if (char === '[') {
         // Start of bracketed segment
         bracket = true;
-        if ( key ) {
-          result.push( key );
+        if (key) {
+          result.push(key);
           key = '';
         }
-      } else if ( char === '.' ) {
-        if ( key ) {
-          result.push( key );
+      } else if (char === '.') {
+        if (key) {
+          result.push(key);
           key = '';
         }
       } else {
@@ -79,8 +79,8 @@ export function toPath( deepKey: string ): string[] {
     index++;
   }
 
-  if ( key ) {
-    result.push( key );
+  if (key) {
+    result.push(key);
   }
 
   return result;

--- a/src/compat/util/toPath.ts
+++ b/src/compat/util/toPath.ts
@@ -19,7 +19,9 @@ export function toPath(deepKey: string): string[] {
   const result: string[] = [];
   const length = deepKey.length;
 
-  if (length === 0) return result;
+  if (length === 0) {
+    return result;
+  }
 
   let index = 0;
   let key = '';


### PR DESCRIPTION
The currently used regular expressions in `toPath()` are expensive, so this PR changes the implementation to not rely on them. Because `toPath` is used in `get`, `set`, `unset`, `has`, and `orderBy`, performance of these functions is also improved.

Performance improvements:
* `toPath()`
  * `toPath: super simple` — 840%
  * `toPath: dots` — 830%
  * `toPath: brackets` — 1270%
  * `toPath: complex` — 1340%
* `get()`
  * `get with string` — 420%
  * `get with string array` — 15%
* `has()`
  * `has with string` — 450%
* `orderBy()`
  * `orderBy (property path)` — 36%
* `set()`
  * `set - dot` — 91%
  * `set - array` — 119%
* `unset()`
  * `unset` — 155%

After these changes, performance of these functions is in most cases on par with lodash.

---

Before:
![Before](https://github.com/user-attachments/assets/520b0dd7-5cd8-476e-8b19-82afd07dd62c)

---

After:
![After](https://github.com/user-attachments/assets/4ef982d6-a40e-409a-aef0-a5d081ffede3)

---