### PR TITLE
feat(predicate): Add isJSON utility function

### DIFF
--- a/docs/ko/reference/predicate/isJSON.md
+++ b/docs/ko/reference/predicate/isJSON.md
@@ -1,0 +1,43 @@
+# isJSON
+
+주어진 값이 유효한 JSON 문자열인지 확인해요. 유효한 JSON 문자열이란, `JSON.parse()`로 성공적으로 파싱할 수 있는 문자열을 말해요. TypeScript의 타입 가드로 사용할 수 있어요. 파라미터로 주어진 값의 타입을 `string`으로 좁혀요.
+
+JSON 규정에 따라 문자열 `null`, `true`, `false`, 숫자 문자열도 유효한 JSON으로 인정되어 true를 반환해요.
+
+## 인터페이스
+
+```typescript
+function isJSON(value: unknown): value is string;
+```
+
+### 파라미터
+
+- `value` (`unknown`): 유효한 JSON 문자열인지 확인할 값.
+
+### 반환 값
+
+`value is string`: 값이 유효한 JSON 문자열이면 `true`, 아니면 `false`.
+
+## 예시
+
+```typescript
+import { isJSON } from 'es-toolkit/predicate';
+
+const value1 = '{"name":"John","age":30}';
+const value2 = '[1,2,3]';
+const value3 = 'true';
+const value4 = 'null';
+const value5 = '42';
+const value6 = 'invalid json';
+const value7 = { name: 'John' };
+const value8 = null;
+
+console.log(isJSON(value1)); // true
+console.log(isJSON(value2)); // true
+console.log(isJSON(value3)); // true (JSON 명세에 따라 불리언으로 파싱됨)
+console.log(isJSON(value4)); // true (JSON 명세에 따라 null로 파싱됨)
+console.log(isJSON(value5)); // true (JSON 명세에 따라 숫자로 파싱됨)
+console.log(isJSON(value6)); // false
+console.log(isJSON(value7)); // false (문자열이 아님)
+console.log(isJSON(value8)); // false (문자열이 아님)
+```

--- a/docs/reference/predicate/isJSON.md
+++ b/docs/reference/predicate/isJSON.md
@@ -1,0 +1,43 @@
+# isJSON
+
+Checks if a given value is a valid JSON string. A valid JSON string is one that can be successfully parsed using `JSON.parse()`. This function can be used as a type guard in TypeScript, narrowing the type of the argument to `string`.
+
+According to JSON specifications, string values like `null`, `true`, `false`, and numeric strings are considered valid JSON and will return true.
+
+## Interface
+
+```typescript
+function isJSON(value: unknown): value is string;
+```
+
+### Parameters
+
+- `value` (`unknown`): The value to check if it's a valid JSON string.
+
+### Return Value
+
+(`value is string`): Returns `true` if the value is a valid JSON string, otherwise `false`.
+
+## Examples
+
+```typescript
+import { isJSON } from 'es-toolkit/predicate';
+
+const value1 = '{"name":"John","age":30}';
+const value2 = '[1,2,3]';
+const value3 = 'true';
+const value4 = 'null';
+const value5 = '42';
+const value6 = 'invalid json';
+const value7 = { name: 'John' };
+const value8 = null;
+
+console.log(isJSON(value1)); // true
+console.log(isJSON(value2)); // true
+console.log(isJSON(value3)); // true (parsed as boolean per JSON spec)
+console.log(isJSON(value4)); // true (parsed as null per JSON spec)
+console.log(isJSON(value5)); // true (parsed as number per JSON spec)
+console.log(isJSON(value6)); // false
+console.log(isJSON(value7)); // false (not a string)
+console.log(isJSON(value8)); // false (not a string)
+```

--- a/src/predicate/isJSON.spec.ts
+++ b/src/predicate/isJSON.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { isJSON } from './isJSON';
+
+describe('isJSON', () => {
+  it('returns true if the value is a valid JSON string', () => {
+    expect(isJSON('{"name":"John","age":30}')).toBe(true);
+    expect(isJSON('[1,2,3]')).toBe(true);
+    expect(isJSON('"string"')).toBe(true);
+    expect(isJSON('123')).toBe(true);
+    expect(isJSON('true')).toBe(true);
+    expect(isJSON('false')).toBe(true);
+    expect(isJSON('null')).toBe(true);
+  });
+
+  it('returns false if the value is not a valid JSON string', () => {
+    expect(isJSON('invalid json')).toBe(false);
+    expect(isJSON('{"unclosed": "object"')).toBe(false);
+    expect(isJSON('[1,2,')).toBe(false);
+    expect(isJSON('undefined')).toBe(false);
+    expect(isJSON('')).toBe(false);
+  });
+
+  it('returns false if the value is not a string', () => {
+    expect(isJSON(null)).toBe(false);
+    expect(isJSON(undefined)).toBe(false);
+    expect(isJSON(123)).toBe(false);
+    expect(isJSON(true)).toBe(false);
+    expect(isJSON({})).toBe(false);
+    expect(isJSON([])).toBe(false);
+    expect(isJSON(new Date())).toBe(false);
+    expect(isJSON(() => {})).toBe(false);
+  });
+});

--- a/src/predicate/isJSON.ts
+++ b/src/predicate/isJSON.ts
@@ -1,0 +1,32 @@
+/**
+ * Checks if a given value is a valid JSON string.
+ *
+ * A valid JSON string is of type `string` and can be successfully parsed using `JSON.parse()`.
+ * It returns `true` if the value is a valid JSON string, and `false` otherwise.
+ *
+ * This function can also serve as a type predicate in TypeScript, narrowing the type of the
+ * argument to a valid JSON string (`string`).
+ *
+ * @param {unknown} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a valid JSON string, else `false`.
+ *
+ * @example
+ * isJSON('{"name":"John","age":30}'); // true
+ * isJSON('[1,2,3]'); // true
+ * isJSON('true'); // true
+ * isJSON('invalid json'); // false
+ * isJSON({ name: 'John' }); // false (not a string)
+ * isJSON(null); // false (not a string)
+ */
+export function isJSON(value: unknown): value is string {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
# Add isJSON utility function

## Summary
Added a new utility function `isJSON` that checks if a given value is a valid JSON string. This function also acts as a TypeScript type predicate, helping with type narrowing in TypeScript code.

## Implementation Details
- Function takes any value (`unknown` type) as input
- Returns `boolean` indicating if the string can be parsed as valid JSON
- Implements type predicate functionality (`value is string`)
- Uses try/catch with native `JSON.parse()` for validation
- Handles edge cases like JSON primitives ('null', 'true', etc.)

## Usage Examples
```typescript
import { isJSON } from 'es-toolkit/predicate';

// Valid JSON strings
isJSON('{"name":"John","age":30}')  // true
isJSON('[1,2,3]')                  // true
isJSON('true')                     // true (JSON primitive)
isJSON('null')                     // true (JSON primitive)
isJSON('42')                       // true (valid number string)

// Invalid JSON or non-strings
isJSON('invalid json')             // false
isJSON({ name: 'John' })           // false (object, not string)
isJSON(null)                       // false (not a string)