### PR TITLE
fix(maxBy, minBy): return undefined for empty array inputs

### DIFF
--- a/src/array/maxBy.ts
+++ b/src/array/maxBy.ts
@@ -60,7 +60,11 @@ export function maxBy<T>(items: readonly T[], getValue: (element: T) => number):
  *   x => x.age
  * ); // Returns: { name: 'john', age: 30 }
  */
-export function maxBy<T>(items: readonly T[], getValue: (element: T) => number): T {
+export function maxBy<T>(items: readonly T[], getValue: (element: T) => number): T | undefined {
+  if (items.length === 0) {
+    return undefined;
+  }
+
   let maxElement = items[0];
   let max = -Infinity;
 

--- a/src/array/minBy.ts
+++ b/src/array/minBy.ts
@@ -61,6 +61,10 @@ export function minBy<T>(items: readonly T[], getValue: (element: T) => number):
  * ); // Returns: { name: 'joe', age: 26 }
  */
 export function minBy<T>(items: readonly T[], getValue: (element: T) => number): T | undefined {
+  if (items.length === 0) {
+    return undefined;
+  }
+
   let minElement = items[0];
   let min = Infinity;
 


### PR DESCRIPTION
- Added an early return undefined when the input array is empty in both maxBy and minBy functions. This prevents the function from returning the initial element incorrectly when there are no items to evaluate.

- Updated the return type of maxBy to explicitly allow undefined. This reflects the correct behavior when the input array has no elements.

**Benchmarks**
![스크린샷 2025-04-17 오후 9 09 47](https://github.com/user-attachments/assets/8141a81d-1d63-4d6f-96d3-01c2259c7ab4)
