### PR TITLE
fix(docs): update dark theme `color-scheme` for `Sandpack`

### DIFF
--- a/docs/.vitepress/components/Sandpack.vue
+++ b/docs/.vitepress/components/Sandpack.vue
@@ -32,4 +32,7 @@ const props = defineProps(sandboxProps);
 .sp-preview {
   display: none !important;
 }
+.dark {
+  color-scheme: dark;
+}
 </style>


### PR DESCRIPTION
In a component using `Sandpack`, when the dark theme is enabled, there's an issue where the `color-scheme` is applied as light instead of dark.

### Screenshot
<table>
<tr>
<td>
<img width="707" alt="Screenshot 2025-04-03 at 01 42 44" src="https://github.com/user-attachments/assets/864d8047-c961-497d-ab89-764b66a26d3a" />
</td>
<td>
<img width="707" alt="Screenshot 2025-04-03 at 01 42 40" src="https://github.com/user-attachments/assets/5749f32c-13af-4e76-88cb-d05a07722659" />
</td>
</tr>
<tr>
<td align="center">
Before
</td>
<td align="center">
After
</td>
</tr>
</table>