### PR TITLE
fix: Handling cases where undefined or null is passed to the sum function

### DIFF
--- a/src/math/sum.spec.ts
+++ b/src/math/sum.spec.ts
@@ -24,6 +24,12 @@ describe('sum function', () => {
     expect(sum([1, 2, undefined, 3] as unknown as number[])).toBe(6);
     expect(sum([1, 2, null, 3] as unknown as number[])).toBe(6);
     expect(sum([1, 2, null, undefined, 3] as unknown as number[])).toBe(6);
+
+    expect(sum([undefined] as unknown as number[])).toBe(undefined);
+    expect(sum([null] as unknown as number[])).toBe(null);
+    expect(sum([null, undefined] as unknown as number[])).toBe(null);
+    expect(sum([undefined, null] as unknown as number[])).toBe(null);
+    expect(sum([null, undefined, null] as unknown as number[])).toBe(0);
   });
 
   it('handles arrays with NaN, Infinity, and -Infinity values', () => {

--- a/src/math/sum.spec.ts
+++ b/src/math/sum.spec.ts
@@ -17,6 +17,21 @@ describe('sum function', () => {
     expect(result).toBe(-2);
   });
 
+  it('handles arrays with null and undefined', () => {
+    expect(sum([undefined, 1, 2, 3] as unknown as number[])).toBe(6);
+    expect(sum([null, 1, 2, 3] as unknown as number[])).toBe(6);
+    expect(sum([null, undefined, 1, 2, 3] as unknown as number[])).toBe(6);
+    expect(sum([1, 2, undefined, 3] as unknown as number[])).toBe(6);
+    expect(sum([1, 2, null, 3] as unknown as number[])).toBe(6);
+    expect(sum([1, 2, null, undefined, 3] as unknown as number[])).toBe(6);
+  });
+
+  it('handles arrays with NaN, Infinity, and -Infinity values', () => {
+    expect(sum([1, 2, 3, 4, NaN])).toBeNaN();
+    expect(sum([1, 2, 3, 4, Infinity])).toBe(Infinity);
+    expect(sum([1, 2, 3, 4, -Infinity])).toBe(-Infinity);
+  });
+
   it('ensures that adding the sums of two arrays equals the sum of their concatenation.', () => {
     const array1: number[] = [];
     const array2 = [1, 2, 3, 4];

--- a/src/math/sum.ts
+++ b/src/math/sum.ts
@@ -15,7 +15,8 @@ export function sum(nums: readonly number[]): number {
   let result = 0;
 
   for (let i = 0; i < nums.length; i++) {
-    result += nums[i];
+    const value = nums[i];
+    result += typeof value === 'number' ? value : 0;
   }
 
   return result;

--- a/src/math/sum.ts
+++ b/src/math/sum.ts
@@ -12,17 +12,17 @@
  * // result will be 15
  */
 export function sum(nums: readonly number[]): number {
-  let result: number | undefined;
-
   if (nums.length === 0) {
     return 0;
   }
-  for (let i = 0; i < nums.length; i++) {
+
+  let result = nums[0];
+  for (let i = 1; i < nums.length; i++) {
     const current = nums[i];
     if (current !== undefined) {
       result = result === undefined ? current : result + current;
     }
   }
 
-  return result as number;
+  return result;
 }

--- a/src/math/sum.ts
+++ b/src/math/sum.ts
@@ -12,12 +12,15 @@
  * // result will be 15
  */
 export function sum(nums: readonly number[]): number {
-  let result = 0;
+  let result: number | undefined;
 
+  if (nums.length === 0) return 0;
   for (let i = 0; i < nums.length; i++) {
-    const value = nums[i];
-    result += typeof value === 'number' ? value : 0;
+    const current = nums[i];
+    if (current !== undefined) {
+      result = result === undefined ? current : result + current;
+    }
   }
 
-  return result;
+  return result as number;
 }

--- a/src/math/sum.ts
+++ b/src/math/sum.ts
@@ -14,7 +14,9 @@
 export function sum(nums: readonly number[]): number {
   let result: number | undefined;
 
-  if (nums.length === 0) return 0;
+  if (nums.length === 0) {
+    return 0;
+  }
   for (let i = 0; i < nums.length; i++) {
     const current = nums[i];
     if (current !== undefined) {


### PR DESCRIPTION
I modified the sum function to handle cases where undefined or null is passed, similar to Lodash.
Previously, passing `[undefined, 1, 2, 3]` would result in NaN, but now it returns 6. (#942)

Additionally, I added test cases for undefined, null, NaN, and Infinity.