### PR TITLE
feat(compat): add overArgs to compat/function

### DIFF
--- a/benchmarks/performance/overArgs.bench.ts
+++ b/benchmarks/performance/overArgs.bench.ts
@@ -1,0 +1,22 @@
+import { bench, describe } from 'vitest';
+import { overArgs as overArgsCompat_ } from 'es-toolkit/compat';
+import { overArgs as overArgsLodash_ } from 'lodash';
+
+const overArgsTookitCompat = overArgsCompat_;
+const overArgsLodash = overArgsLodash_;
+
+describe('overArgs', () => {
+  const doubled = (n: number) => n * 2;
+  const square = (n: number) => n * n;
+  const targetFunc = (x: number, y: number) => [x, y];
+
+  bench('es-toolkit/compat/overArgs', () => {
+    const func = overArgsTookitCompat(targetFunc, doubled, square);
+    func(4, 2);
+  });
+
+  bench('lodash/overArgs', () => {
+    const func = overArgsLodash(targetFunc, doubled, square);
+    func(4, 2);
+  });
+});

--- a/docs/ja/reference/compat/function/overArgs.md
+++ b/docs/ja/reference/compat/function/overArgs.md
@@ -1,0 +1,96 @@
+# overArgs
+
+::: info
+この関数は互換性のための `es-toolkit/compat` からのみインポートできます。代替となるネイティブ JavaScript API が存在するか、まだ十分に最適化されていないためです。
+
+`es-toolkit/compat` からこの関数をインポートすると、[lodash と全く同じように動作](../../../compatibility.md)します。
+:::
+
+`overArgs` は、対象関数 (`func`) を呼び出す際に渡される引数たちを、事前に指定された変換仕様 (`transformsArgs`) に従って処理し、新しい関数を生成します。これらの変換仕様は、引数が元の `func` に渡される前に、各引数に個別に適用されます。
+
+`transformsArgs` は個別引数として提供されるか、ネストされた配列形式で提供されることがあり、関数内部でフラット化処理された後、各要素が変換仕様として使用されます。
+
+各変換仕様（`value`）は以下のように解釈され、対応する引数に適用される変換関数に変換されます：
+
+- `function`: 対応する引数に直接適用される関数として使用されます。
+- `null` または `undefined`: 対応する引数は変更されずにそのまま渡されます（即ち `identity`）。
+- 長さ 2 の `Array`、`[path, value]`: 対応する引数がオブジェクトであると仮定し、`property(path)` で得られた値が `value` と等しいか確認する述語関数に変換されます（`matchesProperty(path, value)` を使用）。
+- `object` (配列以外): 対応する引数がオブジェクトであると仮定し、オブジェクトのプロパティと一致するか確認する述語関数に変換されます（`matches(object)` を使用）。
+- `string`、`number`、`boolean`、`symbol`: 対応する引数がオブジェクトであると仮定し、その値をプロパティパス/キーとして使用して値にアクセスする関数に変換されます（`property(path/key)` を使用）。`boolean` 値は文字列 `'true'` または `'false'` に変換されて使用されます。
+- その他タイプ: 対応する引数は変更されずにそのまま渡されます（即ち `identity`）。
+
+変換は新しい関数の最初の `n` 個の引数に適用されます。ここで `n` はフラット化された変換仕様の数です。変換数より多い引数は変更されずに元の関数に渡されます。
+
+## インターフェース
+
+```typescript
+function overArgs<TFunc extends (...args: any[]) => any>(
+  func: TFunc,
+  ...transformsArgs: Array<OverArgsTransformArg>
+): (...args: any[]) => ReturnType<TFunc>; // 返される関数の引数型は any[] に単純化されます
+```
+
+### パラメータ
+
+- func (TFunc extends (...args: any[]) => any): 変換された引数で呼び出される対象関数です。
+- transformsArgs (Array<OverArgsTransformArg>): 引数に適用される変換仕様です。個別引数として、またはネストされた配列で提供できます。各仕様のタイプは上記の通りです。
+
+### 戻り値
+
+- (...args: any[]) => ReturnType<TFunc>: 인수에 변환을 적용한 새로운 함수를 반환해요.
+
+## 例
+
+```typescript
+import { overArgs } from 'es-toolkit/compat';
+
+function fn(...args) {
+  return args;
+}
+
+const squareAndCube = (a, b) => `Square: ${a}, Cube: ${b}`;
+const processNumbers = overArgs(
+  squareAndCube,
+  n => n * n,
+  n => n * n * n
+);
+
+console.log(processNumbers(2, 3));
+// => Square: 4, Cube: 27 (2 は 2*2=4 に、3 は 3*3*3=27 に変換されて squareAndCube に渡されます)
+
+const formatUserInfo = (name, age) => `Name: ${name}, Age: ${age}`;
+const processUserObject = overArgs(formatUserInfo, 'name', 'age');
+
+console.log(processUserObject({ name: 'Alice', age: 30, city: 'Seoul' }, { name: 'Bob', age: 25, city: 'Busan' }));
+// => Name: Alice, Age: 25 (最初のオブジェクトの 'name' と 2番目のオブジェクトの 'age' が抽出されて formatUserInfo に渡されます)
+
+const checkAndGet = (isMatch, value) => `Match: ${isMatch}, Value: ${value}`;
+const processObjectMatch = overArgs(checkAndGet, { id: 1 }, 'name');
+
+console.log(processObjectMatch({ id: 1, name: 'Item A' }, { id: 2, name: 'Item B' }));
+// => Match: true, Value: Item B ({ id: 1, name: 'Item A' } は { id: 1 } と一致するため true; { id: 2, name: 'Item B' } から 'name' を抽出)
+
+const checkPropertyValue = isMatch => `Property matches: ${isMatch}`;
+const processArrayMatch = overArgs(checkPropertyValue, ['status', 'active']);
+
+console.log(processArrayMatch({ status: 'active', type: 'user' }));
+// => Property matches: true ({ status: 'active', type: 'user' } の 'status' プロパティが 'active' と等しいため true)
+console.log(processArrayMatch({ status: 'inactive', type: 'admin' }));
+// => Property matches: false ({ status: 'inactive', type: 'admin' } の 'status' プロパティが 'active' と異なるため false)
+
+const processBooleanKeys = overArgs(fn, true, false);
+const objWithBooleanKeys = { true: 'Enabled', false: 'Disabled' };
+
+console.log(processBooleanKeys(objWithBooleanKeys, objWithBooleanKeys));
+// => [Enabled, Disabled] (各引数から 'true' および 'false' プロパティ値を抽出)
+
+const processNested = overArgs(fn, [s => s.toUpperCase()], ['length', o => o.value]);
+
+console.log(processNested('hello', 'world', { value: 123 }));
+// overArgs は transformsArgs をフラット化: [s=>s.toUpperCase(), 'length', o => o.value]
+// 最初の引数 'hello' に s=>s.toUpperCase() を適用 -> 'HELLO'
+// 2番目の引数 'world' に 'length' (property('length')) を適用 -> 5
+// 3番目の引数 { value: 123 } に o=>o.value を適用 -> 123
+// fn('HELLO', 5, 123) を呼び出し
+// => [HELLO, 5, 123]
+```

