### PR TITLE
fix/(intersectionBy, differenceBy, differenceWith): should allow array with different element type.

### DIFF
--- a/docs/ja/reference/array/differenceBy.md
+++ b/docs/ja/reference/array/differenceBy.md
@@ -7,14 +7,14 @@
 ## インターフェース
 
 ```typescript
-function differenceBy<T, U>(firstArr: T[], secondArr: T[], mapper: (value: T) => U): T[];
+function differenceBy<T, U>(firstArr: T[], secondArr: U[], mapper: (value: T | U) => unknown): T[];
 ```
 
 ### パラメータ
 
 - `firstArr` (`T[]`): 差分を計算する配列です。この配列が主な配列で、この配列の要素が比較されフィルタリングされます。
-- `secondArr` (`T[]`): 最初の配列から除外する要素を含む配列です。
-- `mapper` (`(value: T) => U`): 2つの配列の要素をマッピングする関数です。この関数は2つの配列の各要素に適用され、マッピングされた値を基準に比較を行います。
+- `secondArr` (`U[]`): 最初の配列から除外する要素を含む配列です。
+- `mapper` (`(value: T | U) => unknown`): 2つの配列の要素をマッピングする関数です。この関数は2つの配列の各要素に適用され、マッピングされた値を基準に比較を行います。
 
 ### 戻り値
 
@@ -30,4 +30,10 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const mapper = item => item.id;
 const result = differenceBy(array1, array2, mapper);
 // resultは[{ id: 1 }, { id: 3 }, { id: 5 }]になります。idが2の要素は両方の配列に存在するため、結果から除外されます。
+
+const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+const array2 = [2, 4];
+const mapper = item => (typeof item === 'object' ? item.id : item);
+const result = differenceBy(array1, array2, mapper);
+// resultは[{ id: 1 }, { id: 3 }]になります。2はマッピング後に両方の配列に存在するため、結果から除外されます。
 ```

--- a/docs/ja/reference/array/differenceWith.md
+++ b/docs/ja/reference/array/differenceWith.md
@@ -7,14 +7,14 @@
 ## インターフェース
 
 ```typescript
-function differenceWith<T>(firstArr: T[], secondArr: T[], areItemsEqual: (x: T, y: T) => boolean): T[];
+function differenceWith<T, U>(firstArr: T[], secondArr: U[], areItemsEqual: (x: T, y: U) => boolean): T[];
 ```
 
 ### パラメータ
 
 - `firstArr` (`T[]`): 差分を計算する配列です。この配列が主な配列で、この配列の要素が比較されフィルタリングされます。
-- `secondArr` (`T[]`): 最初の配列から除外する要素を含む配列です。
-- `areItemsEqual` (`(x: T, y: T) => boolean`): 2つの要素が同じかどうかを決定する関数です。
+- `secondArr` (`U[]`): 最初の配列から除外する要素を含む配列です。
+- `areItemsEqual` (`(x: T, y: U) => boolean`): 2つの要素が同じかどうかを決定する関数です。
 
 ### 戻り値
 
@@ -30,4 +30,10 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const areItemsEqual = (a, b) => a.id === b.id;
 const result = differenceWith(array1, array2, areItemsEqual);
 // resultは[{ id: 1 }, { id: 3 }]になります。idが2の要素は同じと見なされ、結果から除外されます。
+
+const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+const array2 = [2, 4];
+const areItemsEqual = (a, b) => a.id === b;
+const result = differenceWith(array1, array2, areItemsEqual);
+// resultは[{ id: 1 }, { id: 3 }]になります。idが2の要素は2番目の配列の要素と同じと見なされ、結果から除外されます。
 ```

--- a/docs/ja/reference/array/intersectionBy.md
+++ b/docs/ja/reference/array/intersectionBy.md
@@ -9,14 +9,14 @@
 ## インターフェース
 
 ```typescript
-function intersectionBy<T, U>(firstArr: T[], secondArr: T[], mapper: (item: T) => U): T[];
+function intersectionBy<T, U>(firstArr: T[], secondArr: U[], mapper: (item: T | U) => unknown): T[];
 ```
 
 ### パラメータ
 
 - `firstArr` (`T[]`): 比較する最初の配列。
