### PR TITLE
fix(throttle): Align `throttle` behavior with lodash when `throttleMs` is 0.

### DIFF
--- a/src/compat/array/keyBy.ts
+++ b/src/compat/array/keyBy.ts
@@ -1,5 +1,5 @@
 import { reduce } from './reduce.ts';
-import { identity } from '../../function';
+import { identity } from '../../function/identity.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { isObjectLike } from '../predicate/isObjectLike.ts';
 import { iteratee as createIteratee } from '../util/iteratee.ts';

--- a/src/compat/array/xorBy.ts
+++ b/src/compat/array/xorBy.ts
@@ -3,9 +3,9 @@ import { intersectionBy } from './intersectionBy.ts';
 import { last } from './last.ts';
 import { unionBy } from './unionBy.ts';
 import { windowed } from '../../array/windowed.ts';
-import { identity } from '../../function/identity';
+import { identity } from '../../function/identity.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
-import { iteratee } from '../util/iteratee';
+import { iteratee } from '../util/iteratee.ts';
 
 /**
  * Creates an array of unique values that is the symmetric difference of the given arrays after applying the iteratee function to each element.

--- a/src/compat/function/debounce.ts
+++ b/src/compat/function/debounce.ts
@@ -114,16 +114,16 @@ export function debounce<F extends (...args: any[]) => any>(
     if (maxWait != null) {
       if (pendingAt === null) {
         pendingAt = Date.now();
-      } else {
-        if (Date.now() - pendingAt >= maxWait) {
-          result = func.apply(this, args);
-          pendingAt = Date.now();
+      }
 
-          _debounced.cancel();
-          _debounced.schedule();
+      if (Date.now() - pendingAt >= maxWait) {
+        result = func.apply(this, args);
+        pendingAt = Date.now();
 
-          return result;
-        }
+        _debounced.cancel();
+        _debounced.schedule();
+
+        return result;
       }
     }
 

--- a/src/compat/function/throttle.spec.ts
+++ b/src/compat/function/throttle.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { throttle } from './throttle';
 import { identity } from '../../function/identity';
 import { noop } from '../../function/noop';
@@ -329,5 +329,23 @@ describe('throttle', () => {
 
     await delay(64);
     expect(callCount).toBe(0);
+  });
+
+  it('should invoke the function immediately if wait is 0', () => {
+    const fn = vi.fn();
+
+    const throttled = throttle(fn, 0, { leading: true, trailing: true });
+
+    throttled();
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    throttled();
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    throttled();
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    throttled();
+    expect(fn).toHaveBeenCalledTimes(4);
   });
 });


### PR DESCRIPTION
When `throttleMs` is set to 0, lodash's `_.throttle` immediately invokes the throttled function. 

Previously, `es-toolkit/compat` behaved differently in this scenario. This change adjusts the condition to match lodash's immediate invocation for throttleMs = 0, ensuring compatibility.