--- a/docs/ko/reference/compat/function/overArgs.md
+++ b/docs/ko/reference/compat/function/overArgs.md
@@ -1,0 +1,96 @@
+# overArgs
+
+::: info
+이 함수는 호환성을 위한 `es-toolkit/compat` 에서만 가져올 수 있어요. 대체할 수 있는 네이티브 JavaScript API가 있거나, 아직 충분히 최적화되지 않았기 때문이에요.
+
+`es-toolkit/compat`에서 이 함수를 가져오면, [lodash와 완전히 똑같이 동작](../../../compatibility.md)해요.
+:::
+
+`overArgs`는 대상 함수(`func`)를 호출할 때 전달되는 인자들을 미리 지정된 변환 스펙(`transformsArgs`)에 따라 처리하여 새로운 함수를 생성해요. 이 변환 스펙들은 원래 `func`에 인자가 전달되기 전에 각 인자에 개별적으로 적용됩니다.
+
+`transformsArgs`는 개별 인자로 제공되거나 네스티드 배열 형태로 제공될 수 있으며, 함수 내부에서 평탄화된 후 각 요소가 변환 스펙으로 사용됩니다.
+
+각 변환 스펙(`value`)은 다음과 같이 해석되어 해당 인수에 적용될 변환 함수로 변환됩니다:
+
+- `function`: 해당 인수에 직접 적용될 함수로 사용됩니다.
+- `null` 또는 `undefined`: 해당 인수는 변경되지 않고 그대로 전달됩니다 (`identity`).
+- 길이가 2인 `Array`, `[path, value]`: 해당 인수가 객체라고 가정하고, `property(path)`로 얻은 값이 `value`와 같은지 확인하는 술어 함수로 변환됩니다 (`matchesProperty(path, value)` 사용).
+- `object` (배열 제외): 해당 인수가 객체라고 가정하고, 객체의 속성과 일치하는지 확인하는 술어 함수로 변환됩니다 (`matches(object)` 사용).
+- `string`, `number`, `boolean`, `symbol`: 해당 인수가 객체라고 가정하고, 해당 값을 속성 경로/키로 사용하여 값에 접근하는 함수로 변환됩니다 (`property(path/key)` 사용). `boolean` 값은 문자열 `'true'` 또는 `'false'`로 변환되어 사용됩니다.
+- 그 외 다른 유형: 해당 인수는 변경되지 않고 그대로 전달됩니다 (`identity`).
+
+변환은 새로운 함수의 첫 `n`개 인수에 적용됩니다. 여기서 `n`은 평탄화된 변환 스펙의 수입니다. 변환 수보다 많은 인수는 변경되지 않고 원본 함수에 전달됩니다.
+
+## 인터페이스
+
+```typescript
+function overArgs<TFunc extends (...args: any[]) => any>(
+  func: TFunc,
+  ...transformsArgs: Array<OverArgsTransformArg>
+): (...args: any[]) => ReturnType<TFunc>; // 반환된 함수의 인자 타입은 any[]로 단순화
+```
+
+### 파라미터
+
+- func (TFunc extends (...args: any[]) => any): 변환된 인자로 호출될 대상 함수예요.
+- transformsArgs (Array<OverArgsTransformArg>): 인수에 적용될 변환 스펙들이에요. 개별 인자 또는 네스티드 배열로 제공될 수 있어요. 각 스펙의 유형은 위 설명과 같아요.
+
+### 반환 값
+
+- (...args: any[]) => ReturnType<TFunc>: 인수에 변환을 적용한 새로운 함수를 반환해요.
+
+## 예시
+
+```typescript
+import { overArgs } from 'es-toolkit/compat';
+
+function fn(...args) {
+  return args;
+}
+
+const squareAndCube = (a, b) => `Square: ${a}, Cube: ${b}`;
+const processNumbers = overArgs(
+  squareAndCube,
+  n => n * n,
+  n => n * n * n
+);
+
+console.log(processNumbers(2, 3));
+// => Square: 4, Cube: 27 (2는 2*2=4로, 3은 3*3*3=27로 변환되어 squareAndCube에 전달됨)
+
+const formatUserInfo = (name, age) => `Name: ${name}, Age: ${age}`;
+const processUserObject = overArgs(formatUserInfo, 'name', 'age');
+
+console.log(processUserObject({ name: 'Alice', age: 30, city: 'Seoul' }, { name: 'Bob', age: 25, city: 'Busan' }));
+// => Name: Alice, Age: 25 (첫 번째 객체의 'name'과 두 번째 객체의 'age'가 추출되어 formatUserInfo에 전달됨)
+
+const checkAndGet = (isMatch, value) => `Match: ${isMatch}, Value: ${value}`;
+const processObjectMatch = overArgs(checkAndGet, { id: 1 }, 'name');
+
+console.log(processObjectMatch({ id: 1, name: 'Item A' }, { id: 2, name: 'Item B' }));
+// => Match: true, Value: Item B ({ id: 1, name: 'Item A' }는 { id: 1 }과 일치하므로 true, { id: 2, name: 'Item B' }에서 'name' 추출)
+
+const checkPropertyValue = isMatch => `Property matches: ${isMatch}`;
+const processArrayMatch = overArgs(checkPropertyValue, ['status', 'active']);
+
+console.log(processArrayMatch({ status: 'active', type: 'user' }));
+// => Property matches: true ({ status: 'active', type: 'user' }의 'status' 속성이 'active'와 같으므로 true)
+console.log(processArrayMatch({ status: 'inactive', type: 'admin' }));
+// => Property matches: false ({ status: 'inactive', type: 'admin' }의 'status' 속성이 'active'와 다르므로 false)
+
+const processBooleanKeys = overArgs(fn, true, false);
+const objWithBooleanKeys = { true: 'Enabled', false: 'Disabled' };
+
+console.log(processBooleanKeys(objWithBooleanKeys, objWithBooleanKeys));
+// => [Enabled, Disabled] (각 인자에서 'true' 및 'false' 속성 값 추출)
+
+const processNested = overArgs(fn, [s => s.toUpperCase()], ['length', o => o.value]);
+
+console.log(processNested('hello', 'world', { value: 123 }));
+// overArgs는 transformsArgs를 평탄화: [s=>s.toUpperCase(), 'length', o => o.value]
+// 첫 인자 'hello'에 s=>s.toUpperCase() 적용 -> 'HELLO'
+// 두 인자 'world'에 'length' (property('length')) 적용 -> 5
+// 세 인자 { value: 123 }에 o=>o.value 적용 -> 123
+// fn('HELLO', 5, 123) 호출
+// => [HELLO, 5, 123]
+```

