### PR TITLE
(feature) Add Custom Delimiter Support to flattenObject Utility

### DIFF
--- a/docs/ja/reference/object/flattenObject.md
+++ b/docs/ja/reference/object/flattenObject.md
@@ -8,12 +8,13 @@
 ## インターフェース
 
 ```typescript
-function flattenObject(object: object): Record<string, any>;
+function flattenObject(object: object, delimiter = '.'): Record<string, any>;
 ```
 
 ### パラメータ
 
 - `object` (`object`): 平坦化するオブジェクト。
+- `delimiter` (`string`): ネストされたキーの区切り文字。
 
 ### 戻り値
 
@@ -38,5 +39,16 @@ console.log(flattened);
 //   'a.b.c': 1,
 //   'd.0': 2,
 //   'd.1': 3
+// }
+```
+
+```typescript
+const flattened = flattenObject(nestedObject, '/');
+console.log(flattened);
+// 出力:
+// {
+//   'a/b/c': 1,
+//   'd/0': 2,
+//   'd/1': 3
 // }
 ```

--- a/docs/ja/reference/object/flattenObject.md
+++ b/docs/ja/reference/object/flattenObject.md
@@ -8,13 +8,13 @@
 ## インターフェース
 
 ```typescript
-function flattenObject(object: object, delimiter = '.'): Record<string, any>;
+function flattenObject(object: object, { delimiter = '.' }: FlattenObjectOptions = {}): Record<string, any>;
 ```
 
 ### パラメータ
 
 - `object` (`object`): 平坦化するオブジェクト。
-- `delimiter` (`string`): ネストされたキーの区切り文字。
+- `delimiter` (`string`): ネストされたキーの区切り文字。デフォルトは `'.'`。
 
 ### 戻り値
 
@@ -43,7 +43,7 @@ console.log(flattened);
 ```
 
 ```typescript
-const flattened = flattenObject(nestedObject, '/');
+const flattened = flattenObject(nestedObject, { delimiter: '/' });
 console.log(flattened);
 // 出力:
 // {

--- a/docs/ko/reference/object/flattenObject.md
+++ b/docs/ko/reference/object/flattenObject.md
@@ -8,12 +8,13 @@
 ## 인터페이스
 
 ```typescript
-function flattenObject(object: object): Record<string, any>;
+function flattenObject(object: object, delimiter = '.'): Record<string, any>;
 ```
 
 ### 파라미터
 
 - `object` (`object`): 평탄화할 객체.
+- `delimiter` (`string`): 네스팅된 키의 구분자.
 
 ### 반환 값
 
@@ -38,5 +39,16 @@ console.log(flattened);
 //   'a.b.c': 1,
 //   'd.0': 2,
 //   'd.1': 3
+// }
+```
+
+```typescript
+const flattened = flattenObject(nestedObject, '/');
+console.log(flattened);
+// Output:
+// {
+//   'a/b/c': 1,
+//   'd/0': 2,
+//   'd/1': 3
 // }
 ```

--- a/docs/ko/reference/object/flattenObject.md
+++ b/docs/ko/reference/object/flattenObject.md
@@ -8,13 +8,13 @@
 ## 인터페이스
 
 ```typescript
-function flattenObject(object: object, delimiter = '.'): Record<string, any>;
+function flattenObject(object: object, { delimiter = '.' }: FlattenObjectOptions = {}): Record<string, any>;
 ```
 
 ### 파라미터
 
 - `object` (`object`): 평탄화할 객체.
-- `delimiter` (`string`): 네스팅된 키의 구분자.
+- `delimiter` (`string`): 중첩된 키의 구분자. 기본값은 `.`.
 
 ### 반환 값
 
@@ -43,7 +43,7 @@ console.log(flattened);
 ```
 
 ```typescript
-const flattened = flattenObject(nestedObject, '/');
+const flattened = flattenObject(nestedObject, { delimiter: '/' });
 console.log(flattened);
 // Output:
 // {

--- a/docs/reference/object/flattenObject.md
+++ b/docs/reference/object/flattenObject.md
@@ -8,13 +8,13 @@ Flattens a nested object into a single-level object with dot-separated keys.
 ## Signature
 
 ```typescript
-function flattenObject(object: object, delimiter = '.'): Record<string, any>;
+function flattenObject(object: object, { delimiter = '.' }: FlattenObjectOptions = {}): Record<string, any>;
 ```
 
 ### Parameters
 
 - `object` (`object`): The object to flatten.
