### PR TITLE
feat(bench): add vitest benchmark for ary function

### DIFF
--- a/benchmarks/performance/ary.bench.ts
+++ b/benchmarks/performance/ary.bench.ts
@@ -1,14 +1,21 @@
 import { bench, describe } from 'vitest';
-import { ary as aryToolkit_ } from 'es-toolkit/compat';
+import { ary as aryToolkit_ } from 'es-toolkit';
+import { ary as aryCompactToolkit_ } from 'es-toolkit/compat';
 import { ary as aryLodash_ } from 'lodash';
 
 const aryToolkit = aryToolkit_;
+const aryCompactToolkit = aryCompactToolkit_;
 const aryLodash = aryLodash_;
 
 describe('ary', () => {
   bench('es-toolkit/ary', () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     aryToolkit((_a, _b, _c) => undefined, 2);
+  });
+
+  bench('es-toolkit/compat/ary', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    aryCompactToolkit((_a, _b, _c) => undefined, 2);
   });
 
   bench('lodash/ary', () => {


### PR DESCRIPTION
Added the missing benchmark for the ary function from es-toolkit in ary.bench.ts

<img width="876" alt="스크린샷 2025-05-01 오후 3 13 53" src="https://github.com/user-attachments/assets/5897615e-9a67-4a45-a812-8f9da5faf901" />