--- a/docs/reference/compat/function/overArgs.md
+++ b/docs/reference/compat/function/overArgs.md
@@ -1,0 +1,110 @@
+# overArgs
+
+::: info
+This function can only be imported from `es-toolkit/compat` for compatibility purposes. This is either because a native JavaScript API alternative exists, or it is not yet fully optimized.
+
+When you import this function from `es-toolkit/compat`, it behaves [exactly the same as lodash](../../../compatibility.md).
+:::
+
+`overArgs` creates a new function that processes the arguments passed to the target function (`func`) according to a set of predefined transformation specifications (`transformsArgs`). These transformation specifications are applied individually to each argument before they are passed to the original `func`.
+
+`transformsArgs` can be provided as individual arguments or as nested arrays. They are flattened within the function, and each resulting element is used as a transformation specification.
+
+Each transformation specification (`value`) is interpreted and converted into a transformation function to be applied to the corresponding argument as follows:
+
+- `function`: Used as a function to be applied directly to the corresponding argument.
+- `null` or `undefined`: The corresponding argument is passed through unchanged (`identity`).
+- An `Array` of length 2, `[path, value]`: Assumes the corresponding argument is an object and is converted into a predicate function that checks if the value obtained via `property(path)` is equal to `value` (uses `matchesProperty(path, value)`).
+- `object` (excluding arrays): Assumes the corresponding argument is an object and is converted into a predicate function that checks if the object's properties match the specified object (uses `matches(object)`).
+- `string`, `number`, `boolean`, `symbol`: Assumes the corresponding argument is an object and is converted into a function that accesses a value using the value as a property path/key (uses `property(path/key)`). `boolean` values are converted to the string `'true'` or `'false'` before being used.
+- Any other type: The corresponding argument is passed through unchanged (`identity`).
+
+The transformations are applied to the first `n` arguments of the new function, where `n` is the number of flattened transformation specifications. Arguments beyond the number of transformations are passed through unchanged to the original function.
+
+## Signature
+
+```typescript
+function overArgs<TFunc extends (...args: any[]) => any>(
+  func: TFunc,
+  ...transformsArgs: Array<OverArgsTransformArg>
+): (...args: any[]) => ReturnType<TFunc>; // The parameter type of the returned function is simplified to any[]
+```
+
+### Parameters
+
+- func (TFunc extends (...args: any[]) => any): The target function to be invoked with the transformed arguments.
+- transformsArgs (Array<OverArgsTransformArg>): The transformation specifications to be applied to the arguments. These can be provided as individual arguments or nested arrays. The type of each specification is described above.
+
+### Returns
+
+- (...args: any[]) => ReturnType<TFunc>: Returns a new function that applies transformations to its arguments.
+
+## Examples
+
+```typescript
+import { overArgs } from 'es-toolkit/compat';
+
+// Helper function that returns its arguments as an array
+function fn(...args) {
+  return args;
+}
+
+// 1. Example using function transform specifications
+const squareAndCube = (a, b) => `Square: ${a}, Cube: ${b}`;
+const processNumbers = overArgs(
+  squareAndCube,
+  n => n * n,
+  n => n * n * n
+);
+
+console.log('Example 1 (Function transforms):');
+console.log(processNumbers(2, 3));
+// => Square: 4, Cube: 27 (2 is transformed to 2*2=4, 3 is transformed to 3*3*3=27 before being passed to squareAndCube)
+
+// 2. Example using property path (string) transform specifications
+const formatUserInfo = (name, age) => `Name: ${name}, Age: ${age}`;
+const processUserObject = overArgs(formatUserInfo, 'name', 'age');
+
+console.log('\nExample 2 (Property string transforms):');
+console.log(processUserObject({ name: 'Alice', age: 30, city: 'Seoul' }, { name: 'Bob', age: 25, city: 'Busan' }));
+// => Name: Alice, Age: 25 (Extracts 'name' from the first object and 'age' from the second object before passing to formatUserInfo)
+
+// 3. Example using object matcher transform specifications
+// (Assuming the match function works correctly)
+const checkAndGet = (isMatch, value) => `Match: ${isMatch}, Value: ${value}`;
+const processObjectMatch = overArgs(checkAndGet, { id: 1 }, 'name');
+
+console.log('\nExample 3 (Object matcher + Property string):');
+console.log(processObjectMatch({ id: 1, name: 'Item A' }, { id: 2, name: 'Item B' }));
+// => Match: true, Value: Item B ({ id: 1, name: 'Item A' } matches { id: 1 }, so result is true; extracts 'name' from { id: 2, name: 'Item B' })
+
+// 4. Example using [path, value] array matcher transform specifications
+const checkPropertyValue = isMatch => `Property matches: ${isMatch}`;
+const processArrayMatch = overArgs(checkPropertyValue, ['status', 'active']);
+
+console.log('\nExample 4 ([path, value] matcher):');
+console.log(processArrayMatch({ status: 'active', type: 'user' }));
+// => Property matches: true (The 'status' property of { status: 'active', type: 'user' } is equal to 'active', so result is true)
+console.log(processArrayMatch({ status: 'inactive', type: 'admin' }));
+// => Property matches: false (The 'status' property of { status: 'inactive', type: 'admin' } is not equal to 'active', so result is false)
+
+// 5. Example using boolean transform specifications
+const processBooleanKeys = overArgs(fn, true, false);
+const objWithBooleanKeys = { true: 'Enabled', false: 'Disabled' };
+
+console.log('\nExample 5 (Boolean transforms):');
+console.log(processBooleanKeys(objWithBooleanKeys, objWithBooleanKeys));
+// => [Enabled, Disabled] (Extracts the 'true' and 'false' property values from each argument)
+
+// 6. Example using nested array forms of transformsArgs (demonstrating flatten effect)
+const processNested = overArgs(fn, [s => s.toUpperCase()], ['length', o => o.value]);
+
+console.log('\nExample 6 (Nested transformsArgs):');
+console.log(processNested('hello', 'world', { value: 123 }));
+// overArgs flattens transformsArgs: [s=>s.toUpperCase(), 'length', o => o.value]
+// Applies s=>s.toUpperCase() to the first arg 'hello' -> 'HELLO'
+// Applies 'length' (property('length')) to the second arg 'world' -> 5
+// Applies o=>o.value to the third arg { value: 123 } -> 123
+// Calls fn('HELLO', 5, 123)
+// => [HELLO, 5, 123]
+```

