### PR TITLE
feat(compat): add `invokeMap` to compat/array

### DIFF
--- a/benchmarks/performance/invokeMap.bench.ts
+++ b/benchmarks/performance/invokeMap.bench.ts
@@ -1,0 +1,30 @@
+import { bench, describe } from 'vitest';
+import { invokeMap as invokeMapToolkitCompat_ } from 'es-toolkit/compat';
+import { invokeMap as invokeMapLodash_ } from 'lodash';
+
+const invokeMapToolkitCompat = invokeMapToolkitCompat_;
+const invokeMapLodash = invokeMapLodash_;
+
+describe('invokeMap', () => {
+  const stringArray = ['a', 'b', 'c'];
+  const numberObject = { a: 1, b: 2, c: 3 };
+  const largeArray = Array.from({ length: 1000 }, (_, i) => String(i));
+  const array = ['a', 'b', 'c'];
+  const func = function (left, right) {
+    return left + this.toUpperCase() + right;
+  };
+
+  bench('es-toolkit/invokeMap/compat', () => {
+    invokeMapToolkitCompat(stringArray, 'toUpperCase');
+    invokeMapToolkitCompat(numberObject, 'toFixed', 1);
+    invokeMapToolkitCompat(largeArray, 'toString');
+    invokeMapToolkitCompat(array, func, '(', ')');
+  });
+
+  bench('lodash/invokeMap', () => {
+    invokeMapLodash(stringArray, 'toUpperCase');
+    invokeMapLodash(numberObject, 'toFixed', 1);
+    invokeMapLodash(largeArray, 'toString');
+    invokeMapLodash(array, func, '(', ')');
+  });
+});

--- a/docs/ja/reference/compat/array/invokeMap.md
+++ b/docs/ja/reference/compat/array/invokeMap.md
@@ -1,0 +1,67 @@
+# invokeMap
+
+::: info
+この関数は互換性のために `es-toolkit/compat` からのみインポートできます。代替可能なネイティブ JavaScript API があるか、まだ十分に最適化されていないためです。
+
+`es-toolkit/compat` からこの関数をインポートすると、[lodash と完全に同じように動作](mdc:../../../compatibility.md)します。
+:::
+
+コレクションの各要素の `path` にあるメソッドを呼び出し、呼び出された各メソッドの結果を配列として返します。追加の引数は、呼び出される各メソッドに渡されます。`path` が関数の場合、コレクションの各要素に対して呼び出され、`this` が各要素にバインドされます。
+
+## インターフェース
+
+```typescript
+function invokeMap<T, R>(
+  collection: T[] | Record<string, T> | null | undefined,
+  path: PropertyKey | PropertyKey[] | ((this: T, ...args: any[]) => R),
+  ...args: unknown[]
+): Array<R | undefined>;
+```
+
+### パラメータ
+
+- `collection` (`T[] | Record<string, T> | null | undefined`): 反復処理するコレクションです。
+- `path` (`PropertyKey | PropertyKey[] | ((this: T, ...args: any[]) => R)`): 呼び出すメソッドのパス（文字列、数値、シンボル、またはこれらの配列）または呼び出す関数です。
+- `args` (`...unknown[]`): 各メソッドを呼び出す際に渡す引数です。
+
+### 戻り値
+
+(`Array<R | undefined>`): 結果の配列を返します。パスが見つからないか、メソッドの呼び出し結果が `undefined` の場合、その要素は `undefined` となります。
+
+## 例
+
+```typescript
+import { invokeMap } from 'es-toolkit/compat';
+
+// 各要素のメソッドを呼び出す
+invokeMap(['a', 'b', 'c'], 'toUpperCase');
+// => ['A', 'B', 'C']
+
+// 引数付きでメソッドを呼び出す
+invokeMap(
+  [
+    [5, 1, 7],
+    [3, 2, 1],
+  ],
+  'sort'
+);
+// => [[1, 5, 7], [1, 2, 3]]
+
+// オブジェクトの各値に対してメソッドを呼び出す
+invokeMap({ a: 1, b: 2, c: 3 }, 'toFixed', 1);
+// => ['1.0', '2.0', '3.0']
+
+// メソッド名の代わりに関数を使用する
+invokeMap(
+  ['a', 'b', 'c'],
+  function (this: string, prefix: string, suffix: string) {
+    return prefix + this.toUpperCase() + suffix;
+  },
+  '(',
+  ')'
+);
+// => ['(A)', '(B)', '(C)']
+
+invokeMap([123, 456], String.prototype.split, '');
+// => [['1', '2', '3'], ['4', '5', '6']]
+```