-- `secondArr` (`T[]`): 比較する2番目の配列。
-- `mapper` (`(item: T) => U`): 比較するために要素を新しい値に変換する関数。
+- `secondArr` (`U[]`): 比較する2番目の配列。
+- `mapper` (`(item: T | U) => unknown`): 比較するために要素を新しい値に変換する関数。
 
 ### 戻り値
 
@@ -30,6 +30,16 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const mapper = item => item.id;
 const result = intersectionBy(array1, array2, mapper);
 // `mapper`で変換したとき、両方の配列に含まれる要素からなる [{ id: 2 }] 値が返されます。
+
+const array1 = [
+  { id: 1, name: 'jane' },
+  { id: 2, name: 'amy' },
+  { id: 3, name: 'michael' },
+];
+const array2 = [2, 4];
+const mapper = item => (typeof item === 'object' ? item.id : item);
+const result = intersectionBy(array1, array2, mapper);
+// `mapper`で変換したとき、両方の配列に含まれる要素からなる [{ id: 2, name: 'amy' }] 値が返されます。
 ```
 
 ## Lodashとの互換性

--- a/docs/ko/reference/array/differenceBy.md
+++ b/docs/ko/reference/array/differenceBy.md
@@ -7,14 +7,14 @@
 ## 인터페이스
 
 ```typescript
-function differenceBy<T, U>(firstArr: T[], secondArr: T[], mapper: (value: T) => U): T[];
+function differenceBy<T, U>(firstArr: T[], secondArr: U[], mapper: (value: T | U) => unknown): T[];
 ```
 
 ### 파라미터
 
 - `firstArr` (`T[]`): 차이를 계산할 배열이에요. 이 배열이 주 배열이고, 이 배열의 요소들이 비교되고 필터링돼요.
-- `secondArr` (`T[]`): 첫 번째 배열에서 제외할 요소들을 포함한 배열이에요.
-- `mapper` (`(value: T) => U`): 두 배열의 요소들을 매핑할 함수에요. 이 함수는 두 배열의 각 요소에 적용되며, 매핑된 값들을 기준으로 비교를 해요.
+- `secondArr` (`U[]`): 첫 번째 배열에서 제외할 요소들을 포함한 배열이에요.
+- `mapper` (`(value: T | U) => unknown`): 두 배열의 요소들을 매핑할 함수에요. 이 함수는 두 배열의 각 요소에 적용되며, 매핑된 값들을 기준으로 비교를 해요.
 
 ### 반환 값
 
@@ -30,4 +30,10 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const mapper = item => item.id;
 const result = differenceBy(array1, array2, mapper);
 // result는 [{ id: 1 }, { id: 3 }, { id: 5 }]가 돼요. id가 2인 요소들은 두 배열 모두에 있어서 결과에서 제외돼요.
+
+const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+const array2 = [2, 4];
+const mapper = item => (typeof item === 'object' ? item.id : item);
+const result = differenceBy(array1, array2, mapper);
+// result는 [{ id: 1 }, { id: 3 }]가 돼요. 매핑 결과가 2인 요소들은 두 배열 모두에 있어서 결과에서 제외돼요.
 ```

--- a/docs/ko/reference/array/differenceWith.md
+++ b/docs/ko/reference/array/differenceWith.md
@@ -7,14 +7,14 @@
 ## 인터페이스
 
 ```typescript
-function differenceWith<T>(firstArr: T[], secondArr: T[], areItemsEqual: (x: T, y: T) => boolean): T[];
+function differenceWith<T, U>(firstArr: T[], secondArr: U[], areItemsEqual: (x: T, y: U) => boolean): T[];
 ```
 
 ### 파라미터
 
 - `firstArr` (`T[]`): 차이를 계산할 배열이에요. 이 배열이 주 배열이고, 이 배열의 요소들이 비교되고 필터링돼요.
-- `secondArr` (`T[]`) : 첫 번째 배열에서 제외할 요소들을 포함한 배열이에요.
-- `areItemsEqual` (`(x: T, y: T) => boolean`): 두 요소가 동일한지 결정할 함수에요.
+- `secondArr` (`U[]`) : 첫 번째 배열에서 제외할 요소들을 포함한 배열이에요.
+- `areItemsEqual` (`(x: T, y: U) => boolean`): 두 요소가 동일한지 결정할 함수에요.
 
 ### 반환 값
 
@@ -28,6 +28,12 @@ import { differenceWith } from 'es-toolkit/array';
 const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
 const array2 = [{ id: 2 }, { id: 4 }];
 const areItemsEqual = (a, b) => a.id === b.id;