--- a/docs/zh_hans/reference/compat/function/overArgs.md
+++ b/docs/zh_hans/reference/compat/function/overArgs.md
@@ -1,0 +1,110 @@
+# overArgs
+
+::: info
+此函数只能从用于兼容性的 `es-toolkit/compat` 中导入。这是因为存在可替代它的原生 JavaScript API，或者因为它尚未完全优化。
+
+从 `es-toolkit/compat` 导入此函数时，其行为与 [lodash 完全相同](../../../compatibility.md)。
+:::
+
+`overArgs` 创建一个新函数，该函数在调用目标函数 (`func`) 时，会根据预先指定的转换规范 (`transformsArgs`) 来处理传入的参数。这些转换规范会在参数传递给原始 `func` 之前，分别应用于每个参数。
+
+`transformsArgs` 可以作为独立参数或嵌套数组提供，在函数内部进行扁平化处理后，每个元素都被用作一个转换规范。
+
+每个转换规范（`value`）会被解析并转换为应用于对应参数的转换函数，解析规则如下：
+
+- `function`: 用作直接应用于对应参数的函数。
+- `null` 或 `undefined`: 对应的参数不会改变，直接传递（即 `identity`）。
+- 长度为 2 的 `Array`，`[path, value]`: 假定对应的参数是对象，会被转换为一个断言函数，用于检查通过 `property(path)` 获取的值是否与 `value` 相等（使用 `matchesProperty(path, value)`）。
+- `object` (非数组): 假定对应的参数是对象，会被转换为一个断言函数，用于检查对象属性是否与该对象匹配（使用 `matches(object)`）。
+- `string`、`number`、`boolean`、`symbol`: 假定对应的参数是对象，会被转换为一个函数，用于使用该值作为属性路径/键来访问值（使用 `property(path/key)`）。`boolean` 值会被转换为字符串 `'true'` 或 `'false'` 后使用。
+- 其他类型: 对应的参数不会改变，直接传递（即 `identity`）。
+
+转换会应用于新函数的前 `n` 个参数，其中 `n` 是扁平化后的转换规范数量。超出转换数量的参数会不变地传递给原始函数。
+
+## 签名
+
+```typescript
+function overArgs<TFunc extends (...args: any[]) => any>(
+  func: TFunc,
+  ...transformsArgs: Array<OverArgsTransformArg>
+): (...args: any[]) => ReturnType<TFunc>; // 返回的新函数参数类型简化为 any[]
+```
+
+### 参数
+
+- func (TFunc extends (...args: any[]) => any): 将被转换后的参数调用的目标函数。
+- transformsArgs (Array<OverArgsTransformArg>): 应用于参数的转换规范。可以作为独立参数或嵌套数组提供。每个规范的类型如上所述。
+
+### 返回值
+
+- (...args: any[]) => ReturnType<TFunc>: 返回一个应用了参数转换的新函数。
+
+## 示例
+
+```typescript
+import { overArgs } from 'es-toolkit/compat';
+
+// 返回参数数组的辅助函数
+function fn(...args) {
+  return args;
+}
+
+// 1. 函数转换规范示例
+const squareAndCube = (a, b) => `Square: ${a}, Cube: ${b}`;
+const processNumbers = overArgs(
+  squareAndCube,
+  n => n * n,
+  n => n * n * n
+);
+
+console.log('Example 1 (Function transforms):');
+console.log(processNumbers(2, 3));
+// => Square: 4, Cube: 27 (2 被转换为 2*2=4, 3 被转换为 3*3*3=27 后传递给 squareAndCube)
+
+// 2. 属性路径 (string) 转换规范示例
+const formatUserInfo = (name, age) => `Name: ${name}, Age: ${age}`;
+const processUserObject = overArgs(formatUserInfo, 'name', 'age');
+
+console.log('\nExample 2 (Property string transforms):');
+console.log(processUserObject({ name: 'Alice', age: 30, city: 'Seoul' }, { name: 'Bob', age: 25, city: 'Busan' }));
+// => Name: Alice, Age: 25 (从第一个对象提取 'name' 属性, 从第二个对象提取 'age' 属性后传递给 formatUserInfo)
+
+// 3. 对象匹配器转换规范示例
+// (假定 match 函数工作正常)
+const checkAndGet = (isMatch, value) => `Match: ${isMatch}, Value: ${value}`;
+const processObjectMatch = overArgs(checkAndGet, { id: 1 }, 'name');
+
+console.log('\nExample 3 (Object matcher + Property string):');
+console.log(processObjectMatch({ id: 1, name: 'Item A' }, { id: 2, name: 'Item B' }));
+// => Match: true, Value: Item B ({ id: 1, name: 'Item A' } 与 { id: 1 } 匹配, 因此结果为 true; 从 { id: 2, name: 'Item B' } 提取 'name')
+
+// 4. [path, value] 数组匹配器转换规范示例
+const checkPropertyValue = isMatch => `Property matches: ${isMatch}`;
+const processArrayMatch = overArgs(checkPropertyValue, ['status', 'active']);
+
+console.log('\nExample 4 ([path, value] matcher):');
+console.log(processArrayMatch({ status: 'active', type: 'user' }));
+// => Property matches: true ({ status: 'active', type: 'user' } 的 'status' 属性与 'active' 相等, 因此结果为 true)
+console.log(processArrayMatch({ status: 'inactive', type: 'admin' }));
+// => Property matches: false ({ status: 'inactive', type: 'admin' } 的 'status' 属性与 'active' 不相等, 因此结果为 false)
+
+// 5. boolean 转换规范示例
+const processBooleanKeys = overArgs(fn, true, false);
+const objWithBooleanKeys = { true: 'Enabled', false: 'Disabled' };
+
+console.log('\nExample 5 (Boolean transforms):');
+console.log(processBooleanKeys(objWithBooleanKeys, objWithBooleanKeys));
+// => [Enabled, Disabled] (从每个参数中提取 'true' 和 'false' 属性值)
+
+// 6. 嵌套数组形式 transformsArgs 示例 (确认 flatten 的效果)
+const processNested = overArgs(fn, [s => s.toUpperCase()], ['length', o => o.value]);
+
+console.log('\nExample 6 (Nested transformsArgs):');
+console.log(processNested('hello', 'world', { value: 123 }));
+// overArgs 扁平化 transformsArgs: [s=>s.toUpperCase(), 'length', o => o.value]
+// 对第一个参数 'hello' 应用 s=>s.toUpperCase() -> 'HELLO'
+// 对第二个参数 'world' 应用 'length' (property('length')) -> 5
+// 对第三个参数 { value: 123 } 应用 o=>o.value -> 123
+// 调用 fn('HELLO', 5, 123)
+// => [HELLO, 5, 123]
+```