--- a/docs/ko/reference/compat/array/invokeMap.md
+++ b/docs/ko/reference/compat/array/invokeMap.md
@@ -1,0 +1,67 @@
+# invokeMap
+
+::: info
+이 함수는 호환성을 위한 `es-toolkit/compat` 에서만 가져올 수 있어요. 대체할 수 있는 네이티브 JavaScript API가 있거나, 아직 충분히 최적화되지 않았기 때문이에요.
+
+`es-toolkit/compat`에서 이 함수를 가져오면, [lodash와 완전히 똑같이 동작](mdc:../../../compatibility.md)해요.
+:::
+
+컬렉션의 각 요소에서 `path`에 해당하는 메서드를 호출하고, 호출된 각 메서드의 결과를 배열로 반환해요. 추가 인자들은 각각의 호출되는 메서드에 전달돼요. 만약 `path`가 함수라면, 컬렉션의 각 요소에 대해 호출되며 `this`가 각 요소에 바인딩돼요.
+
+## 인터페이스
+
+```typescript
+function invokeMap<T, R>(
+  collection: T[] | Record<string, T> | null | undefined,
+  path: PropertyKey | PropertyKey[] | ((this: T, ...args: any[]) => R),
+  ...args: unknown[]
+): Array<R | undefined>;
+```
+
+### 파라미터
+
+- `collection` (`T[] | Record<string, T> | null | undefined`): 순회할 컬렉션이에요.
+- `path` (`PropertyKey | PropertyKey[] | ((this: T, ...args: any[]) => R)`): 호출할 메서드의 경로(문자열, 숫자, 심볼, 또는 이들의 배열)나 호출할 함수예요.
+- `args` (`...unknown[]`): 각 메서드를 호출할 때 전달할 인자들이에요.
+
+### 반환 값
+
+(`Array<R | undefined>`): 결과 배열을 반환해요. 경로를 찾을 수 없거나 메서드 호출 결과가 `undefined`인 경우 해당 요소는 `undefined`가 돼요.
+
+## 예시
+
+```typescript
+import { invokeMap } from 'es-toolkit/compat';
+
+// 각 요소의 메서드 호출하기
+invokeMap(['a', 'b', 'c'], 'toUpperCase');
+// => ['A', 'B', 'C']
+
+// 인자와 함께 메서드 호출하기
+invokeMap(
+  [
+    [5, 1, 7],
+    [3, 2, 1],
+  ],
+  'sort'
+);
+// => [[1, 5, 7], [1, 2, 3]]
+
+// 객체의 각 값에 대해 메서드 호출하기
+invokeMap({ a: 1, b: 2, c: 3 }, 'toFixed', 1);
+// => ['1.0', '2.0', '3.0']
+
+// 메서드 이름 대신 함수 사용하기
+invokeMap(
+  ['a', 'b', 'c'],
+  function (this: string, prefix: string, suffix: string) {
+    return prefix + this.toUpperCase() + suffix;
+  },
+  '(',
+  ')'
+);
+// => ['(A)', '(B)', '(C)']
+
+invokeMap([123, 456], String.prototype.split, '');
+// => [['1', '2', '3'], ['4', '5', '6']]
+```

--- a/docs/reference/compat/array/invokeMap.md
+++ b/docs/reference/compat/array/invokeMap.md
@@ -1,0 +1,67 @@
+# invokeMap
+
+::: info
+This function is only available in `es-toolkit/compat` for compatibility reasons. It either has alternative native JavaScript APIs or isn't fully optimized yet.
+
+When imported from `es-toolkit/compat`, it behaves exactly like lodash and provides the same functionalities, as detailed @here.
+:::
+
+Invokes the method at `path` of each element in `collection`, returning an array of the results of each invoked method. Any additional arguments are provided to each invoked method. If `path` is a function, it's invoked for, and `this` bound to, each element in `collection`.
+
+## Signature
+
+```typescript
+function invokeMap<T, R>(
+  collection: T[] | Record<string, T> | null | undefined,
+  path: PropertyKey | PropertyKey[] | ((this: T, ...args: any[]) => R),
+  ...args: unknown[]
+): Array<R | undefined>;
+```
+
+### Parameters
+
+- `collection` (`T[] | Record<string, T> | null | undefined`): The collection to iterate over.
+- `path` (`PropertyKey | PropertyKey[] | ((this: T, ...args: any[]) => R)`): The path of the method to invoke (string, number, symbol, or an array of these) or the function to invoke.
+- `args` (`...unknown[]`): The arguments to invoke each method with.
+
+### Returns
+
+(`Array<R | undefined>`): Returns the array of results. Elements are `undefined` if the path is not found or the method invocation results in `undefined`.
+
+## Examples
+
+```typescript
+import { invokeMap } from 'es-toolkit/compat';
+
+// Invoke a method on each element
+invokeMap(['a', 'b', 'c'], 'toUpperCase');
+// => ['A', 'B', 'C']
+
+// Invoke a method with arguments
+invokeMap(
+  [
+    [5, 1, 7],
+    [3, 2, 1],
+  ],
+  'sort'
+);
+// => [[1, 5, 7], [1, 2, 3]]
+
+// Invoke a method on each value in an object
+invokeMap({ a: 1, b: 2, c: 3 }, 'toFixed', 1);
+// => ['1.0', '2.0', '3.0']
+
+// Use a function instead of a method name
+invokeMap(
+  ['a', 'b', 'c'],
+  function (this: string, prefix: string, suffix: string) {
+    return prefix + this.toUpperCase() + suffix;
+  },
+  '(',
+  ')'
+);
+// => ['(A)', '(B)', '(C)']
+
+invokeMap([123, 456], String.prototype.split, '');
+// => [['1', '2', '3'], ['4', '5', '6']]
+```

