### PR TITLE
feat(compat): Implement compat/pickBy

### DIFF
--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -143,6 +143,7 @@ export { merge } from './object/merge.ts';
 export { mergeWith } from './object/mergeWith.ts';
 export { omit } from './object/omit.ts';
 export { pick } from './object/pick.ts';
+export { pickBy } from './object/pickBy.ts';
 export { property } from './object/property.ts';
 export { propertyOf } from './object/propertyOf.ts';
 export { set } from './object/set.ts';

--- a/src/compat/object/pickBy.spec.ts
+++ b/src/compat/object/pickBy.spec.ts
@@ -42,4 +42,18 @@ describe('pickBy', () => {
     const result = pickBy(obj);
     expect(result).toEqual(obj);
   });
+
+  it('should return an empty object if the object is null', () => {
+    const obj = null;
+    const shouldPick = (value: string) => typeof value === 'string';
+    const result = pickBy(obj as unknown as object, shouldPick);
+    expect(result).toEqual({});
+  });
+
+  it('should return an empty object if the object is undefined', () => {
+    const obj = undefined;
+    const shouldPick = (value: string) => typeof value === 'string';
+    const result = pickBy(obj as unknown as object, shouldPick);
+    expect(result).toEqual({});
+  });
 });

--- a/src/compat/object/pickBy.spec.ts
+++ b/src/compat/object/pickBy.spec.ts
@@ -1,59 +1,165 @@
-import { describe, expect, it } from 'vitest';
-import { pickBy } from './pickBy';
+import * as lodashStable from "es-toolkit/compat";
+import { describe, expect, it } from "vitest";
+import { pickBy } from "./pickBy";
+import { stubTrue } from "../util/stubTrue";
 
