### PR TITLE
chore: add error package build handling and updated package.json

### DIFF
--- a/.scripts/postbuild.sh
+++ b/.scripts/postbuild.sh
@@ -4,6 +4,7 @@
 # TypeScript projects configured with "moduleResolution": "node10"
 # (which is the default when using "module": "commonjs").
 echo "export * from './dist/array';" > array.d.ts
+echo "export * from './dist/error';" > error.d.ts
 echo "export * from './dist/compat';" > compat.d.ts
 echo "export * from './dist/function';" > function.d.ts
 echo "export * from './dist/math';" > math.d.ts

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     ".": "./src/index.ts",
     "./array": "./src/array/index.ts",
     "./compat": "./src/compat/index.ts",
+    "./error": "./src/error/index.ts",
     "./function": "./src/function/index.ts",
     "./math": "./src/math/index.ts",
     "./object": "./src/object/index.ts",
@@ -46,6 +47,26 @@
         "require": {
           "types": "./dist/index.d.ts",
           "default": "./dist/index.js"
+        }
+      },
+      "./compat": {
+        "import": {
+          "types": "./dist/compat/index.d.mts",
+          "default": "./dist/compat/index.mjs"
+        },
+        "require": {
+          "types": "./dist/compat/index.d.ts",
+          "default": "./dist/compat/index.js"
+        }
+      },
+      "./error": {
+        "import": {
+          "types": "./dist/error/index.d.mts",
+          "default": "./dist/error/index.mjs"
+        },
+        "require": {
+          "types": "./dist/error/index.d.ts",
+          "default": "./dist/error/index.js"
         }
       },
       "./array": {
@@ -126,16 +147,6 @@
         "require": {
           "types": "./dist/util/index.d.ts",
           "default": "./dist/util/index.js"
-        }
-      },
-      "./compat": {
-        "import": {
-          "types": "./dist/compat/index.d.mts",
-          "default": "./dist/compat/index.mjs"
-        },
-        "require": {
-          "types": "./dist/compat/index.d.ts",
-          "default": "./dist/compat/index.js"
         }
       },
       "./package.json": "./package.json"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,16 @@
           "default": "./dist/index.js"
         }
       },
+      "./array": {
+        "import": {
+          "types": "./dist/array/index.d.mts",
+          "default": "./dist/array/index.mjs"
+        },
+        "require": {
+          "types": "./dist/array/index.d.ts",
+          "default": "./dist/array/index.js"
+        }
+      },
       "./compat": {
         "import": {
           "types": "./dist/compat/index.d.mts",
@@ -67,16 +77,6 @@
         "require": {
           "types": "./dist/error/index.d.ts",
           "default": "./dist/error/index.js"
-        }
-      },
-      "./array": {
-        "import": {
-          "types": "./dist/array/index.d.mts",
-          "default": "./dist/array/index.mjs"
-        },
-        "require": {
-          "types": "./dist/array/index.d.ts",
-          "default": "./dist/array/index.js"
         }
       },
       "./function": {

--- a/tests/check-dist.spec.ts
+++ b/tests/check-dist.spec.ts
@@ -25,6 +25,8 @@ async function getPackageJsonOfTarball() {
 const ENTRYPOINTS = [
   '.',
   './array',
+  './compat',
+  './error',
   './function',
   './math',
   './object',
@@ -32,7 +34,6 @@ const ENTRYPOINTS = [
   './promise',
   './string',
   './util',
-  './compat',
 ];
 
 describe(`es-toolkit's package tarball`, () => {


### PR DESCRIPTION
Adds handling for `error` packages that are missing during the build process. 
Also modifies `package.json` to ensure smooth [SubPath](https://nodejs.org/api/packages.html#subpath-exports) is applied.

I'm wondering if I'm missing handling for the `error` package, or if this is intentional?

I think this should be added since we provide documentation and modules for the `error` package in terms of libraries. 

docs: https://es-toolkit.slash.page/reference/error/AbortError.html

![스크린샷 2025-01-17 오전 1 35 42](https://github.com/user-attachments/assets/90accb25-c1bb-42cb-8602-5c3ad14cfda9)

<br />

## Result

This will create the `src/error.d.ts` file, which will also create an `index` file inside the `error` folder.

<img width="263" alt="스크린샷 2025-01-17 오전 1 24 02" src="https://github.com/user-attachments/assets/043cc938-c96b-4db6-a3da-20076f8080e9" />

<img width="256" alt="스크린샷 2025-01-17 오전 1 24 14" src="https://github.com/user-attachments/assets/e2263a3d-1ded-4f30-9455-2f5567f213bc" />
