### PR TITLE
feat: packages/gritql-lodash-to-es-toolkit

### DIFF
--- a/packages/gritql-lodash-to-es-toolkit/.grit/.gitignore
+++ b/packages/gritql-lodash-to-es-toolkit/.grit/.gitignore
@@ -1,0 +1,2 @@
+.gritmodules*
+*.log

--- a/packages/gritql-lodash-to-es-toolkit/.grit/grit.yaml
+++ b/packages/gritql-lodash-to-es-toolkit/.grit/grit.yaml
@@ -1,0 +1,44 @@
+version: 0.0.1
+patterns:
+  - name: lodash_default_import_to_es_toolkit_compat
+    level: info
+    title: 'Convert lodash default import to es-toolkit/compat namespace import'
+    description: "Transforms `import _ from 'lodash'` to `import * as _ from 'es-toolkit/compat'`"
+    body: |
+      `import $name from 'lodash'` => `import * as $name from 'es-toolkit/compat'`
+
+  - name: lodash_named_imports_to_es_toolkit_compat
+    level: info
+    title: 'Convert lodash named imports to es-toolkit/compat'
+    description: "Transforms `import { func1, func2 } from 'lodash'` to `import { func1, func2 } from 'es-toolkit/compat'`"
+    body: |
+      `import { $imports } from 'lodash'` => `import { $imports } from 'es-toolkit/compat'`
+
+  - name: lodash_individual_imports_to_es_toolkit_compat
+    level: info
+    title: 'Convert individual lodash function imports to es-toolkit/compat named imports'
+    description: "Transforms `import debounce from 'lodash/debounce'` to `import { debounce } from 'es-toolkit/compat'`"
+    body: |
+      `import $funcName from 'lodash/$moduleName'` => `import { $moduleName } from 'es-toolkit/compat'` where {
+        $funcName <: identifier(),
+        $moduleName <: identifier(),
+        $funcName <: $moduleName
+      }
+
+  - name: lodash_individual_imports_aliased_to_es_toolkit_compat
+    level: info
+    title: 'Convert aliased individual lodash function imports to es-toolkit/compat'
+    description: "Transforms `import myDebounce from 'lodash/debounce'` to `import { debounce as myDebounce } from 'es-toolkit/compat'`"
+    body: |
+      `import $alias from 'lodash/$funcName'` => `import { $funcName as $alias } from 'es-toolkit/compat'` where {
+        $alias <: identifier(),
+        $funcName <: identifier(),
+        $alias <: not $funcName
+      }
+
+  - name: lodash_es_imports_to_es_toolkit_compat
+    level: info
+    title: 'Convert lodash-es imports to es-toolkit/compat'
+    description: "Transforms `import { func1, func2 } from 'lodash-es'` to `import { func1, func2 } from 'es-toolkit/compat'`"
+    body: |
+      `import { $imports } from 'lodash-es'` => `import { $imports } from 'es-toolkit/compat'`