--- a/src/compat/_internal/square.ts
+++ b/src/compat/_internal/square.ts
@@ -1,0 +1,3 @@
+export function square(n: number) {
+  return n * n;
+}

--- a/src/compat/compat.ts
+++ b/src/compat/compat.ts
@@ -110,7 +110,7 @@ export { negate } from './function/negate.ts';
 export { nthArg } from './function/nthArg.ts';
 // FIXME: Replace with compat version
 export { once } from '../function/once.ts';
-// export { overArgs } from './function/overArgs.ts';
+export { overArgs } from './function/overArgs.ts';
 export { partial } from './function/partial.ts';
 export { partialRight } from './function/partialRight.ts';
 export { rearg } from './function/rearg.ts';

--- a/src/compat/function/overArgs.spec.ts
+++ b/src/compat/function/overArgs.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { overArgs } from './overArgs';
+import { doubled } from '../_internal/doubled';
+import { slice } from '../_internal/slice';
+import { square } from '../_internal/square';
+import { identity, noop } from '../compat';
+
+describe('overArgs', () => {
+  function fn() {
+    return slice.call(arguments);
+  }
+
+  it('should transform each argument', () => {
+    const over = overArgs(fn, doubled, square);
+    expect(over(5, 10)).toEqual([10, 100]);
+  });
+
+  it('should use `_.identity` when a predicate is nullish', () => {
+    const over = overArgs(fn, undefined, null);
+    expect(over('a', 'b')).toEqual(['a', 'b']);
+  });
+
+  it('should work with `_.property` shorthands', () => {
+    const over = overArgs(fn, 'b', 'a');
+    expect(over({ b: 2 }, { a: 1 })).toEqual([2, 1]);
+  });
+
+  it('should work with `_.matches` shorthands', () => {
+    const over = overArgs(fn, { b: 1 }, { a: 1 });
+    expect(over({ b: 2 }, { a: 1 })).toEqual([false, true]);
+  });
+
+  it('should work with `_.matchesProperty` shorthands', () => {
+    const over = overArgs(fn, [
+      ['b', 1],
+      ['a', 1],
+    ]);
+    expect(over({ b: 2 }, { a: 1 })).toEqual([false, true]);
+  });
+
+  it('should differentiate between `_.property` and `_.matchesProperty` shorthands', () => {
+    let over = overArgs(fn, ['a', 1]);
+    expect(over({ a: 1 }, { 1: 2 })).toEqual([1, 2]);
+
+    over = overArgs(fn, [['a', 1]]);
+    expect(over({ a: 1 })).toEqual([true]);
+  });
+
+  it('should flatten `transforms`', () => {
+    const over = overArgs(fn, [doubled, square], String);
+    expect(over(5, 10, 15)).toEqual([10, 100, '15']);
+  });
+
+  it('should not transform any argument greater than the number of transforms', () => {
+    const over = overArgs(fn, doubled, square);
+    expect(over(5, 10, 18)).toEqual([10, 100, 18]);
+  });
+
+  it('should not transform any arguments if no transforms are given', () => {
+    const over = overArgs(fn);
+    expect(over(5, 10, 18)).toEqual([5, 10, 18]);
+  });
+
+  it('should not pass `undefined` if there are more transforms than arguments', () => {
+    const over = overArgs(fn, doubled, identity);
+    expect(over(5)).toEqual([10]);
+  });
+
+  it('should provide the correct argument to each transform', () => {
+    const argsList: any[] = [];
+    const transform = function () {
+      argsList.push(slice.call(arguments));
+    };
+    const over = overArgs(noop, transform, transform, transform);
+
+    over('a', 'b');
+    expect(argsList).toEqual([['a'], ['b']]);
+  });
+
+  it('should use `this` binding of function for `transforms`', () => {
+    type TestContext = { over: any; true: number };
+
+    const over = overArgs(
+      function (this: TestContext, x: keyof TestContext) {
+        return this[x];
+      },
+      function (this: TestContext, x: TestContext) {
+        return this === x;
+      }
+    );
+
+    const object = { over: over, true: 1 };
+    expect(object.over(object)).toBe(1);
+  });
+});

