### PR TITLE
feat(functionsIn): Add `functionsIn` to compat/object

### DIFF
--- a/benchmarks/performance/functionsIn.bench.ts
+++ b/benchmarks/performance/functionsIn.bench.ts
@@ -1,0 +1,45 @@
+import { bench, describe } from 'vitest';
+import { functionsIn as functionsInToolkitCompat_ } from 'es-toolkit/compat';
+import { functionsIn as functionsInLodash_ } from 'lodash';
+
+const functionsInToolkitCompat = functionsInToolkitCompat_;
+const functionsInLodash = functionsInLodash_;
+
+describe('functionsIn', () => {
+  function Foo() {
+    this.a = function () {
+      return 'a';
+    };
+    this.b = function () {
+      return 'b';
+    };
+  }
+
+  Foo.prototype.c = function () {
+    return 'c';
+  };
+
+  const foo = new Foo();
+  const plainObject = {
+    a: function () {
+      return 'a';
+    },
+    b: function () {
+      return 'b';
+    },
+  };
+
+  bench('es-toolkit/compat/functionsIn', () => {
+    functionsInToolkitCompat(foo);
+    functionsInToolkitCompat(plainObject);
+    functionsInToolkitCompat(null);
+    functionsInToolkitCompat(undefined);
+  });
+
+  bench('lodash/functionsIn', () => {
+    functionsInLodash(foo);
+    functionsInLodash(plainObject);
+    functionsInLodash(null);
+    functionsInLodash(undefined);
+  });
+});

--- a/docs/ja/reference/compat/object/functionsIn.md
+++ b/docs/ja/reference/compat/object/functionsIn.md
@@ -1,0 +1,67 @@
+# functionsIn
+
+::: info
+この関数は互換性のために `es-toolkit/compat` からのみインポートできます。代替可能なネイティブ JavaScript API があるか、まだ十分に最適化されていないためです。
+
+`es-toolkit/compat` からこの関数をインポートすると、[lodash と完全に同じように動作](mdc:../../../compatibility.md)します。
+:::
+
+オブジェクトの独自プロパティと継承された列挙可能なプロパティから、関数プロパティ名の配列を生成します。
+
+## インターフェース
+
+```typescript
+function functionsIn(object: any): string[];
+```
+
+### パラメータ
+
+- `object`: 検査するオブジェクト。
+
+### 戻り値
+
+(`string[]`): オブジェクトの独自プロパティと継承された列挙可能なプロパティから、関数プロパティ名の配列を返します。
+
+## 例
+
+```typescript
+import { functionsIn } from 'es-toolkit/compat';
+
+function Foo() {
+  this.a = function () {
+    return 'a';
+  };
+  this.b = function () {
+    return 'b';
+  };
+}
+
+Foo.prototype.c = function () {
+  return 'c';
+};
+
+// 継承された関数を含む関数プロパティ名を取得
+functionsIn(new Foo());
+// => ['a', 'b', 'c']
+
+// プレーンオブジェクトでも動作
+const object = {
+  a: function () {
+    return 'a';
+  },
+  b: function () {
+    return 'b';
+  },
+};
+
+functionsIn(object);
+// => ['a', 'b']
+
+// オブジェクト以外の場合は空配列を返す
+functionsIn(null);
+// => []
+functionsIn(undefined);
+// => []
+functionsIn(1);
+// => []
+```

