### PR TITLE
fix(stubObject): Update return type to `Record<PropertyKey, never>`

### DIFF
--- a/docs/ja/reference/compat/util/stubObject.md
+++ b/docs/ja/reference/compat/util/stubObject.md
@@ -11,12 +11,12 @@
 ## インターフェース
 
 ```typescript
-function stubObject(): {};
+function stubObject(): Record<PropertyKey, never>;
 ```
 
 ### 戻り値
 
-(`Object`): 空のオブジェクト。
+(`Record<PropertyKey, never>`): 空のオブジェクト。
 
 ## 例
 

--- a/docs/ko/reference/compat/util/stubObject.md
+++ b/docs/ko/reference/compat/util/stubObject.md
@@ -11,12 +11,12 @@
 ## 인터페이스
 
 ```typescript
-function stubObject(): {};
+function stubObject(): Record<PropertyKey, never>;
 ```
 
 ### 반환 값
 
-(`{}`): 빈 객체.
+(`Record<PropertyKey, never>`): 빈 객체.
 
 ## 예시
 

--- a/docs/reference/compat/util/stubObject.md
+++ b/docs/reference/compat/util/stubObject.md
@@ -11,12 +11,12 @@ Returns an empty object.
 ## Signature
 
 ```typescript
-function stubObject(): {};
+function stubObject(): Record<PropertyKey, never>;
 ```
 
 ### Returns
 
-(`{}`): An empty object.
+(`Record<PropertyKey, never>`): An empty object.
 
 ## Examples
 

--- a/docs/zh_hans/reference/compat/util/stubObject.md
+++ b/docs/zh_hans/reference/compat/util/stubObject.md
@@ -11,12 +11,12 @@
 ## 签名
 
 ```typescript
-function stubObject(): {};
+function stubObject(): Record<PropertyKey, never>;
 ```
 
 ### 返回值
 
-(`{}`): 一个空对象。
+(`Record<PropertyKey, never>`): 一个空对象。
 
 ## 示例
 

--- a/src/compat/util/stubObject.ts
+++ b/src/compat/util/stubObject.ts
@@ -1,10 +1,10 @@
 /**
  * Returns an empty object.
  *
- * @returns {Object} An empty object.
+ * @returns {Record<PropertyKey, never>} An empty object.
  * @example
  * stubObject() // Returns {}
  */
-export function stubObject(): {} {
+export function stubObject(): Record<PropertyKey, never> {
   return {};
 }


### PR DESCRIPTION
I believe the return type of `stubObject` would be more accurately represented as `Record<PropertyKey, never>`, as this clearly indicates an empty object. Using `{}` in TypeScript might confuse since it represents a non-nullable value (equal to `NonNullable<unknown>`) rather than specifically an empty object.