### PR TITLE
feat(scripts): add support for .mjs and .d.mts exports in compat module

### DIFF
--- a/.scripts/postbuild.sh
+++ b/.scripts/postbuild.sh
@@ -13,6 +13,8 @@ create_compat_export() {
     local name=$2
     echo "module.exports = require('../dist/compat/$category/$name.js').$name;" > compat/$name.js
     echo "export { $name as default } from '../dist/compat/$category/$name.js';" > compat/$name.d.ts
+    echo "export { $name as default } from '../dist/compat/$category/$name.mjs';" > compat/$name.mjs
+    echo "export { $name as default } from '../dist/compat/$category/$name.mjs';" > compat/$name.d.mts
 }
 
 # Function to create compat alias
@@ -22,6 +24,8 @@ create_compat_alias() {
     local alias=$3
     echo "module.exports = require('../dist/compat/$category/$original.js').$original;" > compat/$alias.js
     echo "export { $original as default } from '../dist/compat/$category/$original.js';" > compat/$alias.d.ts
+    echo "export { $original as default } from '../dist/compat/$category/$original.mjs';" > compat/$alias.mjs
+    echo "export { $original as default } from '../dist/compat/$category/$original.mjs';" > compat/$alias.d.mts
 }
 
 # Create root exports

--- a/package.json
+++ b/package.json
@@ -82,6 +82,10 @@
         }
       },
       "./compat/*": {
+        "import": {
+          "types": "./compat/*.d.mts",
+          "default": "./compat/*.mjs"
+        },
         "require": {
           "types": "./compat/*.d.ts",
           "default": "./compat/*.js"


### PR DESCRIPTION
Although the main environment is CommonJS (CJS), since some environments like testing use ESM, we're adding ESM files under the compat/* path to support dual module paths.