### PR TITLE
feat(toSnakeObject): Add toSnakeObject export to object index

### DIFF
--- a/docs/ja/reference/object/toSnakeObject.md
+++ b/docs/ja/reference/object/toSnakeObject.md
@@ -1,0 +1,69 @@
+# toSnakeObject
+
+オブジェクトのキーをスネークケース（snake_case）に変換します。
+
+この関数は元のオブジェクトを変更しません。
+
+## インターフェース
+
+```typescript
+function toSnakeObject<T extends Record<PropertyKey, any>>(obj: T): Record<string, any>;
+```
+
+### パラメータ
+
+- `obj` (`T`): キーをスネークケースに変換するオブジェクト。
+
+### 戻り値
+
+(`Record<string, any>`): キーがスネークケースに変換された新しいオブジェクト。
+
+## 例
+
+```typescript
+const user = {
+  firstName: 'Gweesin',
+  lastName: 'Chan',
+  contactInfo: {
+    emailAddress: 'john@example.com',
+    phoneNumber: '123-456-7890'
+  }
+};
+
+const formattedUser = toSnakeObject(user);
+console.log(formattedUser);
+// 出力: {
+//   first_name: 'Gweesin',
+//   last_name: 'Chan',
+//   contact_info: {
+//     email_address: 'john@example.com',
+//     phone_number: '123-456-7890'
+//   }
+// }
+```
+
+## 説明
+
+`toSnakeObject` 関数は、オブジェクトおよびそのネストされたオブジェクトのすべてのキーを再帰的にスネークケースに変換します。この関数は、どの深さのネストされたオブジェクトにも適用可能で、元のオブジェクトを変更しません。
+
+## デモ
+
+::: sandpack
+
+```ts index.ts
+import { toSnakeObject } from 'es-toolkit';
+
+const user = {
+  firstName: 'Gweesin',
+  lastName: 'Chan',
+  contactInfo: {
+    emailAddress: 'john@example.com',
+    phoneNumber: '123-456-7890'
+  }
+};
+
+const formattedUser = toSnakeObject(user);
+console.log(formattedUser);
+```
+
+:::

--- a/docs/ko/reference/object/toSnakeObject.md
+++ b/docs/ko/reference/object/toSnakeObject.md
@@ -1,0 +1,69 @@
+# toSnakeObject
+
+객체의 키를 스네이크 케이스(snake_case)로 변환합니다.
+
+이 함수는 원본 객체를 수정하지 않습니다.
+
+## 인터페이스
+
+```typescript
+function toSnakeObject<T extends Record<PropertyKey, any>>(obj: T): Record<string, any>;
+```
+
+### 매개변수
+
+- `obj` (`T`): 키를 스네이크 케이스로 변환할 객체.
+
+### 반환 값
+
+(`Record<string, any>`): 키가 스네이크 케이스로 변환된 새 객체.
+
+## 예제
+
+```typescript
+const user = {
+  firstName: 'Gweesin',
+  lastName: 'Chan',
+  contactInfo: {
+    emailAddress: 'john@example.com',
+    phoneNumber: '123-456-7890'
+  }
+};
+
+const formattedUser = toSnakeObject(user);
+console.log(formattedUser);
+// 출력: {
+//   first_name: 'Gweesin',
+//   last_name: 'Chan',
+//   contact_info: {
+//     email_address: 'john@example.com',
+//     phone_number: '123-456-7890'
+//   }
+// }
+```
+
+## 설명
+
+`toSnakeObject` 함수는 객체와 그 중첩된 객체의 모든 키를 재귀적으로 스네이크 케이스로 변환합니다. 이 함수는 어떤 깊이의 중첩 객체에도 적용 가능하며, 원본 객체를 변경하지 않습니다.
+
+## 데모
+
+::: sandpack
+
+```ts index.ts
+import { toSnakeObject } from 'es-toolkit';
+
+const user = {
+  firstName: 'Gweesin',
+  lastName: 'Chan',
+  contactInfo: {
+    emailAddress: 'john@example.com',
+    phoneNumber: '123-456-7890'
+  }
+};
+
+const formattedUser = toSnakeObject(user);
+console.log(formattedUser);
+```
+
+:::