--- a/src/compat/function/overArgs.ts
+++ b/src/compat/function/overArgs.ts
@@ -1,0 +1,121 @@
+import { flatten } from '../../array';
+import { identity, matches, matchesProperty, property, unary } from '../compat';
+
+type MatchesPropertyArray = [string | Array<string | number>, any];
+
+type MatchesObject = Record<string, any>;
+
+type ProcessTransformElementInput =
+  | ((arg: any) => any) // Case: A function itself
+  | MatchesPropertyArray // Case: A specific array pattern for property matching
+  | MatchesObject // Case: A general object for predicate matching
+  | string // Case: A string for property access
+  | number // Case: A number for property access
+  | boolean // Case: A boolean for property access
+  | symbol // Case: A symbol for property access
+  | null // Case: Null value
+  | undefined; // Case: Undefined value
+
+type ProcessedTransformFunction = (arg: any) => any;
+
+/**
+ * Processes a single transformation element specification into a function.
+ * This internal helper function determines the type of transformation based on the input value.
+ *
+ * @param {ProcessTransformElementInput} value The value specifying the transformation.
+ * @returns {ProcessedTransformFunction} Returns a function that performs the specified transformation.
+ */
+function processTransformElement(value: ProcessTransformElementInput): ProcessedTransformFunction {
+  if (value === null) {
+    return identity;
+  }
+
+  if (typeof value === 'function') {
+    return unary(value as (...args: any[]) => any);
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 2) {
+      const path = value[0];
+      if (typeof path === 'string' || Array.isArray(path)) {
+        return unary(matchesProperty(path, value[1]));
+      }
+    }
+  }
+
+  if (typeof value === 'object') {
+    return unary(matches(value));
+  }
+
+  if (typeof value === 'boolean') {
+    const path = typeof value === 'boolean' ? String(value) : value;
+    return unary(property(path));
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'symbol') {
+    return unary(property(value));
+  }
+
+  return identity;
+}
+
+type OverArgsTransformArg = ProcessTransformElementInput | Array<OverArgsTransformArg>;
+
+/**
+ * Creates a function that invokes `func` with arguments transformed according to the
+ * corresponding transformation functions.
+ *
+ * The `transformsArgs` provide the specifications for the transformations.
+ * Each specification can be:
+ * - A `function`: The function is applied to the corresponding argument.
+ * - `null` or `undefined`: The argument is passed through unchanged.
+ * - A `string`, `number`, `boolean`, or `symbol`: Used as a property path/key to access a value on the corresponding argument.
+ * - An `object` (not array): Used as a predicate object to check if the corresponding argument matches properties.
+ * - An `Array` of length 2, `[path, value]`: Used as a property matcher to check if the corresponding argument has the property at `path` equal to `value`.
+ *
+ * Transformations are applied to the first `n` arguments of the new function, where `n` is the number of transformation specifications provided.
+ * Arguments beyond the number of transformations are passed through unchanged.
+ *
+ * @template TFunc The type of the function to invoke.
+ * @param {TFunc} func The function to invoke.
+ * @param {...Array<OverArgsTransformArg>} transformsArgs The transformation specifications. Can be provided as individual arguments or nested arrays.
+ * @returns {(...args: Parameters<TFunc>) => ReturnType<TFunc>} Returns the new function that applies the transformations to its arguments before invoking `func`.
+ *
+ * @example
+ * const doubled = (num: number) => num * 2;
+ * const squared = (num: number) => num * num;
+ * const func = overArgs((x, y) => [x, y], [doubled, squared]);
+ * console.log(func(2, 3));
+ * // => [4, 9]
+ *
+ * @example
+ * const multiplyAndAdd = (a: number, b: number) => (a * 2) + b;
+ * const doubleFirstArg = overArgs(multiplyAndAdd, (num: number) => num * 2);
+ * console.log(doubleFirstArg(5, 10));
+ * // => 30 (5 * 2 + 10 = 20, 20 + 10 = 30)
+ */
+export function overArgs<TFunc extends (...args: any[]) => any>(
+  func: TFunc,
+  ...transformsArgs: Array<OverArgsTransformArg>
+): (...args: any[]) => ReturnType<TFunc> {
+  const transforms: Array<(arg: any) => any> = flatten(transformsArgs).map(processTransformElement);
+
+  const funcsLength = transforms.length;
+
+  return function (this: ThisParameterType<TFunc>, ...args: Parameters<TFunc>): ReturnType<TFunc> {
+    const context = this;
+    const argsCount = args.length;
+    const limit = Math.min(argsCount, funcsLength);
+    const processedArgs: any[] = new Array(argsCount);
+    for (let i = 0; i < argsCount; i++) {
+      processedArgs[i] = args[i];
+    }
+
+    for (let i = 0; i < limit; i++) {
+      const transform = transforms[i];
+      processedArgs[i] = transform.call(context, args[i]);
+    }
+
+    return func.apply(context, processedArgs);
+  };
+}


### PR DESCRIPTION
close #1013

Apologies for the duplicate PR
though it may be lacking, I've submitted this for my learning process.

The testcases follow [lodash.overArgs](https://github.com/lodash/lodash/blob/v5-wip/test/overArgs.spec.js).

## Test
![image](https://github.com/user-attachments/assets/0711a778-99dd-4dfb-9bff-fc47e7e78b89)

## Test Coverage
![image](https://github.com/user-attachments/assets/56241ddf-76e3-49b2-952c-6d6d2bcb0b67)

## Bench Test
![image](https://github.com/user-attachments/assets/e670b2e0-233e-46f7-9b50-c6d9bde8da80)