-- `delimiter` (`string`): The delimiter to use between nested keys.
+- `delimiter` (`string`): The delimiter to use between nested keys. Defaults to `'.'`.
 
 ### Returns
 
@@ -43,7 +43,7 @@ console.log(flattened);
 ```
 
 ```typescript
-const flattened = flattenObject(nestedObject, '/');
+const flattened = flattenObject(nestedObject, { delimiter: '/' });
 console.log(flattened);
 // Output:
 // {

--- a/docs/reference/object/flattenObject.md
+++ b/docs/reference/object/flattenObject.md
@@ -8,12 +8,13 @@ Flattens a nested object into a single-level object with dot-separated keys.
 ## Signature
 
 ```typescript
-function flattenObject(object: object): Record<string, any>;
+function flattenObject(object: object, delimiter = '.'): Record<string, any>;
 ```
 
 ### Parameters
 
 - `object` (`object`): The object to flatten.
+- `delimiter` (`string`): The delimiter to use between nested keys.
 
 ### Returns
 
@@ -38,5 +39,16 @@ console.log(flattened);
 //   'a.b.c': 1,
 //   'd.0': 2,
 //   'd.1': 3
+// }
+```
+
+```typescript
+const flattened = flattenObject(nestedObject, '/');
+console.log(flattened);
+// Output:
+// {
+//   'a/b/c': 1,
+//   'd/0': 2,
+//   'd/1': 3
 // }
 ```

--- a/docs/zh_hans/reference/object/flattenObject.md
+++ b/docs/zh_hans/reference/object/flattenObject.md
@@ -8,13 +8,13 @@
 ## 签名
 
 ```typescript
-function flattenObject(object: object, delimiter = '.'): Record<string, any>;
+function flattenObject(object: object, { delimiter = '.' }: FlattenObjectOptions = {}): Record<string, any>;
 ```
 
 ### 参数
 
 - `object` (`object`): 要扁平化的对象。
-- `delimiter` (`string`): 嵌套键之间的分隔符。
+- `delimiter` (`string`): 嵌套键之间的分隔符。默认为 `'.'`。
 
 ### 返回值
 
@@ -43,7 +43,7 @@ console.log(flattened);
 ```
 
 ```typescript
-const flattened = flattenObject(nestedObject, '/');
+const flattened = flattenObject(nestedObject, { delimiter: '/' });
 console.log(flattened);
 // 输出:
 // {

--- a/docs/zh_hans/reference/object/flattenObject.md
+++ b/docs/zh_hans/reference/object/flattenObject.md
@@ -8,12 +8,13 @@
 ## 签名
 
 ```typescript
-function flattenObject(object: object): Record<string, any>;
+function flattenObject(object: object, delimiter = '.'): Record<string, any>;
 ```
 
 ### 参数
 
 - `object` (`object`): 要扁平化的对象。
+- `delimiter` (`string`): 嵌套键之间的分隔符。
 
 ### 返回值
 
@@ -38,5 +39,16 @@ console.log(flattened);
 //   'a.b.c': 1,
 //   'd.0': 2,
 //   'd.1': 3
+// }
+```
+
+```typescript
+const flattened = flattenObject(nestedObject, '/');
+console.log(flattened);
+// 输出:
+// {
+//   'a/b/c': 1,
+//   'd/0': 2,
+//   'd/1': 3
 // }
 ```