+const result = differenceWith(array1, array2, areItemsEqual);
+// result는 [{ id: 1 }, { id: 3 }]가 돼요. id가 2인 요소들은 동일하다고 간주돼서 결과에서 제외돼요.
+
+const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+const array2 = [2, 4];
+const areItemsEqual = (a, b) => a.id === b;
 const result = differenceWith(array1, array2, areItemsEqual);
 // result는 [{ id: 1 }, { id: 3 }]가 돼요. id가 2인 요소들은 동일하다고 간주돼서 결과에서 제외돼요.
 ```

--- a/docs/ko/reference/array/intersectionBy.md
+++ b/docs/ko/reference/array/intersectionBy.md
@@ -9,14 +9,14 @@
 ## 인터페이스
 
 ```typescript
-function intersectionBy<T, U>(firstArr: T[], secondArr: T[], mapper: (item: T) => U): T[];
+function intersectionBy<T, U>(firstArr: T[], secondArr: U[], mapper: (item: T | U) => unknown): T[];
 ```
 
 ### 파라미터
 
 - `firstArr` (`T[]`): 비교할 첫 번째 배열.
-- `secondArr` (`T[]`): 비교할 두 번째 배열.
-- `mapper` (`(item: T) => U`): 비교하기 위해 요소를 새로운 값으로 변환할 함수.
+- `secondArr` (`U[]`): 비교할 두 번째 배열.
+- `mapper` (`(item: T | U) => unknown`): 비교하기 위해 요소를 새로운 값으로 변환할 함수.
 
 ### 반환 값
 
@@ -30,6 +30,16 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const mapper = item => item.id;
 const result = intersectionBy(array1, array2, mapper);
 // `mapper`로 변환했을 때 두 배열 모두에 포함되는 요소로 이루어진 [{ id: 2 }] 값이 반환되어요.
+
+const array1 = [
+  { id: 1, name: 'jane' },
+  { id: 2, name: 'amy' },
+  { id: 3, name: 'michael' },
+];
+const array2 = [2, 4];
+const mapper = item => (typeof item === 'object' ? item.id : item);
+const result = intersectionBy(array1, array2, mapper);
+// `mapper`로 변환했을 때 두 배열 모두에 포함되는 요소로 이루어진 [{ id: 2, name: 'amy' }] 값이 반환되어요.
 ```
 
 ## Lodash와의 호환성

--- a/docs/reference/array/differenceBy.md
+++ b/docs/reference/array/differenceBy.md
@@ -10,14 +10,14 @@ mapped, match an element in the mapped version of the second array.
 ## Signature
 
 ```typescript
-function differenceBy<T, U>(firstArr: T[], secondArr: T[], mapper: (value: T) => U): T[];
+function differenceBy<T, U>(firstArr: T[], secondArr: U[], mapper: (value: T | U) => unknown): T[];
 ```
 
 ### Parameters
 
 - `firstArr` (`T[]`): The primary array from which to derive the difference.
-- `secondArr` (`T[]`): The array containing elements to be excluded from the first array.
-- `mapper` (`(value: T) => U`): The function to map the elements of both arrays. This function is applied to each element in both arrays, and the comparison is made based on the mapped values.
+- `secondArr` (`U[]`): The array containing elements to be excluded from the first array.
+- `mapper` (`(value: T | U) => unknown`): The function to map the elements of both arrays. This function is applied to each element in both arrays, and the comparison is made based on the mapped values.
 
 ### Returns
 
@@ -33,4 +33,10 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const mapper = item => item.id;
 const result = differenceBy(array1, array2, mapper);
 // result will be [{ id: 1 }, { id: 3 }, { id: 5 }] since the elements with id 2 are in both arrays and are excluded from the result.
+
+const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+const array2 = [2, 4];
+const mapper = item => (typeof item === 'object' ? item.id : item);
+const result = differenceBy(array1, array2, mapper);
+// result will be [{ id: 1 }, { id: 3 }] since 2 is present in both arrays after mapping, and is excluded from the result.
 ```

--- a/docs/reference/array/differenceWith.md
+++ b/docs/reference/array/differenceWith.md
@@ -9,14 +9,14 @@ if elements are equal is made using the provided custom function.
 ## Signature
 
 ```typescript
