### PR TITLE
docs: edit link when clicking reference tab in nav

### DIFF
--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -31,7 +31,7 @@ function nav(): DefaultTheme.NavItem[] {
   return [
     { text: 'Home', link: '/' },
     { text: 'Introduction', link: '/intro' },
-    { text: 'Reference', link: '/reference/array/chunk' },
+    { text: 'Reference', link: '/reference/array/at' },
   ];
 }
 

--- a/docs/.vitepress/ja.mts
+++ b/docs/.vitepress/ja.mts
@@ -30,7 +30,7 @@ function nav(): DefaultTheme.NavItem[] {
   return [
     { text: 'ホーム', link: '/ja' },
     { text: '導入', link: '/ja/intro' },
-    { text: 'リファレンス', link: '/ja/reference/array/chunk' },
+    { text: 'リファレンス', link: '/ja/reference/array/at' },
   ];
 }
 

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -30,7 +30,7 @@ function nav(): DefaultTheme.NavItem[] {
   return [
     { text: '홈', link: '/ko' },
     { text: '소개', link: '/ko/intro' },
-    { text: '레퍼런스', link: '/ko/reference/array/chunk' },
+    { text: '레퍼런스', link: '/ko/reference/array/at' },
   ];
 }
 

--- a/docs/.vitepress/zh_hans.mts
+++ b/docs/.vitepress/zh_hans.mts
@@ -31,7 +31,7 @@ function nav(): DefaultTheme.NavItem[] {
   return [
     { text: '主页', link: '/zh_hans/' },
     { text: '简介', link: '/zh_hans/intro' },
-    { text: '参考', link: '/zh_hans/reference/array/chunk' },
+    { text: '参考', link: '/zh_hans/reference/array/at' },
   ];
 }
 


### PR DESCRIPTION
ES Toolkit Docs has the navigation links that allow users to access each category. Currently, clicking on the Reference tab redirects to the [Chunk](https://es-toolkit.slash.page/reference/array/chunk.html) page, which is the third item in the Reference category. This behavior is unexpected and may confuse users.

To improve usability, I’ve updated the links to direct users to the first subpage in the category, which is the [at](https://es-toolkit.slash.page/reference/array/at.html) page. This ensures a more intuitive navigation experience.