### PR TITLE
fix(cloneDeep): Resolving the error where classes do not inherit the prototype of objects.

### DIFF
--- a/src/object/cloneDeep.spec.ts
+++ b/src/object/cloneDeep.spec.ts
@@ -171,6 +171,22 @@ describe('cloneDeep', () => {
     });
   });
 
+  it('should clone instances of custom classes', () => {
+    class CustomTest {
+      constructor(public value: number) {}
+      myFunc() {
+        return `value is ${this.value}`;
+      }
+    }
+
+    const instance = new CustomTest(5);
+    const clonedInstance = cloneDeep(instance);
+
+    expect(clonedInstance).not.toBe(instance);
+    expect(clonedInstance).toEqual(instance);
+    expect(clonedInstance.myFunc()).toBe('value is 5');
+  });
+
   //-------------------------------------------------------------------------------------
   // File
   //-------------------------------------------------------------------------------------

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -191,6 +191,7 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
 
     return result as T;
   }
+
   return obj;
 }
 

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -184,12 +184,12 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
   }
 
   if (typeof obj === 'object' && obj !== null) {
-    const result = Object.create(Object.getPrototypeOf(obj)); 
+    const result = Object.create(Object.getPrototypeOf(obj));
     stack.set(obj, result);
 
-    copyProperties(result, obj, stack); 
+    copyProperties(result, obj, stack);
 
-    return result as T; 
+    return result as T;
   }
   return obj;
 }

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -184,13 +184,13 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
   }
 
   if (typeof obj === 'object' && obj !== null) {
-  const result = Object.create(Object.getPrototypeOf(obj));
-  stack.set(obj, result);
+    const result = Object.create(Object.getPrototypeOf(obj)); 
+    stack.set(obj, result);
 
-  copyProperties(result, obj, stack);
+    copyProperties(result, obj, stack); 
 
-  return result as T;
-}
+    return result as T; 
+  }
   return obj;
 }
 

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -184,14 +184,13 @@ function cloneDeepImpl<T>(obj: T, stack = new Map<any, any>()): T {
   }
 
   if (typeof obj === 'object' && obj !== null) {
-    const result = {};
-    stack.set(obj, result);
+  const result = Object.create(Object.getPrototypeOf(obj));
+  stack.set(obj, result);
 
-    copyProperties(result, obj, stack);
+  copyProperties(result, obj, stack);
 
-    return result as T;
-  }
-
+  return result as T;
+}
   return obj;
 }
 


### PR DESCRIPTION
![cloneDeep](https://github.com/user-attachments/assets/6657ca99-feb1-4128-a92e-6894ced80ad5)