--- a/docs/reference/object/toSnakeObject.md
+++ b/docs/reference/object/toSnakeObject.md
@@ -1,0 +1,69 @@
+# toSnakeObject
+
+Converts the keys of an object to snake_case.
+
+This function does not mutate the original object.
+
+## Interface
+
+```typescript
+function toSnakeObject<T extends Record<PropertyKey, any>>(obj: T): Record<string, any>;
+```
+
+### Parameters
+
+- `obj` (`T`): The object whose keys will be converted to snake_case.
+
+### Return Value
+
+(`Record<string, any>`): A new object with keys converted to snake_case.
+
+## Example
+
+```typescript
+const user = {
+  firstName: 'Gweesin',
+  lastName: 'Chan',
+  contactInfo: {
+    emailAddress: 'john@example.com',
+    phoneNumber: '123-456-7890'
+  }
+};
+
+const formattedUser = toSnakeObject(user);
+console.log(formattedUser);
+// Output: {
+//   first_name: 'Gweesin',
+//   last_name: 'Chan',
+//   contact_info: {
+//     email_address: 'john@example.com',
+//     phone_number: '123-456-7890'
+//   }
+// }
+```
+
+## Description
+
+The `toSnakeObject` function recursively converts all keys of an object and its nested objects to snake_case. It is applicable to objects with any depth of nesting and does not alter the original object.
+
+## Demo
+
+::: sandpack
+
+```ts index.ts
+import { toSnakeObject } from 'es-toolkit';
+
+const user = {
+  firstName: 'Gweesin',
+  lastName: 'Chan',
+  contactInfo: {
+    emailAddress: 'john@example.com',
+    phoneNumber: '123-456-7890'
+  }
+};
+
+const formattedUser = toSnakeObject(user);
+console.log(formattedUser);
+```
+
+:::

--- a/docs/zh_hans/reference/object/toSnakeObject.md
+++ b/docs/zh_hans/reference/object/toSnakeObject.md
@@ -1,0 +1,69 @@
+# toSnakeObject
+
+将对象的键转换为蛇形命名（snake_case）。
+
+此函数不会修改原始对象。
+
+## 接口
+
+```typescript
+function toSnakeObject<T extends Record<PropertyKey, any>>(obj: T): Record<string, any>;
+```
+
+### 参数
+
+- `obj` (`T`): 需要将键转换为蛇形命名的对象。
+
+### 返回值
+
+(`Record<string, any>`): 一个新对象，其中的键已转换为蛇形命名。
+
+## 示例
+
+```typescript
+const user = {
+  firstName: 'Gweesin',
+  lastName: 'Chan',
+  contactInfo: {
+    emailAddress: 'john@example.com',
+    phoneNumber: '123-456-7890'
+  }
+};
+
+const formattedUser = toSnakeObject(user);
+console.log(formattedUser);
+// 输出: {
+//   first_name: 'Gweesin',
+//   last_name: 'Chan',
+//   contact_info: {
+//     email_address: 'john@example.com',
+//     phone_number: '123-456-7890'
+//   }
+// }
+```
+
+## 说明
+
+`toSnakeObject` 函数递归地将对象及其嵌套对象的所有键转换为蛇形命名。它适用于任何深度的嵌套对象，并且不会改变原始对象。
+
+## 演示
+
+::: sandpack
+
+```ts index.ts
+import { toSnakeObject } from 'es-toolkit';
+
+const user = {
+  firstName: 'Gweesin',
+  lastName: 'Chan',
+  contactInfo: {
+    emailAddress: 'john@example.com',
+    phoneNumber: '123-456-7890'
+  }
+};
+
+const formattedUser = toSnakeObject(user);
+console.log(formattedUser);
+```
+
+:::

--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -13,3 +13,4 @@ export { omitBy } from './omitBy.ts';
 export { pick } from './pick.ts';
 export { pickBy } from './pickBy.ts';
 export { toMerged } from './toMerged.ts';
+export { toSnakeObject } from './toSnakeObject.ts';

