### PR TITLE
fix[pullAt]: Improve handling of invalid indices

### DIFF
--- a/src/array/pullAt.spec.ts
+++ b/src/array/pullAt.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { pullAt } from './pullAt';
 
 describe('pullAt', () => {
-  it('should returns index searched of original array and changed original array', () => {
+  it('should remove elements at specified indices and return the removed elements', () => {
     const array = [0, 1, 2, 3, 4, 5];
     const result = pullAt(array, [3, 5]);
 
@@ -10,7 +10,7 @@ describe('pullAt', () => {
     expect(result).toStrictEqual([3, 5]);
   });
 
-  it('even if there are duplicate index values must return an array containing duplicate index values', () => {
+  it('should preserve duplicate values in the returned array when removing at duplicate indices', () => {
     const array = [0, 1, 2, 3, 4, 5];
     const result = pullAt(array, [1, 2, 2, 4]);
 
@@ -18,7 +18,7 @@ describe('pullAt', () => {
     expect(result).toStrictEqual([1, 2, 2, 4]);
   });
 
-  it('even if there are not index value must return an array containing undefined value', () => {
+  it('should return undefined for out-of-bounds indices while still removing valid indices', () => {
     const array = [0, 1, 2, 3, 4, 5];
     const result = pullAt(array, [0, 3, 5, 6]);
 
@@ -26,7 +26,7 @@ describe('pullAt', () => {
     expect(result).toStrictEqual([0, 3, 5, undefined]);
   });
 
-  it('even if there are other instance or type must return an array containing other instance or type values', () => {
+  it('should properly handle non-primitive values in the array', () => {
     const array = [0, { a: 1 }, [2], 3, '4'];
     const result = pullAt(array, [1, 2, 4]);
 
@@ -34,7 +34,7 @@ describe('pullAt', () => {
     expect(result).toStrictEqual([{ a: 1 }, [2], '4']);
   });
 
-  it('even if index array parameter is empty must return an empty array', () => {
+  it('should return an empty array when no indices are provided', () => {
     const array = [0, 1, 2, 3, 4, 5];
     const result = pullAt(array, []);
 
@@ -42,7 +42,7 @@ describe('pullAt', () => {
     expect(result).toStrictEqual([]);
   });
 
-  it('should work with unsorted indexes', () => {
+  it('should handle unsorted indices correctly', () => {
     const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     const actual = pullAt(array, [1, 3, 11, 7, 5, 9]);
 
@@ -50,7 +50,7 @@ describe('pullAt', () => {
     expect(actual).toEqual([2, 4, 12, 8, 6, 10]);
   });
 
-  it('should work with objects', () => {
+  it('should maintain object references correctly', () => {
     const foo = { foo: 1 };
     const bar = { foo: 2 };
 
@@ -59,5 +59,29 @@ describe('pullAt', () => {
 
     expect(arr).toEqual([foo, bar]);
     expect(result).toEqual([foo]);
+  });
+
+  it('should retrieve elements at negative indices but only remove elements at valid positive indices', () => {
+    const array = [0, 1, 2, 3, 4, 5];
+    const result = pullAt(array, [0, -1, 3]);
+
+    expect(array).toStrictEqual([1, 2, 4, 5]);
+    expect(result).toStrictEqual([0, 5, 3]);
+  });
+
+  it('should not modify the array when all indices are invalid', () => {
+    const array = [0, 1, 2, 3];
+    const result = pullAt(array, [-5, 6, 7]);
+
+    expect(array).toStrictEqual([0, 1, 2, 3]);
+    expect(result).toStrictEqual([undefined, undefined, undefined]);
+  });
+
+  it('should remove each valid index only once even if it appears multiple times', () => {
+    const array = [0, 1, 2, 3, 4];
+    const result = pullAt(array, [1, 1, 3]);
+
+    expect(array).toStrictEqual([0, 2, 4]);
+    expect(result).toStrictEqual([1, 1, 3]);
   });
 });

--- a/src/array/pullAt.ts
+++ b/src/array/pullAt.ts
@@ -3,24 +3,35 @@ import { at } from './at.ts';
 /**
  * Removes elements from an array at specified indices and returns the removed elements.
  *
- * This function supports negative indices, which count from the end of the array.
+ * This function retrieves elements at the specified indices using the `at` function (which supports
+ * negative indices), but only removes elements at valid positive indices (0 <= index < array.length)
+ * from the original array.
  *
  * @template T
  * @param {T[]} arr - The array from which elements will be removed.
  * @param {number[]} indicesToRemove - An array of indices specifying the positions of elements to remove.
- * @returns {Array<T | undefined>} An array containing the elements that were removed from the original array.
+ * @returns {Array<T | undefined>} An array containing the elements that were retrieved at the specified indices.
+ *   Returns `undefined` for indices that are out of bounds.
  *
  * @example
  * const numbers = [10, 20, 30, 40, 50];
  * const removed = pullAt(numbers, [1, 3, 4]);
  * console.log(removed); // [20, 40, 50]
  * console.log(numbers); // [10, 30]
+ *
+ * @example
+ * // Handling negative indices and out-of-bounds indices
+ * const numbers = [10, 20, 30, 40];
+ * const removed = pullAt(numbers, [1, -1, 5]);
+ * console.log(removed); // [20, 40, undefined]
+ * console.log(numbers); // [10, 30] (only valid indices affect the array)
  */
 export function pullAt<T>(arr: T[], indicesToRemove: number[]): T[] {
   const removed = at(arr, indicesToRemove);
-  const indices = new Set(indicesToRemove.slice().sort((x, y) => y - x));
 
-  for (const index of indices) {
+  const validIndices = indicesToRemove.filter(index => index >= 0 && index < arr.length).sort((x, y) => y - x);
+
+  for (const index of new Set(validIndices)) {
     arr.splice(index, 1);
   }
 


### PR DESCRIPTION
## Description

This PR improves the pullAt function by safely handling invalid indices and clarifying its behavior. The current implementation attempts to splice elements at all specified indices without validation, which could lead to unexpected behavior when dealing with negative or out-of-bounds indices.

## Changes Made

- Modified pullAt to filter out invalid indices (negative or out-of-bounds) before splicing
- Added more comprehensive documentation explaining how the function handles various index types
- Extended test coverage to verify handling of edge cases

## Bug Details
The original implementation

```ts
export function pullAt<T>(arr: T[], indicesToRemove: number[]): T[] {
  const removed = at(arr, indicesToRemove);
  const indices = new Set(indicesToRemove.slice().sort((x, y) => y - x));

  for (const index of indices) {
    arr.splice(index, 1);
  }

  return removed;
}
```
This had potential issues

Attempting to splice with negative indices would remove elements from the end of the array
Attempting to splice with out-of-bounds indices would have no effect but could lead to confusion
The behavior wasn't clearly documented, especially regarding how it handles invalid indices

## Implementation Details
The new implementation

```ts
export function pullAt<T>(arr: T[], indicesToRemove: number[]): T[] {
  const removed = at(arr, indicesToRemove);

  const validIndices = indicesToRemove
    .filter(index => index >= 0 && index < arr.length)
    .sort((x, y) => y - x);

  for (const index of new Set(validIndices)) {
    arr.splice(index, 1);
  }

  return removed;
}
```

Now the function

- Still uses at to retrieve elements (which supports negative indices)
- But only splices at valid indices (0 ≤ index < arr.length)
- Has clear documentation explaining this behavior distinction

## Test Results
<img width="542" alt="스크린샷 2025-05-09 오후 2 56 07" src="https://github.com/user-attachments/assets/7ddced8f-fe50-4b13-8d2a-e84d3b1d22d7" />


## Before / After
Behavior with pullAt(array, [1, -1, 6]) where array = [0, 1, 2, 3]

### Before

Would retrieve elements [1, 3, undefined] (using at)
Would attempt to splice at indices 6, -1, 1, potentially causing unexpected array modifications

### After

Still retrieves elements [1, 3, undefined] (using at)
Only splices at valid index 1, resulting in predictable array modification
Result: array = [0, 2, 3] and returns [1, 3, undefined]