### PR TITLE
docs: fix typo in flattenObject

### DIFF
--- a/src/object/flattenObject.ts
+++ b/src/object/flattenObject.ts
@@ -3,7 +3,7 @@ import { isPlainObject } from '../predicate/isPlainObject.ts';
 interface FlattenObjectOptions {
   /**
    * The delimiter to use between nested keys.
-   * @default '.''
+   * @default '.'
    */
   delimiter?: string;
 }


### PR DESCRIPTION
fix typo in `src/object/flattenObject.ts`