### PR TITLE
feat(docs): Add Toss open source project banners into sidebar

### DIFF
--- a/docs/.vitepress/components/Banner.vue
+++ b/docs/.vitepress/components/Banner.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="custom-banner-container">
+    <div class="custom-banner-box">
+      <a
+        :href="currentBanner?.link"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="custom-banner-link"
+        @click="currentBanner && trackBannerClick(currentBanner)"
+      >
+        <div class="custom-banner-content">
+          <div class="custom-banner-title">{{ currentBanner?.title }}</div>
+          <div class="custom-banner-description">
+            {{ currentBanner?.description }}
+          </div>
+        </div>
+      </a>
+      <div class="custom-banner-controls">
+        <button
+          v-for="(_, index) in banners"
+          :key="index"
+          :class="['custom-banner-dot', { active: currentBannerIndex === index }]"
+          @click="setBannerIndex(index)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useBanner } from '../composables';
+
+const { banners, currentBanner, setBannerIndex, trackBannerClick, currentBannerIndex } = useBanner();
+</script>
+
+<style scoped>
+.custom-banner-container {
+  margin: 24px 0;
+  border-radius: 8px;
+  overflow: hidden;
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 224px;
+  background-color: var(--vp-c-bg-soft);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease;
+  z-index: 10;
+}
+.custom-banner-container:hover {
+  transform: translateY(-2px);
+}
+.custom-banner-box {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+}
+.custom-banner-link {
+  display: flex;
+  text-decoration: none;
+  color: inherit;
+}
+.custom-banner-image-wrapper {
+  width: 64px;
+  height: 64px;
+  margin-right: 12px;
+  overflow: hidden;
+  border-radius: 6px;
+}
+.custom-banner-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.custom-banner-content {
+  flex: 1;
+}
+.custom-banner-title {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1.4;
+  margin-bottom: 4px;
+  color: var(--vp-c-text-1);
+}
+.custom-banner-description {
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--vp-c-text-2);
+}
+.custom-banner-label {
+  margin-top: 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+  text-align: right;
+}
+.custom-banner-controls {
+  display: flex;
+  justify-content: center;
+  margin-top: 12px;
+}
+.custom-banner-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--vp-c-text-3);
+  margin: 0 4px;
+  padding: 0;
+  border: none;
+  opacity: 0.5;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+.custom-banner-dot.active {
+  opacity: 1;
+  background-color: var(--vp-c-brand);
+}
+@media (max-width: 768px) {
+  .custom-banner-container {
+    position: static;
+    width: 100%;
+    margin-top: 24px;
+  }
+}
+</style>

--- a/docs/.vitepress/components/Banner.vue
+++ b/docs/.vitepress/components/Banner.vue
@@ -1,17 +1,17 @@
 <template>
-  <div class="custom-banner-container">
+  <div v-if="shouldShowBanner && currentBanner" class="custom-banner-container">
     <div class="custom-banner-box">
       <a
-        :href="currentBanner?.link"
+        :href="currentBanner.link"
         target="_blank"
         rel="noopener noreferrer"
         class="custom-banner-link"
         @click="currentBanner && trackBannerClick(currentBanner)"
       >
         <div class="custom-banner-content">
-          <div class="custom-banner-title">{{ currentBanner?.title }}</div>
+          <div class="custom-banner-title">{{ currentBanner.title }}</div>
           <div class="custom-banner-description">
-            {{ currentBanner?.description }}
+            {{ currentBanner.description }}
           </div>
         </div>
       </a>
@@ -30,7 +30,7 @@
 <script setup lang="ts">
 import { useBanner } from '../composables';
 
-const { banners, currentBanner, setBannerIndex, trackBannerClick, currentBannerIndex } = useBanner();
+const { banners, currentBanner, setBannerIndex, trackBannerClick, currentBannerIndex, shouldShowBanner } = useBanner();
 </script>
 
 <style scoped>

--- a/docs/.vitepress/composables/index.ts
+++ b/docs/.vitepress/composables/index.ts
@@ -1,0 +1,1 @@
+export * from './useBanner';

--- a/docs/.vitepress/composables/useBanner.ts
+++ b/docs/.vitepress/composables/useBanner.ts
@@ -1,18 +1,37 @@
 import { computed, onMounted, ref } from 'vue';
