### PR TITLE
chore(eslint): Restrict console usage in source code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,10 @@ export default [
       'no-restricted-syntax': [
         'error',
         {
+          selector: 'CallExpression[callee.object.name="console"]',
+          message: 'console.log() is not allowed in source code.',
+        },
+        {
           selector: 'CallExpression[callee.object.name="Object"][callee.property.name="entries"]',
           message:
             'Do not use Object.entries for performance. Consider using alternatives like Object.keys() or Object.values().',


### PR DESCRIPTION
Sometimes, `console` statements are accidentally left in source files, so we should prevent this using ESLint.