--- a/docs/zh_hans/reference/compat/array/invokeMap.md
+++ b/docs/zh_hans/reference/compat/array/invokeMap.md
@@ -1,0 +1,67 @@
+# invokeMap
+
+::: info
+出于兼容性原因，此函数仅在 `es-toolkit/compat` 中提供。它可能具有替代的原生 JavaScript API，或者尚未完全优化。
+
+从 `es-toolkit/compat` 导入时，它的行为与 lodash 完全一致，并提供相同的功能，详情请见 [这里](mdc:../../../compatibility.md)。
+:::
+
+调用集合中每个元素在 `path` 位置的方法，并返回所有被调用方法的结果数组。任何额外的参数都会被传递给每个被调用的方法。如果 `path` 是一个函数，它会被调用并将 `this` 绑定到集合中的每个元素。
+
+## 签名
+
+```typescript
+function invokeMap<T, R>(
+  collection: T[] | Record<string, T> | null | undefined,
+  path: PropertyKey | PropertyKey[] | ((this: T, ...args: any[]) => R),
+  ...args: unknown[]
+): Array<R | undefined>;
+```
+
+### 参数
+
+- `collection` (`T[] | Record<string, T> | null | undefined`): 要遍历的集合。
+- `path` (`PropertyKey | PropertyKey[] | ((this: T, ...args: any[]) => R)`): 要调用的方法的路径（字符串、数字、符号或这些的数组）或要调用的函数。
+- `args` (`...unknown[]`): 调用每个方法时要传入的参数。
+
+### 返回值
+
+(`Array<R | undefined>`): 返回结果数组。如果找不到路径或方法调用结果为 `undefined`，则相应元素为 `undefined`。
+
+## 示例
+
+```typescript
+import { invokeMap } from 'es-toolkit/compat';
+
+// 调用每个元素的方法
+invokeMap(['a', 'b', 'c'], 'toUpperCase');
+// => ['A', 'B', 'C']
+
+// 使用参数调用方法
+invokeMap(
+  [
+    [5, 1, 7],
+    [3, 2, 1],
+  ],
+  'sort'
+);
+// => [[1, 5, 7], [1, 2, 3]]
+
+// 调用对象中每个值的方法
+invokeMap({ a: 1, b: 2, c: 3 }, 'toFixed', 1);
+// => ['1.0', '2.0', '3.0']
+
+// 使用函数替代方法名
+invokeMap(
+  ['a', 'b', 'c'],
+  function (this: string, prefix: string, suffix: string) {
+    return prefix + this.toUpperCase() + suffix;
+  },
+  '(',
+  ')'
+);
+// => ['(A)', '(B)', '(C)']
+
+invokeMap([123, 456], String.prototype.split, '');
+// => [['1', '2', '3'], ['4', '5', '6']]
+```

