### PR TITLE
docs: fix wrong url 

### DIFF
--- a/docs/.vitepress/data/bannerData.ts
+++ b/docs/.vitepress/data/bannerData.ts
@@ -8,7 +8,7 @@ export const KO_BANNER_DATA: Banner[] = [
   {
     title: '🛠️ frontend-fundamentals',
     description: '프론트엔드 코드를 더 잘 짜는 방법을 고민하고 있나요? 실무에서 비롯한 원칙과 예시들을 모아봤어요.',
-    link: 'https://frontend-fundamentals.com/',
+    link: 'https://frontend-fundamentals.com/code-quality',
   },
   {
     title: '🇰🇷 es-hangul',
@@ -37,7 +37,7 @@ export const EN_BANNER_DATA: Banner[] = [
   {
     title: '🛠️ frontend-fundamentals',
     description: 'Your compass for better code. Four core principles for writing easily modifiable frontend code.',
-    link: 'https://frontend-fundamentals.com/en/',
+    link: 'https://frontend-fundamentals.com/code-quality/en',
   },
   {
     title: '⏳ suspensive',


### PR DESCRIPTION
<img width="786" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/33651882-cc45-4c59-8189-f66ede800f1b" />

Fixed a bug where clicking the `frontend-fundamentals` link from the floating banner at the bottom right of the page on https://es-toolkit.slash.page/ would lead to a 404 page when the site locale was set to English.