--- a/src/object/flattenObject.spec.ts
+++ b/src/object/flattenObject.spec.ts
@@ -157,14 +157,17 @@ describe('flattenObject', function () {
 
   describe('custom delimiters', () => {
     it('handles forward slash delimiter', () => {
-      const result = flattenObject({
-        a: {
-          b: {
-            c: 1,
+      const result = flattenObject(
+        {
+          a: {
+            b: {
+              c: 1,
+            },
+            d: [2, 3],
           },
-          d: [2, 3],
         },
-      }, '/');
+        '/'
+      );
 
       expect(result).toEqual({
         'a/b/c': 1,
@@ -174,17 +177,20 @@ describe('flattenObject', function () {
     });
 
     it('handles dash delimiter', () => {
-      const result = flattenObject({
-        users: {
-          profile: {
-            firstName: 'John',
-            lastName: 'Doe',
-            settings: {
-              theme: 'dark',
+      const result = flattenObject(
+        {
+          users: {
+            profile: {
+              firstName: 'John',
+              lastName: 'Doe',
+              settings: {
+                theme: 'dark',
+              },
             },
           },
         },
-      }, '-');
+        '-'
+      );
 
       expect(result).toEqual({
         'users-profile-firstName': 'John',
@@ -194,37 +200,43 @@ describe('flattenObject', function () {
     });
 
     it('handles underscore delimiter', () => {
-      const result = flattenObject({
-        database: {
-          tables: {
-            users: ['admin', 'guest'],
-            permissions: {
-              read: true,
-              write: false,
+      const result = flattenObject(
+        {
+          database: {
+            tables: {
+              users: ['admin', 'guest'],
+              permissions: {
+                read: true,
+                write: false,
+              },
             },
           },
         },
-      }, '_');
+        '_'
+      );
 
       expect(result).toEqual({
-        'database_tables_users_0': 'admin',
-        'database_tables_users_1': 'guest',
-        'database_tables_permissions_read': true,
-        'database_tables_permissions_write': false,
+        database_tables_users_0: 'admin',
+        database_tables_users_1: 'guest',
+        database_tables_permissions_read: true,
+        database_tables_permissions_write: false,
       });
     });
 
     it('handles multi-character delimiter', () => {
-      const result = flattenObject({
-        app: {
-          config: {
-            api: {
-              url: 'https://api.example.com',
-              key: '12345',
+      const result = flattenObject(
+        {
+          app: {
+            config: {
+              api: {
+                url: 'https://api.example.com',
+                key: '12345',
+              },
             },
           },
         },
-      }, '->');
+        '->'
+      );
 
       expect(result).toEqual({
         'app->config->api->url': 'https://api.example.com',
@@ -233,28 +245,34 @@ describe('flattenObject', function () {
     });
 
     it('handles empty string delimiter', () => {
-      const result = flattenObject({
-        x: {
-          y: {
-            z: 42,
+      const result = flattenObject(
+        {
+          x: {
+            y: {
+              z: 42,
+            },
           },
         },
-      }, '');
+        ''
+      );
 
       expect(result).toEqual({
-        'xyz': 42,
+        xyz: 42,
       });
     });
 
     it('handles special characters delimiter', () => {
-      const result = flattenObject({
-        level1: {
-          level2: {
-            data: 'test',
-            array: [1, 2],
+      const result = flattenObject(
+        {
+          level1: {
+            level2: {
+              data: 'test',
+              array: [1, 2],
+            },
           },
         },
-      }, '@#$');
+        '@#$'
+      );
 
       expect(result).toEqual({
         'level1@#$level2@#$data': 'test',

--- a/src/object/flattenObject.spec.ts
+++ b/src/object/flattenObject.spec.ts
@@ -154,4 +154,113 @@ describe('flattenObject', function () {
       'a.3.0.c': 4,
     });
   });
+
+  describe('custom delimiters', () => {
+    it('handles forward slash delimiter', () => {
+      const result = flattenObject({
+        a: {
+          b: {
+            c: 1,
+          },
+          d: [2, 3],
+        },
+      }, '/');
+
+      expect(result).toEqual({
+        'a/b/c': 1,
+        'a/d/0': 2,
+        'a/d/1': 3,
+      });
+    });
+
+    it('handles dash delimiter', () => {
+      const result = flattenObject({
+        users: {
+          profile: {
+            firstName: 'John',
+            lastName: 'Doe',
+            settings: {
+              theme: 'dark',
+            },
+          },
+        },
+      }, '-');
+
+      expect(result).toEqual({
+        'users-profile-firstName': 'John',
+        'users-profile-lastName': 'Doe',
+        'users-profile-settings-theme': 'dark',
+      });
+    });
+
+    it('handles underscore delimiter', () => {
+      const result = flattenObject({
+        database: {
+          tables: {
+            users: ['admin', 'guest'],
+            permissions: {
+              read: true,
+              write: false,
+            },
+          },
+        },
+      }, '_');
+
+      expect(result).toEqual({
+        'database_tables_users_0': 'admin',
+        'database_tables_users_1': 'guest',
+        'database_tables_permissions_read': true,
+        'database_tables_permissions_write': false,
+      });
+    });
+
+    it('handles multi-character delimiter', () => {
+      const result = flattenObject({
+        app: {
+          config: {
+            api: {
+              url: 'https://api.example.com',
+              key: '12345',
+            },
+          },
+        },
+      }, '->');
+
+      expect(result).toEqual({
+        'app->config->api->url': 'https://api.example.com',
+        'app->config->api->key': '12345',
+      });
+    });
+
+    it('handles empty string delimiter', () => {
+      const result = flattenObject({
+        x: {
+          y: {
+            z: 42,
+          },
+        },
+      }, '');
+
+      expect(result).toEqual({
+        'xyz': 42,
+      });
+    });
+
+    it('handles special characters delimiter', () => {
+      const result = flattenObject({
+        level1: {
+          level2: {
+            data: 'test',
+            array: [1, 2],
+          },
+        },
+      }, '@#$');
+
+      expect(result).toEqual({
+        'level1@#$level2@#$data': 'test',
+        'level1@#$level2@#$array@#$0': 1,
+        'level1@#$level2@#$array@#$1': 2,
+      });
+    });
+  });
 });

--- a/src/object/flattenObject.spec.ts
+++ b/src/object/flattenObject.spec.ts
@@ -166,7 +166,7 @@ describe('flattenObject', function () {
             d: [2, 3],
           },
         },
-        '/'
+        { delimiter: '/' }
       );
 
       expect(result).toEqual({
@@ -189,7 +189,7 @@ describe('flattenObject', function () {
             },
           },
         },
-        '-'
+        { delimiter: '-' }
       );
 
       expect(result).toEqual({
@@ -212,7 +212,7 @@ describe('flattenObject', function () {
             },
           },
         },
-        '_'
+        { delimiter: '_' }
       );
 
       expect(result).toEqual({
@@ -235,7 +235,7 @@ describe('flattenObject', function () {
             },
           },
         },
-        '->'
+        { delimiter: '->' }
       );
 
       expect(result).toEqual({
@@ -253,7 +253,7 @@ describe('flattenObject', function () {
             },
           },
         },
-        ''
+        { delimiter: '' }
       );
 
       expect(result).toEqual({
@@ -271,7 +271,7 @@ describe('flattenObject', function () {
             },
           },
         },
-        '@#$'
+        { delimiter: '@#$' }
       );
 
       expect(result).toEqual({

--- a/src/object/flattenObject.ts
+++ b/src/object/flattenObject.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "../predicate/isPlainObject.ts";
+import { isPlainObject } from '../predicate/isPlainObject.ts';
 
 interface FlattenObjectOptions {
   /**
@@ -34,18 +34,11 @@ interface FlattenObjectOptions {
  * //   'd.1': 3
  * // }
  */
-export function flattenObject(
-  object: object,
-  { delimiter = "." }: FlattenObjectOptions = {},
-): Record<string, any> {
-  return flattenObjectImpl(object, "", delimiter);
+export function flattenObject(object: object, { delimiter = '.' }: FlattenObjectOptions = {}): Record<string, any> {
+  return flattenObjectImpl(object, '', delimiter);
 }
 
-function flattenObjectImpl(
-  object: object,
-  prefix = "",
-  delimiter = ".",
-): Record<string, any> {
+function flattenObjectImpl(object: object, prefix = '', delimiter = '.'): Record<string, any> {
   const result: Record<string, any> = {};
   const keys = Object.keys(object);
 

--- a/src/object/flattenObject.ts
+++ b/src/object/flattenObject.ts
@@ -1,10 +1,18 @@
-import { isPlainObject } from '../predicate/isPlainObject.ts';
+import { isPlainObject } from "../predicate/isPlainObject.ts";
+
+interface FlattenObjectOptions {
+  /**
+   * The delimiter to use between nested keys.
+   * @default '.''
+   */
+  delimiter?: string;
+}
 
 /**
- * Flattens a nested object into a single level object with delimeter-separated keys.
+ * Flattens a nested object into a single level object with delimiter-separated keys.
  *
  * @param {object} object - The object to flatten.
- * @param {string} [delimiter='.'] - The delimiter to use between nested keys.
+ * @param {string} [options.delimiter='.'] - The delimiter to use between nested keys.
  * @returns {Record<string, any>} - The flattened object.
  *
  * @example
@@ -26,11 +34,18 @@ import { isPlainObject } from '../predicate/isPlainObject.ts';
  * //   'd.1': 3
  * // }
  */
-export function flattenObject(object: object, delimiter = '.'): Record<string, any> {
-  return flattenObjectImpl(object, '', delimiter);
+export function flattenObject(
+  object: object,
+  { delimiter = "." }: FlattenObjectOptions = {},
+): Record<string, any> {
+  return flattenObjectImpl(object, "", delimiter);
 }
 
-function flattenObjectImpl(object: object, prefix = '', delimiter = '.'): Record<string, any> {
+function flattenObjectImpl(
+  object: object,
+  prefix = "",
+  delimiter = ".",
+): Record<string, any> {
   const result: Record<string, any> = {};
   const keys = Object.keys(object);
 

--- a/src/object/flattenObject.ts
+++ b/src/object/flattenObject.ts
@@ -1,9 +1,10 @@
 import { isPlainObject } from '../predicate/isPlainObject.ts';
 
 /**
- * Flattens a nested object into a single level object with dot-separated keys.
+ * Flattens a nested object into a single level object with delimeter-separated keys.
  *
  * @param {object} object - The object to flatten.
+ * @param {string} [delimiter='.'] - The delimiter to use between nested keys.
  * @returns {Record<string, any>} - The flattened object.
  *
  * @example
@@ -25,11 +26,11 @@ import { isPlainObject } from '../predicate/isPlainObject.ts';
  * //   'd.1': 3
  * // }
  */
-export function flattenObject(object: object): Record<string, any> {
-  return flattenObjectImpl(object);
+export function flattenObject(object: object, delimiter = '.'): Record<string, any> {
+  return flattenObjectImpl(object, '', delimiter);
 }
 
-function flattenObjectImpl(object: object, prefix = ''): Record<string, any> {
+function flattenObjectImpl(object: object, prefix = '', delimiter = '.'): Record<string, any> {
   const result: Record<string, any> = {};
   const keys = Object.keys(object);
 
@@ -37,15 +38,15 @@ function flattenObjectImpl(object: object, prefix = ''): Record<string, any> {
     const key = keys[i];
     const value = (object as any)[key];
 
-    const prefixedKey = prefix ? `${prefix}.${key}` : key;
+    const prefixedKey = prefix ? `${prefix}${delimiter}${key}` : key;
 
     if (isPlainObject(value) && Object.keys(value).length > 0) {
-      Object.assign(result, flattenObjectImpl(value, prefixedKey));
+      Object.assign(result, flattenObjectImpl(value, prefixedKey, delimiter));
       continue;
     }
 
     if (Array.isArray(value)) {
-      Object.assign(result, flattenObjectImpl(value, prefixedKey));
+      Object.assign(result, flattenObjectImpl(value, prefixedKey, delimiter));
       continue;
     }
 


### PR DESCRIPTION
## Overview
This PR adds a new `delimiter` parameter to the `flattenObject` utility function, allowing users to specify a custom separator for flattened object keys. The default delimiter remains '.' for backward compatibility.


## Why is this useful?

At @lunit-io we wanted to flatten an object into a JSONPath compatible version with `flattenObject`. This required the delimeter to be a `/`, but the current impl did not support this use case.

Handling duplicate cases are out-of-scope of this library, thus not included here.

## Key Changes
- Added optional `delimiter` parameter to `flattenObject` function signature
- Updated implementation to use the custom delimiter when joining nested keys
- Added comprehensive test cases for various delimiter scenarios
- Updated documentation in multiple languages (EN, JA, KO, ZH)

## Core Files Modified
1. `src/object/flattenObject.ts`: Added delimiter parameter and updated implementation
2. `src/object/flattenObject.spec.ts`: Added new test suite for delimiter functionality
3. Documentation files in multiple languages:
   - `docs/reference/object/flattenObject.md`
   - `docs/ja/reference/object/flattenObject.md`
   - `docs/ko/reference/object/flattenObject.md`
   - `docs/zh_hans/reference/object/flattenObject.md`

## Test Coverage
New test suite includes validation for:
- Forward slash delimiter ('/')
- Dash delimiter ('-')
- Underscore delimiter ('_')
- Multi-character delimiter ('->')
- Empty string delimiter ('')
- Special characters delimiter ('@#$')

## Breaking Changes
None. The new parameter is optional with a default value that maintains existing behavior.

## Example Usage
```typescript
const nested = {
  a: { b: { c: 1 } },
  d: [2, 3]
};

// Previous behavior (still works)
flattenObject(nested)
// { 'a.b.c': 1, 'd.0': 2, 'd.1': 3 }

// New functionality
flattenObject(nested, '/')
// { 'a/b/c': 1, 'd/0': 2, 'd/1': 3 }
```