--- a/docs/ko/reference/compat/object/functionsIn.md
+++ b/docs/ko/reference/compat/object/functionsIn.md
@@ -1,0 +1,67 @@
+# functionsIn
+
+::: info
+이 함수는 호환성을 위한 `es-toolkit/compat` 에서만 가져올 수 있어요. 대체할 수 있는 네이티브 JavaScript API가 있거나, 아직 충분히 최적화되지 않았기 때문이에요.
+
+`es-toolkit/compat`에서 이 함수를 가져오면, [lodash와 완전히 똑같이 동작](mdc:../../../compatibility.md)해요.
+:::
+
+객체의 자체 속성과 상속된 열거 가능한 속성에서 함수 속성 이름들의 배열을 생성해요.
+
+## 시그니처
+
+```typescript
+function functionsIn(object: any): string[];
+```
+
+### 파라미터
+
+- `object`: 검사할 객체예요.
+
+### 반환 값
+
+(`string[]`): 객체의 자체 속성과 상속된 열거 가능한 속성에서 함수 속성 이름들의 배열을 반환해요.
+
+## 예시
+
+```typescript
+import { functionsIn } from 'es-toolkit/compat';
+
+function Foo() {
+  this.a = function () {
+    return 'a';
+  };
+  this.b = function () {
+    return 'b';
+  };
+}
+
+Foo.prototype.c = function () {
+  return 'c';
+};
+
+// 상속된 함수를 포함한 함수 속성 이름들을 가져와요
+functionsIn(new Foo());
+// => ['a', 'b', 'c']
+
+// 일반 객체에서도 동작해요
+const object = {
+  a: function () {
+    return 'a';
+  },
+  b: function () {
+    return 'b';
+  },
+};
+
+functionsIn(object);
+// => ['a', 'b']
+
+// 객체가 아닌 경우 빈 배열을 반환해요
+functionsIn(null);
+// => []
+functionsIn(undefined);
+// => []
+functionsIn(1);
+// => []
+```

--- a/docs/reference/compat/object/functionsIn.md
+++ b/docs/reference/compat/object/functionsIn.md
@@ -1,0 +1,68 @@
+# functionsIn
+
+::: info
+This function is only available in `es-toolkit/compat` for compatibility reasons. It either has alternative native JavaScript APIs or isn't fully optimized yet.
+
+When imported from `es-toolkit/compat`, it behaves exactly like lodash and provides the same functionalities, as detailed @here.
+:::
+
+Creates an array of function property names from own and inherited enumerable properties of an object.
+
+## Signature
+
+```typescript
+// When object is any type
+function functionsIn(object: any): string[];
+```
+
+### Parameters
+
+- `object`: The object to inspect.
+
+### Returns
+
+(`string[]`): Returns the array of function property names from both own and inherited enumerable properties of the object.
+
+## Examples
+
+```typescript
+import { functionsIn } from 'es-toolkit/compat';
+
+function Foo() {
+  this.a = function () {
+    return 'a';
+  };
+  this.b = function () {
+    return 'b';
+  };
+}
+
+Foo.prototype.c = function () {
+  return 'c';
+};
+
+// Get function property names including inherited ones
+functionsIn(new Foo());
+// => ['a', 'b', 'c']
+
+// Works with plain objects
+const object = {
+  a: function () {
+    return 'a';
+  },
+  b: function () {
+    return 'b';
+  },
+};
+
+functionsIn(object);
+// => ['a', 'b']
+
+// Returns empty array for non-objects
+functionsIn(null);
+// => []
+functionsIn(undefined);
+// => []
+functionsIn(1);
+// => []
+```

--- a/docs/zh_hans/reference/compat/object/functionsIn.md
+++ b/docs/zh_hans/reference/compat/object/functionsIn.md
@@ -1,0 +1,67 @@
+# functionsIn
+
+::: info
+出于兼容性原因，此函数仅在 `es-toolkit/compat` 中提供。它可能具有替代的原生 JavaScript API，或者尚未完全优化。
+
+从 `es-toolkit/compat` 导入时，它的行为与 lodash 完全一致，并提供相同的功能，详情请见 [这里](mdc:../../../compatibility.md)。
+:::
+
+从对象自身和继承的可枚举属性中创建函数属性名称数组。
+
+## 签名
+
+```typescript
+function functionsIn(object: any): string[];
+```
+
+### 参数
+
+- `object`: 要检查的对象。
+
+### 返回值
+
+(`string[]`): 返回对象自身和继承的可枚举属性中的函数属性名称数组。
+
+## 示例
+
+```typescript
+import { functionsIn } from 'es-toolkit/compat';
+
+function Foo() {
+  this.a = function () {
+    return 'a';
+  };
+  this.b = function () {
+    return 'b';
+  };
+}
+
+Foo.prototype.c = function () {
+  return 'c';
+};
+
+// 获取包括继承的函数在内的函数属性名
+functionsIn(new Foo());
+// => ['a', 'b', 'c']
+
+// 适用于普通对象
+const object = {
+  a: function () {
+    return 'a';
+  },
+  b: function () {
+    return 'b';
+  },
+};
+
+functionsIn(object);
+// => ['a', 'b']
+
+// 对于非对象返回空数组
+functionsIn(null);
+// => []
+functionsIn(undefined);
+// => []
+functionsIn(1);
+// => []
+```

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -136,6 +136,7 @@ export { cloneDeepWith } from './object/cloneDeepWith.ts';
 export { defaults } from './object/defaults.ts';
 export { findKey } from './object/findKey.ts';
 export { fromPairs } from './object/fromPairs.ts';