-describe('pickBy', () => {
-  it('should pick properties based on the predicate function', () => {
-    const obj = { a: 1, b: 'pick', c: 3 };
-    const shouldPick = (value: string | number) => typeof value === 'string';
-    const result = pickBy(obj, shouldPick);
-    expect(result).toEqual({ b: 'pick' });
+describe("pickBy", () => {
+  it("should work with a predicate argument", () => {
+    const object = { a: 1, b: 2, c: 3, d: 4 };
+
+    const actual = pickBy(object, (n) => n === 1 || n === 3);
+
+    expect(actual).toEqual({ a: 1, c: 3 });
   });
 
-  it('should return an empty object if no properties satisfy the predicate', () => {
+  it("should not treat keys with dots as deep paths", () => {
+    const object = { "a.b.c": 1 };
+    const actual = pickBy(object, stubTrue);
+
+    expect(actual).toEqual({ "a.b.c": 1 });
+  });
+
+  it("should pick properties based on the predicate function", () => {
+    const obj = { a: 1, b: "pick", c: 3 };
+    const shouldPick = (value: string | number) => typeof value === "string";
+    const result = pickBy(obj, shouldPick);
+    expect(result).toEqual({ b: "pick" });
+  });
+
+  it("should return an empty object if no properties satisfy the predicate", () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const shouldPick = (value: number) => typeof value === 'string';
+    const shouldPick = (value: number) => typeof value === "string";
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({});
   });
 
-  it('should return the same object if all properties satisfy the predicate', () => {
-    const obj = { a: 'pick', b: 'pick', c: 'pick' };
-    const shouldPick = (value: string) => typeof value === 'string';
+  it("should return the same object if all properties satisfy the predicate", () => {
+    const obj = { a: "pick", b: "pick", c: "pick" };
+    const shouldPick = (value: string) => typeof value === "string";
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual(obj);
   });
 
-  it('should work with an empty object', () => {
+  it("should work with an empty object", () => {
     const obj = {};
     const shouldPick = (value: never) => value;
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({});
   });
 
-  it('should work with nested objects', () => {
-    const obj = { a: 1, b: { nested: 'pick' }, c: 3 };
-    const shouldPick = (value: number | { nested: string }, key: string) => key === 'b';
+  it("should work with nested objects", () => {
+    const obj = { a: 1, b: { nested: "pick" }, c: 3 };
+    const shouldPick = (value: number | { nested: string }, key: string) =>
+      key === "b";
     const result = pickBy(obj, shouldPick);
-    expect(result).toEqual({ b: { nested: 'pick' } });
+    expect(result).toEqual({ b: { nested: "pick" } });
   });
 
-  it('should work with no predicate function', () => {
-    const obj = { a: 1, b: 'pick', c: 3 };
+  it("should work with no predicate function", () => {
+    const obj = { a: 1, b: "pick", c: 3 };
     const result = pickBy(obj);
     expect(result).toEqual(obj);
   });
 
-  it('should return an empty object if the object is null', () => {
+  it("should return an empty object if the object is null", () => {
     const obj = null;
-    const shouldPick = (value: string) => typeof value === 'string';
+    const shouldPick = (value: string) => typeof value === "string";
     const result = pickBy(obj as unknown as object, shouldPick);
     expect(result).toEqual({});
   });
 
-  it('should return an empty object if the object is undefined', () => {
+  it("should return an empty object if the object is undefined", () => {
     const obj = undefined;
-    const shouldPick = (value: string) => typeof value === 'string';
+    const shouldPick = (value: string) => typeof value === "string";
     const result = pickBy(obj as unknown as object, shouldPick);
     expect(result).toEqual({});
+  });
+
+  it(`should provide correct iteratee arguments`, () => {
+    const array = [1, 2, 3];
+
+    let args: any;
+    const expected: any = [1, 0, array];
+
+    // eslint-disable-next-line
+    // @ts-ignore
+    pickBy(array, function () {
+      args || (args = Array.prototype.slice.call(arguments));
+    });
+
+    expected[1] += "";
+
+    expect(args).toEqual(expected);
+  });
+
+  it(`should treat sparse arrays as dense`, () => {
+    const array = [1];
+    array[2] = 3;
+
+    let expected = [
+      [1, "0", array],
+      [undefined, "1", array],
+      [3, "2", array],
+    ];
+
+    expected = lodashStable.map(expected, (args) => {
+      args[1] += "";
+      return args;
+    });
+
+    const argsList: any = [];
+    pickBy(array, function () {
+      argsList.push(Array.prototype.slice.call(arguments));
+      return true;
+    });
+
+    expect(argsList).toEqual(expected);
+  });
+
+  it(`iterates over own string keyed properties of objects`, () => {
+    function Foo(this: any) {
+      // eslint-disable-next-line
+      // @ts-ignore
+      this.a = 1;
+    }
+    Foo.prototype.b = 2;
+
+    const values: any[] = [];
+    // eslint-disable-next-line
+    // @ts-ignore
+    pickBy(new Foo(), (value) => {
+      values.push(value);
+    });
+    expect(values).toEqual([1]);
+  });
+
+  it(`should ignore changes to \`length\``, () => {
+    let count = 0;
+    const array = [1];
+
+    pickBy(array, () => {
+      if (++count === 1) {
+        array.push(2);
+      }
+      return true;
+    });
+
+    expect(count).toBe(1);
+  });
+
+  it(`should ignore added \`object\` properties`, () => {
+    let count = 0;
+    const object = { a: 1 };
+
+    pickBy(object, () => {
+      if (++count === 1) {
+        // eslint-disable-next-line
+        // @ts-ignore
+        object.b = 2;
+      }
+      return true;
+    });
+
+    expect(count).toBe(1);
   });
 });

--- a/src/compat/object/pickBy.spec.ts
+++ b/src/compat/object/pickBy.spec.ts
@@ -1,76 +1,75 @@
-import * as lodashStable from "es-toolkit/compat";
-import { describe, expect, it } from "vitest";
-import { pickBy } from "./pickBy";
-import { stubTrue } from "../util/stubTrue";
+import { describe, expect, it } from 'vitest';
+import * as lodashStable from 'es-toolkit/compat';
+import { pickBy } from './pickBy';
+import { stubTrue } from '../util/stubTrue';
 
-describe("pickBy", () => {
-  it("should work with a predicate argument", () => {
+describe('pickBy', () => {
+  it('should work with a predicate argument', () => {
     const object = { a: 1, b: 2, c: 3, d: 4 };
 
-    const actual = pickBy(object, (n) => n === 1 || n === 3);
+    const actual = pickBy(object, n => n === 1 || n === 3);
 
     expect(actual).toEqual({ a: 1, c: 3 });
   });
 
-  it("should not treat keys with dots as deep paths", () => {
-    const object = { "a.b.c": 1 };
+  it('should not treat keys with dots as deep paths', () => {
+    const object = { 'a.b.c': 1 };
     const actual = pickBy(object, stubTrue);
 
-    expect(actual).toEqual({ "a.b.c": 1 });
+    expect(actual).toEqual({ 'a.b.c': 1 });
   });
 
-  it("should pick properties based on the predicate function", () => {
-    const obj = { a: 1, b: "pick", c: 3 };
-    const shouldPick = (value: string | number) => typeof value === "string";
+  it('should pick properties based on the predicate function', () => {
+    const obj = { a: 1, b: 'pick', c: 3 };
+    const shouldPick = (value: string | number) => typeof value === 'string';
     const result = pickBy(obj, shouldPick);
-    expect(result).toEqual({ b: "pick" });
+    expect(result).toEqual({ b: 'pick' });
   });
 
-  it("should return an empty object if no properties satisfy the predicate", () => {
+  it('should return an empty object if no properties satisfy the predicate', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const shouldPick = (value: number) => typeof value === "string";
+    const shouldPick = (value: number) => typeof value === 'string';
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({});
   });
 
-  it("should return the same object if all properties satisfy the predicate", () => {
-    const obj = { a: "pick", b: "pick", c: "pick" };
-    const shouldPick = (value: string) => typeof value === "string";
+  it('should return the same object if all properties satisfy the predicate', () => {
+    const obj = { a: 'pick', b: 'pick', c: 'pick' };
+    const shouldPick = (value: string) => typeof value === 'string';
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual(obj);
   });
 
-  it("should work with an empty object", () => {
+  it('should work with an empty object', () => {
     const obj = {};
     const shouldPick = (value: never) => value;
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({});
   });
 
-  it("should work with nested objects", () => {
-    const obj = { a: 1, b: { nested: "pick" }, c: 3 };
-    const shouldPick = (value: number | { nested: string }, key: string) =>
-      key === "b";
+  it('should work with nested objects', () => {
+    const obj = { a: 1, b: { nested: 'pick' }, c: 3 };
+    const shouldPick = (value: number | { nested: string }, key: string) => key === 'b';
     const result = pickBy(obj, shouldPick);
-    expect(result).toEqual({ b: { nested: "pick" } });
+    expect(result).toEqual({ b: { nested: 'pick' } });
   });
 
-  it("should work with no predicate function", () => {
-    const obj = { a: 1, b: "pick", c: 3 };
+  it('should work with no predicate function', () => {
+    const obj = { a: 1, b: 'pick', c: 3 };
     const result = pickBy(obj);
     expect(result).toEqual(obj);
   });
 
-  it("should return an empty object if the object is null", () => {
+  it('should return an empty object if the object is null', () => {
     const obj = null;
-    const shouldPick = (value: string) => typeof value === "string";
+    const shouldPick = (value: string) => typeof value === 'string';
     const result = pickBy(obj as unknown as object, shouldPick);
     expect(result).toEqual({});
   });
 
-  it("should return an empty object if the object is undefined", () => {
+  it('should return an empty object if the object is undefined', () => {
     const obj = undefined;
-    const shouldPick = (value: string) => typeof value === "string";
+    const shouldPick = (value: string) => typeof value === 'string';
     const result = pickBy(obj as unknown as object, shouldPick);
     expect(result).toEqual({});
   });
@@ -84,9 +83,11 @@ describe("pickBy", () => {
     // eslint-disable-next-line
     // @ts-ignore
     pickBy(array, function () {
+      // eslint-disable-next-line
       args || (args = Array.prototype.slice.call(arguments));
     });
 
+    // eslint-disable-next-line
     expected[1] += "";
 
     expect(args).toEqual(expected);
@@ -97,18 +98,20 @@ describe("pickBy", () => {
     array[2] = 3;
 
     let expected = [
-      [1, "0", array],
-      [undefined, "1", array],
-      [3, "2", array],
+      [1, '0', array],
+      [undefined, '1', array],
+      [3, '2', array],
     ];
 
-    expected = lodashStable.map(expected, (args) => {
+    expected = lodashStable.map(expected, args => {
+      // eslint-disable-next-line
       args[1] += "";
       return args;
     });
 
     const argsList: any = [];
     pickBy(array, function () {
+      // eslint-disable-next-line
       argsList.push(Array.prototype.slice.call(arguments));
       return true;
     });
@@ -127,7 +130,7 @@ describe("pickBy", () => {
     const values: any[] = [];
     // eslint-disable-next-line
     // @ts-ignore
-    pickBy(new Foo(), (value) => {
+    pickBy(new Foo(), value => {
       values.push(value);
     });
     expect(values).toEqual([1]);

--- a/src/compat/object/pickBy.spec.ts
+++ b/src/compat/object/pickBy.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { pickBy } from './pickBy';
+
+describe('pickBy', () => {
+  it('should pick properties based on the predicate function', () => {
+    const obj = { a: 1, b: 'pick', c: 3 };
+    const shouldPick = (value: string | number) => typeof value === 'string';
+    const result = pickBy(obj, shouldPick);
+    expect(result).toEqual({ b: 'pick' });
+  });
+
+  it('should return an empty object if no properties satisfy the predicate', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const shouldPick = (value: number) => typeof value === 'string';
+    const result = pickBy(obj, shouldPick);
+    expect(result).toEqual({});
+  });
+
+  it('should return the same object if all properties satisfy the predicate', () => {
+    const obj = { a: 'pick', b: 'pick', c: 'pick' };
+    const shouldPick = (value: string) => typeof value === 'string';
+    const result = pickBy(obj, shouldPick);
+    expect(result).toEqual(obj);
+  });
+
+  it('should work with an empty object', () => {
+    const obj = {};
+    const shouldPick = (value: never) => value;
+    const result = pickBy(obj, shouldPick);
+    expect(result).toEqual({});
+  });
+
+  it('should work with nested objects', () => {
+    const obj = { a: 1, b: { nested: 'pick' }, c: 3 };
+    const shouldPick = (value: number | { nested: string }, key: string) => key === 'b';
+    const result = pickBy(obj, shouldPick);
+    expect(result).toEqual({ b: { nested: 'pick' } });
+  });
+
+  it('should work with no predicate function', () => {
+    const obj = { a: 1, b: 'pick', c: 3 };
+    const result = pickBy(obj);
+    expect(result).toEqual(obj);
+  });
+});

--- a/src/compat/object/pickBy.ts
+++ b/src/compat/object/pickBy.ts
@@ -21,7 +21,9 @@ export function pickBy<T extends Record<string, any>>(
   obj: T,
   shouldPick?: (value: T[keyof T], key: keyof T) => boolean
 ): Partial<T> {
-  if (obj === null || obj === undefined) return {};
+  if (obj === null || obj === undefined) {
+    return {};
+  }
   const result: Partial<T> = {};
 
   if (shouldPick === undefined) {

--- a/src/compat/object/pickBy.ts
+++ b/src/compat/object/pickBy.ts
@@ -1,5 +1,5 @@
-import { range } from "../../math/range.ts";
-import { isArrayLike } from "../predicate/isArrayLike.ts";
+import { range } from '../../math/range.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
  * Creates a new object composed of the properties that satisfy the predicate function.
@@ -22,7 +22,7 @@ import { isArrayLike } from "../predicate/isArrayLike.ts";
  */
 export function pickBy<T extends Record<string, any>>(
   obj: T,
-  shouldPick?: (value: T[keyof T], key: keyof T, obj: T) => boolean,
+  shouldPick?: (value: T[keyof T], key: keyof T, obj: T) => boolean
 ): Partial<T> {
   if (obj == null) {
     return {};
@@ -34,9 +34,7 @@ export function pickBy<T extends Record<string, any>>(
     return obj;
   }
 
-  const keys = isArrayLike(obj)
-    ? range(0, obj.length)
-    : Object.keys(obj) as Array<keyof T>;
+  const keys = isArrayLike(obj) ? range(0, obj.length) : (Object.keys(obj) as Array<keyof T>);
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i].toString() as keyof T;

--- a/src/compat/object/pickBy.ts
+++ b/src/compat/object/pickBy.ts
@@ -1,0 +1,40 @@
+/**
+ * Creates a new object composed of the properties that satisfy the predicate function.
+ *
+ * This function takes an object and a predicate function, and returns a new object that
+ * includes only the properties for which the predicate function returns true.
+ *
+ * @template T - The type of object.
+ * @param {T} obj - The object to pick properties from.
+ * @param {(value: T[keyof T], key: keyof T) => boolean} shouldPick - A predicate function that determines
+ * whether a property should be picked. It takes the property's key and value as arguments and returns `true`
+ * if the property should be picked, and `false` otherwise.
+ * @returns {Partial<T>} A new object with the properties that satisfy the predicate function.
+ *
+ * @example
+ * const obj = { a: 1, b: 'pick', c: 3 };
+ * const shouldPick = (value) => typeof value === 'string';
+ * const result = pickBy(obj, shouldPick);
+ * // result will be { b: 'pick' }
+ */
+export function pickBy<T extends Record<string, any>>(
+  obj: T,
+  shouldPick?: (value: T[keyof T], key: keyof T) => boolean
+): Partial<T> {
+  const result: Partial<T> = {};
+
+  if (shouldPick === undefined) {
+    return obj;
+  }
+  const keys = Object.keys(obj) as Array<keyof T>;
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = obj[key];
+
+    if (shouldPick(value, key)) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}

--- a/src/compat/object/pickBy.ts
+++ b/src/compat/object/pickBy.ts
@@ -21,6 +21,7 @@ export function pickBy<T extends Record<string, any>>(
   obj: T,
   shouldPick?: (value: T[keyof T], key: keyof T) => boolean
 ): Partial<T> {
+  if (obj === null || obj === undefined) return {};
   const result: Partial<T> = {};
 
   if (shouldPick === undefined) {

--- a/src/compat/object/pickBy.ts
+++ b/src/compat/object/pickBy.ts
@@ -1,3 +1,6 @@
+import { range } from "../../math/range.ts";
+import { isArrayLike } from "../predicate/isArrayLike.ts";
+
 /**
  * Creates a new object composed of the properties that satisfy the predicate function.
  *
@@ -19,22 +22,27 @@
  */
 export function pickBy<T extends Record<string, any>>(
   obj: T,
-  shouldPick?: (value: T[keyof T], key: keyof T) => boolean
+  shouldPick?: (value: T[keyof T], key: keyof T, obj: T) => boolean,
 ): Partial<T> {
-  if (obj === null || obj === undefined) {
+  if (obj == null) {
     return {};
   }
+
   const result: Partial<T> = {};
 
-  if (shouldPick === undefined) {
+  if (shouldPick == null) {
     return obj;
   }
-  const keys = Object.keys(obj) as Array<keyof T>;
+
+  const keys = isArrayLike(obj)
+    ? range(0, obj.length)
+    : Object.keys(obj) as Array<keyof T>;
+
   for (let i = 0; i < keys.length; i++) {
-    const key = keys[i];
+    const key = keys[i].toString() as keyof T;
     const value = obj[key];
 
-    if (shouldPick(value, key)) {
+    if (shouldPick(value, key, obj)) {
       result[key] = value;
     }
   }


### PR DESCRIPTION
I added the `pickBy` function to compat, which behaviors similar to Lodash's `pickBy`:
the second param of the function is optional.

Thanks to: #946 