-import { type Banner, BANNER_DATA } from '../data/bannerData';
+import { type Banner, EN_BANNER_DATA, KO_BANNER_DATA } from '../data/bannerData';
 
 export function useBanner() {
-  const banners = ref<Banner[]>(BANNER_DATA);
+  const currentLang = ref<string | null>(null);
+  const banners = computed<Banner[]>(() => {
+    if (currentLang.value === 'ko') {
+      return KO_BANNER_DATA;
+    }
+    if (currentLang.value === 'en') {
+      return EN_BANNER_DATA;
+    }
+    return [];
+  });
+
+  const shouldShowBanner = computed(() => {
+    return banners.value.length > 0;
+  });
 
   const currentBannerIndex = ref(0);
 
   const currentBanner = computed(() => {
+    if (!shouldShowBanner.value) {
+      return null;
+    }
     return banners.value[currentBannerIndex.value];
   });
 
   const rotationInterval = 30000;
 
   const rotateBanner = () => {
+    if (!shouldShowBanner.value) {
+      return;
+    }
     currentBannerIndex.value = (currentBannerIndex.value + 1) % banners.value.length;
   };
 
@@ -21,6 +40,13 @@ export function useBanner() {
   };
 
   onMounted(() => {
+    // 현재 언어 설정
+    currentLang.value = getCurrentLang();
+
+    if (!shouldShowBanner.value) {
+      return;
+    }
+
     // 초기에 랜덤한 배너 표시
     currentBannerIndex.value = getRandomBannerIndex();
 
@@ -33,6 +59,9 @@ export function useBanner() {
   });
 
   const setBannerIndex = (index: number) => {
+    if (!shouldShowBanner.value) {
+      return;
+    }
     if (index >= 0 && index < banners.value.length) {
       currentBannerIndex.value = index;
     }
@@ -49,5 +78,21 @@ export function useBanner() {
     rotateBanner,
     setBannerIndex,
     trackBannerClick,
+    shouldShowBanner,
   };
 }
+
+const getCurrentLang = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const path = window.location.pathname;
+  if (path.startsWith('/ko/')) {
+    return 'ko';
+  }
+  if (path.startsWith('/zh_hans/') || path.startsWith('/ja/')) {
+    return null;
+  }
+  return 'en';
+};

--- a/docs/.vitepress/composables/useBanner.ts
+++ b/docs/.vitepress/composables/useBanner.ts
@@ -1,0 +1,53 @@
+import { computed, onMounted, ref } from 'vue';
+import { type Banner, BANNER_DATA } from '../data/bannerData';
+
+export function useBanner() {
+  const banners = ref<Banner[]>(BANNER_DATA);
+
+  const currentBannerIndex = ref(0);
+
+  const currentBanner = computed(() => {
+    return banners.value[currentBannerIndex.value];
+  });
+
+  const rotationInterval = 30000;
+
+  const rotateBanner = () => {
+    currentBannerIndex.value = (currentBannerIndex.value + 1) % banners.value.length;
+  };
+
+  const getRandomBannerIndex = () => {
+    return Math.floor(Math.random() * banners.value.length);
+  };
+
+  onMounted(() => {
+    // 초기에 랜덤한 배너 표시
+    currentBannerIndex.value = getRandomBannerIndex();
+
+    // 일정 시간 간격으로 배너 로테이션
+    const intervalId = setInterval(rotateBanner, rotationInterval);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  });
+
+  const setBannerIndex = (index: number) => {
+    if (index >= 0 && index < banners.value.length) {
+      currentBannerIndex.value = index;
+    }
+  };
+
+  const trackBannerClick = (banner: Banner) => {
+    console.log('Banner clicked:', banner.title);
+  };
+
+  return {
+    banners,
+    currentBanner,
+    currentBannerIndex,
+    rotateBanner,
+    setBannerIndex,
+    trackBannerClick,
+  };
+}

--- a/docs/.vitepress/data/bannerData.ts
+++ b/docs/.vitepress/data/bannerData.ts
@@ -8,7 +8,7 @@ export const KO_BANNER_DATA: Banner[] = [
   {
     title: '🛠️ frontend-fundamentals',
     description: '프론트엔드 코드를 더 잘 짜는 방법을 고민하고 있나요? 실제 경험에서 나온 원칙과 예시들을 모아봤어요.',
-    link: 'https://github.com/toss/frontend-fundamentals',
+    link: 'https://frontend-fundamentals.com/',
   },
   {
     title: '🇰🇷 es-hangul',
@@ -37,25 +37,22 @@ export const KO_BANNER_DATA: Banner[] = [
 export const EN_BANNER_DATA: Banner[] = [
   {
     title: '🛠️ frontend-fundamentals',
-    description:
-      'Looking for better ways to write frontend code? Check out principles and examples from real-world experience.',
-    link: 'https://github.com/toss/frontend-fundamentals',
+    description: 'Your compass for better code. Four core principles for writing easily modifiable frontend code.',
+    link: 'https://frontend-fundamentals.com/en/',
   },
   {
     title: '⏳ suspensive',
-    description:
-      'Is React Suspense challenging to use? This utility helps you implement it in production with minimal effort.',
+    description: 'Make React Suspense easy. Less code, more power for async operations.',
     link: 'https://github.com/toss/suspensive',
   },
   {
     title: '🧩 use-funnel',
-    description:
-      'Managing multi-step flows like signup or checkout? This hook helps you organize complex user journeys cleanly.',
+    description: 'Multi-step flows made simple. Perfect for funnels such as signup, checkout, and onboarding flows.',
     link: 'https://github.com/toss/use-funnel',
   },
   {
     title: '✨ overlay-kit',
-    description: 'Tired of writing the same modal code? Try these accessible modal and popover components for your UI.',
+    description: 'Accessible modals and popovers with zero hassle.',
     link: 'https://github.com/toss/overlay-kit',
   },
 ];

--- a/docs/.vitepress/data/bannerData.ts
+++ b/docs/.vitepress/data/bannerData.ts
@@ -7,7 +7,7 @@ export interface Banner {
 export const KO_BANNER_DATA: Banner[] = [
   {
     title: '🛠️ frontend-fundamentals',
-    description: '프론트엔드 코드를 더 잘 짜는 방법을 고민하고 있나요? 실제 경험에서 나온 원칙과 예시들을 모아봤어요.',
+    description: '프론트엔드 코드를 더 잘 짜는 방법을 고민하고 있나요? 실무에서 비롯한 원칙과 예시들을 모아봤어요.',
     link: 'https://frontend-fundamentals.com/',
   },
   {
@@ -17,7 +17,7 @@ export const KO_BANNER_DATA: Banner[] = [
   },
   {
     title: '⏳ suspensive',
-    description: 'React Suspense 쓰고 싶은데 어렵게 느껴지셨나요? 실제 서비스에 바로 적용할 수 있게 도와드려요.',
+    description: 'React Suspense를 실무에서 더 쉽게 활용하고 싶으신가요? 비동기 데이터 로딩을 간결하게 처리해보세요.',
     link: 'https://github.com/toss/suspensive',
   },
   {
@@ -29,7 +29,7 @@ export const KO_BANNER_DATA: Banner[] = [
   {
     title: '✨ overlay-kit',
     description:
-      '모달 만들기, 매번 같은 코드를 반복하고 계신가요? 접근성까지 신경 쓴 모달/팝오버 컴포넌트를 소개합니다.',
+      '모달 만들기, 매번 같은 코드를 반복하고 계신가요? 접근성까지 보장된 모달/팝오버 컴포넌트를 소개합니다.',
     link: 'https://github.com/toss/overlay-kit',
   },
 ];

--- a/docs/.vitepress/data/bannerData.ts
+++ b/docs/.vitepress/data/bannerData.ts
@@ -4,7 +4,7 @@ export interface Banner {
   link: string;
 }
 
-export const BANNER_DATA: Banner[] = [
+export const KO_BANNER_DATA: Banner[] = [
   {
     title: '🛠️ frontend-fundamentals',
     description: '프론트엔드 코드를 더 잘 짜는 방법을 고민하고 있나요? 실제 경험에서 나온 원칙과 예시들을 모아봤어요.',
@@ -23,13 +23,39 @@ export const BANNER_DATA: Banner[] = [
   {
     title: '🧩 use-funnel',
     description:
-      '회원가입이나 결제처럼 여러 단계로 이뤄진 화면, 관리하기 복잡하죠? use-funnel 훅을 통해 깔끔하게 정리해보세요.',
+      '회원가입이나 결제처럼 여러 단계로 이뤄진 화면, 관리하기 복잡하죠? useFunnel 훅으로 깔끔하게 정리해보세요.',
     link: 'https://github.com/toss/use-funnel',
   },
   {
     title: '✨ overlay-kit',
     description:
       '모달 만들기, 매번 같은 코드를 반복하고 계신가요? 접근성까지 신경 쓴 모달/팝오버 컴포넌트를 소개합니다.',
+    link: 'https://github.com/toss/overlay-kit',
+  },
+];
+
+export const EN_BANNER_DATA: Banner[] = [
+  {
+    title: '🛠️ frontend-fundamentals',
+    description:
+      'Looking for better ways to write frontend code? Check out principles and examples from real-world experience.',
+    link: 'https://github.com/toss/frontend-fundamentals',
+  },
+  {
+    title: '⏳ suspensive',
+    description:
+      'Is React Suspense challenging to use? This utility helps you implement it in production with minimal effort.',
+    link: 'https://github.com/toss/suspensive',
+  },
+  {
+    title: '🧩 use-funnel',
+    description:
+      'Managing multi-step flows like signup or checkout? This hook helps you organize complex user journeys cleanly.',
+    link: 'https://github.com/toss/use-funnel',
+  },
+  {
+    title: '✨ overlay-kit',
+    description: 'Tired of writing the same modal code? Try these accessible modal and popover components for your UI.',
     link: 'https://github.com/toss/overlay-kit',
   },
 ];

--- a/docs/.vitepress/data/bannerData.ts
+++ b/docs/.vitepress/data/bannerData.ts
@@ -1,0 +1,30 @@
+export interface Banner {
+  title: string;
+  description: string;
+  link: string;
+}
+
+export const BANNER_DATA: Banner[] = [
+  {
+    title: '🎙️ 조건부 렌더링, 어떻게 처리하시나요?',
+    description:
+      '논리 연산자(&&)와 삼항 연산자(?:)를 활용하는 전통적인 방식, 혹은 <If /> 같은 선언적인 컴포넌트를 사용하는 방식. 어떤 접근법이 효과적일까요?',
+    link: 'https://github.com/toss/frontend-fundamentals/discussions/4',
+  },
+  {
+    title: '[🏟️ 3월 콜로세움] 처음 커리어 시작은 대기업에서 vs 스타트업에서 어디가 좋을까?',
+    description: 'UpVote을 많이 받은 코멘트 작성자에게는 Frontend Fundamentals 굿즈를 보내드려요.',
+    link: 'https://github.com/toss/frontend-fundamentals/discussions/172',
+  },
+  {
+    title: '토스에서 Desktop Frontend Engineer를 모시고 있어요.',
+    description: '수많은 기능을 어떻게 우아한 코드로 구현할 수 있을까요? 함께 개발해요!',
+    link: 'https://toss.im/career/job-detail?job_id=4664498003',
+  },
+  {
+    title: '🎙️ if문의 return이 간단한 한 줄이라면 어떻게 사용하시나요?',
+    description:
+      '간단한 조건문에서 return을 한 줄로 작성할지, 중괄호 {}를 사용할지 고민되시나요? 가독성, 코드 일관성, 유지보수성, Diff 최소화 등의 측면에서 다양한 의견이 오갔습니다.',
+    link: 'https://github.com/toss/frontend-fundamentals/discussions/41',
+  },
+];

--- a/docs/.vitepress/data/bannerData.ts
+++ b/docs/.vitepress/data/bannerData.ts
@@ -6,25 +6,30 @@ export interface Banner {
 
 export const BANNER_DATA: Banner[] = [
   {
-    title: '🎙️ 조건부 렌더링, 어떻게 처리하시나요?',
+    title: '🛠️ frontend-fundamentals',
+    description: '프론트엔드 코드를 더 잘 짜는 방법을 고민하고 있나요? 실제 경험에서 나온 원칙과 예시들을 모아봤어요.',
+    link: 'https://github.com/toss/frontend-fundamentals',
+  },
+  {
+    title: '🇰🇷 es-hangul',
+    description: '조사 붙이기, 초성 검색 같은 한글 작업을 쉽게 처리해주는 라이브러리예요.',
+    link: 'https://github.com/toss/es-hangul',
+  },
+  {
+    title: '⏳ suspensive',
+    description: 'React Suspense 쓰고 싶은데 어렵게 느껴지셨나요? 실제 서비스에 바로 적용할 수 있게 도와드려요.',
+    link: 'https://github.com/toss/suspensive',
+  },
+  {
+    title: '🧩 use-funnel',
     description:
-      '논리 연산자(&&)와 삼항 연산자(?:)를 활용하는 전통적인 방식, 혹은 <If /> 같은 선언적인 컴포넌트를 사용하는 방식. 어떤 접근법이 효과적일까요?',
-    link: 'https://github.com/toss/frontend-fundamentals/discussions/4',
+      '회원가입이나 결제처럼 여러 단계로 이뤄진 화면, 관리하기 복잡하죠? use-funnel 훅을 통해 깔끔하게 정리해보세요.',
+    link: 'https://github.com/toss/use-funnel',
   },
   {
-    title: '[🏟️ 3월 콜로세움] 처음 커리어 시작은 대기업에서 vs 스타트업에서 어디가 좋을까?',
-    description: 'UpVote을 많이 받은 코멘트 작성자에게는 Frontend Fundamentals 굿즈를 보내드려요.',
-    link: 'https://github.com/toss/frontend-fundamentals/discussions/172',
-  },
-  {
-    title: '토스에서 Desktop Frontend Engineer를 모시고 있어요.',
-    description: '수많은 기능을 어떻게 우아한 코드로 구현할 수 있을까요? 함께 개발해요!',
-    link: 'https://toss.im/career/job-detail?job_id=4664498003',
-  },
-  {
-    title: '🎙️ if문의 return이 간단한 한 줄이라면 어떻게 사용하시나요?',
+    title: '✨ overlay-kit',
     description:
-      '간단한 조건문에서 return을 한 줄로 작성할지, 중괄호 {}를 사용할지 고민되시나요? 가독성, 코드 일관성, 유지보수성, Diff 최소화 등의 측면에서 다양한 의견이 오갔습니다.',
-    link: 'https://github.com/toss/frontend-fundamentals/discussions/41',
+      '모달 만들기, 매번 같은 코드를 반복하고 계신가요? 접근성까지 신경 쓴 모달/팝오버 컴포넌트를 소개합니다.',
+    link: 'https://github.com/toss/overlay-kit',
   },
 ];

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,6 +1,7 @@
 import DefaultTheme from 'vitepress/theme';
-import { defineAsyncComponent } from 'vue';
+import { defineAsyncComponent, h } from 'vue';
 import './index.css';
+import Banner from '../components/Banner.vue';
 import CompatibilityStatus from '../components/CompatibilityStatus.vue';
 
 /** @type {import('vitepress').Theme} */
@@ -12,5 +13,11 @@ export default {
       defineAsyncComponent(() => import('../components/Sandpack.vue'))
     );
     app.component('CompatibilityStatus', CompatibilityStatus);
+    app.component('Banner', Banner);
+  },
+  Layout: () => {
+    return h(DefaultTheme.Layout, null, {
+      'layout-bottom': () => h(Banner),
+    });
   },
 };


### PR DESCRIPTION
Added a rotational banner to the VitePress documentation to showcase Toss open source projects. The banner is fixed at the bottom of the document and displays content based on the user's language setting (Korean/English).

![image](https://github.com/user-attachments/assets/3216f967-9d85-436f-a884-451bda389fcf)
![image](https://github.com/user-attachments/assets/730e9e82-5378-498f-9840-759cc8fcd2d9)

## Key Changes
1. Banner Component Implementation

- Fixed position banner in the bottom right corner of the document
- Auto-rotation feature: automatically transitions to a different banner every 30 seconds
- Interactive indicators allowing users to manually select banners

2. Multilingual Support

- Korean pages: Displays Korean banners
- English pages: Displays English banners
- Other languages (Chinese, Japanese, etc.): Banner is hidden