### PR TITLE
perf(toPairs): improve performance by pre-allocating array and using iterator values

### DIFF
--- a/src/compat/_internal/mapToEntries.ts
+++ b/src/compat/_internal/mapToEntries.ts
@@ -1,0 +1,10 @@
+export function mapToEntries(map: Map<any, any>) {
+  const arr = new Array(map.size);
+  const keys = map.keys();
+  const values = map.values();
+
+  for (let i = 0; i < arr.length; i++) {
+    arr[i] = [keys.next().value, values.next().value];
+  }
+  return arr;
+}

--- a/src/compat/_internal/setToEntries.ts
+++ b/src/compat/_internal/setToEntries.ts
@@ -1,0 +1,10 @@
+export function setToEntries(set: Set<any>) {
+  const arr = new Array(set.size);
+  const values = set.values();
+
+  for (let i = 0; i < arr.length; i++) {
+    const value = values.next().value;
+    arr[i] = [value, value];
+  }
+  return arr;
+}

--- a/src/compat/object/toPairs.ts
+++ b/src/compat/object/toPairs.ts
@@ -1,4 +1,6 @@
 import { keys as keysToolkit } from './keys.ts';
+import { mapToEntries } from '../_internal/mapToEntries.ts';
+import { setToEntries } from '../_internal/setToEntries.ts';
 
 /**
  * Creates an array of string keyed-value pairs from an object.
@@ -53,8 +55,12 @@ export function toPairs<K, V>(map: Map<K, V>): Array<[key: K, value: V]>;
  * toPairs(map); // [['a', 1], ['b', 2]]
  */
 export function toPairs(object: Record<any, any> | Set<any> | Map<any, any>): Array<[key: PropertyKey, value: any]> {
-  if (object instanceof Set || object instanceof Map) {
-    return Array.from(object.entries());
+  if (object instanceof Set) {
+    return setToEntries(object);
+  }
+
+  if (object instanceof Map) {
+    return mapToEntries(object);
   }
 
   const keys = keysToolkit(object);

--- a/src/compat/object/toPairsIn.ts
+++ b/src/compat/object/toPairsIn.ts
@@ -1,4 +1,6 @@
 import { keysIn as keysInToolkit } from './keysIn.ts';
+import { mapToEntries } from '../_internal/mapToEntries.ts';
+import { setToEntries } from '../_internal/setToEntries.ts';
 
 /**
  * Creates an array of string keyed-value pairs from an object, including inherited properties.
@@ -53,8 +55,12 @@ export function toPairsIn<K, V>(map: Map<K, V>): Array<[key: K, value: V]>;
  * toPairsIn(map); // [['a', 1], ['b', 2]]
  */
 export function toPairsIn(object: Record<any, any> | Set<any> | Map<any, any>): Array<[key: PropertyKey, value: any]> {
-  if (object instanceof Set || object instanceof Map) {
-    return Array.from(object.entries());
+  if (object instanceof Set) {
+    return setToEntries(object);
+  }
+
+  if (object instanceof Map) {
+    return mapToEntries(object);
   }
 
   const keys = keysInToolkit(object);


### PR DESCRIPTION
For `Map` and `Set`, I improved the performance of `toPairs/toPairsIn` with better logic than converting to `entries` via `Array.from(obj.entries())`.

This logic pre-allocates an array and uses Iterator values.

## Performance
### AS-IS
![oldNewPairs](https://github.com/user-attachments/assets/f27f9d18-9534-4eac-ac31-c01d67fe40ea)

### TO-BE
![스크린샷 2025-04-15 오후 4 08 44](https://github.com/user-attachments/assets/b7fb1c5a-0cf9-4e9c-8a54-f5e4fa6db165)
