### PR TITLE
chore: fix ESLint errors

### DIFF
--- a/src/array/remove.spec.ts
+++ b/src/array/remove.spec.ts
@@ -10,6 +10,7 @@ describe('remove', () => {
   });
 
   it('should handle sparse arrays correctly', () => {
+    // eslint-disable-next-line no-sparse-arrays
     const sparseArray = [1, , 3, , 5];
     const removed = remove(sparseArray, value => value === undefined);
     expect(sparseArray).toEqual([1, 3, 5]);

--- a/src/array/windowed.ts
+++ b/src/array/windowed.ts
@@ -49,7 +49,7 @@ export interface WindowedOptions {
 export function windowed<T>(
   arr: readonly T[],
   size: number,
-  step: number = 1,
+  step = 1,
   { partialWindows = false }: WindowedOptions = {}
 ): T[][] {
   if (size <= 0 || !Number.isInteger(size)) {

--- a/src/compat/_internal/isPrototype.ts
+++ b/src/compat/_internal/isPrototype.ts
@@ -1,4 +1,4 @@
-export function isPrototype(value: {}) {
+export function isPrototype(value: object) {
   const constructor = value?.constructor;
   const prototype = typeof constructor === 'function' ? constructor.prototype : Object.prototype;
 

--- a/src/compat/array/differenceWith.spec.ts
+++ b/src/compat/array/differenceWith.spec.ts
@@ -83,10 +83,13 @@ describe('differenceWith', () => {
   it(`should ignore values that are not array-like`, () => {
     const array = [1, null, 3];
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     expect(differenceWith(args, 3, { 0: 1 })).toEqual([1, 2, 3]);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     expect(differenceWith(null, array, 1)).toEqual([]);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     expect(differenceWith(array, args, null)).toEqual([null]);
   });

--- a/src/compat/array/each.spec.ts
+++ b/src/compat/array/each.spec.ts
@@ -103,6 +103,7 @@ describe('each', () => {
     const expected = [1, 0, array];
 
     func(array, function () {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions, prefer-rest-params
       args || (args = slice.call(arguments));
     });
     expect(args).toEqual(expected);
@@ -120,6 +121,7 @@ describe('each', () => {
 
     const argsList: any[] = [];
     func(array, function () {
+      // eslint-disable-next-line prefer-rest-params
       argsList.push(slice.call(arguments));
       return true;
     });
@@ -177,6 +179,7 @@ describe('each', () => {
 
     const actual = values.map(length => isIteratedAsObject({ length: length }));
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const Foo = function (a: any) {};
     Foo.a = 1;
 

--- a/src/compat/array/forEach.spec.ts
+++ b/src/compat/array/forEach.spec.ts
@@ -103,6 +103,7 @@ describe('forEach', () => {
     const expected = [1, 0, array];
 
     func(array, function () {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions, prefer-rest-params
       args || (args = slice.call(arguments));
     });
     expect(args).toEqual(expected);
@@ -120,6 +121,7 @@ describe('forEach', () => {
 
     const argsList: any[] = [];
     func(array, function () {
+      // eslint-disable-next-line prefer-rest-params
       argsList.push(slice.call(arguments));
       return true;
     });
@@ -177,6 +179,7 @@ describe('forEach', () => {
 
     const actual = values.map(length => isIteratedAsObject({ length: length }));
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const Foo = function (a: any) {};
     Foo.a = 1;
 

--- a/src/compat/array/intersectionBy.spec.ts
+++ b/src/compat/array/intersectionBy.spec.ts
@@ -83,7 +83,8 @@ describe('intersectionBy', () => {
 
   it('should treat values that are not arrays or `arguments` objects as empty', () => {
     const array = [0, 1, null, 3];
-    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
     expect(intersection(array, 3, { 0: 1 }, null)).toEqual([]);
     expect(intersection(null, array, null, [2, 3])).toEqual([]);
     expect(intersection(array, null, args, null)).toEqual([]);
@@ -110,6 +111,7 @@ describe('intersectionBy', () => {
     let args: number[] | undefined;
 
     intersectionBy([2.1, 1.2], [2.3, 3.4], function () {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions, prefer-rest-params
       args || (args = slice.call(arguments));
     });
 

--- a/src/compat/array/map.spec.ts
+++ b/src/compat/array/map.spec.ts
@@ -103,6 +103,7 @@ describe('map', () => {
       const expected = [1, 0, array];
 
       func(array, function () {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions, prefer-rest-params
         args || (args = Array.prototype.slice.call(arguments));
       });
 
@@ -113,7 +114,7 @@ describe('map', () => {
       const array = [1];
       array[2] = 3;
 
-      let expected = [
+      const expected = [
         [1, 0, array],
         [undefined, 1, array],
         [3, 2, array],
@@ -121,6 +122,7 @@ describe('map', () => {
 
       const argsList: any[] = [];
       func(array, function () {
+        // eslint-disable-next-line prefer-rest-params
         argsList.push(Array.prototype.slice.call(arguments));
         return !(isFind || isSome);
       });

--- a/src/compat/array/map.ts
+++ b/src/compat/array/map.ts
@@ -137,7 +137,7 @@ export function map<T, K extends keyof T>(collection: ArrayLike<T>, iteratee: K)
  * const arrayLike = {0: 1, 1: 2, 2: 3, length: 3};
  * map(arrayLike); // => {0: 1, 1: 2, 2: 3, length: 3}
  */
-export function map<T, U>(collection: ArrayLike<T>, iteratee?: null | undefined): ArrayLike<T>;
+export function map<T>(collection: ArrayLike<T>, iteratee?: null | undefined): ArrayLike<T>;
 
 /**
  * Maps each value in an object to a new array of values using an iteratee function.

--- a/src/compat/array/nth.spec.ts
+++ b/src/compat/array/nth.spec.ts
@@ -10,7 +10,7 @@ describe('nth', () => {
   const array = ['a', 'b', 'c', 'd'];
 
   it('should get the nth element of `array`', () => {
-    const actual = array.map((value, index) => nth(array, index));
+    const actual = array.map((_value, index) => nth(array, index));
 
     expect(actual).toEqual(array);
   });
@@ -25,6 +25,7 @@ describe('nth', () => {
     let values = falsey;
     let expected = values.map(stubA);
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     let actual = values.map(n => (n ? nth(array, n) : nth(array)));
 
@@ -33,6 +34,7 @@ describe('nth', () => {
     values = ['1', 1.6];
     expected = values.map(stubB);
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     actual = values.map(n => nth(array, n));
 

--- a/src/compat/array/nth.ts
+++ b/src/compat/array/nth.ts
@@ -12,7 +12,7 @@ import { toInteger } from '../util/toInteger.ts';
  * nth([1, 2, 3], 1); // => 2
  * nth([1, 2, 3], -1); // => 3
  */
-export function nth<T>(array: ArrayLike<T> | null | undefined, n: number = 0): T | undefined {
+export function nth<T>(array: ArrayLike<T> | null | undefined, n = 0): T | undefined {
   if (!isArrayLikeObject(array) || array.length === 0) {
     return undefined;
   }

--- a/src/compat/array/pull.spec.ts
+++ b/src/compat/array/pull.spec.ts
@@ -6,6 +6,7 @@ describe('pull', () => {
   const func = pullToolkit;
 
   function pull(array: any[], values: any[]) {
+    // eslint-disable-next-line prefer-spread
     return func.apply(undefined, [array].concat(values) as any);
   }
 

--- a/src/compat/array/pull.ts
+++ b/src/compat/array/pull.ts
@@ -1,4 +1,3 @@
-import { flatten } from './flatten.ts';
 import { pull as pullToolkit } from '../../array/pull.ts';
 
 /**

--- a/src/compat/array/remove.spec.ts
+++ b/src/compat/array/remove.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { remove } from './remove';
 
 const isEven = function (n: number) {
+  // eslint-disable-next-line eqeqeq
   return n % 2 == 0;
 };
 
@@ -20,6 +21,7 @@ describe('remove', () => {
     const clone = array.slice();
 
     remove(array, function (n, index) {
+      // eslint-disable-next-line prefer-rest-params
       const args = Array.prototype.slice.call(arguments);
       args[2] = args[2].slice();
       argsList.push(args);

--- a/src/compat/object/cloneDeepWith.spec.ts
+++ b/src/compat/object/cloneDeepWith.spec.ts
@@ -87,7 +87,6 @@ describe('cloneDeepWith', function () {
     const object: any = new Foo();
 
     func(object, function () {
-      // eslint-disable-next-line prefer-rest-params
       const length = arguments.length;
       // eslint-disable-next-line prefer-rest-params
       const args = Array.prototype.slice.call(arguments, 0, length - (length > 1 ? 1 : 0));

--- a/src/compat/util/method.spec.ts
+++ b/src/compat/util/method.spec.ts
@@ -81,6 +81,7 @@ describe('method', () => {
   });
 
   it('should return `undefined` when `object` is nullish', () => {
+    // eslint-disable-next-line no-sparse-arrays
     const values = [, null, undefined];
     const expected = map(values, noop);
 
@@ -94,6 +95,7 @@ describe('method', () => {
   });
 
   it('should return `undefined` for deep paths when `object` is nullish', () => {
+    // eslint-disable-next-line no-sparse-arrays
     const values = [, null, undefined];
     const expected = map(values, noop);
 
@@ -118,6 +120,7 @@ describe('method', () => {
   it('should apply partial arguments to function', () => {
     const object = {
       fn: function () {
+        // eslint-disable-next-line prefer-rest-params
         return Array.prototype.slice.call(arguments);
       },
     };

--- a/src/compat/util/now.spec.ts
+++ b/src/compat/util/now.spec.ts
@@ -4,7 +4,7 @@ import { delay } from '../../promise/delay';
 
 describe('now', () => {
   it('should return the number of milliseconds that have elapsed since the Unix epoch', async () => {
-    const stamp = +new Date();
+    const stamp = Number(new Date());
     const actual = now();
 
     expect(actual).toBeGreaterThanOrEqual(stamp);

--- a/src/compat/util/stubObject.ts
+++ b/src/compat/util/stubObject.ts
@@ -5,6 +5,6 @@
  * @example
  * stubObject() // Returns {}
  */
-export function stubObject(): {} {
+export function stubObject(): object {
   return {};
 }

--- a/src/compat/util/uniqueId.spec.ts
+++ b/src/compat/util/uniqueId.spec.ts
@@ -13,6 +13,7 @@ describe('uniqueId', () => {
   });
 
   it('should coerce the prefix argument to a string', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     const ids = [uniqueId(3), uniqueId(2), uniqueId(1), uniqueId(true)];
     expect(ids[0].startsWith('3')).toBe(true);


### PR DESCRIPTION
Ignore test files' ESLint errors via comments, change {} to object, and remove redundant type declarations.