-function differenceWith<T>(firstArr: T[], secondArr: T[], areItemsEqual: (x: T, y: T) => boolean): T[];
+function differenceWith<T, U>(firstArr: T[], secondArr: U[], areItemsEqual: (x: T, y: U) => boolean): T[];
 ```
 
 ### Parameters
 
 - `firstArr` (`T[]`): The array from which to get the difference.
-- `secondArr` (`T[]`) :The array containing elements to exclude from the first array.
-- `areItemsEqual` (`(x: T, y: T) => boolean`): A function to determine if two items are equal.
+- `secondArr` (`U[]`) :The array containing elements to exclude from the first array.
+- `areItemsEqual` (`(x: T, y: U) => boolean`): A function to determine if two items are equal.
 
 ### Returns
 
@@ -32,4 +32,10 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const areItemsEqual = (a, b) => a.id === b.id;
 const result = differenceWith(array1, array2, areItemsEqual);
 // result will be [{ id: 1 }, { id: 3 }] since the elements with id 2 are considered equal and are excluded from the result.
+
+const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+const array2 = [2, 4];
+const areItemsEqual = (a, b) => a.id === b;
+const result = differenceWith(array1, array2, areItemsEqual);
+// result will be [{ id: 1 }, { id: 3 }] since the element with id 2 is considered equal to the second array's element and is excluded from the result.
 ```

--- a/docs/reference/array/intersectionBy.md
+++ b/docs/reference/array/intersectionBy.md
@@ -10,14 +10,14 @@ that do not have corresponding mapped values in the second array.
 ## Signature
 
 ```typescript
-function intersectionBy<T, U>(firstArr: T[], secondArr: T[], mapper: (item: T) => U): T[];
+function intersectionBy<T, U>(firstArr: T[], secondArr: U[], mapper: (item: T | U) => unknown): T[];
 ```
 
 ### Parameters
 
 - `firstArr` (`T[]`): The first array to compare.
-- `secondArr` (`T[]`): The second array to compare.
-- `mapper` (`(item: T) => U`): A function to map the elements of both arrays for comparison.
+- `secondArr` (`U[]`): The second array to compare.
+- `mapper` (`(item: T | U) => unknown`): A function to map the elements of both arrays for comparison.
 
 ### Returns
 
@@ -31,6 +31,16 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const mapper = item => item.id;
 const result = intersectionBy(array1, array2, mapper);
 // result will be [{ id: 2 }] since only this element has a matching id in both arrays.
+
+const array1 = [
+  { id: 1, name: 'jane' },
+  { id: 2, name: 'amy' },
+  { id: 3, name: 'michael' },
+];
+const array2 = [2, 4];
+const mapper = item => (typeof item === 'object' ? item.id : item);
+const result = intersectionBy(array1, array2, mapper);
+// result will be [{ id: 2, name: 'amy' }] since only this element has a matching id that is equal to seconds array's element.
 ```
 
 ## Lodash Compatibility

--- a/docs/zh_hans/reference/array/differenceBy.md
+++ b/docs/zh_hans/reference/array/differenceBy.md
@@ -9,14 +9,14 @@
 ## 签名
 
 ```typescript
-function differenceBy<T, U>(firstArr: T[], secondArr: T[], mapper: (value: T) => U): T[];
+function differenceBy<T, U>(firstArr: T[], secondArr: U[], mapper: (value: T | U) => unknown): T[];
 ```
 
 ### 参数
 
 - `firstArr` (`T[]`): 主要的数组，从中计算差异。
-- `secondArr` (`T[]`): 包含要从第一个数组中排除的元素的数组。
-- `mapper` (`(value: T) => U`): 用于映射两个数组元素的函数。该函数应用于两个数组中的每个元素，并基于映射后的值进行比较。
+- `secondArr` (`U[]`): 包含要从第一个数组中排除的元素的数组。
+- `mapper` (`(value: T | U) => unknown`): 用于映射两个数组元素的函数。该函数应用于两个数组中的每个元素，并基于映射后的值进行比较。
 
 ### 返回值
 
@@ -32,4 +32,10 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const mapper = item => item.id;
 const result = differenceBy(array1, array2, mapper);
 // 结果将是 [{ id: 1 }, { id: 3 }, { id: 5 }] 因为具有 id 为 2 的元素在两个数组中都存在，所以它们被排除在结果之外。
+
+const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+const array2 = [2, 4];
+const mapper = item => (typeof item === 'object' ? item.id : item);
+const result = differenceBy(array1, array2, mapper);
+// 结果将是 [{ id: 1 }, { id: 3 }] 因为 2 在映射后存在于两个数组中，所以它被排除在结果之外。
 ```

