### PR TITLE
feat(groupBy): update type to return non-empty arrays

### DIFF
--- a/src/array/groupBy.ts
+++ b/src/array/groupBy.ts
@@ -9,7 +9,7 @@
  * @template K - The type of keys.
  * @param {T[]} arr - The array to group.
  * @param {(item: T) => K} getKeyFromItem - A function that generates a key from an element.
- * @returns {Record<K, T[]>} An object where each key is associated with an array of elements that
+ * @returns {Record<K, [T, ...T[]]>} An object where each key is associated with a non-empty array of elements that
  * share that key.
  *
  * @example
@@ -30,18 +30,18 @@
  * //   ]
  * // }
  */
-export function groupBy<T, K extends PropertyKey>(arr: readonly T[], getKeyFromItem: (item: T) => K): Record<K, T[]> {
-  const result = {} as Record<K, T[]>;
+export function groupBy<T, K extends PropertyKey>(arr: readonly T[], getKeyFromItem: (item: T) => K): Record<K, [T, ...T[]]> {
+  const result = {} as Record<K, [T, ...T[]]>;
 
   for (let i = 0; i < arr.length; i++) {
     const item = arr[i];
     const key = getKeyFromItem(item);
 
     if (!Object.hasOwn(result, key)) {
-      result[key] = [];
+      result[key] = [item];
+    } else {
+      result[key].push(item);
     }
-
-    result[key].push(item);
   }
 
   return result;

--- a/src/array/groupBy.ts
+++ b/src/array/groupBy.ts
@@ -30,7 +30,10 @@
  * //   ]
  * // }
  */
-export function groupBy<T, K extends PropertyKey>(arr: readonly T[], getKeyFromItem: (item: T) => K): Record<K, [T, ...T[]]> {
+export function groupBy<T, K extends PropertyKey>(
+  arr: readonly T[],
+  getKeyFromItem: (item: T) => K
+): Record<K, [T, ...T[]]> {
   const result = {} as Record<K, [T, ...T[]]>;
 
   for (let i = 0; i < arr.length; i++) {


### PR DESCRIPTION
`groupBy` is guaranteed to return a non-empty array for each key. Typing it this way allows one to avoid errors under `noUncheckedIndexAccess`. [See here.](https://www.typescriptlang.org/play/?noUncheckedIndexedAccess=true#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwHMYdkAHAIQE8AeAFQBp4BpeEADwxFWAGd4AFYqRAwMlJiEoA+ABQAoePCycAtjwBc8AJKcYUAEYQQdKfQWFiZEZpnKQKzbQCU8ALxTmZp5oBK4HDDA1EyMtADaALpSANxycgDe5mB4PBjwqMhqbhYkFJQyYQCMjABMjADMEYwyqC7u6fAApPAlTrHmiAHwMsmoqTlk8DiI8ADy+gBW4BgAdABuUBDIIDw1mTxOLomKir39C0sgmhkq+iLZRLlhAAwRsYoAvnJPcqCQsAgo6Nh4A3kAcngAKIqUhiOiMFjsTjcPiCHDCUTiSSycx2NSaHQiAxGExmRSXKwwGzoxx1DwhOTeeB+ZKBYKMMIMeAzVnhCJRdrbeB7NInPiuP5UQGoEFg-JFUoVKrdWpuDz4ZqtdqKTowbq8v5DEbjKaYeaLZarfmbeDc3YpNIHZbHTJndWCwmkG53cxPJ5AA)