### PR TITLE
feat(isFiniteNumber): add `isFiniteNumber`

### DIFF
--- a/docs/ko/reference/predicate/isFiniteNumber.md
+++ b/docs/ko/reference/predicate/isFiniteNumber.md
@@ -1,0 +1,43 @@
+# isFiniteNumber
+
+주어진 값이 유한한 숫자인지 확인해요.
+
+유한한 숫자란, `Infinity`, `-Infinity`, `NaN`이 아닌 숫자를 말해요.
+
+TypeScript의 타입 가드로 사용할 수 있어요. 파라미터로 주어진 값의 타입을 `number`로 좁혀요.
+
+## 인터페이스
+
+```typescript
+function isFiniteNumber(value: unknown): value is number;
+```
+
+### 파라미터
+
+- `value` (`unknown`): 유효한 길이인지 확인할 값.
+
+### 반환 값
+
+(`value is number`): 값이 유한한 숫자이면 `true`, 아니면 `false`.
+
+## 예시
+
+```typescript
+import { isFiniteNumber } from 'es-toolkit/predicate';
+
+const value1 = 42;
+const value2 = -42;
+const value3 = Infinity;
+const value4 = -Infinity;
+const value5 = NaN;
+const value6 = 'string';
+const value7 = {};
+
+console.log(isFiniteNumber(value1)); // true
+console.log(isFiniteNumber(value2)); // true
+console.log(isFiniteNumber(value3)); // false
+console.log(isFiniteNumber(value4)); // false
+console.log(isFiniteNumber(value5)); // false
+console.log(isFiniteNumber(value6)); // false
+console.log(isFiniteNumber(value7)); // false
+```

--- a/docs/reference/predicate/isFiniteNumber.md
+++ b/docs/reference/predicate/isFiniteNumber.md
@@ -1,0 +1,41 @@
+# isFiniteNumber
+
+Checks if a given value is a finite number.
+A finite number is a number that is not `Infinity`, `-Infinity`, or `NaN`.
+You can use it as a TypeScript type guard, narrowing the type of the parameter to `number`.
+
+## Interface
+
+```typescript
+function isFiniteNumber(value: unknown): value is number;
+```
+
+### Parameters
+
+- `value` (`unknown`): The value to check if it is a finite number.
+
+### Returns
+
+(`value is number`): Returns `true` if the value is a finite number; otherwise, `false`.
+
+## Examples
+
+```typescript
+import { isFiniteNumber } from 'es-toolkit/predicate';
+
+const value1 = 42;
+const value2 = -42;
+const value3 = Infinity;
+const value4 = -Infinity;
+const value5 = NaN;
+const value6 = 'string';
+const value7 = {};
+
+console.log(isFiniteNumber(value1)); // true
+console.log(isFiniteNumber(value2)); // true
+console.log(isFiniteNumber(value3)); // false
+console.log(isFiniteNumber(value4)); // false
+console.log(isFiniteNumber(value5)); // false
+console.log(isFiniteNumber(value6)); // false
+console.log(isFiniteNumber(value7)); // false
+```

--- a/src/predicate/isFiniteNumber.spec.ts
+++ b/src/predicate/isFiniteNumber.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { isFiniteNumber } from './isFiniteNumber';
+
+describe('isFiniteNumber', () => {
+  it('should return `true` for finite numbers', () => {
+    const values = [
+      0,
+      42,
+      -1,
+      3.14,
+      Number.MAX_SAFE_INTEGER,
+      Number.MIN_SAFE_INTEGER
+    ];
+    const expected = values.map(() => true);
+    const actual = values.map(isFiniteNumber);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return `false` for non-finite numbers and other types', () => {
+    const values = [
+      Infinity,
+      -Infinity,
+      NaN,
+      '42',
+      null,
+      undefined,
+      {},
+      [],
+      true,
+      false
+    ];
+    const expected = values.map(() => false);
+    const actual = values.map(isFiniteNumber);
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/predicate/isFiniteNumber.spec.ts
+++ b/src/predicate/isFiniteNumber.spec.ts
@@ -3,14 +3,7 @@ import { isFiniteNumber } from './isFiniteNumber';
 
 describe('isFiniteNumber', () => {
   it('should return `true` for finite numbers', () => {
-    const values = [
-      0,
-      42,
-      -1,
-      3.14,
-      Number.MAX_SAFE_INTEGER,
-      Number.MIN_SAFE_INTEGER
-    ];
+    const values = [0, 42, -1, 3.14, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER];
     const expected = values.map(() => true);
     const actual = values.map(isFiniteNumber);
 
@@ -18,18 +11,7 @@ describe('isFiniteNumber', () => {
   });
 
   it('should return `false` for non-finite numbers and other types', () => {
-    const values = [
-      Infinity,
-      -Infinity,
-      NaN,
-      '42',
-      null,
-      undefined,
-      {},
-      [],
-      true,
-      false
-    ];
+    const values = [Infinity, -Infinity, NaN, '42', null, undefined, {}, [], true, false];
     const expected = values.map(() => false);
     const actual = values.map(isFiniteNumber);
 

--- a/src/predicate/isFiniteNumber.ts
+++ b/src/predicate/isFiniteNumber.ts
@@ -16,6 +16,5 @@
  * isFiniteNumber('string'); // false
  */
 export function isFiniteNumber(value: unknown): value is number {
-    return typeof value === 'number' && isFinite(value);
-  }
-  
+  return typeof value === 'number' && isFinite(value);
+}

--- a/src/predicate/isFiniteNumber.ts
+++ b/src/predicate/isFiniteNumber.ts
@@ -1,0 +1,21 @@
+/**
+ * Checks if the given value is a finite number.
+ *
+ * This function tests whether the provided value is a finite number.
+ * It returns `true` if the value is a finite number, and `false` otherwise.
+ * The function also serves as a type predicate in TypeScript, narrowing the type of the argument to `number`.
+ *
+ * @param {unknown} value The value to check.
+ * @returns {boolean} if the value is a finite number, `false` otherwise.
+ *
+ * @example
+ * isFiniteNumber(42); // true
+ * isFiniteNumber(Infinity); // false
+ * isFiniteNumber(-Infinity); // false
+ * isFiniteNumber(NaN); // false
+ * isFiniteNumber('string'); // false
+ */
+export function isFiniteNumber(value: unknown): value is number {
+    return typeof value === 'number' && isFinite(value);
+  }
+  


### PR DESCRIPTION
# Add isFiniteNumber utility function

## Summary
Added a new utility function `isFiniteNumber` that checks if a given value is a finite number. This function also acts as a TypeScript type predicate, helping with type narrowing in TypeScript code.

## Implementation Details
- Function takes any value (`unknown` type) as input
- Returns `boolean` indicating if the value is a finite number
- Implements type predicate functionality (`value is number`)
- Uses native `typeof` and `isFinite` checks

## Usage Examples
```typescript
import { isFiniteNumber } from '@utils/number';

// Regular numbers
isFiniteNumber(42)        // true
isFiniteNumber(-123.45)   // true

// Special number values
isFiniteNumber(Infinity)  // false
isFiniteNumber(-Infinity) // false
isFiniteNumber(NaN)      // false

// Non-number values
isFiniteNumber('123')     // false
isFiniteNumber(null)      // false
isFiniteNumber(undefined) // false