### PR TITLE
docs: update links in main pages

### DIFF
--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -17,7 +17,7 @@ hero:
       link: /ja/intro
     - theme: alt
       text: リファレンス
-      link: /ja/reference/array/chunk
+      link: /ja/reference/array/at
     - theme: alt
       text: インストールと使用方法
       link: /ja/usage

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -17,7 +17,7 @@ hero:
       link: /ko/intro
     - theme: alt
       text: 레퍼런스
-      link: /ko/reference/array/chunk
+      link: /ko/reference/array/at
     - theme: alt
       text: 설치 및 사용
       link: /ko/usage

--- a/docs/zh_hans/index.md
+++ b/docs/zh_hans/index.md
@@ -17,7 +17,7 @@ hero:
       link: /zh_hans/intro
     - theme: alt
       text: 参考文档
-      link: /zh_hans/reference/array/chunk
+      link: /zh_hans/reference/array/at
     - theme: alt
       text: 使用指南
       link: /zh_hans/usage


### PR DESCRIPTION
The reference button on the main page for all languages always navigates to the `at` page.