### PR TITLE
docs(trim): minor typo at korean docs

### DIFF
--- a/docs/ko/reference/string/trim.md
+++ b/docs/ko/reference/string/trim.md
@@ -15,7 +15,7 @@ function trim(str: string, chars?: string | string[]): string;
 
 ### 반환 값
 
-(`string`): 지정된 문자가 제거된 후의 결과 문자열입니다요.
+(`string`): 지정된 문자가 제거된 후의 결과 문자열입니다.
 
 ## 예시
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4c6c366d-468f-48a9-bb3a-acedfc944a84)
