### PR TITLE
perf(pull): faster `pull`

### DIFF
--- a/benchmarks/performance/pull.bench.ts
+++ b/benchmarks/performance/pull.bench.ts
@@ -1,0 +1,42 @@
+import { bench, describe } from 'vitest';
+import { pull as pullToolkit } from 'es-toolkit/compat';
+import { pull as pullLodash } from 'lodash';
+
+describe('pull array size 100', () => {
+  const array = [...Array(100)].map((_, i) => i);
+  const even = [...Array(50)].map((_, i) => i * 2);
+
+  bench('es-toolkit/pull', () => {
+    pullToolkit([...array], even);
+  });
+
+  bench('lodash/pull', () => {
+    pullLodash([...array], ...even);
+  });
+});
+
+describe('pull array size 1000', () => {
+  const array = [...Array(1000)].map((_, i) => i);
+  const even = [...Array(500)].map((_, i) => i * 2);
+
+  bench('es-toolkit/pull', () => {
+    pullToolkit([...array], [...even]);
+  });
+
+  bench('lodash/pull', () => {
+    pullLodash([...array], ...even);
+  });
+});
+
+describe('pull array size 10000', () => {
+  const array = [...Array(10000)].map((_, i) => i);
+  const even = [...Array(5000)].map((_, i) => i * 2);
+
+  bench('es-toolkit/pull', () => {
+    pullToolkit([...array], [...even]);
+  });
+
+  bench('lodash/pull', () => {
+    pullLodash([...array], ...even);
+  });
+});

--- a/src/array/pull.ts
+++ b/src/array/pull.ts
@@ -16,12 +16,20 @@
  */
 export function pull<T>(arr: T[], valuesToRemove: readonly unknown[]): T[] {
   const valuesSet = new Set(valuesToRemove);
+  let resultIndex = 0;
 
-  for (let i = arr.length - 1; i >= 0; i--) {
-    if (valuesSet.has(arr[i])) {
-      arr.splice(i, 1);
+  for (let i = 0; i < arr.length; i++) {
+    if (valuesSet.has(arr[i])) continue;
+
+    if (!(i in arr)) {
+      delete arr[resultIndex++];
+      continue;
     }
+
+    arr[resultIndex++] = arr[i];
   }
+
+  arr.length = resultIndex;
 
   return arr;
 }

--- a/src/array/pull.ts
+++ b/src/array/pull.ts
@@ -23,7 +23,8 @@ export function pull<T>(arr: T[], valuesToRemove: readonly unknown[]): T[] {
       continue;
     }
 
-    if (!(i in arr)) {
+    // For handling sparse arrays
+    if (!Object.hasOwn(arr, i)) {
       delete arr[resultIndex++];
       continue;
     }

--- a/src/array/pull.ts
+++ b/src/array/pull.ts
@@ -19,7 +19,9 @@ export function pull<T>(arr: T[], valuesToRemove: readonly unknown[]): T[] {
   let resultIndex = 0;
 
   for (let i = 0; i < arr.length; i++) {
-    if (valuesSet.has(arr[i])) continue;
+    if (valuesSet.has(arr[i])) {
+      continue;
+    }
 
     if (!(i in arr)) {
       delete arr[resultIndex++];


### PR DESCRIPTION
Reduce time complexity of `pull` from O($n^2$) to O(n).

Benchmark with lodash: 
![pull-after](https://github.com/user-attachments/assets/da0d1c68-36e0-4fdc-b975-bb0dafc66f8c)


Benchmark with old implementation: https://stackblitz.com/edit/vitest-dev-vitest-1rmnz8?file=pull.bench.ts