### PR TITLE
fix(toArray): simplify impl

### DIFF
--- a/src/compat/util/toArray.ts
+++ b/src/compat/util/toArray.ts
@@ -23,10 +23,6 @@ export function toArray(value?: unknown): any[] {
     return Array.from(value);
   }
 
-  if (typeof value === 'string') {
-    return value.split('');
-  }
-
   if (typeof value === 'object') {
     return Object.values(value);
   }


### PR DESCRIPTION
In fact, isArrayLike already overrides the string case