### PR TITLE
fix(reverse): Export reverse from compat barrel file

### DIFF
--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -59,6 +59,7 @@ export { map } from './array/map.ts';
 export { nth } from './array/nth.ts';
 export { orderBy } from './array/orderBy.ts';
 export { pull } from './array/pull.ts';
+export { reverse } from './array/reverse.ts';
 export { sample } from './array/sample.ts';
 export { size } from './array/size.ts';
 export { slice } from './array/slice.ts';


### PR DESCRIPTION
Upgraded to `v1.30.1` and saw the changelog saying that `reverse` was now available in `es-toolkit/compat`. However, when I went to use it, I got the following error:

```
 "reverse" is not exported by "../../node_modules/es-toolkit/dist/compat/index.mjs", imported by "src/components/..."
```