### PR TITLE
docs: Remove unnecessary readonly keywords

### DIFF
--- a/docs/ja/reference/compat/array/castArray.md
+++ b/docs/ja/reference/compat/array/castArray.md
@@ -16,7 +16,7 @@ function castArray<T>(value?: T | T[]): T[];
 
 ### パラメータ
 
-- `value` (`T | readonly T[]`): 配列にキャストされる値。
+- `value` (`T | T[]`): 配列にキャストされる値。
 
 ### 戻り値
 

--- a/docs/ja/reference/compat/object/get.md
+++ b/docs/ja/reference/compat/object/get.md
@@ -82,7 +82,7 @@ function get<T, P extends string, D = Get<T, P>>(
 ): Exclude<Get<T, P>, null | undefined> | D;
 
 function get(object: unknown, path: PropertyKey, defaultValue?: unknown): any;
-function get(object: unknown, path: PropertyKey | readonly PropertyKey[], defaultValue?: unknown): any;
+function get(object: unknown, path: PropertyKey | PropertyKey[], defaultValue?: unknown): any;
 ```
 
 ### パラメータ

--- a/docs/ja/reference/compat/object/property.md
+++ b/docs/ja/reference/compat/object/property.md
@@ -11,7 +11,7 @@
 ## インターフェース
 
 ```typescript
-function property(path: PropertyKey | readonly PropertyKey[]): (object: unknown) => any;
+function property(path: PropertyKey | PropertyKey[]): (object: unknown) => any;
 ```
 
 ### パラメータ

--- a/docs/ko/reference/compat/array/castArray.md
+++ b/docs/ko/reference/compat/array/castArray.md
@@ -11,12 +11,12 @@
 ## 인터페이스
 
 ```typescript
-function castArray<T>(value?: T | readonly T[]): T[];
+function castArray<T>(value?: T | T[]): T[];
 ```
 
 ### 파라미터
 
-- `value` (`T | readonly T[]`): 배열로 변환할 값.
+- `value` (`T | T[]`): 배열로 변환할 값.
 
 ### 반환 값
 

--- a/docs/ko/reference/compat/object/get.md
+++ b/docs/ko/reference/compat/object/get.md
@@ -82,7 +82,7 @@ function get<T, P extends string, D = Get<T, P>>(
 ): Exclude<Get<T, P>, null | undefined> | D;
 
 function get(object: unknown, path: PropertyKey, defaultValue?: unknown): any;
-function get(object: unknown, path: PropertyKey | readonly PropertyKey[], defaultValue?: unknown): any;
+function get(object: unknown, path: PropertyKey | PropertyKey[], defaultValue?: unknown): any;
 ```
 
 ### 파라미터

--- a/docs/ko/reference/compat/object/property.md
+++ b/docs/ko/reference/compat/object/property.md
@@ -11,7 +11,7 @@
 ## 인터페이스
 
 ```typescript
-function property(path: PropertyKey | readonly PropertyKey[]): (object: unknown) => any;
+function property(path: PropertyKey | PropertyKey[]): (object: unknown) => any;
 ```
 
 ### 파라미터


### PR DESCRIPTION
Although there is 'readonly' in the actual interface, it appears to be the overall writing guideline of es-toolkit to omit 'readonly' from arguments and return types when describing method interfaces in the docs. However, I found and fixed inconsistencies in several functions where this wasn't followed.