--- a/docs/zh_hans/reference/array/differenceWith.md
+++ b/docs/zh_hans/reference/array/differenceWith.md
@@ -9,14 +9,14 @@
 ## 签名
 
 ```typescript
-function differenceWith<T>(firstArr: T[], secondArr: T[], areItemsEqual: (x: T, y: T) => boolean): T[];
+function differenceWith<T, U>(firstArr: T[], secondArr: U[], areItemsEqual: (x: T, y: U) => boolean): T[];
 ```
 
 ### 参数
 
 - `firstArr` (`T[]`): 要获取差异的数组。
-- `secondArr` (`T[]`): 包含要从第一个数组中排除的元素的数组。
-- `areItemsEqual` (`(x: T, y: T) => boolean`): 用于确定两个项是否相等的函数。
+- `secondArr` (`U[]`): 包含要从第一个数组中排除的元素的数组。
+- `areItemsEqual` (`(x: T, y: U) => boolean`): 用于确定两个项是否相等的函数。
 
 ### 返回值
 
@@ -32,4 +32,10 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const areItemsEqual = (a, b) => a.id === b.id;
 const result = differenceWith(array1, array2, areItemsEqual);
 // 结果将是 [{ id: 1 }, { id: 3 }] 因为具有 id 为 2 的元素被认为是相等的，因此被排除在结果之外。
+
+const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+const array2 = [2, 4];
+const areItemsEqual = (a, b) => a.id === b;
+const result = differenceWith(array1, array2, areItemsEqual);
+// 结果将是 [{ id: 1 }, { id: 3 }] 因为具有 id 为 2 的元素被认为与第二个数组的元素相等，因此被排除在结果之外。
 ```

--- a/docs/zh_hans/reference/array/intersectionBy.md
+++ b/docs/zh_hans/reference/array/intersectionBy.md
@@ -9,14 +9,14 @@
 ## 签名
 
 ```typescript
-function intersectionBy<T, U>(firstArr: T[], secondArr: T[], mapper: (item: T) => U): T[];
+function intersectionBy<T, U>(firstArr: T[], secondArr: U[], mapper: (item: T | U) => unknown): T[];
 ```
 
 ### 参数
 
 - `firstArr` (`T[]`): 要比较的第一个数组。
-- `secondArr` (`T[]`): 要比较的第二个数组。
-- `mapper` (`(item: T) => U`): 用于映射两个数组元素以进行比较的函数。
+- `secondArr` (`U[]`): 要比较的第二个数组。
+- `mapper` (`(item: T | U) => unknown`): 用于映射两个数组元素以进行比较的函数。
 
 ### 返回值
 
@@ -30,6 +30,16 @@ const array2 = [{ id: 2 }, { id: 4 }];
 const mapper = item => item.id;
 const result = intersectionBy(array1, array2, mapper);
 // 结果将是 [{ id: 2 }] 因为只有这个元素在两个数组中具有匹配的 id。
+
+const array1 = [
+  { id: 1, name: 'jane' },
+  { id: 2, name: 'amy' },
+  { id: 3, name: 'michael' },
+];
+const array2 = [2, 4];
+const mapper = item => (typeof item === 'object' ? item.id : item);
+const result = intersectionBy(array1, array2, mapper);
+// 结果将是 [{ id: 2, name: 'amy' }] 因为只有这个元素具有与第二个数组元素相等的匹配 id。
 ```
 
 ## Lodash 兼容性

--- a/src/array/differenceBy.spec.ts
+++ b/src/array/differenceBy.spec.ts
@@ -6,4 +6,25 @@ describe('differenceBy', () => {
     expect(differenceBy([1.2, 2.3, 3.4], [1.2], Math.floor)).toEqual([2.3, 3.4]);
     expect(differenceBy([], [1.2], Math.floor)).toEqual([]);
   });
