### PR TITLE
fix(compat): align compat HOF behavior with lodash for sparse arrays

### DIFF
--- a/src/compat/array/every.spec.ts
+++ b/src/compat/array/every.spec.ts
@@ -158,4 +158,12 @@ describe('every', () => {
     expect(every(objects, [0, 1])).toBe(false);
     expect(every(objects, [Symbol.for('c'), 1])).toBe(true);
   });
+
+  it('should handle sparse arrays correctly', () => {
+    // eslint-disable-next-line no-sparse-arrays
+    const sparseArray = [1, , 3, , 5] as any[];
+
+    expect(every(sparseArray, value => value > 0)).toEqual(false);
+    expect(every(sparseArray, value => value === undefined)).toEqual(false);
+  });
 });

--- a/src/compat/array/filter.spec.ts
+++ b/src/compat/array/filter.spec.ts
@@ -161,4 +161,12 @@ describe('filter', () => {
 
     expect(actual).toEqual([0]);
   });
+
+  it('should handle sparse arrays correctly', () => {
+    // eslint-disable-next-line no-sparse-arrays
+    const sparseArray = [1, , 3, , 5] as any[];
+
+    expect(filter(sparseArray, value => value > 0)).toEqual([1, 3, 5]);
+    expect(filter(sparseArray, value => value === undefined)).toEqual([undefined, undefined]);
+  });
 });

--- a/src/compat/array/filter.ts
+++ b/src/compat/array/filter.ts
@@ -1,4 +1,3 @@
-import { isArray } from '../predicate/isArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { iteratee } from '../util/iteratee.ts';
 
@@ -170,8 +169,6 @@ export function filter<T>(
     return [];
   }
 
-  const collection = isArray(source) ? source : Object.values(source);
-
   predicate = iteratee(predicate);
 
   if (!Array.isArray(source)) {
@@ -191,5 +188,15 @@ export function filter<T>(
     return result;
   }
 
-  return collection.filter(predicate);
+  const result: T[] = [];
+  const length = source.length;
+
+  for (let i = 0; i < length; i++) {
+    const value = source[i];
+    if (predicate(value, i, source)) {
+      result.push(value);
+    }
+  }
+
+  return result;
 }

--- a/src/compat/array/reject.spec.ts
+++ b/src/compat/array/reject.spec.ts
@@ -149,4 +149,11 @@ describe('reject', () => {
 
     expect(actual).toEqual([0]);
   });
+
+  it('should handle sparse arrays correctly', () => {
+    // eslint-disable-next-line no-sparse-arrays
+    const sparseArray = [1, , 3, , 5] as any[];
+
+    expect(reject(sparseArray, value => value > 2)).toEqual([1, undefined, undefined]);
+  });
 });

--- a/src/compat/array/some.spec.ts
+++ b/src/compat/array/some.spec.ts
@@ -181,4 +181,12 @@ describe('some', () => {
     expect(some('123', value => value === '3')).toBe(true);
     expect(some(args, value => value === 1)).toBe(true);
   });
+
+  it('should handle sparse arrays correctly', () => {
+    // eslint-disable-next-line no-sparse-arrays
+    const sparseArray = [1, , 3, , 5] as any[];
+
+    expect(some(sparseArray, value => value > 0)).toEqual(true);
+    expect(some(sparseArray, value => value === undefined)).toEqual(true);
+  });
 });

--- a/src/compat/array/some.ts
+++ b/src/compat/array/some.ts
@@ -227,22 +227,55 @@ export function some<T>(
 
         return false;
       }
-      return values.some(predicate);
+
+      for (let i = 0; i < source.length; i++) {
+        if (predicate(source[i] as T, i, source)) {
+          return true;
+        }
+      }
+      return false;
     }
     case 'object': {
       if (Array.isArray(predicate) && predicate.length === 2) {
         const key = predicate[0];
         const value = predicate[1];
 
-        return values.some(matchesProperty(key, value));
+        const matchFunc = matchesProperty(key, value);
+        if (Array.isArray(source)) {
+          for (let i = 0; i < source.length; i++) {
+            if (matchFunc(source[i])) {
+              return true;
+            }
+          }
+          return false;
+        }
+        return values.some(matchFunc);
       } else {
-        return values.some(matches(predicate));
+        const matchFunc = matches(predicate);
+        if (Array.isArray(source)) {
+          for (let i = 0; i < source.length; i++) {
+            if (matchFunc(source[i])) {
+              return true;
+            }
+          }
+          return false;
+        }
+        return values.some(matchFunc);
       }
     }
     case 'number':
     case 'symbol':
     case 'string': {
-      return values.some(property(predicate));
+      const propFunc = property(predicate);
+      if (Array.isArray(source)) {
+        for (let i = 0; i < source.length; i++) {
+          if (propFunc(source[i])) {
+            return true;
+          }
+        }
+        return false;
+      }
+      return values.some(propFunc);
     }
   }
 }


### PR DESCRIPTION
close #1161

I think we only need to fix `filter`, `every`, and `some` methods. The rest of the higher-order functions in `compat` use `for` loops instead of JavaScript’s built-in higher-order functions, which skip empty slots in sparse arrays, so I believe they can handle those empty slots properly.
 