### PR TITLE
fix(isFunction): type fixed so that the utility can be used as a type guard

### DIFF
--- a/src/predicate/isFunction.ts
+++ b/src/predicate/isFunction.ts
@@ -11,6 +11,6 @@
  * isFunction(Proxy); // true
  * isFunction(Int8Array); // true
  */
-export function isFunction(value: unknown): value is (...args: unknown[]) => unknown {
+export function isFunction(value: unknown): value is (...args: any[]) => any {
   return typeof value === 'function';
 }


### PR DESCRIPTION
closes https://github.com/toss/es-toolkit/issues/947

Code example ([playfround](https://www.typescriptlang.org/play/?ssl=23&ssc=116&pln=1&pc=1#code/KYDwDg9gTgLgBAMwK4DsDGMCWEV0wZwDFUNsUA1ARgAoA3AQwBslgAuOVAaxQgHcUAlOwbNgefHGoA6GfSgBzfOy49+AbQC6AuAF4AfBxTc+uAN4AoOFbhRgMJFFwwAnmGAQEcES106dcAHJkdCwcAIBucwBfc3NQSFhEElDcAmIQsnIAJjomFmUjVUFhPLECSRkpOUV2ehRnTW19ODrnOAtrGzsHJ1d3T28xP38g5LII6NiXNzgAFT6AEwB5ACMAKwAeWYAlYDQDfw7rWzRoBfYdvcjO+lIcADl6AFs2OHwYKEwUeTgAH0lqCczhddmgmgZ3p9vgJIjFzKcUO84BB1nsYBdFqtNigkE8VsAoAd2pZjntgXBKFkAMwAGhJVluKUeL3YgLJUAW4K6pw5vn8lKpcAA-IEPiwAnB2EEmPhgBKAPTyuAwAAWYlOCzKEjWSCRdTgoGeYEYYkYEEYk3MisMxn4NLgKyQ8Ceuvg+LeHy+8nhOCRtnw5towAWAEE7ihmcAqLpxOlw1RqCi1miquHI9oRUmU4yyJHE6iMFIgRztOws4Wcw9nsBYtbIV6fYj4P7A8Gw0zq9kY2kxjhsvnkxW09WM8iCzBUx2XgOU8XOZKx4OJ5WI9WgA)):

```ts
export function isFunctionV1(value: unknown): value is (...args: unknown[]) => unknown {
    return typeof value === 'function';
}

export function isFunctionV2(value: unknown): value is (...args: any[]) => any {
    return typeof value === 'function';
}

type TypedObj<TRec> = {
    record: TRec;
    actionName: string | ((record: TRec) => string);
}

const object: TypedObj<number> = {
    record: 123,
    actionName: (record) => record === 123 ? 'true' : 'false' // the code is just an example lol
}

// unknown, but must be string
const resolvedActionNameV1 = isFunctionV1(object.actionName) ? object.actionName(object.record) : object.actionName

// string
const resolvedActionNameV2 = isFunctionV2(object.actionName) ? object.actionName(object.record) : object.actionName
```

Lodash reference: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0f1c10dd0c95923e635037b71eb1e8893d7ace80/types/lodash/common/lang.d.ts#L728-L736