### PR TITLE
feat(isString): replace typeof checks with isString utility

### DIFF
--- a/benchmarks/performance/isEqualWith.bench.ts
+++ b/benchmarks/performance/isEqualWith.bench.ts
@@ -1,4 +1,5 @@
 import { bench, describe } from 'vitest';
+import { isString } from 'es-toolkit';
 import { isEqualWith as isEqualWithToolkit_ } from 'es-toolkit';
 import { isEqualWith as isEqualWithToolkitCompat_ } from 'es-toolkit/compat';
 import { isEqualWith as isEqualWithLodash_ } from 'lodash';
@@ -9,7 +10,7 @@ const isEqualWithLodash = isEqualWithLodash_;
 
 describe('isEqualWith primitives', () => {
   const customizer = (a, b) => {
-    if (typeof a === 'string' && typeof b === 'string') {
+    if (isString(a) && isString(b)) {
       return a.toLowerCase() === b.toLowerCase();
     }
   };

--- a/benchmarks/performance/omitBy.bench.ts
+++ b/benchmarks/performance/omitBy.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from 'vitest';
 import { omitBy as omitByToolkit_ } from 'es-toolkit';
+import { isString } from 'es-toolkit';
 import { omitBy as omitByLodash_ } from 'lodash';
 
 const omitByToolkit = omitByToolkit_;
@@ -7,7 +8,7 @@ const omitByLodash = omitByLodash_;
 
 describe('omitBy', () => {
   const obj = { a: 1, b: 'omit', c: 3, d: 'test', e: 0 };
-  const shouldOmit = (value: number | string) => typeof value === 'string';
+  const shouldOmit = (value: number | string) => isString(value);
 
   bench('es-toolkit/omitBy', () => {
     omitByToolkit(obj, shouldOmit);

--- a/src/compat/_internal/compareValues.ts
+++ b/src/compat/_internal/compareValues.ts
@@ -1,3 +1,5 @@
+import { isString } from '../predicate/isString.ts';
+
 function getPriority(a: unknown): 0 | 1 | 2 | 3 | 4 {
   if (typeof a === 'symbol') {
     return 1;
@@ -21,7 +23,7 @@ function getPriority(a: unknown): 0 | 1 | 2 | 3 | 4 {
 export const compareValues = <V>(a: V, b: V, order: string) => {
   if (a !== b) {
     // If both values are strings, compare them using localeCompare.
-    if (typeof a === 'string' && typeof b === 'string') {
+    if (isString(a) && isString(b)) {
       return order === 'desc' ? b.localeCompare(a) : a.localeCompare(b);
     }
 

--- a/src/compat/_internal/isIterateeCall.ts
+++ b/src/compat/_internal/isIterateeCall.ts
@@ -1,6 +1,7 @@
 import { isIndex } from './isIndex.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { isObject } from '../predicate/isObject.ts';
+import { isString } from '../predicate/isString.ts';
 import { eq } from '../util/eq.ts';
 
 export function isIterateeCall(value: unknown, index: unknown, object: unknown): boolean {
@@ -10,7 +11,7 @@ export function isIterateeCall(value: unknown, index: unknown, object: unknown):
 
   if (
     (typeof index === 'number' && isArrayLike(object) && isIndex(index) && index < object.length) ||
-    (typeof index === 'string' && index in object)
+    (isString(index) && index in object)
   ) {
     return eq((object as any)[index], value);
   }

--- a/src/compat/_internal/isKey.ts
+++ b/src/compat/_internal/isKey.ts
@@ -1,3 +1,4 @@
+import { isString } from '../predicate/isString.ts';
 import { isSymbol } from '../predicate/isSymbol.ts';
 
 /**  Matches any deep property path. (e.g. `a.b[0].c`)*/
@@ -28,7 +29,7 @@ export function isKey(value?: unknown, object?: unknown): value is PropertyKey {
   }
 
   return (
-    (typeof value === 'string' && (regexIsPlainProp.test(value) || !regexIsDeepProp.test(value))) ||
+    (isString(value) && (regexIsPlainProp.test(value) || !regexIsDeepProp.test(value))) ||
     (object != null && Object.hasOwn(object, value as PropertyKey))
   );
 }

--- a/src/compat/_internal/toKey.ts
+++ b/src/compat/_internal/toKey.ts
@@ -1,3 +1,5 @@
+import { isString } from '../predicate/isString.ts';
+
 /**
  * Converts `value` to a string key if it's not a string or symbol.
  *
@@ -5,8 +7,9 @@
  * @param {*} value The value to inspect.
  * @returns {string|symbol} Returns the key.
  */
+
 export function toKey(value: any) {
-  if (typeof value === 'string' || typeof value === 'symbol') {
+  if (isString(value) || typeof value === 'symbol') {
     return value;
   }
   if (Object.is(value.valueOf(), -0)) {

--- a/src/compat/array/intersectionBy.ts
+++ b/src/compat/array/intersectionBy.ts
@@ -4,6 +4,7 @@ import { uniq } from '../../array/uniq.ts';
 import { identity } from '../../function/identity.ts';
 import { property } from '../object/property.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
+import { isString } from '../predicate/isString.ts';
 
 /**
  * Returns the intersection of multiple arrays after applying the iteratee function to their elements.
@@ -188,7 +189,7 @@ export function intersectionBy<T>(
       result = intersectionByToolkit(result, Array.from(value), identity);
     } else if (typeof lastValue === 'function') {
       result = intersectionByToolkit(result, Array.from(value), value => lastValue(value));
-    } else if (typeof lastValue === 'string') {
+    } else if (isString(lastValue)) {
       result = intersectionByToolkit(result, Array.from(value), property(lastValue));
     }
   }

--- a/src/compat/math/add.ts
+++ b/src/compat/math/add.ts
@@ -1,3 +1,4 @@
+import { isString } from '../predicate/isString.ts';
 import { toNumber } from '../util/toNumber.ts';
 import { toString } from '../util/toString.ts';
 
@@ -23,7 +24,7 @@ export function add(value: number, other: number): number {
   if (value === undefined || other === undefined) {
     return value ?? other;
   }
-  if (typeof value === 'string' || typeof other === 'string') {
+  if (isString(value) || isString(other)) {
     value = toString(value) as any;
     other = toString(other) as any;
   } else {

--- a/src/compat/math/divide.ts
+++ b/src/compat/math/divide.ts
@@ -1,3 +1,4 @@
+import { isString } from '../predicate/isString.ts';
 import { toNumber } from '../util/toNumber.ts';
 import { toString } from '../util/toString.ts';
 
@@ -25,7 +26,7 @@ export function divide(value: number, other: number): number {
     return value ?? other;
   }
 
-  if (typeof value === 'string' || typeof other === 'string') {
+  if (isString(value) || isString(other)) {
     value = toString(value) as any;
     other = toString(other) as any;
   } else {

--- a/src/compat/math/multiply.ts
+++ b/src/compat/math/multiply.ts
@@ -1,3 +1,4 @@
+import { isString } from '../predicate/isString.ts';
 import { toNumber } from '../util/toNumber.ts';
 import { toString } from '../util/toString.ts';
 
@@ -26,7 +27,7 @@ export function multiply(value: number, other: number): number {
     return value ?? other;
   }
 
-  if (typeof value === 'string' || typeof other === 'string') {
+  if (isString(value) || isString(other)) {
     value = toString(value) as any;
     other = toString(other) as any;
   } else {

--- a/src/compat/math/subtract.ts
+++ b/src/compat/math/subtract.ts
@@ -1,3 +1,4 @@
+import { isString } from '../predicate/isString.ts';
 import { toNumber } from '../util/toNumber.ts';
 import { toString } from '../util/toString.ts';
 
@@ -22,7 +23,7 @@ export function subtract(value: number, other: number): number {
   if (value === undefined || other === undefined) {
     return value ?? other;
   }
-  if (typeof value === 'string' || typeof other === 'string') {
+  if (isString(value) || isString(other)) {
     value = toString(value) as any;
     other = toString(other) as any;
   } else {

--- a/src/compat/object/findKey.ts
+++ b/src/compat/object/findKey.ts
@@ -1,6 +1,7 @@
 import { property } from './property.ts';
 import { findKey as findKeyToolkit } from '../../object/findKey.ts';
 import { isObject } from '../predicate/isObject.ts';
+import { isString } from '../predicate/isString.ts';
 import { matches } from '../predicate/matches.ts';
 import { matchesProperty } from '../predicate/matchesProperty.ts';
 
@@ -126,7 +127,7 @@ function findKeyImpl<T extends Record<any, any>>(
     return findKeyToolkit(obj, matches(predicate));
   }
 
-  if (typeof predicate === 'string') {
+  if (isString(predicate)) {
     return findKeyToolkit(obj, property(predicate));
   }
 }

--- a/src/compat/object/has.ts
+++ b/src/compat/object/has.ts
@@ -1,6 +1,7 @@
 import { isDeepKey } from '../_internal/isDeepKey.ts';
 import { isIndex } from '../_internal/isIndex.ts';
 import { isArguments } from '../predicate/isArguments.ts';
+import { isString } from '../predicate/isString.ts';
 import { toPath } from '../util/toPath.ts';
 
 /**
@@ -68,7 +69,7 @@ export function has(object: any, path: PropertyKey | readonly PropertyKey[]): bo
 
   if (Array.isArray(path)) {
     resolvedPath = path;
-  } else if (typeof path === 'string' && isDeepKey(path) && object?.[path] == null) {
+  } else if (isString(path) && isDeepKey(path) && object?.[path] == null) {
     resolvedPath = toPath(path);
   } else {
     resolvedPath = [path];

--- a/src/compat/object/keys.spec.ts
+++ b/src/compat/object/keys.spec.ts
@@ -7,6 +7,7 @@ import { objectProto } from '../_internal/objectProto';
 import { primitives } from '../_internal/primitives';
 import { strictArgs } from '../_internal/strictArgs';
 import { stringProto } from '../_internal/stringProto';
+import { isString } from '../predicate/isString.ts';
 import { constant } from '../util/constant';
 import { stubArray } from '../util/stubArray';
 
@@ -132,7 +133,7 @@ describe('keys', () => {
   });
 
   it('should coerce primitives to objects (test in IE 9)', () => {
-    const expected = primitives.map(value => (typeof value === 'string' ? ['0'] : []));
+    const expected = primitives.map(value => (isString(value) ? ['0'] : []));
 
     const actual = primitives.map(keys);
     expect(actual).toEqual(expected);

--- a/src/compat/object/keysIn.spec.ts
+++ b/src/compat/object/keysIn.spec.ts
@@ -3,6 +3,7 @@ import { keysIn } from './keysIn';
 import { args } from '../_internal/args';
 import { primitives } from '../_internal/primitives';
 import { strictArgs } from '../_internal/strictArgs';
+import { isString } from '../predicate/isString.ts';
 import { stubArray } from '../util/stubArray';
 
 describe('keys methods', () => {
@@ -146,7 +147,7 @@ describe('keys methods', () => {
   });
 
   it(`\`keysIn\` should coerce primitives to objects (test in IE 9)`, () => {
-    const expected = primitives.map(value => (typeof value === 'string' ? ['0'] : []));
+    const expected = primitives.map(value => (isString(value) ? ['0'] : []));
 
     // eslint-disable-next-line
     // @ts-ignore

--- a/src/compat/object/pick.ts
+++ b/src/compat/object/pick.ts
@@ -3,6 +3,7 @@ import { has } from './has.ts';
 import { set } from './set.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { isNil } from '../predicate/isNil.ts';
+import { isString } from '../predicate/isString.ts';
 
 /**
  * Creates a new object composed of the picked object properties.
@@ -126,7 +127,7 @@ export function pick<
         continue;
       }
 
-      if (typeof key === 'string' && Object.hasOwn(obj, key)) {
+      if (isString(key) && Object.hasOwn(obj, key)) {
         result[key] = value;
       } else {
         set(result, key, value);

--- a/src/compat/object/pickBy.spec.ts
+++ b/src/compat/object/pickBy.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import * as lodashStable from 'es-toolkit/compat';
 import { pickBy } from './pickBy';
 import { symbol } from '../_internal/symbol';
+import { isString } from '../predicate/isString.ts';
 import { stubTrue } from '../util/stubTrue';
 
 describe('pickBy', () => {
@@ -91,21 +92,21 @@ describe('pickBy', () => {
 
   it('should pick properties based on the predicate function', () => {
     const obj = { a: 1, b: 'pick', c: 3 };
-    const shouldPick = (value: string | number) => typeof value === 'string';
+    const shouldPick = (value: string | number) => isString(value);
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({ b: 'pick' });
   });
 
   it('should return an empty object if no properties satisfy the predicate', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const shouldPick = (value: number) => typeof value === 'string';
+    const shouldPick = (value: number) => isString(value);
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({});
   });
 
   it('should return the same object if all properties satisfy the predicate', () => {
     const obj = { a: 'pick', b: 'pick', c: 'pick' };
-    const shouldPick = (value: string) => typeof value === 'string';
+    const shouldPick = (value: string) => isString(value);
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual(obj);
   });
@@ -132,14 +133,14 @@ describe('pickBy', () => {
 
   it('should return an empty object if the object is null', () => {
     const obj = null;
-    const shouldPick = (value: string) => typeof value === 'string';
+    const shouldPick = (value: string) => isString(value);
     const result = pickBy(obj as unknown as object, shouldPick);
     expect(result).toEqual({});
   });
 
   it('should return an empty object if the object is undefined', () => {
     const obj = undefined;
-    const shouldPick = (value: string) => typeof value === 'string';
+    const shouldPick = (value: string) => isString(value);
     const result = pickBy(obj as unknown as object, shouldPick);
     expect(result).toEqual({});
   });

--- a/src/compat/object/updateWith.ts
+++ b/src/compat/object/updateWith.ts
@@ -3,6 +3,7 @@ import { isIndex } from '../_internal/isIndex.ts';
 import { isKey } from '../_internal/isKey.ts';
 import { toKey } from '../_internal/toKey.ts';
 import { isObject } from '../predicate/isObject.ts';
+import { isString } from '../predicate/isString.ts';
 import { toPath } from '../util/toPath.ts';
 
 /**
@@ -26,13 +27,7 @@ export function updateWith<T extends object | null | undefined>(
     return obj;
   }
 
-  const resolvedPath = isKey(path, obj)
-    ? [path]
-    : Array.isArray(path)
-      ? path
-      : typeof path === 'string'
-        ? toPath(path)
-        : [path];
+  const resolvedPath = isKey(path, obj) ? [path] : Array.isArray(path) ? path : isString(path) ? toPath(path) : [path];
 
   let current: any = obj;
 

--- a/src/compat/util/gt.ts
+++ b/src/compat/util/gt.ts
@@ -1,4 +1,5 @@
 import { toNumber } from './toNumber.ts';
+import { isString } from '../predicate/isString.ts';
 
 /**
  * Checks if value is greater than other.
@@ -13,7 +14,7 @@ import { toNumber } from './toNumber.ts';
  * gt(1, 3); // false
  */
 export function gt(value: unknown, other: unknown): boolean {
-  if (typeof value === 'string' && typeof other === 'string') {
+  if (isString(value) && isString(other)) {
     return value > other;
   }
 

--- a/src/compat/util/gte.ts
+++ b/src/compat/util/gte.ts
@@ -1,4 +1,5 @@
 import { toNumber } from './toNumber.ts';
+import { isString } from '../predicate/isString.ts';
 
 /**
  * Checks if value is greater than or equal to other.
@@ -13,7 +14,7 @@ import { toNumber } from './toNumber.ts';
  * gte(1, 3); // => false
  */
 export function gte(value: unknown, other: unknown): boolean {
-  if (typeof value === 'string' && typeof other === 'string') {
+  if (isString(value) && isString(other)) {
     return value >= other;
   }
 

--- a/src/compat/util/lt.ts
+++ b/src/compat/util/lt.ts
@@ -1,4 +1,5 @@
 import { toNumber } from './toNumber.ts';
+import { isString } from '../predicate/isString.ts';
 
 /**
  * Checks if value is less than other.
@@ -13,7 +14,7 @@ import { toNumber } from './toNumber.ts';
  * lt(3, 1); // false
  */
 export function lt(value: unknown, other: unknown): boolean {
-  if (typeof value === 'string' && typeof other === 'string') {
+  if (isString(value) && isString(other)) {
     return value < other;
   }
 

--- a/src/compat/util/lte.ts
+++ b/src/compat/util/lte.ts
@@ -1,4 +1,5 @@
 import { toNumber } from './toNumber.ts';
+import { isString } from '../predicate/isString.ts';
 
 /**
  * Checks if value is less than or equal to other.
@@ -13,7 +14,7 @@ import { toNumber } from './toNumber.ts';
  * lte(3, 1); // => false
  */
 export function lte(value: unknown, other: unknown): boolean {
-  if (typeof value === 'string' && typeof other === 'string') {
+  if (isString(value) && isString(other)) {
     return value <= other;
   }
 

--- a/src/object/findKey.spec.ts
+++ b/src/object/findKey.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { findKey } from './findKey';
+import { isString } from '../predicate/isString.ts';
 
 describe('findKey', () => {
   const users = {
@@ -34,7 +35,7 @@ describe('findKey', () => {
       bool: true,
     };
 
-    expect(findKey(data, value => typeof value === 'string')).toBe('str');
+    expect(findKey(data, value => isString(value))).toBe('str');
   });
 
   it('should pass the key and object to the predicate function', () => {

--- a/src/object/omitBy.spec.ts
+++ b/src/object/omitBy.spec.ts
@@ -1,24 +1,25 @@
 import { describe, expect, it } from 'vitest';
 import { omitBy } from './omitBy';
+import { isString } from '../predicate/isString.ts';
 
 describe('omitBy', () => {
   it('should omit properties based on the predicate function', () => {
     const obj = { a: 1, b: 'omit', c: 3 };
-    const shouldOmit = (value: number | string) => typeof value === 'string';
+    const shouldOmit = (value: number | string) => isString(value);
     const result = omitBy(obj, shouldOmit);
     expect(result).toEqual({ a: 1, c: 3 });
   });
 
   it('should return an empty object if all properties are omitted', () => {
     const obj = { a: 'omit', b: 'omit' };
-    const shouldOmit = (value: string) => typeof value === 'string';
+    const shouldOmit = (value: string) => isString(value);
     const result = omitBy(obj, shouldOmit);
     expect(result).toEqual({});
   });
 
   it('should return the same object if no properties are omitted', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const shouldOmit = (value: number) => typeof value === 'string';
+    const shouldOmit = (value: number) => isString(value);
     const result = omitBy(obj, shouldOmit);
     expect(result).toEqual(obj);
   });

--- a/src/object/pickBy.spec.ts
+++ b/src/object/pickBy.spec.ts
@@ -1,24 +1,25 @@
 import { describe, expect, it } from 'vitest';
 import { pickBy } from './pickBy';
+import { isString } from '../predicate/isString.ts';
 
 describe('pickBy', () => {
   it('should pick properties based on the predicate function', () => {
     const obj = { a: 1, b: 'pick', c: 3 };
-    const shouldPick = (value: string | number) => typeof value === 'string';
+    const shouldPick = (value: string | number) => isString(value);
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({ b: 'pick' });
   });
 
   it('should return an empty object if no properties satisfy the predicate', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const shouldPick = (value: number) => typeof value === 'string';
+    const shouldPick = (value: number) => isString(value);
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({});
   });
 
   it('should return the same object if all properties satisfy the predicate', () => {
     const obj = { a: 'pick', b: 'pick', c: 'pick' };
-    const shouldPick = (value: string) => typeof value === 'string';
+    const shouldPick = (value: string) => isString(value);
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual(obj);
   });

--- a/src/predicate/isEqualWith.spec.ts
+++ b/src/predicate/isEqualWith.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { isEqualWith } from './isEqualWith';
+import { isString } from './isString';
 import { args } from '../compat/_internal/args';
 import { arrayViews } from '../compat/_internal/arrayViews';
 import { stubFalse } from '../compat/util/stubFalse';
@@ -11,7 +12,7 @@ describe('isEqualWith', () => {
 
   it('should use the customizer function for string comparison', () => {
     const customizer = (a: any, b: any) => {
-      if (typeof a === 'string' && typeof b === 'string') {
+      if (isString(a) && isString(b)) {
         return a.toLowerCase() === b.toLowerCase();
       }
     };


### PR DESCRIPTION
**Summary**
- This pull request replaces all occurrences of `typeof value === 'string'` with the `isString` utility function provided by `es-toolkit`.

**Details**
- Replaced primitive string type checks with `isString()` in relevant benchmark tests and other internal usages.
- This improves code readability and keeps type checks consistent across the codebase.
- No functional changes were made.

**Why**
- Using `isString` improves type safety by working as a type predicate.
- Aligns with the project's design principle of code simplicity and reusability.

**Test & Bench**
- All existing tests pass successfully.
![스크린샷 2025-04-07 오후 10 34 43](https://github.com/user-attachments/assets/0d94c938-2cc8-4e4f-ba42-803f4f7ea960)

<img width="961" alt="스크린샷 2025-04-08 오전 9 25 29" src="https://github.com/user-attachments/assets/6964e07f-7dfa-4283-8783-3df14d978e62" />