--- a/src/compat/array/invokeMap.spec.ts
+++ b/src/compat/array/invokeMap.spec.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { invokeMap } from './invokeMap';
+import { stubOne } from '../_internal/stubOne';
+
+describe('invokeMap', () => {
+  it('should invoke a methods on each element of `collection`', () => {
+    const array = ['a', 'b', 'c'];
+    const actual = invokeMap(array, 'toUpperCase');
+
+    expect(actual).toEqual(['A', 'B', 'C']);
+  });
+
+  it('should support invoking with arguments', () => {
+    const array = [
+      function () {
+        // eslint-disable-next-line prefer-rest-params
+        return Array.from(arguments);
+      },
+    ];
+    const actual = invokeMap(array, 'call', null, 'a', 'b', 'c');
+
+    expect(actual).toEqual([['a', 'b', 'c']]);
+  });
+
+  it('should work with a function for `methodName`', () => {
+    const array = ['a', 'b', 'c'];
+
+    const actual = invokeMap(
+      array,
+      function (this: any, left: string, right: string) {
+        return left + this.toUpperCase() + right;
+      },
+      '(',
+      ')'
+    );
+
+    expect(actual).toEqual(['(A)', '(B)', '(C)']);
+  });
+
+  it('should work with an object for `collection`', () => {
+    const object = { a: 1, b: 2, c: 3 };
+    const actual = invokeMap(object, 'toFixed', 1);
+
+    expect(actual).toEqual(['1.0', '2.0', '3.0']);
+  });
+
+  it('should treat number, null, or undefined for `collection` as empty', () => {
+    // @ts-expect-error - `path` parameter is not optional
+    expect(invokeMap(1)).toEqual([]);
+    // @ts-expect-error - `path` parameter is not optional
+    expect(invokeMap(null)).toEqual([]);
+    // @ts-expect-error - `path` parameter is not optional
+    expect(invokeMap(undefined)).toEqual([]);
+  });
+
+  it('should not error on nullish elements', () => {
+    const array = ['a', null, undefined, 'd'];
+    const actual = invokeMap(array, 'toUpperCase');
+
+    expect(actual).toEqual(['A', undefined, undefined, 'D']);
+  });
+
+  it('should not error on elements with missing properties', () => {
+    const objects = [null, undefined, stubOne].map(value => ({ a: value }));
+    const expected = objects.map(object => (object.a ? object.a() : undefined));
+    const actual = invokeMap(objects, 'a');
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should invoke deep property methods with the correct `this` binding', () => {
+    const object = {
+      a: {
+        b: function () {
+          return this.c;
+        },
+        c: 1,
+      },
+    };
+
+    const paths = ['a.b', ['a', 'b']];
+
+    paths.forEach(path => {
+      expect(invokeMap([object], path)).toEqual([1]);
+    });
+  });
+
+  it('should bind `this` correctly for array path', () => {
+    const singlePropObject = {
+      value: function () {
+        return this;
+      },
+    };
+    expect(invokeMap([singlePropObject], ['value'])[0]).toBe(singlePropObject);
+
+    const emptyPathObject = {
+      '': function () {
+        return this;
+      },
+    };
+    expect(invokeMap([emptyPathObject], []).length).toBe(1);
+    expect(invokeMap([emptyPathObject], [])[0]).toBeUndefined();
+
+    const nestedObject = {
+      a: {
+        b: {
+          c: function () {
+            return this;
+          },
+        },
+      },
+    };
+    expect(invokeMap([nestedObject], ['a', 'b', 'c'])[0]).toBe(nestedObject.a.b);
+  });
+
+  it('should bind `this` correctly for string path', () => {
+    const singlePropObject = {
+      value: function () {
+        return this;
+      },
+    };
+    expect(invokeMap([singlePropObject], 'value')[0]).toBe(singlePropObject);
+
+    const emptyPathObject = {
+      '': function () {
+        return this;
+      },
+    };
+    const result = invokeMap([emptyPathObject], '');
+    expect(result[0]).toBe(emptyPathObject);
+
+    const nestedObject = {
+      a: {
+        b: {
+          c: function () {
+            return this;
+          },
+        },
+      },
+    };
+    expect(invokeMap([nestedObject], 'a.b.c')[0]).toBe(nestedObject.a.b);
+
+    const objectWithEmptyPart = {
+      a: {
+        '': {
+          c: function () {
+            return this;
+          },
+        },
+      },
+    };
+
+    const aEmptyDotC = invokeMap([objectWithEmptyPart], 'a..c');
+    expect(aEmptyDotC[0]).toBeUndefined();
+  });
+});

