### PR TITLE
fix(groupBy): preserve Object prototype method

### DIFF
--- a/src/array/groupBy.spec.ts
+++ b/src/array/groupBy.spec.ts
@@ -46,6 +46,21 @@ describe('groupBy', () => {
     });
   });
 
+  it('should preserve Object prototype', () => {
+    const array = [
+      { category: 'fruit', name: 'apple' },
+      { category: 'fruit', name: 'banana' },
+    ]
+    const result = groupBy(array, item => item.category)
+    
+    expect('toString' in result).toBeTruthy()
+    expect(typeof result.toString).toBe('function')
+    expect(result.fruit).toEqual([
+      { category: 'fruit', name: 'apple' },
+      { category: 'fruit', name: 'banana' },
+    ])
+  })
+
   it('should handle an empty array', () => {
     const array: Array<{ category: string; name: string }> = [];
 

--- a/src/array/groupBy.spec.ts
+++ b/src/array/groupBy.spec.ts
@@ -50,16 +50,16 @@ describe('groupBy', () => {
     const array = [
       { category: 'fruit', name: 'apple' },
       { category: 'fruit', name: 'banana' },
-    ]
-    const result = groupBy(array, item => item.category)
-    
-    expect('toString' in result).toBeTruthy()
-    expect(typeof result.toString).toBe('function')
+    ];
+    const result = groupBy(array, item => item.category);
+
+    expect('toString' in result).toBeTruthy();
+    expect(typeof result.toString).toBe('function');
     expect(result.fruit).toEqual([
       { category: 'fruit', name: 'apple' },
       { category: 'fruit', name: 'banana' },
-    ])
-  })
+    ]);
+  });
 
   it('should handle an empty array', () => {
     const array: Array<{ category: string; name: string }> = [];

--- a/src/array/groupBy.spec.ts
+++ b/src/array/groupBy.spec.ts
@@ -46,21 +46,6 @@ describe('groupBy', () => {
     });
   });
 
-  it('should preserve Object prototype', () => {
-    const array = [
-      { category: 'fruit', name: 'apple' },
-      { category: 'fruit', name: 'banana' },
-    ];
-    const result = groupBy(array, item => item.category);
-
-    expect('toString' in result).toBeTruthy();
-    expect(typeof result.toString).toBe('function');
-    expect(result.fruit).toEqual([
-      { category: 'fruit', name: 'apple' },
-      { category: 'fruit', name: 'banana' },
-    ]);
-  });
-
   it('should handle an empty array', () => {
     const array: Array<{ category: string; name: string }> = [];
 

--- a/src/array/groupBy.ts
+++ b/src/array/groupBy.ts
@@ -31,13 +31,13 @@
  * // }
  */
 export function groupBy<T, K extends PropertyKey>(arr: readonly T[], getKeyFromItem: (item: T) => K): Record<K, T[]> {
-  const result = Object.create({}) as Record<K, T[]>;
+  const result = {} as Record<K, T[]>;
 
   for (let i = 0; i < arr.length; i++) {
     const item = arr[i];
     const key = getKeyFromItem(item);
 
-    if (!Array.isArray(result[key])) {
+    if (result[key] == null) {
       result[key] = [];
     }
 

--- a/src/array/groupBy.ts
+++ b/src/array/groupBy.ts
@@ -31,13 +31,13 @@
  * // }
  */
 export function groupBy<T, K extends PropertyKey>(arr: readonly T[], getKeyFromItem: (item: T) => K): Record<K, T[]> {
-  const result = Object.create(null) as Record<K, T[]>;
+  const result = Object.create({}) as Record<K, T[]>;
 
   for (let i = 0; i < arr.length; i++) {
     const item = arr[i];
     const key = getKeyFromItem(item);
 
-    if (result[key] == null) {
+    if (!Array.isArray(result[key])) {
       result[key] = [];
     }
 


### PR DESCRIPTION
## What this PR solves
- Fix the `groupBy` function to properly preserve Object prototype (like `toString`, `valueOf`).

## Motivation
While implementing "[fix(groupBy): Support keys like toString or valueOf in groupBy](https://github.com/toss/es-toolkit/commit/1f336b045692e06f852c9b87064a3ae8c5577c7c#diff-636dea33563199f80586e9579e588a6bd655799bd2e43fbed0d3a13ed9286468R27)", we noticed that prototype methods were removed entirely. This is likely unintended behavior unless the user specifically uses these method names as keys.

For example, even when not using 'toString' as a grouping key, attempting to convert the result object to a string would fail:
```typescript
const data = [{ category: 'fruit', name: 'apple' }];
const result = groupBy(data, item => item.category);

// This throws TypeError: Cannot convert object to primitive value
String(result);
```

