### PR TITLE
docs: add example in browser console

### DIFF
--- a/docs/.vitepress/shared.mts
+++ b/docs/.vitepress/shared.mts
@@ -64,6 +64,18 @@ export const shared = defineConfig({
             '%cTry es-toolkit in the console! 😃',
             'background: #0064FF; color: white; padding: 2px 4px; border-radius: 3px;'
           );
+          console.log(
+            '%cExample: es',
+            'background: #0064FF; color: white; padding: 2px 4px; border-radius: 3px;'
+          );
+          console.log('%ces.at([10, 20, 30, 40, 50], [1, 3, 4]);', 'font-weight: bold;');
+          console.log('%c// [20, 40, 50]', 'font-weight: bold;');
+          console.log(
+            '%cExample: esCompat',
+            'background: #0064FF; color: white; padding: 2px 4px; border-radius: 3px;'
+          );
+          console.log('%cesCompat.concat([1, 2, 3], [4, 5, 6]);', 'font-weight: bold;');
+          console.log('%c// [1, 2, 3, 4, 5, 6]', 'font-weight: bold;');
         }, 1000);
       `
     ],

--- a/docs/.vitepress/shared.mts
+++ b/docs/.vitepress/shared.mts
@@ -65,7 +65,7 @@ export const shared = defineConfig({
             'background: #0064FF; color: white; padding: 2px 4px; border-radius: 3px;'
           );
           console.log(
-            '%cExample: es',
+            '%cExample for es-toolkit',
             'background: #0064FF; color: white; padding: 2px 4px; border-radius: 3px;'
           );
           console.log('%ces.at([10, 20, 30, 40, 50], [1, 3, 4]);', 'font-weight: bold;');

--- a/docs/.vitepress/shared.mts
+++ b/docs/.vitepress/shared.mts
@@ -71,7 +71,7 @@ export const shared = defineConfig({
           console.log('%ces.at([10, 20, 30, 40, 50], [1, 3, 4]);', 'font-weight: bold;');
           console.log('%c// [20, 40, 50]', 'font-weight: bold;');
           console.log(
-            '%cExample: esCompat',
+            '%cExample for es-toolkit/compat',
             'background: #0064FF; color: white; padding: 2px 4px; border-radius: 3px;'
           );
           console.log('%cesCompat.concat([1, 2, 3], [4, 5, 6]);', 'font-weight: bold;');


### PR DESCRIPTION
- Add usage example for the browser console, based on our discussion on Discord.


<img src="https://github.com/user-attachments/assets/6df90277-58e2-4be3-9102-bcbe5a64f0fc" alt="이미지 설명" width="400">

