### PR TITLE
feat(compat): Implement compat/maxBy

### DIFF
--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -114,6 +114,7 @@ export { divide } from './math/divide.ts';
 export { floor } from './math/floor.ts';
 export { inRange } from './math/inRange.ts';
 export { max } from './math/max.ts';
+export { maxBy } from './math/maxBy.ts';
 export { min } from './math/min.ts';
 export { multiply } from './math/multiply.ts';
 export { parseInt } from './math/parseInt.ts';

--- a/src/compat/math/maxBy.spec.ts
+++ b/src/compat/math/maxBy.spec.ts
@@ -2,123 +2,43 @@ import { describe, expect, it } from 'vitest';
 import { maxBy } from './maxBy';
 
 describe('maxBy', () => {
-  it('maxBy selects one max value in array', () => {
-    const people = [
-      { name: 'Mark', age: 25 },
-      { name: 'Nunu', age: 30 },
-      { name: 'Overmars', age: 20 },
-    ];
-    const result = maxBy(people, person => person.age);
-    expect(result).toEqual({ name: 'Nunu', age: 30 });
+  it('should work with Date objects', () => {
+    const curr = new Date();
+    const past = new Date(0);
+
+    expect(maxBy([curr, past], date => date.getTime())).toBe(curr);
   });
 
-  it('if there are two max values, first one is selected', () => {
-    const people = [
-      { name: 'Mark', age: 25 },
-      { name: 'Nunu', age: 30 },
-      { name: 'Overmars', age: 30 },
-    ];
-    const result = maxBy(people, person => person.age);
-    expect(result).toEqual({ name: 'Nunu', age: 30 });
+  it('should work with extremely large arrays', () => {
+    const array = Array.from({ length: 5e5 }, (_, i) => i);
+    expect(maxBy(array, x => x)).toBe(499999);
   });
 
-  it('if array is single-element, return unique element of array', () => {
-    const people = [{ name: 'Mark', age: 25 }];
-    const result = maxBy(people, person => person.age);
-    expect(result).toEqual({ name: 'Mark', age: 25 });
+  it('should work when chaining on an array with only one value', () => {
+    const array = [40];
+    expect(maxBy(array, x => x)).toBe(40);
   });
 
-  it('if array is empty, return undefined', () => {
-    type Person = { name: string; age: number };
-    const people: Person[] = [];
-    const result = maxBy(people, person => person.age);
-    expect(result).toBeUndefined();
+  const array = [1, 2, 3];
+
+  it('should work with an `iteratee`', () => {
+    const actual = maxBy(array, n => -n);
+    expect(actual).toBe(1);
   });
 
-  it('supports iteratee as a string', () => {
-    const people = [
-      { name: 'Mark', age: 25 },
-      { name: 'Nunu', age: 30 },
-      { name: 'Overmars', age: 20 },
-    ];
-    expect(maxBy(people, 'age')).toEqual({ name: 'Nunu', age: 30 });
+  it('should work with `_.property` shorthands', () => {
+    const objects = [{ a: 2 }, { a: 3 }, { a: 1 }];
+    expect(maxBy(objects, 'a')).toEqual(objects[1]);
+
+    const arrays = [[2], [3], [1]];
+    expect(maxBy(arrays, 0)).toEqual(arrays[1]);
   });
 
-  it('supports iteratee as an object matcher', () => {
-    const people = [
-      { name: 'Mark', age: 25 },
-      { name: 'Nunu', age: 30 },
-      { name: 'Overmars', age: 20 },
-    ];
-    expect(maxBy(people, { age: 30 })).toEqual({ name: 'Nunu', age: 30 });
-  });
+  it('should work when `iteratee` returns +/-Infinity', () => {
+    const value = -Infinity;
+    const object = { a: value };
 
-  it('supports iteratee as a key-value pair', () => {
-    const people = [
-      { name: 'Mark', age: 25 },
-      { name: 'Nunu', age: 30 },
-      { name: 'Overmars', age: 20 },
-    ];
-    expect(maxBy(people, ['age', 30])).toEqual({ name: 'Nunu', age: 30 });
-  });
-
-  it('works with an array of numbers', () => {
-    const numbers = [1, 2, 3, 10, 4, 5];
-    expect(maxBy(numbers, x => x)).toBe(10);
-  });
-
-  it('works with an array of negative numbers', () => {
-    const numbers = [-10, -5, -20, -1];
-    expect(maxBy(numbers, x => x)).toBe(-1);
-  });
-
-  it('works with an array containing Infinity and NaN', () => {
-    const numbers = [5, Infinity, 10, NaN, 7];
-    expect(maxBy(numbers, x => x)).toBe(Infinity);
-  });
-
-  it('ignores undefined values in objects', () => {
-    const people = [
-      { name: 'Mark', age: 25 },
-      { name: 'Nunu', age: undefined },
-      { name: 'Overmars', age: 30 },
-    ];
-    expect(maxBy(people, 'age')).toEqual({ name: 'Overmars', age: 30 });
-  });
-
-  it('returns undefined if all values are undefined', () => {
-    const people = [
-      { name: 'Mark', age: undefined },
-      { name: 'Nunu', age: undefined },
-    ];
-    expect(maxBy(people, 'age')).toBeUndefined();
-  });
-
-  it('works with objects missing the iteratee property', () => {
-    const data = [{ name: 'Mark', age: 25 }, { name: 'Nunu' }, { name: 'Overmars', age: 30 }];
-    expect(maxBy(data, 'age')).toEqual({ name: 'Overmars', age: 30 });
-  });
-
-  it('returns the first element if all values are equal', () => {
-    const people = [
-      { name: 'Mark', age: 30 },
-      { name: 'Nunu', age: 30 },
-      { name: 'Overmars', age: 30 },
-    ];
-    expect(maxBy(people, 'age')).toEqual({ name: 'Mark', age: 30 });
-  });
-
-  it('returns the correct object when comparing floating-point numbers', () => {
-    const items = [
-      { name: 'Mark', score: 3.1 },
-      { name: 'Nunu', score: 2.7 },
-      { name: 'Overmars', score: 1.6 },
-    ];
-    expect(maxBy(items, 'score')).toEqual({ name: 'Mark', score: 3.1 });
-  });
-
-  it('returns undefined if all values are NaN', () => {
-    const items = [NaN, NaN, NaN];
-    expect(maxBy(items, x => x)).toBeUndefined();
+    const actual = maxBy([object, { a: value }], obj => obj.a);
+    expect(actual).toBe(object);
   });
 });

--- a/src/compat/math/maxBy.spec.ts
+++ b/src/compat/math/maxBy.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { maxBy } from './maxBy';
+
+describe('maxBy', () => {
+  it('maxBy selects one max value in array', () => {
+    const people = [
+      { name: 'Mark', age: 25 },
+      { name: 'Nunu', age: 30 },
+      { name: 'Overmars', age: 20 },
+    ];
+    const result = maxBy(people, person => person.age);
+    expect(result).toEqual({ name: 'Nunu', age: 30 });
+  });
+
+  it('if there are two max values, first one is selected', () => {
+    const people = [
+      { name: 'Mark', age: 25 },
+      { name: 'Nunu', age: 30 },
+      { name: 'Overmars', age: 30 },
+    ];
+    const result = maxBy(people, person => person.age);
+    expect(result).toEqual({ name: 'Nunu', age: 30 });
+  });
+
+  it('if array is single-element, return unique element of array', () => {
+    const people = [{ name: 'Mark', age: 25 }];
+    const result = maxBy(people, person => person.age);
+    expect(result).toEqual({ name: 'Mark', age: 25 });
+  });
+
+  it('if array is empty, return undefined', () => {
+    type Person = { name: string; age: number };
+    const people: Person[] = [];
+    const result = maxBy(people, person => person.age);
+    expect(result).toBeUndefined();
+  });
+
+  it('supports iteratee as a string', () => {
+    const people = [
+      { name: 'Mark', age: 25 },
+      { name: 'Nunu', age: 30 },
+      { name: 'Overmars', age: 20 },
+    ];
+    expect(maxBy(people, 'age')).toEqual({ name: 'Nunu', age: 30 });
+  });
+
+  it('supports iteratee as an object matcher', () => {
+    const people = [
+      { name: 'Mark', age: 25 },
+      { name: 'Nunu', age: 30 },
+      { name: 'Overmars', age: 20 },
+    ];
+    expect(maxBy(people, { age: 30 })).toEqual({ name: 'Nunu', age: 30 });
+  });
+
+  it('supports iteratee as a key-value pair', () => {
+    const people = [
+      { name: 'Mark', age: 25 },
+      { name: 'Nunu', age: 30 },
+      { name: 'Overmars', age: 20 },
+    ];
+    expect(maxBy(people, ['age', 30])).toEqual({ name: 'Nunu', age: 30 });
+  });
+
+  it('works with an array of numbers', () => {
+    const numbers = [1, 2, 3, 10, 4, 5];
+    expect(maxBy(numbers, x => x)).toBe(10);
+  });
+
+  it('works with an array of negative numbers', () => {
+    const numbers = [-10, -5, -20, -1];
+    expect(maxBy(numbers, x => x)).toBe(-1);
+  });
+
+  it('works with an array containing Infinity and NaN', () => {
+    const numbers = [5, Infinity, 10, NaN, 7];
+    expect(maxBy(numbers, x => x)).toBe(Infinity);
+  });
+
+  it('ignores undefined values in objects', () => {
+    const people = [
+      { name: 'Mark', age: 25 },
+      { name: 'Nunu', age: undefined },
+      { name: 'Overmars', age: 30 },
+    ];
+    expect(maxBy(people, 'age')).toEqual({ name: 'Overmars', age: 30 });
+  });
+
+  it('returns undefined if all values are undefined', () => {
+    const people = [
+      { name: 'Mark', age: undefined },
+      { name: 'Nunu', age: undefined },
+    ];
+    expect(maxBy(people, 'age')).toBeUndefined();
+  });
+
+  it('works with objects missing the iteratee property', () => {
+    const data = [{ name: 'Mark', age: 25 }, { name: 'Nunu' }, { name: 'Overmars', age: 30 }];
+    expect(maxBy(data, 'age')).toEqual({ name: 'Overmars', age: 30 });
+  });
+
+  it('returns the first element if all values are equal', () => {
+    const people = [
+      { name: 'Mark', age: 30 },
+      { name: 'Nunu', age: 30 },
+      { name: 'Overmars', age: 30 },
+    ];
+    expect(maxBy(people, 'age')).toEqual({ name: 'Mark', age: 30 });
+  });
+
+  it('returns the correct object when comparing floating-point numbers', () => {
+    const items = [
+      { name: 'Mark', score: 3.1 },
+      { name: 'Nunu', score: 2.7 },
+      { name: 'Overmars', score: 1.6 },
+    ];
+    expect(maxBy(items, 'score')).toEqual({ name: 'Mark', score: 3.1 });
+  });
+
+  it('returns undefined if all values are NaN', () => {
+    const items = [NaN, NaN, NaN];
+    expect(maxBy(items, x => x)).toBeUndefined();
+  });
+});

--- a/src/compat/math/maxBy.ts
+++ b/src/compat/math/maxBy.ts
@@ -1,43 +1,11 @@
-import { property } from '../object/property';
-import { isArray } from '../predicate/isArray';
+import { maxBy as maxByToolkit } from "../../array/maxBy.ts";
+import { iteratee as iterateeToolkit } from "../util/iteratee.ts";
 
 /**
  * Finds the element in an array that has the maximum value when applying
  * the `iteratee` to each element.
  *
  * @template T - The type of elements in the array.
- * @param {[T, ...T[]]} items The nonempty array of elements to search.
- * @param {((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>} iteratee
- * The criteria used to determine the maximum value.
- *  - If a **function** is provided, it extracts a numeric value from each element.
- *  - If a **string** is provided, it is treated as a key to extract values from the objects.
- *  - If a **[key, value]** pair is provided, it matches elements with the specified key-value pair.
- *  - If an **object** is provided, it matches elements that contain the specified properties.
- * @returns {T} The element with the maximum value as determined by the `iteratee`.
- * @example
- * maxBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: { a: 3 }
- * maxBy([], x => x.a); // Returns: undefined
- * maxBy(
- *   [
- *     { name: 'john', age: 30 },
- *     { name: 'jane', age: 28 },
- *     { name: 'joe', age: 26 },
- *   ],
- *   x => x.age
- * ); // Returns: { name: 'john', age: 30 }
- * maxBy([{ a: 1 }, { a: 2 }], 'a'); // Returns: { a: 2 }
- * maxBy([{ a: 1 }, { a: 2 }], ['a', 1]); // Returns: { a: 1 }
- * maxBy([{ a: 1 }, { a: 2 }], { a: 1 }); // Returns: { a: 1 }
- */
-export function maxBy<T>(
-  items: readonly [T, ...T[]],
-  iteratee: ((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>
-): T;
-/**
- * Finds the element in an array that has the maximum value when applying
- * the `iteratee` to each element.
- *
- * @template T - The type of elements in the array.
  * @param {T[]} items The array of elements to search.
  * @param {((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>} iteratee
  * The criteria used to determine the maximum value.
@@ -62,98 +30,16 @@ export function maxBy<T>(
  * maxBy([{ a: 1 }, { a: 2 }], { a: 1 }); // Returns: { a: 1 }
  */
 export function maxBy<T>(
-  items: readonly T[],
-  iteratee: ((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>
-): T | undefined;
-/**
- * Finds the element in an array that has the maximum value when applying
- * the `iteratee` to each element.
- *
- * @template T - The type of elements in the array.
- * @param {T[]} items The array of elements to search.
- * @param {((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>} iteratee
- * The criteria used to determine the maximum value.
- *  - If a **function** is provided, it extracts a numeric value from each element.
- *  - If a **string** is provided, it is treated as a key to extract values from the objects.
- *  - If a **[key, value]** pair is provided, it matches elements with the specified key-value pair.
- *  - If an **object** is provided, it matches elements that contain the specified properties.
- * @returns {T | undefined} The element with the maximum value as determined by the `iteratee`.
- * @example
- * maxBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: { a: 3 }
- * maxBy([], x => x.a); // Returns: undefined
- * maxBy(
- *   [
- *     { name: 'john', age: 30 },
- *     { name: 'jane', age: 28 },
- *     { name: 'joe', age: 26 },
- *   ],
- *   x => x.age
- * ); // Returns: { name: 'john', age: 30 }
- * maxBy([{ a: 1 }, { a: 2 }], 'a'); // Returns: { a: 2 }
- * maxBy([{ a: 1 }, { a: 2 }], ['a', 1]); // Returns: { a: 1 }
- * maxBy([{ a: 1 }, { a: 2 }], { a: 1 }); // Returns: { a: 1 }
- */
-export function maxBy<T>(
-  items: readonly T[],
-  iteratee: ((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>
+  items: ArrayLike<T> | null | undefined,
+  iteratee:
+    | ((element: T) => number)
+    | keyof T
+    | [keyof T, unknown]
+    | Partial<T>,
 ): T | undefined {
-  if (!items.length) {
+  if (items == null) {
     return undefined;
   }
 
-  let getValue: (element: T) => number | undefined;
-
-  switch (typeof iteratee) {
-    case 'function':
-      getValue = (item: T) => {
-        const value = iteratee(item);
-        return typeof value === 'number' ? value : undefined;
-      };
-      break;
-    case 'number':
-      getValue = (item: T) => {
-        if (Array.isArray(item)) {
-          const value = item[iteratee];
-          return typeof value === 'number' ? value : undefined;
-        }
-        return undefined;
-      };
-      break;
-    case 'string':
-    case 'symbol':
-      getValue = (item: T) => {
-        const value = property(iteratee as keyof T)(item);
-        return typeof value === 'number' ? value : undefined;
-      };
-      break;
-    case 'object':
-      if (isArray(iteratee)) {
-        getValue = (item: T) => {
-          const value = property(iteratee[0] as keyof T)(item);
-          return typeof value === 'number' ? value : undefined;
-        };
-      } else {
-        getValue = (item: T) => {
-          const key = Object.keys(iteratee)[0] as keyof T;
-          const value = property(key)(item);
-          return typeof value === 'number' ? value : undefined;
-        };
-      }
-      break;
-    default:
-      getValue = () => undefined;
-  }
-
-  let maxElement: T | undefined = undefined;
-  let maxValue: number | undefined = undefined;
-
-  for (let i = 0; i < items.length; i++) {
-    const value = getValue(items[i]);
-    if (value !== undefined && !Number.isNaN(value) && (maxValue === undefined || value > maxValue)) {
-      maxValue = value;
-      maxElement = items[i];
-    }
-  }
-
-  return maxElement;
+  return maxByToolkit(Array.from(items), iterateeToolkit(iteratee));
 }

--- a/src/compat/math/maxBy.ts
+++ b/src/compat/math/maxBy.ts
@@ -1,0 +1,145 @@
+import { identity } from '../../function';
+import { property } from '../object/property';
+import { isArray } from '../predicate/isArray';
+import { matches } from '../predicate/matches';
+import { matchesProperty } from '../predicate/matchesProperty';
+
+/**
+ * Finds the element in an array that has the maximum value when applying
+ * the `iteratee` to each element.
+ *
+ * @template T - The type of elements in the array.
+ * @param {[T, ...T[]]} items The nonempty array of elements to search.
+ * @param {((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>} iteratee
+ * The criteria used to determine the maximum value.
+ *  - If a **function** is provided, it extracts a numeric value from each element.
+ *  - If a **string** is provided, it is treated as a key to extract values from the objects.
+ *  - If a **[key, value]** pair is provided, it matches elements with the specified key-value pair.
+ *  - If an **object** is provided, it matches elements that contain the specified properties.
+ * @returns {T} The element with the maximum value as determined by the `iteratee`.
+ * @example
+ * maxBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: { a: 3 }
+ * maxBy([], x => x.a); // Returns: undefined
+ * maxBy(
+ *   [
+ *     { name: 'john', age: 30 },
+ *     { name: 'jane', age: 28 },
+ *     { name: 'joe', age: 26 },
+ *   ],
+ *   x => x.age
+ * ); // Returns: { name: 'john', age: 30 }
+ * maxBy([{ a: 1 }, { a: 2 }], 'a'); // Returns: { a: 2 }
+ * maxBy([{ a: 1 }, { a: 2 }], ['a', 1]); // Returns: { a: 1 }
+ * maxBy([{ a: 1 }, { a: 2 }], { a: 1 }); // Returns: { a: 1 }
+ */
+export function maxBy<T>(
+  items: readonly [T, ...T[]],
+  iteratee: ((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>
+): T;
+/**
+ * Finds the element in an array that has the maximum value when applying
+ * the `iteratee` to each element.
+ *
+ * @template T - The type of elements in the array.
+ * @param {T[]} items The array of elements to search.
+ * @param {((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>} iteratee
+ * The criteria used to determine the maximum value.
+ *  - If a **function** is provided, it extracts a numeric value from each element.
+ *  - If a **string** is provided, it is treated as a key to extract values from the objects.
+ *  - If a **[key, value]** pair is provided, it matches elements with the specified key-value pair.
+ *  - If an **object** is provided, it matches elements that contain the specified properties.
+ * @returns {T | undefined} The element with the maximum value as determined by the `iteratee`.
+ * @example
+ * maxBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: { a: 3 }
+ * maxBy([], x => x.a); // Returns: undefined
+ * maxBy(
+ *   [
+ *     { name: 'john', age: 30 },
+ *     { name: 'jane', age: 28 },
+ *     { name: 'joe', age: 26 },
+ *   ],
+ *   x => x.age
+ * ); // Returns: { name: 'john', age: 30 }
+ * maxBy([{ a: 1 }, { a: 2 }], 'a'); // Returns: { a: 2 }
+ * maxBy([{ a: 1 }, { a: 2 }], ['a', 1]); // Returns: { a: 1 }
+ * maxBy([{ a: 1 }, { a: 2 }], { a: 1 }); // Returns: { a: 1 }
+ */
+export function maxBy<T>(
+  items: readonly T[],
+  iteratee: ((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>
+): T | undefined;
+/**
+ * Finds the element in an array that has the maximum value when applying
+ * the `iteratee` to each element.
+ *
+ * @template T - The type of elements in the array.
+ * @param {T[]} items The array of elements to search.
+ * @param {((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>} iteratee
+ * The criteria used to determine the maximum value.
+ *  - If a **function** is provided, it extracts a numeric value from each element.
+ *  - If a **string** is provided, it is treated as a key to extract values from the objects.
+ *  - If a **[key, value]** pair is provided, it matches elements with the specified key-value pair.
+ *  - If an **object** is provided, it matches elements that contain the specified properties.
+ * @returns {T | undefined} The element with the maximum value as determined by the `iteratee`.
+ * @example
+ * maxBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: { a: 3 }
+ * maxBy([], x => x.a); // Returns: undefined
+ * maxBy(
+ *   [
+ *     { name: 'john', age: 30 },
+ *     { name: 'jane', age: 28 },
+ *     { name: 'joe', age: 26 },
+ *   ],
+ *   x => x.age
+ * ); // Returns: { name: 'john', age: 30 }
+ * maxBy([{ a: 1 }, { a: 2 }], 'a'); // Returns: { a: 2 }
+ * maxBy([{ a: 1 }, { a: 2 }], ['a', 1]); // Returns: { a: 1 }
+ * maxBy([{ a: 1 }, { a: 2 }], { a: 1 }); // Returns: { a: 1 }
+ */
+export function maxBy<T>(
+  items: readonly T[],
+  iteratee: ((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>
+): T | undefined {
+  if (!items.length) return undefined;
+  let getValue: (element: T) => number | undefined;
+
+  switch (typeof iteratee) {
+    case 'function':
+      getValue = (item: T) => {
+        const value = iteratee(item);
+        return value === undefined || isNaN(value) ? undefined : value;
+      };
+      break;
+    case 'string':
+    case 'symbol':
+      getValue = (item: T) => {
+        const value = property(iteratee)(item);
+        return value === undefined || isNaN(value) ? undefined : value;
+      };
+      break;
+    case 'object':
+      if (isArray(iteratee)) {
+        const predicate = matchesProperty(iteratee[0], iteratee[1]);
+        getValue = (item: T) => (predicate(item) ? Infinity : -Infinity);
+      } else {
+        const predicate = matches(iteratee);
+        getValue = (item: T) => (predicate(item) ? Infinity : -Infinity);
+      }
+      break;
+    default:
+      getValue = () => undefined;
+  }
+
+  let maxElement: T | undefined = undefined;
+  let maxValue: number = -Infinity;
+
+  for (let i = 0; i < items.length; i++) {
+    const value = getValue(items[i]);
+    if (value !== undefined && value > maxValue) {
+      maxValue = value;
+      maxElement = items[i];
+    }
+  }
+
+  return maxElement;
+}

--- a/src/compat/math/maxBy.ts
+++ b/src/compat/math/maxBy.ts
@@ -1,7 +1,5 @@
 import { property } from '../object/property';
 import { isArray } from '../predicate/isArray';
-import { matches } from '../predicate/matches';
-import { matchesProperty } from '../predicate/matchesProperty';
 
 /**
  * Finds the element in an array that has the maximum value when applying

--- a/src/compat/math/maxBy.ts
+++ b/src/compat/math/maxBy.ts
@@ -1,5 +1,5 @@
-import { maxBy as maxByToolkit } from "../../array/maxBy.ts";
-import { iteratee as iterateeToolkit } from "../util/iteratee.ts";
+import { maxBy as maxByToolkit } from '../../array/maxBy.ts';
+import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
 
 /**
  * Finds the element in an array that has the maximum value when applying
@@ -31,11 +31,7 @@ import { iteratee as iterateeToolkit } from "../util/iteratee.ts";
  */
 export function maxBy<T>(
   items: ArrayLike<T> | null | undefined,
-  iteratee:
-    | ((element: T) => number)
-    | keyof T
-    | [keyof T, unknown]
-    | Partial<T>,
+  iteratee: ((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>
 ): T | undefined {
   if (items == null) {
     return undefined;

--- a/src/compat/math/maxBy.ts
+++ b/src/compat/math/maxBy.ts
@@ -1,4 +1,3 @@
-import { identity } from '../../function';
 import { property } from '../object/property';
 import { isArray } from '../predicate/isArray';
 import { matches } from '../predicate/matches';
@@ -100,7 +99,9 @@ export function maxBy<T>(
   items: readonly T[],
   iteratee: ((element: T) => number) | keyof T | [keyof T, unknown] | Partial<T>
 ): T | undefined {
-  if (!items.length) return undefined;
+  if (!items.length) {
+    return undefined;
+  }
   let getValue: (element: T) => number | undefined;
 
   switch (typeof iteratee) {


### PR DESCRIPTION
I implemented the `maxBy` function to compat, which behaviors similar to Lodash's `maxBy`.

The function finds the element in an array with the maximum value based on a given iteratee, which can be:
- function returning a numeric value
- string representing a property key
- [key, value] pair for property matching
- partial object for deep property matching

Unit tests covering various edge cases have also been added.

Thanks to: #948  