+
+  it('should return the difference of two arrays with different element types using the `mapper` function', () => {
+    type CSV = { id: number; csv: number };
+    type JSON = { id: number; json: number };
+
+    const array1: CSV[] = [
+      { id: 1, csv: 1 },
+      { id: 2, csv: 1 },
+      { id: 3, csv: 1 },
+    ];
+    const array2: JSON[] = [
+      { id: 2, json: 2 },
+      { id: 4, json: 2 },
+    ];
+
+    const result = differenceBy(array1, array2, value => value.id);
+    expect(result).toEqual([
+      { id: 1, csv: 1 },
+      { id: 3, csv: 1 },
+    ]);
+  });
 });

--- a/src/array/differenceBy.ts
+++ b/src/array/differenceBy.ts
@@ -10,8 +10,8 @@
  *
  * @template T, U
  * @param {T[]} firstArr - The primary array from which to derive the difference.
- * @param {T[]} secondArr - The array containing elements to be excluded from the first array.
- * @param {(value: T) => U} mapper - The function to map the elements of both arrays. This function
+ * @param {U[]} secondArr - The array containing elements to be excluded from the first array.
+ * @param {(value: T | U) => unknown} mapper - The function to map the elements of both arrays. This function
  * is applied to each element in both arrays, and the comparison is made based on the mapped values.
  * @returns {T[]} A new array containing the elements from the first array that do not have a corresponding
  * mapped identity in the second array.
@@ -22,8 +22,19 @@
  * const mapper = item => item.id;
  * const result = differenceBy(array1, array2, mapper);
  * // result will be [{ id: 1 }, { id: 3 }] since the elements with id 2 are in both arrays and are excluded from the result.
+ *
+ * @example
+ * const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+ * const array2 = [2, 4];
+ * const mapper = item => (typeof item === 'object' ? item.id : item);
+ * const result = differenceBy(array1, array2, mapper);
+ * // result will be [{ id: 1 }, { id: 3 }] since 2 is present in both arrays after mapping, and is excluded from the result.
  */
