### PR TITLE
feat(unionBy, unionWith): add `unionBy`, `unionWith` to `compat/array`

### DIFF
--- a/benchmarks/performance/unionBy.bench.ts
+++ b/benchmarks/performance/unionBy.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from 'vitest';
 import { unionBy as unionByToolkit_ } from 'es-toolkit';
+import { unionBy as unionByToolkitCompat_ } from 'es-toolkit/compat';
 import { unionBy as unionByLodash_ } from 'lodash';
 
 const unionByToolkit = unionByToolkit_;
@@ -8,6 +9,10 @@ const unionByLodash = unionByLodash_;
 describe('unionBy', () => {
   bench('es-toolkit/unionBy', () => {
     unionByToolkit([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], x => x.id);
+  });
+
+  bench('es-toolkit/compat/unionBy', () => {
+    unionByToolkitCompat_([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], x => x.id);
   });
 
   bench('lodash/unionBy', () => {
@@ -21,6 +26,10 @@ describe('unionBy/largeArray', () => {
 
   bench('es-toolkit/unionBy', () => {
     unionByToolkit(largeArray1, largeArray2, x => x.id);
+  });
+
+  bench('es-toolkit/compat/unionBy', () => {
+    unionByToolkitCompat_(largeArray1, largeArray2, x => x.id);
   });
 
   bench('lodash/unionBy', () => {

--- a/benchmarks/performance/unionBy.bench.ts
+++ b/benchmarks/performance/unionBy.bench.ts
@@ -4,35 +4,41 @@ import { unionBy as unionByToolkitCompat_ } from 'es-toolkit/compat';
 import { unionBy as unionByLodash_ } from 'lodash';
 
 const unionByToolkit = unionByToolkit_;
+const unionByToolkitCompat = unionByToolkitCompat_;
 const unionByLodash = unionByLodash_;
 
 describe('unionBy', () => {
+  const array1 = [{ id: 1 }, { id: 2 }];
+  const array2 = [{ id: 2 }, { id: 3 }];
+  const getId = x => x.id;
+
   bench('es-toolkit/unionBy', () => {
-    unionByToolkit([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], x => x.id);
+    unionByToolkit(array1, array2, getId);
   });
 
   bench('es-toolkit/compat/unionBy', () => {
-    unionByToolkitCompat_([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], x => x.id);
+    unionByToolkitCompat(array1, array2, getId);
   });
 
   bench('lodash/unionBy', () => {
-    unionByLodash([{ id: 1 }, { id: 2 }], [{ id: 2 }, { id: 3 }], x => x.id);
+    unionByLodash(array1, array2, getId);
   });
 });
 
 describe('unionBy/largeArray', () => {
   const largeArray1 = Array.from({ length: 10000 }, (_, i) => ({ id: i }));
   const largeArray2 = Array.from({ length: 10000 }, (_, i) => ({ id: i + 5000 }));
+  const getId = x => x.id;
 
   bench('es-toolkit/unionBy', () => {
-    unionByToolkit(largeArray1, largeArray2, x => x.id);
+    unionByToolkit(largeArray1, largeArray2, getId);
   });
 
   bench('es-toolkit/compat/unionBy', () => {
-    unionByToolkitCompat_(largeArray1, largeArray2, x => x.id);
+    unionByToolkitCompat(largeArray1, largeArray2, getId);
   });
 
   bench('lodash/unionBy', () => {
-    unionByLodash(largeArray1, largeArray2, x => x.id);
+    unionByLodash(largeArray1, largeArray2, getId);
   });
 });

--- a/benchmarks/performance/unionWith.bench.ts
+++ b/benchmarks/performance/unionWith.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from 'vitest';
 import { unionWith as unionWithToolkit_ } from 'es-toolkit';
+import { unionWith as unionWithToolkitCompat_ } from 'es-toolkit/compat';
 import { unionWith as unionWithLodash_ } from 'lodash';
 
 const unionWithToolkit = unionWithToolkit_;
@@ -11,6 +12,13 @@ describe('unionWith', () => {
     const array2 = [{ id: 2 }, { id: 3 }];
     const areItemsEqual = (a, b) => a.id === b.id;
     unionWithToolkit(array1, array2, areItemsEqual);
+  });
+
+  bench('es-toolkit/compat/unionWith', () => {
+    const array1 = [{ id: 1 }, { id: 2 }];
+    const array2 = [{ id: 2 }, { id: 3 }];
+    const areItemsEqual = (a, b) => a.id === b.id;
+    unionWithToolkitCompat_(array1, array2, areItemsEqual);
   });
 
   bench('lodash/unionWith', () => {
@@ -27,6 +35,10 @@ describe('unionWith/largeArray', () => {
 
   bench('es-toolkit/unionWith', () => {
     unionWithToolkit(largeArray1, largeArray2, (a, b) => a.id === b.id);
+  });
+
+  bench('es-toolkit/compat/unionWith', () => {
+    unionWithToolkitCompat_(largeArray1, largeArray2, (a, b) => a.id === b.id);
   });
 
   bench('lodash/unionWith', () => {

--- a/benchmarks/performance/unionWith.bench.ts
+++ b/benchmarks/performance/unionWith.bench.ts
@@ -4,27 +4,23 @@ import { unionWith as unionWithToolkitCompat_ } from 'es-toolkit/compat';
 import { unionWith as unionWithLodash_ } from 'lodash';
 
 const unionWithToolkit = unionWithToolkit_;
+const unionWithToolkitCompat = unionWithToolkitCompat_;
 const unionWithLodash = unionWithLodash_;
 
 describe('unionWith', () => {
+  const array1 = [{ id: 1 }, { id: 2 }];
+  const array2 = [{ id: 2 }, { id: 3 }];
+  const areItemsEqual = (a, b) => a.id === b.id;
+
   bench('es-toolkit/unionWith', () => {
-    const array1 = [{ id: 1 }, { id: 2 }];
-    const array2 = [{ id: 2 }, { id: 3 }];
-    const areItemsEqual = (a, b) => a.id === b.id;
     unionWithToolkit(array1, array2, areItemsEqual);
   });
 
   bench('es-toolkit/compat/unionWith', () => {
-    const array1 = [{ id: 1 }, { id: 2 }];
-    const array2 = [{ id: 2 }, { id: 3 }];
-    const areItemsEqual = (a, b) => a.id === b.id;
-    unionWithToolkitCompat_(array1, array2, areItemsEqual);
+    unionWithToolkitCompat(array1, array2, areItemsEqual);
   });
 
   bench('lodash/unionWith', () => {
-    const array1 = [{ id: 1 }, { id: 2 }];
-    const array2 = [{ id: 2 }, { id: 3 }];
-    const areItemsEqual = (a, b) => a.id === b.id;
     unionWithLodash(array1, array2, areItemsEqual);
   });
 });
@@ -32,16 +28,17 @@ describe('unionWith', () => {
 describe('unionWith/largeArray', () => {
   const largeArray1 = Array.from({ length: 10000 }, (_, i) => ({ id: i }));
   const largeArray2 = Array.from({ length: 10000 }, (_, i) => ({ id: i + 5000 }));
+  const areItemsEqual = (a, b) => a.id === b.id;
 
   bench('es-toolkit/unionWith', () => {
-    unionWithToolkit(largeArray1, largeArray2, (a, b) => a.id === b.id);
+    unionWithToolkit(largeArray1, largeArray2, areItemsEqual);
   });
 
   bench('es-toolkit/compat/unionWith', () => {
-    unionWithToolkitCompat_(largeArray1, largeArray2, (a, b) => a.id === b.id);
+    unionWithToolkitCompat(largeArray1, largeArray2, areItemsEqual);
   });
 
   bench('lodash/unionWith', () => {
-    unionWithLodash(largeArray1, largeArray2, (a, b) => a.id === b.id);
+    unionWithLodash(largeArray1, largeArray2, areItemsEqual);
   });
 });

--- a/src/compat/array/unionBy.spec.ts
+++ b/src/compat/array/unionBy.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { unionBy } from './unionBy';
+import { args } from '../_internal/args';
+
+/**
+ * @see https://github.com/lodash/lodash/blob/v5-wip/test/union-methods.spec.js
+ * @see https://github.com/lodash/lodash/blob/v5-wip/test/unionBy.spec.js
+ */
+describe('unionBy', () => {
+  it('should return the union of two arrays', () => {
+    const actual = unionBy([2], [1, 2]);
+    expect(actual).toEqual([2, 1]);
+  });
+
+  it('should return the union of multiple arrays', () => {
+    const actual = unionBy([2], [1, 2], [2, 3]);
+    expect(actual).toEqual([2, 1, 3]);
+  });
+
+  it('should not flatten nested arrays', () => {
+    const actual = unionBy([1, 3, 2], [1, [5]], [2, [4]]);
+    expect(actual).toEqual([1, 3, 2, [5], [4]]);
+  });
+
+  it('should ignore values that are not arrays or arguments objects', () => {
+    const array = [0];
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(unionBy(array, 3, { '0': 1 }, null)).toEqual(array);
+    expect(unionBy(null, array, null, [2, 1])).toEqual([0, 2, 1]);
+    expect(unionBy(array, null, args, null)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('should accept an `iteratee`', () => {
+    const actual1 = unionBy([2.1], [1.2, 2.3], Math.floor);
+    expect(actual1).toEqual([2.1, 1.2]);
+
+    const actual2 = unionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], 'x');
+    expect(actual2).toEqual([{ x: 1 }, { x: 2 }]);
+  });
+
+  it('should provide correct `iteratee` arguments', () => {
+    let args: any;
+
+    unionBy([2.1], [1.2, 2.3], function (...params) {
+      if (args === undefined) {
+        args = params;
+      }
+    });
+
+    expect(args).toEqual([2.1]);
+  });
+
+  it('should output values from the first possible array', () => {
+    const actual = unionBy([{ x: 1, y: 1 }], [{ x: 1, y: 2 }], 'x');
+    expect(actual).toEqual([{ x: 1, y: 1 }]);
+  });
+});

--- a/src/compat/array/unionBy.ts
+++ b/src/compat/array/unionBy.ts
@@ -31,8 +31,7 @@ type Iteratee<T> = PropertyKey | Partial<T> | ((value: T) => unknown);
 
 export function unionBy<T>(...values: Array<ArrayLike<T> | null | undefined | Iteratee<T>>): T[] {
   const lastValue = last(values);
-  const validArray = values.filter(isArrayLikeObject);
-  const flattened = flattenArrayLike<T>(validArray);
+  const flattened = flattenArrayLike<T>(values);
 
   if (isArrayLikeObject(lastValue) || lastValue == null) {
     return uniq(flattened);

--- a/src/compat/array/unionBy.ts
+++ b/src/compat/array/unionBy.ts
@@ -1,0 +1,42 @@
+import { last } from '../../array/last.ts';
+import { uniq } from '../../array/uniq.ts';
+import { uniqBy } from '../../array/uniqBy.ts';
+import { flattenArrayLike } from '../_internal/flattenArrayLike.ts';
+import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
+import { iteratee } from '../util/iteratee.ts';
+
+type Iteratee<T> = PropertyKey | Partial<T> | ((value: T) => unknown);
+
+/**
+ * This function takes multiple arrays and returns a new array containing only the unique values
+ * from all input arrays, preserving the order of their first occurrence.
+ * An iteratee function can be provided for comparison and it output values from the first possible array
+ *
+ * @template T - The type of elements in the arrays.
+ * @param {...(ArrayLike<T> | null | undefined | Iteratee<T>)} values - The arrays to inspect, or the iteratee function.
+ * @returns {T[]} Returns the new array of combined unique values.
+ *
+ * @example
+ * // Returns [2.1, 1.2]
+ * unionBy([2.1], [1.2, 2.3], Math.floor);
+ *
+ * @example
+ * // Returns [{ x: 1 }, { x: 2 }]
+ * unionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], 'x');
+ *
+ * @example
+ * // Returns [{ x: 1, y: 1 }]
+ * unionBy([{ x: 1, y: 1 }], [{ x: 1, y: 2 }], 'x');
+ */
+
+export function unionBy<T>(...values: Array<ArrayLike<T> | null | undefined | Iteratee<T>>): T[] {
+  const lastValue = last(values);
+  const validArray = values.filter(isArrayLikeObject);
+  const flattened = flattenArrayLike<T>(validArray);
+
+  if (isArrayLikeObject(lastValue) || lastValue == null) {
+    return uniq(flattened);
+  }
+
+  return uniqBy(flattened, iteratee(lastValue));
+}

--- a/src/compat/array/unionWith.spec.ts
+++ b/src/compat/array/unionWith.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { unionWith } from './unionWith';
+import { isEqual } from '../../predicate';
+import { args } from '../_internal/args';
+
+/**
+ * @see https://github.com/lodash/lodash/blob/v5-wip/test/union-methods.spec.js
+ * @see https://github.com/lodash/lodash/blob/v5-wip/test/unionWith.spec.js
+ */
+describe('unionWith', () => {
+  it('should return the union of two arrays', () => {
+    const actual = unionWith([2], [1, 2]);
+    expect(actual).toEqual([2, 1]);
+  });
+
+  it('should return the union of multiple arrays', () => {
+    const actual = unionWith([2], [1, 2], [2, 3]);
+    expect(actual).toEqual([2, 1, 3]);
+  });
+
+  it('should not flatten nested arrays', () => {
+    const actual = unionWith([1, 3, 2], [1, [5]], [2, [4]]);
+    expect(actual).toEqual([1, 3, 2, [5], [4]]);
+  });
+
+  it('should ignore values that are not arrays or arguments objects', () => {
+    const array = [0];
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(unionWith(array, 3, { '0': 1 }, null)).toEqual(array);
+    expect(unionWith(null, array, null, [2, 1])).toEqual([0, 2, 1]);
+    expect(unionWith(array, null, args, null)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('should work with a `comparator`', () => {
+    const objects = [
+      { x: 1, y: 2 },
+      { x: 2, y: 1 },
+    ];
+    const others = [
+      { x: 1, y: 1 },
+      { x: 1, y: 2 },
+    ];
+    const actual = unionWith(objects, others, isEqual);
+
+    expect(actual).toEqual([objects[0], objects[1], others[0]]);
+  });
+
+  it('should output values from the first possible array', () => {
+    const objects = [{ x: 1, y: 1 }];
+    const others = [{ x: 1, y: 2 }];
+
+    const actual = unionWith(objects, others, (a, b) => a.x === b.x);
+
+    expect(actual).toEqual([{ x: 1, y: 1 }]);
+  });
+});

--- a/src/compat/array/unionWith.ts
+++ b/src/compat/array/unionWith.ts
@@ -1,0 +1,47 @@
+import { last } from '../../array/last.ts';
+import { uniq } from '../../array/uniq.ts';
+import { uniqWith } from '../../array/uniqWith.ts';
+import { flattenArrayLike } from '../_internal/flattenArrayLike.ts';
+import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
+
+type Comparator<T> = (x: T, y: T) => boolean;
+
+/**
+ * This function takes multiple arrays and returns a new array containing only the unique values
+ * from all input arrays, preserving the order of their first occurrence.
+ * A comparator function can be provided for comparison and it output values from the first possible array
+ *
+ * @template T - The type of elements in the arrays.
+ * @param {...(ArrayLike<T> | null | undefined | Comparator<T, U>)} values - The arrays to inspect, or the comparator function.
+ * @returns {T[]} Returns the new array of combined unique values.
+ *
+ * @example
+ * const objects = [
+ *   { x: 1, y: 2 },
+ *   { x: 2, y: 1 },
+ * ];
+ * const others = [
+ *   { x: 1, y: 1 },
+ *   { x: 1, y: 2 },
+ * ];
+ * // Returns [objects[0], objects[1], others[0]]
+ * unionWith(objects, others, isEqual);
+ *
+ * @example
+ * const objects = [{ x: 1, y: 1 }];
+ * const others = [{ x: 1, y: 2 }];
+ * // Returns [{ x: 1, y: 1 }]
+ * unionWith(objects, others, (a, b) => a.x === b.x);
+ */
+
+export function unionWith<T>(...values: Array<ArrayLike<T> | null | undefined | Comparator<T>>): T[] {
+  const lastValue = last(values);
+  const validArray = values.filter(isArrayLikeObject);
+  const flattened = flattenArrayLike<T>(validArray);
+
+  if (isArrayLikeObject(lastValue) || lastValue == null) {
+    return uniq(flattened);
+  }
+
+  return uniqWith(flattened, lastValue);
+}

--- a/src/compat/array/unionWith.ts
+++ b/src/compat/array/unionWith.ts
@@ -36,8 +36,7 @@ type Comparator<T> = (x: T, y: T) => boolean;
 
 export function unionWith<T>(...values: Array<ArrayLike<T> | null | undefined | Comparator<T>>): T[] {
   const lastValue = last(values);
-  const validArray = values.filter(isArrayLikeObject);
-  const flattened = flattenArrayLike<T>(validArray);
+  const flattened = flattenArrayLike<T>(values);
 
   if (isArrayLikeObject(lastValue) || lastValue == null) {
     return uniq(flattened);

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -82,6 +82,7 @@ export { takeRight } from './array/takeRight.ts';
 export { takeRightWhile } from './array/takeRightWhile.ts';
 export { union } from './array/union.ts';
 export { unionBy } from './array/unionBy.ts';
+export { unionWith } from './array/unionWith.ts';
 export { uniq } from './array/uniq.ts';
 export { uniqBy } from './array/uniqBy.ts';
 export { unzip } from './array/unzip.ts';

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -81,6 +81,7 @@ export { take } from './array/take.ts';
 export { takeRight } from './array/takeRight.ts';
 export { takeRightWhile } from './array/takeRightWhile.ts';
 export { union } from './array/union.ts';
+export { unionBy } from './array/unionBy.ts';
 export { uniq } from './array/uniq.ts';
 export { uniqBy } from './array/uniqBy.ts';
 export { unzip } from './array/unzip.ts';


### PR DESCRIPTION
closes #991
closes #992

# test
<img width="676" alt="image" src="https://github.com/user-attachments/assets/c630492e-e4a9-4354-83c9-073e03cb9920" />
<img width="672" alt="image" src="https://github.com/user-attachments/assets/c0879515-1f84-4fe0-850a-c07103034597" />

# bench
<img width="720" alt="image" src="https://github.com/user-attachments/assets/bf70a0de-efde-4837-8b35-fa7d67832b3c" />