--- a/src/compat/array/invokeMap.ts
+++ b/src/compat/array/invokeMap.ts
@@ -1,0 +1,84 @@
+import { isFunction, isNil } from '../../predicate';
+import { get } from '../object/get';
+import { isArrayLike } from '../predicate/isArrayLike';
+
+/**
+ * Invokes the method at `path` of each element in `collection`, returning
+ * an array of the results of each invoked method. Any additional arguments
+ * are provided to each invoked method. If `path` is a function, it's invoked
+ * for, and `this` bound to, each element in `collection`.
+ *
+ * @template T The type of the elements in the collection.
+ * @template R The type of the resolved values from the invoked methods.
+ * @param {T[] | Record<string, T> | null | undefined} collection The collection to iterate over.
+ * @param {PropertyKey | PropertyKey[] | ((this: T, ...args: unknown[]) => R)} path The path of the method to invoke (string, number, symbol, or an array of these) or the function to invoke.
+ * @param {...unknown} [args] The arguments to invoke each method with.
+ * @returns {Array<R | undefined>} Returns the array of results. Elements are `undefined` if the path is not found or the method invocation results in `undefined`.
+ *
+ * @example
+ * // Invoke a method on each element
+ * invokeMap(['a', 'b', 'c'], 'toUpperCase');
+ * // => ['A', 'B', 'C']
+ *
+ * // Invoke a method with arguments
+ * invokeMap([[5, 1, 7], [3, 2, 1]], 'sort');
+ * // => [[1, 5, 7], [1, 2, 3]]
+ *
+ * // Invoke a method on each value in an object
+ * invokeMap({ a: 1, b: 2, c: 3 }, 'toFixed', 1);
+ * // => ['1.0', '2.0', '3.0']
+ *
+ * // Use a function instead of a method name
+ * invokeMap(
+ *   ['a', 'b', 'c'],
+ *   function(this: string, prefix: string, suffix: string) {
+ *     return prefix + this.toUpperCase() + suffix;
+ *   },
+ *   '(',
+ *   ')'
+ * );
+ * // => ['(A)', '(B)', '(C)']
+ *
+ * invokeMap([123, 456], String.prototype.split, '');
+ * // => [['1', '2', '3'], ['4', '5', '6']]
+ */
+export function invokeMap<T, R>(
+  collection: T[] | Record<string, T> | null | undefined,
+  path: PropertyKey | PropertyKey[] | ((this: T, ...args: any[]) => R),
+  ...args: unknown[]
+): Array<R | undefined> {
+  if (isNil(collection)) {
+    return [];
+  }
+
+  const values = isArrayLike(collection) ? (Array.from(collection) as T[]) : (Object.values(collection) as T[]);
+  const result: Array<R | undefined> = [];
+
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i];
+
+    if (isFunction(path)) {
+      result.push(path.apply(value, args));
+      continue;
+    }
+
+    const method = get(value, path);
+
+    let thisContext = value;
+
+    if (Array.isArray(path)) {
+      const pathExceptLast = path.slice(0, -1);
+      if (pathExceptLast.length > 0) {
+        thisContext = get(value, pathExceptLast);
+      }
+    } else if (typeof path === 'string' && path.includes('.')) {
+      const parts = path.split('.');
+      const pathExceptLast = parts.slice(0, -1).join('.');
+      thisContext = get(value, pathExceptLast);
+    }
+
+    result.push(method == null ? undefined : method.apply(thisContext, args));
+  }
+
+  return result;
+}

--- a/src/compat/array/invokeMap.ts
+++ b/src/compat/array/invokeMap.ts
@@ -1,6 +1,6 @@
-import { isFunction, isNil } from '../../predicate';
-import { get } from '../object/get';
-import { isArrayLike } from '../predicate/isArrayLike';
+import { isFunction, isNil } from '../../predicate/index.ts';
+import { get } from '../object/get.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
  * Invokes the method at `path` of each element in `collection`, returning

--- a/src/compat/compat.ts
+++ b/src/compat/compat.ts
@@ -35,7 +35,7 @@ export { initial } from './array/initial.ts';
 export { intersection } from './array/intersection.ts';
 export { intersectionBy } from './array/intersectionBy.ts';
 export { intersectionWith } from './array/intersectionWith.ts';
-// export { invokeMap } from './array/invokeMap.ts';
+export { invokeMap } from './array/invokeMap.ts';
 export { join } from './array/join.ts';
 export { keyBy } from './array/keyBy.ts';
 export { last } from './array/last.ts';


### PR DESCRIPTION
close #1006

> The testcases follow [lodash.invokeMap](https://github.com/lodash/lodash/blob/v5-wip/test/invokeMap.spec.js).

### Test List

<img width="739" alt="image" src="https://github.com/user-attachments/assets/e0dc18df-d29d-4296-8439-64ba6dc298ba" />


### Test Coverage

<img width="520" alt="image" src="https://github.com/user-attachments/assets/e6abcd88-d7aa-445c-9b4e-b830ced8ffba" />


## Bench Test 

<img width="902" alt="image" src="https://github.com/user-attachments/assets/fe16b8a8-d267-49b6-81a1-9b48955b95fd" />