-export function differenceBy<T, U>(firstArr: readonly T[], secondArr: readonly T[], mapper: (value: T) => U): T[] {
+export function differenceBy<T, U>(
+  firstArr: readonly T[],
+  secondArr: readonly U[],
+  mapper: (value: T | U) => unknown
+): T[] {
   const mappedSecondSet = new Set(secondArr.map(item => mapper(item)));
 
   return firstArr.filter(item => {

--- a/src/array/differenceWith.spec.ts
+++ b/src/array/differenceWith.spec.ts
@@ -11,6 +11,27 @@ describe('differenceWith', () => {
     expect(differenceWith(array1, array2, (a, b) => a.id === b.id)).toEqual([{ id: 1 }, { id: 3 }]);
   });
 
+  it('should return the difference of two arrays with different element types using the `areItemsEqual` function', () => {
+    type CSV = { id: number; csv: number };
+    type JSON = { id: number; json: number };
+
+    const array1: CSV[] = [
+      { id: 1, csv: 1 },
+      { id: 2, csv: 1 },
+      { id: 3, csv: 1 },
+    ];
+    const array2: JSON[] = [
+      { id: 2, json: 2 },
+      { id: 4, json: 2 },
+    ];
+
+    const result = differenceWith(array1, array2, (a, b) => a.id === b.id);
+    expect(result).toEqual([
+      { id: 1, csv: 1 },
+      { id: 3, csv: 1 },
+    ]);
+  });
+
   it('should handle duplicate elements correctly', () => {
     expect(differenceWith([1, 1, 2, 2, 3], [2], (a, b) => a === b)).toEqual([1, 1, 3]);
   });

--- a/src/array/differenceWith.ts
+++ b/src/array/differenceWith.ts
@@ -5,10 +5,10 @@
  * the elements that are present in the first array but not in the second array. The comparison to determine
  * if elements are equal is made using the provided custom function.
  *
- * @template T
+ * @template T, U
  * @param {T[]} firstArr - The array from which to get the difference.
- * @param {T[]} secondArr - The array containing elements to exclude from the first array.
- * @param {(x: T, y: T) => boolean} areItemsEqual - A function to determine if two items are equal.
+ * @param {U[]} secondArr - The array containing elements to exclude from the first array.
+ * @param {(x: T, y: U) => boolean} areItemsEqual - A function to determine if two items are equal.
  * @returns {T[]} A new array containing the elements from the first array that do not match any elements in the second array
  * according to the custom equality function.
  *
@@ -18,11 +18,18 @@
  * const areItemsEqual = (a, b) => a.id === b.id;
  * const result = differenceWith(array1, array2, areItemsEqual);
  * // result will be [{ id: 1 }, { id: 3 }] since the elements with id 2 are considered equal and are excluded from the result.
+ *
+ * @example
+ * const array1 = [{ id: 1 }, { id: 2 }, { id: 3 }];
+ * const array2 = [2, 4];
+ * const areItemsEqual = (a, b) => a.id === b;
+ * const result = differenceWith(array1, array2, areItemsEqual);
+ * // result will be [{ id: 1 }, { id: 3 }] since the element with id 2 is considered equal to the second array's element and is excluded from the result.
  */
-export function differenceWith<T>(
+export function differenceWith<T, U>(
   firstArr: readonly T[],
-  secondArr: readonly T[],
-  areItemsEqual: (x: T, y: T) => boolean
+  secondArr: readonly U[],
+  areItemsEqual: (x: T, y: U) => boolean
 ): T[] {
   return firstArr.filter(firstItem => {
     return secondArr.every(secondItem => {

--- a/src/array/intersectionBy.spec.ts
+++ b/src/array/intersectionBy.spec.ts
@@ -6,4 +6,22 @@ describe('intersectionBy', () => {
     expect(intersectionBy([1.2, 2.1], [1.4, 3.1], Math.floor)).toStrictEqual([1.2]);
     expect(intersectionBy([{ foo: 1 }, { foo: 2 }], [{ foo: 1 }, { foo: 3 }], x => x.foo)).toStrictEqual([{ foo: 1 }]);
   });
+
+  it('should return the intersection of two arrays with different element types using a `mapper` function', () => {
+    type CSV = { id: number; csv: number };
+    type JSON = { id: number; json: number };
+
+    const array1: CSV[] = [
+      { id: 1, csv: 1 },
+      { id: 2, csv: 1 },
+      { id: 3, csv: 1 },
+    ];
+    const array2: JSON[] = [
+      { id: 2, json: 2 },
+      { id: 4, json: 2 },
+    ];
+
+    const result = intersectionBy(array1, array2, value => value.id);
+    expect(result).toEqual([{ id: 2, csv: 1 }]);
+  });
 });

--- a/src/array/intersectionBy.ts
+++ b/src/array/intersectionBy.ts
@@ -6,11 +6,11 @@
  * mapped elements in the second array. It effectively filters out any elements from the first array
  * that do not have corresponding mapped values in the second array.
  *
- * @template T - The type of elements in the array.
- * @template U - The type of mapped elements.
+ * @template T - The type of elements in the first array.
+ * @template U - The type of elements in the second array.
  * @param {T[]} firstArr - The first array to compare.
- * @param {T[]} secondArr - The second array to compare.
- * @param {(item: T) => U} mapper - A function to map the elements of both arrays for comparison.
+ * @param {U[]} secondArr - The second array to compare.
+ * @param {(item: T | U) => unknown} mapper - A function to map the elements of both arrays for comparison.
  * @returns {T[]} A new array containing the elements from the first array that have corresponding mapped values in the second array.
  *
  * @example
@@ -19,8 +19,23 @@
  * const mapper = item => item.id;
  * const result = intersectionBy(array1, array2, mapper);
  * // result will be [{ id: 2 }] since only this element has a matching id in both arrays.
+ *
+ * @example
+ * const array1 = [
+ *   { id: 1, name: 'jane' },
+ *   { id: 2, name: 'amy' },
+ *   { id: 3, name: 'michael' },
+ * ];
+ * const array2 = [2, 4];
+ * const mapper = item => (typeof item === 'object' ? item.id : item);
+ * const result = intersectionBy(array1, array2, mapper);
+ * // result will be [{ id: 2, name: 'amy' }] since only this element has a matching id that is equal to seconds array's element.
  */
-export function intersectionBy<T, U>(firstArr: readonly T[], secondArr: readonly T[], mapper: (item: T) => U): T[] {
+export function intersectionBy<T, U>(
+  firstArr: readonly T[],
+  secondArr: readonly U[],
+  mapper: (item: T | U) => unknown
+): T[] {
   const mappedSecondSet = new Set(secondArr.map(mapper));
   return firstArr.filter(item => mappedSecondSet.has(mapper(item)));
 }


### PR DESCRIPTION
I think #819 hasn’t been fixed yet.
`intersectionBy`, `differenceWith`, and `differenceBy` should also support arrays with different element types.