### PR TITLE
fix(compat/defaults): handle `undefined` and `null` sources in `compat/defaults`

### DIFF
--- a/src/compat/object/defaults.spec.ts
+++ b/src/compat/object/defaults.spec.ts
@@ -75,4 +75,16 @@ describe('defaults', () => {
   it('should match the type of lodash', () => {
     expectTypeOf(defaults).toEqualTypeOf<typeof defaultsLodash>();
   });
+
+  it('should not throw an error when a source is `undefined`', () => {
+    const source = undefined;
+    const actual = defaults({ a: 1 }, source);
+    expect(actual).toEqual({ a: 1 });
+  });
+
+  it('should not throw an error when a source is `null`', () => {
+    const source = null;
+    const actual = defaults({ a: 1 }, source);
+    expect(actual).toEqual({ a: 1 });
+  });
 });

--- a/src/compat/object/defaults.ts
+++ b/src/compat/object/defaults.ts
@@ -1,3 +1,4 @@
+import { isNil } from '../../predicate/isNil.ts';
 import { isIterateeCall } from '../_internal/isIterateeCall.ts';
 import { eq } from '../util/eq.ts';
 
@@ -149,6 +150,10 @@ export function defaults<T extends object, S extends object>(object: T, ...sourc
   }
 
   for (let i = 0; i < length; i++) {
+    if (isNil(sources[i])) {
+      continue;
+    }
+
     const source = sources[i];
     const keys = Object.keys(source) as Array<keyof S>;
 


### PR DESCRIPTION
## Summary

Before, the `sources` parameter had a strict type, so unless a user intentionally hacked around the type system, `null` or `undefined` values were never passed.
Later, while making the type compatible with Lodash, it became possible to pass nil (`null` or `undefined`) values.
When this happened, `compat/defaults` would throw an error, while Lodash’s `defaults` would simply ignore those values without a problem.

This change fixes that issue by making `compat/defaults` handle nil values the same way as Lodash — safely skipping them without errors.

## Before Change

The following code would throw an error when a null or undefined source parameter is provided:

```ts
import { defaults as esDefaults } from "es-toolkit/compat";

function main() {
  esDefaults({ a: 1 }, null);
}

main();
```

<img width="408" alt="image" src="https://github.com/user-attachments/assets/40b4412f-9bcc-4ac8-b8e7-ca3f3926f011" />

> Note: In Lodash’s defaults, passing null or undefined as a source does not cause an error — it simply ignores those values.
The current behavior in es-toolkit is inconsistent with that.

## After Change

The defaults function has been updated to safely ignore null or undefined sources.
If a nil (null/undefined) source is passed, it will simply be skipped without throwing an error.

```ts
import { defaults as esDefaults } from "es-toolkit/compat";

function main() {
  esDefaults({ a: 1 }, null); // returns { a: 1 }
}

main();
```

## Testing

<img width="785" alt="image" src="https://github.com/user-attachments/assets/b076227a-4965-4e52-b554-9f74bb017634" />


## Coverage

<img width="464" alt="image" src="https://github.com/user-attachments/assets/577a5a46-991c-4dc8-8516-face3380516c" />