+export { functionsIn } from './object/functionsIn.ts';
 export { get } from './object/get.ts';
 export { has } from './object/has.ts';
 export { invertBy } from './object/invertBy.ts';

--- a/src/compat/object/functionsIn.spec.ts
+++ b/src/compat/object/functionsIn.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { functionsIn } from './functionsIn';
+
+describe('functionsIn', () => {
+  function Foo(this: any) {
+    this.a = function () {
+      return 'a';
+    };
+    this.b = function () {
+      return 'b';
+    };
+  }
+
+  Foo.prototype.c = function () {
+    return 'c';
+  };
+
+  it('should return the function property names of an object', () => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(functionsIn(new Foo())).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should return an empty array for non objects', () => {
+    const values = [null, undefined, 1, 'abc', true, Symbol('test')];
+    const expected = values.map(() => []);
+
+    const actual = values.map(value => functionsIn(value));
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should include inherited functions', () => {
+    function Bar(this: any) {
+      this.a = function () {
+        return 'a';
+      };
+    }
+
+    Bar.prototype.b = function () {
+      return 'b';
+    };
+
+    // eslint-disable-next-line
+    // @ts-ignore
+    const bar = new Bar();
+
+    expect(functionsIn(bar)).toEqual(['a', 'b']);
+  });
+
+  it('should work with plain objects', () => {
+    const object = {
+      a: function () {
+        return 'a';
+      },
+      b: function () {
+        return 'b';
+      },
+    };
+
+    expect(functionsIn(object)).toEqual(['a', 'b']);
+  });
+});

--- a/src/compat/object/functionsIn.ts
+++ b/src/compat/object/functionsIn.ts
@@ -1,0 +1,34 @@
+import { isFunction } from '../../predicate';
+
+/**
+ * Creates an array of function property names from own and inherited enumerable properties of an object.
+ *
+ * @param {*} object The object to inspect.
+ * @returns {Array} Returns the function names.
+ * @example
+ *
+ * function Foo() {
+ *   this.a = function() { return 'a'; };
+ *   this.b = function() { return 'b'; };
+ * }
+ *
+ * Foo.prototype.c = function() { return 'c'; };
+ *
+ * functionsIn(new Foo);
+ * // => ['a', 'b', 'c']
+ */
+export function functionsIn(object: any): string[] {
+  if (object == null) {
+    return [];
+  }
+
+  const result: string[] = [];
+
+  for (const key in object) {
+    if (isFunction(object[key])) {
+      result.push(key);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
close #1037

> 🚧 Since there is no official test case for `functionsIn` in Lodash, so I referred to [`functions`](https://github.com/lodash/lodash/blob/v5-wip/test/functions.spec.js) in Lodash instead.


## Test Results

### Test List

<img width="887" alt="Pasted Graphic 20" src="https://github.com/user-attachments/assets/a9c8d474-49b9-4512-a1ec-fb5091d423ee" />

### Test Coverage

<img width="626" alt="conpatobject" src="https://github.com/user-attachments/assets/b2bc1263-6918-4226-b582-24d242c9805b" />

## Bench Test 

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/e62de70b-7b7f-4e20-9808-ec28986948eb" />