--- a/src/object/toSnakeObject.spec.ts
+++ b/src/object/toSnakeObject.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { toSnakeObject } from './toSnakeObject';
+
+describe.only('toSnakeObject', () => {
+  it('should convert object keys to snake_case', () => {
+    const input = {
+      firstName: 'Gweesin',
+      lastName: 'Chan',
+      emailAddress: 'john@example.com',
+    };
+
+    const expected = {
+      first_name: 'Gweesin',
+      last_name: 'Chan',
+      email_address: 'john@example.com',
+    };
+
+    expect(toSnakeObject(input)).toEqual(expected);
+  });
+
+  it('should handle nested objects', () => {
+    const input = {
+      userInfo: {
+        firstName: 'Gweesin',
+        lastName: 'Chan',
+        contactDetails: {
+          emailAddress: 'john@example.com',
+          phoneNumber: '123-456-7890',
+        },
+      },
+    };
+
+    const expected = {
+      user_info: {
+        first_name: 'Gweesin',
+        last_name: 'Chan',
+        contact_details: {
+          email_address: 'john@example.com',
+          phone_number: '123-456-7890',
+        },
+      },
+    };
+
+    expect(toSnakeObject(input)).toEqual(expected);
+  });
+
+  it('should handle arrays', () => {
+    const input = {
+      userList: [
+        { firstName: 'Gweesin', lastName: 'Chan' },
+        { firstName: 'Jane', lastName: 'Smith' },
+      ],
+    };
+
+    const expected = {
+      user_list: [
+        { first_name: 'Gweesin', last_name: 'Chan' },
+        { first_name: 'Jane', last_name: 'Smith' },
+      ],
+    };
+
+    expect(toSnakeObject(input)).toEqual(expected);
+  });
+
+  it('should not modify the original object', () => {
+    const input = {
+      firstName: 'Gweesin',
+      contactInfo: {
+        emailAddress: 'john@example.com',
+      },
+    };
+
+    const originalInput = { ...input };
+    toSnakeObject(input);
+
+    expect(input).toEqual(originalInput);
+  });
+});

--- a/src/object/toSnakeObject.spec.ts
+++ b/src/object/toSnakeObject.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { toSnakeObject } from './toSnakeObject';
 
-describe.only('toSnakeObject', () => {
+describe('toSnakeObject', () => {
   it('should convert object keys to snake_case', () => {
     const input = {
       firstName: 'Gweesin',

--- a/src/object/toSnakeObject.ts
+++ b/src/object/toSnakeObject.ts
@@ -1,0 +1,50 @@
+import { snakeCase } from '../string/snakeCase.ts';
+
+/**
+ * Converts the keys of an object to snake_case.
+ * This function does not mutate the original object.
+ *
+ * @param {T} obj - The object whose keys will be converted to snake_case.
+ * @returns {T} A new object with keys in snake_case.
+ *
+ * @template T - Type of the object.
+ *
+ * @example
+ * const user = {
+ *   firstName: 'John',
+ *   lastName: 'Doe', 
+ *   contactInfo: {
+ *     emailAddress: 'john@example.com',
+ *     phoneNumber: '123-456-7890'
+ *   }
+ * };
+ * 
+ * const formattedUser = toSnakeObject(user);
+ * console.log(formattedUser);
+ * // Output: {
+ * //   first_name: 'John',
+ * //   last_name: 'Doe',
+ * //   contact_info: {
+ * //     email_address: 'john@example.com', 
+ * //     phone_number: '123-456-7890'
+ * //   }
+ * // }
+ */
+export function toSnakeObject<T extends Record<PropertyKey, any>>(obj: T): Record<string, any> {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(item => toSnakeObject(item));
+  }
+
+  const result: Record<string, any> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    const newKey = snakeCase(key);
+    result[newKey] = toSnakeObject(value);
+  }
+
+  return result;
+}


### PR DESCRIPTION

**Add toSnakeObject Utility Function**

**Summary**

Added a new utility function `toSnakeObject` that converts the keys of an object to snake_case. This function is designed to handle objects with any depth of nesting and ensures that the original object remains unaltered.

**Implementation Details**

- The function accepts an object with keys in any case format.
- It returns a new object with all keys converted to snake_case.
- The function is recursive, allowing it to handle nested objects and arrays.
- Utilizes a helper function `snakeCase` to perform the key conversion.
- Ensures immutability by not modifying the original object.

**Usage Examples**

```typescript
import { toSnakeObject } from 'es-toolkit/object';

// Convert object keys to snake_case
const user = {
  firstName: 'John',
  lastName: 'Doe',
  contactInfo: {
    emailAddress: 'john@example.com',
    phoneNumber: '123-456-7890'
  }
};

const formattedUser = toSnakeObject(user);
console.log(formattedUser);
// Output: {
//   first_name: 'John',
//   last_name: 'Doe',
//   contact_info: {
//     email_address: 'john@example.com',
//     phone_number: '123-456-7890'
//   }
// }
```

This function is particularly useful for applications that require consistent key formatting, such as when interfacing with APIs that expect snake_case keys.
