### PR TITLE
feat(retry-custom-delay): add support for custom delay function based on attempts

### DIFF
--- a/docs/ja/reference/function/retry.md
+++ b/docs/ja/reference/function/retry.md
@@ -14,8 +14,11 @@ function retry<T>(func: () => Promise<T>, { retries, delay, signal }: RetryOptio
 
 - `func` (`() => Promise<T>`): `Promise`を返す関数。
 - `retries`: 再試行する回数。デフォルトは `Number.POSITIVE_INFINITY` で、成功するまで再試行します。
-- `delay`: 再試行の間隔。単位はミリ秒(ms)で、デフォルトは `0` です。
+- `delay`: 再試行の間隔。ミリ秒単位の数値、または現在の試行回数 (`attempts`) を受け取って遅延を動的に決定する関数。デフォルトは `0` です。
 - `signal`: 再試行をキャンセルするための `AbortSignal`。
+
+delay: 再試行の間隔。ミリ秒単位の数値、または現在の試行回数（attempts）を受け取って遅延を動的に決定する関数。デフォルトは 0 です。
+
 
 ### 戻り値
 
@@ -40,9 +43,16 @@ console.log(data2);
 const data3 = await retry(() => fetchData(), { retries: 3, delay: 100 });
 console.log(data3);
 
+// 試行回数に応じて、遅延を線形に増やすことができます（例: attempts * 50ms）
+const data4 = await retry(() => fetchData(), {
+  retries: 5,
+  delay: (attempts) => attempts * 50,
+});
+console.log(data4);
+
 const controller = new AbortController();
 
-// `fetchData`の再試行作業を`signal`でキャンセルできます。
-const data4 = await retry(() => fetchData(), { signal: controller.signal });
-console.log(data4);
+// `AbortSignal` を使用して再試行をキャンセルできます。
+const data5 = await retry(() => fetchData(), { signal: controller.signal });
+console.log(data5);
 ```

--- a/docs/ko/reference/function/retry.md
+++ b/docs/ko/reference/function/retry.md
@@ -14,7 +14,7 @@ function retry<T>(func: () => Promise<T>, { retries, delay, signal }: RetryOptio
 
 - `func` (`() => Promise<T>`): `Promise`를 반환하는 함수.
 - `retries`: 재시도할 횟수. 기본값은 `Number.POSITIVE_INFINITY`로, 성공할 때까지 재시도해요.
-- `delay`: 재시도 사이 간격. 단위는 밀리세컨드(ms)로, 기본값은 `0`이에요.
+- `delay`: 재시도 사이 간격. 밀리세컨드(ms) 단위의 숫자이거나, 현재 재시도 횟수(`attempts`)를 기반으로 동적으로 간격을 계산하는 함수일 수 있어요. 기본값은 `0`이에요.
 - `signal`: 재시도를 취소할 수 있는 `AbortSignal`.
 
 ### 반환 값
@@ -40,9 +40,16 @@ console.log(data2);
 const data3 = await retry(() => fetchData(), { retries: 3, delay: 100 });
 console.log(data3);
 
+// 재시도 횟수에 따라 딜레이가 커지는 함수로 설정할 수 있어요 
+const data4 = await retry(() => fetchData(), {
+  retries: 5,
+  delay: (attempts) => attempt * 50,
+});
+console.log(data4);
+
 const controller = new AbortController();
 
 // `fetchData`를 재시도하는 작업을 `signal`로 취소할 수 있어요.
-const data4 = await retry(() => fetchData(), { signal: controller.signal });
-console.log(data4);
+const data5 = await retry(() => fetchData(), { signal: controller.signal });
+console.log(data5);
 ```

--- a/docs/reference/function/retry.md
+++ b/docs/reference/function/retry.md
@@ -14,7 +14,7 @@ function retry<T>(func: () => Promise<T>, { retries, delay, signal }: RetryOptio
 
 - `func` (`() => Promise<T>`): A function that returns a `Promise`.
 - `retries`: The number of times to retry. The default is `Number.POSITIVE_INFINITY`, which means it will retry until it succeeds.
-- `delay`: The interval between retries, measured in milliseconds (ms). The default is `0`.
+- `delay`: The interval between retries, measured in milliseconds (ms). or a function that returns a delay based on the current attempt. The default is `0`.
 - `signal`: An `AbortSignal` that can be used to cancel the retries.
 
 ### Returns
@@ -40,9 +40,16 @@ console.log(data2);
 const data3 = await retry(() => fetchData(), { retries: 3, delay: 100 });
 console.log(data3);
 
+// Retry 5 times with a linearly increasing delay
+const data4 = await retry(() => fetchData(), {
+  retries: 5,
+  delay: (attempts) => attempts * 50,
+});
+console.log(data4);
+
 const controller = new AbortController();
 
 // The retry operation for `fetchData` can be canceled with the `signal`.
-const data4 = await retry(() => fetchData(), { signal: controller.signal });
-console.log(data4);
+const data5 = await retry(() => fetchData(), { signal: controller.signal });
+console.log(data5);
 ```

--- a/src/function/retry.spec.ts
+++ b/src/function/retry.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { performance } from 'node:perf_hooks';
 import { retry } from './retry';
 
 describe('retry', () => {
@@ -23,9 +24,9 @@ describe('retry', () => {
   it('should retry with the specified delay between attempts', async () => {
     const func = vi.fn().mockRejectedValueOnce(new Error('failure')).mockResolvedValue('success');
     const delay = 100;
-    const start = Date.now();
+    const start = performance.now();
     const result = await retry(func, { delay, retries: 2 });
-    const end = Date.now();
+    const end = performance.now();
     expect(result).toBe('success');
     expect(func).toHaveBeenCalledTimes(2);
     expect(end - start).toBeGreaterThanOrEqual(delay);
@@ -45,9 +46,9 @@ describe('retry', () => {
       return d;
     });
 
-    const start = Date.now();
+    const start = performance.now();
     const result = await retry(func, { delay: delayFn, retries: 3 });
-    const end = Date.now();
+    const end = performance.now();
 
     const totalDelay = delays.reduce((sum, d) => sum + d, 0);
 

--- a/src/function/retry.ts
+++ b/src/function/retry.ts
@@ -7,7 +7,7 @@ interface RetryOptions {
    *
    * @default 0
    * @example
-   * delay: (attempts) => Math.random() * 100 * 2 ** attempts
+   * delay: (attempts) => attempt * 50
    */
   delay?: number | ((attempts: number) => number);
 
@@ -72,8 +72,15 @@ export async function retry<T>(func: () => Promise<T>, retries: number): Promise
  * // Retry a function with a fixed delay
  * retry(() => fetchData(), { delay: 1000, retries: 5 });
  *
- * // Retry a function with exponential backoff + jitter
- * retry(() => fetchData(), { delay: (attempt) => Math.random() * 100 * 2 ** attempt, retries: 5 });
+ * // Retry a function with a delay increasing linearly by 50ms per attempt
+ * retry(() => fetchData(), { delay: (attempts) => attempt * 50, retries: 5 });
+ *
+ * @example
+ * // Retry a function with exponential backoff + jitter (max delay 10 seconds)
+ * retry(() => fetchData(), {
+ *   delay: (attempts) => Math.min(Math.random() * 100 * 2 ** attempts, 10000),
+ *   retries: 5
+ * });
  */
 export async function retry<T>(func: () => Promise<T>, options: RetryOptions): Promise<T>;
 

--- a/src/function/retry.ts
+++ b/src/function/retry.ts
@@ -120,9 +120,7 @@ export async function retry<T>(func: () => Promise<T>, _options?: number | Retry
       error = err;
 
       const currentDelay = typeof delay === 'function' ? delay(attempts) : delay;
-      if (currentDelay > 0) {
-        await delayToolkit(currentDelay);
-      }
+      await delayToolkit(currentDelay);
     }
   }
 

--- a/src/function/retry.ts
+++ b/src/function/retry.ts
@@ -59,7 +59,7 @@ export async function retry<T>(func: () => Promise<T>, retries: number): Promise
  * @template T
  * @param {() => Promise<T>} func - The function to retry. It should return a promise.
  * @param {RetryOptions} options - Options to configure the retry behavior.
- * @param {number | ((attempts: number) => number)} [options.delay=0] - Delay between retries.
+ * @param {number | ((attempts: number) => number)} [options.delay=0] - Delay(milliseconds) between retries.
  * @param {number} [options.retries=Infinity] - The number of retries to attempt.
  * @param {AbortSignal} [options.signal] - An AbortSignal to cancel the retry operation.
  * @returns {Promise<T>} A promise that resolves with the value of the successful function call.


### PR DESCRIPTION
### What’s Changed
adds support for customizing the retry delay based on the current attempt count via a user-defined function.

This work continues from the discussion in [#940](https://github.com/toss/es-toolkit/pull/940), where we explored adding jitter/backoff strategies while keeping the implementation simple.


* RetryOptions.delay now accepts a function (attempts: number) => number

* Test cases updated to verify behavior with both fixed and dynamic delays

* Used performance.now() in tests for more accurate delay measurements