--- a/packages/gritql-lodash-to-es-toolkit/README-ko_kr.md
+++ b/packages/gritql-lodash-to-es-toolkit/README-ko_kr.md
@@ -1,0 +1,104 @@
+# @es-toolkit/gritql-lodash-to-es-toolkit
+
+🔧 **lodash에서 es-toolkit/compat으로 마이그레이션하는 GritQL 패턴**
+
+이 패키지는 lodash import문을 es-toolkit/compat import문으로 자동 변환하는 [GritQL](https://docs.grit.io/) 패턴을 제공합니다. GritQL은 소스코드를 검색하고 수정하는 강력한 쿼리 언어로, 기존 codemod들에 비해 뛰어난 성능과 조합성을 제공합니다.
+
+## 📖 단계별 가이드
+
+### 1. Grit CLI 설치
+
+```bash
+curl -fsSL https://docs.grit.io/install | bash
+```
+
+자세한 내용은 [grit 문서](https://docs.grit.io/cli/quickstart#installation)를 확인하세요.
+
+### 2. 프로젝트에서 Grit 초기화
+
+```bash
+cd your-project
+grit init
+```
+
+### 3. GitHub에서 패턴 다운로드
+
+```bash
+# GitHub에서 최신 패턴을 직접 다운로드
+curl -fsSL https://raw.githubusercontent.com/toss/es-toolkit/main/packages/gritql-lodash-to-es-toolkit/.grit/grit.yaml -o .grit/grit.yaml
+```
+
+### 4. 변환 실행
+
+**변경사항 미리보기 (권장):**
+
+```bash
+grit apply --dry-run
+```
+
+**모든 패턴 적용:**
+
+```bash
+grit apply
+```
+
+**특정 패턴만 적용:**
+
+```bash
+# 기본 import만 변환
+grit apply lodash_default_import_to_es_toolkit_compat
+
+# named import만 변환
+grit apply lodash_named_imports_to_es_toolkit_compat
+
+# 개별 함수 import만 변환
+grit apply lodash_individual_imports_to_es_toolkit_compat
+```
+
+## 🔍 변환 예시
+
+### 변환 전:
+
+```javascript
+import _ from 'lodash';
+import {
+    map,
+    filter
+} from 'lodash';
+import debounce from 'lodash/debounce';
+import {
+    chunk
+} from 'lodash-es';
+```
+
+### 변환 후:
+
+```javascript
+import * as _ from 'es-toolkit/compat';
+import {
+    map,
+    filter
+} from 'es-toolkit/compat';
+import {
+    debounce
+} from 'es-toolkit/compat';
+import {
+    chunk
+} from 'es-toolkit/compat';
+```
+
+## 🎯 패턴 상세 정보
+
+| 패턴 이름 | 변환 내용 |
+|-----------|-----------|
+| `lodash_default_import_to_es_toolkit_compat` | `import _ from 'lodash'` → `import * as _ from 'es-toolkit/compat'` |
+| `lodash_named_imports_to_es_toolkit_compat` | `import { map } from 'lodash'` → `import { map } from 'es-toolkit/compat'` |
+| `lodash_individual_imports_to_es_toolkit_compat` | `import debounce from 'lodash/debounce'` → `import { debounce } from 'es-toolkit/compat'` |
+| `lodash_individual_imports_aliased_to_es_toolkit_compat` | `import myDebounce from 'lodash/debounce'` → `import { debounce as myDebounce } from 'es-toolkit/compat'` |
+| `lodash_es_imports_to_es_toolkit_compat` | `import { map } from 'lodash-es'` → `import { map } from 'es-toolkit/compat'` |
+
+## 📚 더 알아보기
+
+* [GritQL 문서](https://docs.grit.io/)
+* [es-toolkit 문서](https://es-toolkit.slash.page/)
+* [마이그레이션 가이드](https://es-toolkit.slash.page/docs/migration)

--- a/packages/gritql-lodash-to-es-toolkit/README.md
+++ b/packages/gritql-lodash-to-es-toolkit/README.md
@@ -1,0 +1,104 @@
+# @es-toolkit/gritql-lodash-to-es-toolkit
+
+🔧 **GritQL patterns for migrating from lodash to es-toolkit/compat**
+
+This package provides [GritQL](https://docs.grit.io/) patterns to automatically transform lodash import statements to es-toolkit/compat imports. GritQL is a powerful query language for searching and modifying source code, offering superior performance and composability compared to traditional codemods.
+
+## 📖 Step-by-Step Guide
+
+### 1. Install Grit CLI
+
+```bash
+curl -fsSL https://docs.grit.io/install | bash
+```
+
+Check [grit docs](https://docs.grit.io/cli/quickstart#installation)
+
+### 2. Initialize Grit in your project
+
+```bash
+cd your-project
+grit init
+```
+
+### 3. Download patterns from GitHub
+
+```bash
+# Download the latest patterns directly from GitHub
+curl -fsSL https://raw.githubusercontent.com/toss/es-toolkit/main/packages/gritql-lodash-to-es-toolkit/.grit/grit.yaml -o .grit/grit.yaml
+```
+
+### 4. Run transformations
+
+**Preview changes (recommended first):**
+
+```bash
+grit apply --dry-run
+```
+
+**Apply all patterns:**
+
+```bash
+grit apply
+```
+
+**Apply specific patterns:**
+
+```bash
+# Default imports only
+grit apply lodash_default_import_to_es_toolkit_compat
+
+# Named imports only
+grit apply lodash_named_imports_to_es_toolkit_compat
+
+# Individual imports only
+grit apply lodash_individual_imports_to_es_toolkit_compat
+```
+
+## 🔍 Examples
+
+### Before transformation:
+
+```javascript
+import _ from 'lodash';
+import {
+    map,
+    filter
+} from 'lodash';
+import debounce from 'lodash/debounce';
+import {
+    chunk
+} from 'lodash-es';
+```
+
+### After transformation:
+
+```javascript
+import * as _ from 'es-toolkit/compat';
+import {
+    map,
+    filter
+} from 'es-toolkit/compat';
+import {
+    debounce
+} from 'es-toolkit/compat';
+import {
+    chunk
+} from 'es-toolkit/compat';
+```
+
+## 🎯 Pattern Details
+
+| Pattern Name | Transforms |
+|--------------|------------|
+| `lodash_default_import_to_es_toolkit_compat` | `import _ from 'lodash'` → `import * as _ from 'es-toolkit/compat'` |
+| `lodash_named_imports_to_es_toolkit_compat` | `import { map } from 'lodash'` → `import { map } from 'es-toolkit/compat'` |
+| `lodash_individual_imports_to_es_toolkit_compat` | `import debounce from 'lodash/debounce'` → `import { debounce } from 'es-toolkit/compat'` |
+| `lodash_individual_imports_aliased_to_es_toolkit_compat` | `import myDebounce from 'lodash/debounce'` → `import { debounce as myDebounce } from 'es-toolkit/compat'` |
+| `lodash_es_imports_to_es_toolkit_compat` | `import { map } from 'lodash-es'` → `import { map } from 'es-toolkit/compat'` |
+
+## 📚 Learn More
+
+* [GritQL Documentation](https://docs.grit.io/)
+* [es-toolkit Documentation](https://es-toolkit.slash.page/)
+* [Migration Guide](https://es-toolkit.slash.page/docs/migration) 

--- a/packages/gritql-lodash-to-es-toolkit/examples/after.js
+++ b/packages/gritql-lodash-to-es-toolkit/examples/after.js
@@ -1,0 +1,74 @@
+// Example file showing es-toolkit/compat imports after transformation
+// This file demonstrates the expected output after applying GritQL patterns
+// 1. Default import → Namespace import
+import * as _ from 'es-toolkit/compat';
+// 2. Named imports
+import { map, reduce } from 'es-toolkit/compat';
+// 3. Individual function imports (same name) → Named imports
+import { debounce } from 'es-toolkit/compat';
+import { throttle } from 'es-toolkit/compat';
+import { isEqual } from 'es-toolkit/compat';
+// 4. Individual function imports (aliased) → Named imports with alias
+import { debounce as myDebounce } from 'es-toolkit/compat';
+import { cloneDeep as myCloneDeep } from 'es-toolkit/compat';
+// 5. lodash-es imports → es-toolkit/compat imports
+import { chunk, uniq } from 'es-toolkit/compat';
+import { orderBy } from 'es-toolkit/compat';
+// 6. Mixed quote styles preserved
+import { merge } from 'es-toolkit/compat';
+import { pick } from 'es-toolkit/compat';
+
+// Usage examples (code remains the same)
+const data = [1, 2, 3, 4, 5];
+
+// Using namespace import
+const doubled = _.map(data, x => x * 2);
+const filtered = _.filter(data, x => x > 2);
+
+// Using named imports
+const mapped = map(data, x => x * 3);
+const reduced = reduce(data, (acc, val) => acc + val, 0);
+
+// Using individual imports
+const debouncedFn = debounce(() => {
+  console.log('Debounced!');
+}, 300);
+
+const throttledFn = throttle(() => {
+  console.log('Throttled!');
+}, 1000);
+
+const equalCheck = isEqual({ a: 1 }, { a: 1 });
+
+// Using aliased imports
+const myDebouncedFn = myDebounce(() => {
+  console.log('My debounced function');
+}, 500);
+
+const cloned = myCloneDeep({ a: 1, b: { c: 2 } });
+
+// Using es-toolkit/compat imports
+const chunked = chunk(data, 2);
+const unique = uniq([1, 2, 2, 3, 3, 4]);
+const ordered = orderBy([{ a: 2 }, { a: 1 }], ['a'], ['desc']);
+
+// Using transformed imports
+const merged = merge({ a: 1 }, { b: 2 });
+const picked = pick({ a: 1, b: 2, c: 3 }, ['a', 'b']);
+
+export {
+  doubled,
+  filtered,
+  mapped,
+  reduced,
+  debouncedFn,
+  throttledFn,
+  equalCheck,
+  myDebouncedFn,
+  cloned,
+  chunked,
+  unique,
+  ordered,
+  merged,
+  picked,
+};

--- a/packages/gritql-lodash-to-es-toolkit/examples/before.js
+++ b/packages/gritql-lodash-to-es-toolkit/examples/before.js
@@ -1,0 +1,74 @@
+// Example file showing various lodash import patterns
+// This file demonstrates all the patterns that will be transformed
+// 1. Default import
+import _ from 'lodash';
+// 2. Named imports
+import { map, reduce } from 'lodash';
+// 5. lodash-es imports
+import { chunk, uniq } from 'lodash-es';
+import { orderBy } from 'lodash-es';
+import myCloneDeep from 'lodash/cloneDeep';
+// 3. Individual function imports (same name)
+import debounce from 'lodash/debounce';
+// 4. Individual function imports (aliased)
+import myDebounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
+// 6. Mixed quote styles
+import merge from 'lodash/merge';
+import pick from 'lodash/pick';
+import throttle from 'lodash/throttle';
+
+// Usage examples
+const data = [1, 2, 3, 4, 5];
+
+// Using default import
+const doubled = _.map(data, x => x * 2);
+const filtered = _.filter(data, x => x > 2);
+
+// Using named imports
+const mapped = map(data, x => x * 3);
+const reduced = reduce(data, (acc, val) => acc + val, 0);
+
+// Using individual imports
+const debouncedFn = debounce(() => {
+  console.log('Debounced!');
+}, 300);
+
+const throttledFn = throttle(() => {
+  console.log('Throttled!');
+}, 1000);
+
+const equalCheck = isEqual({ a: 1 }, { a: 1 });
+
+// Using aliased imports
+const myDebouncedFn = myDebounce(() => {
+  console.log('My debounced function');
+}, 500);
+
+const cloned = myCloneDeep({ a: 1, b: { c: 2 } });
+
+// Using lodash-es imports
+const chunked = chunk(data, 2);
+const unique = uniq([1, 2, 2, 3, 3, 4]);
+const ordered = orderBy([{ a: 2 }, { a: 1 }], ['a'], ['desc']);
+
+// Using mixed quote imports
+const merged = merge({ a: 1 }, { b: 2 });
+const picked = pick({ a: 1, b: 2, c: 3 }, ['a', 'b']);
+
+export {
+  doubled,
+  filtered,
+  mapped,
+  reduced,
+  debouncedFn,
+  throttledFn,
+  equalCheck,
+  myDebouncedFn,
+  cloned,
+  chunked,
+  unique,
+  ordered,
+  merged,
+  picked,
+};


### PR DESCRIPTION
Hi team!

As mentioned in this comment (https://github.com/toss/es-toolkit/pull/1200#issuecomment-2951924569), I thought GritQL would also be a good approach, so I've set up a simple structure for it.

> Please feel free to close this PR when does need anymore! 🙏 

However, the `grit auth login` command doesn't work on my local machine, so I wasn't able to actually test it 😢

---

I couldn't find documentation about testing in the official GritQL docs, so it seems like a separate testing environment would need to be set up to make testing possible.

> I think this could also be considered a tradeoff point 🤔

Personally, I think codemod would be better due to the maturity of the library and community, but GritQL is definitely a tool with clear advantages as well.

I'd appreciate it if the maintainers could make the judgment call. Thank you 👍