### PR TITLE
feat(upperSnakeCase): add upperSnakeCase function

### DIFF
--- a/benchmarks/performance/upperSnakeCase.bench.ts
+++ b/benchmarks/performance/upperSnakeCase.bench.ts
@@ -1,0 +1,34 @@
+import { bench, describe } from 'vitest';
+import { upperSnakeCase as upperSnakeCaseToolkit_ } from 'es-toolkit';
+import { snakeCase as snakeCaseLodash_ } from 'lodash';
+
+const upperSnakeCaseToolkit = upperSnakeCaseToolkit_;
+const snakeCaseLodash = snakeCaseLodash_;
+
+describe('upperSnakeCase', () => {
+  bench('es-toolkit/upperSnakeCase', () => {
+    upperSnakeCaseToolkit('hello world');
+    upperSnakeCaseToolkit('--foo--bar__baz 123');
+    upperSnakeCaseToolkit('123numericValues');
+    upperSnakeCaseToolkit('XMLHttpRequest');
+    upperSnakeCaseToolkit('hello-World_of XML_httpRequest');
+    upperSnakeCaseToolkit('camelCase');
+    upperSnakeCaseToolkit('PascalCase');
+    upperSnakeCaseToolkit('some whitespace');
+    upperSnakeCaseToolkit('hyphen-text');
+    upperSnakeCaseToolkit('HTTPRequest');
+  });
+
+  bench('lodash/snakeCase + toUpperCase', () => {
+    snakeCaseLodash('hello world').toUpperCase();
+    snakeCaseLodash('--foo--bar__baz 123').toUpperCase();
+    snakeCaseLodash('123numericValues').toUpperCase();
+    snakeCaseLodash('XMLHttpRequest').toUpperCase();
+    snakeCaseLodash('hello-World_of XML_httpRequest').toUpperCase();
+    snakeCaseLodash('camelCase').toUpperCase();
+    snakeCaseLodash('PascalCase').toUpperCase();
+    snakeCaseLodash('some whitespace').toUpperCase();
+    snakeCaseLodash('hyphen-text').toUpperCase();
+    snakeCaseLodash('HTTPRequest').toUpperCase();
+  });
+});

--- a/src/string/index.ts
+++ b/src/string/index.ts
@@ -18,4 +18,5 @@ export { trimStart } from './trimStart.ts';
 export { unescape } from './unescape.ts';
 export { upperCase } from './upperCase.ts';
 export { upperFirst } from './upperFirst.ts';
+export { upperSnakeCase } from './upperSnakeCase.ts';
 export { words } from './words.ts';

--- a/src/string/upperSnakeCase.spec.ts
+++ b/src/string/upperSnakeCase.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { upperSnakeCase } from './upperSnakeCase';
+
+describe('upperSnakeCase', () => {
+  it('should convert camelCase to upper snake case', () => {
+    expect(upperSnakeCase('camelCase')).toBe('CAMEL_CASE');
+  });
+
+  it('should convert PascalCase to upper snake case', () => {
+    expect(upperSnakeCase('PascalCase')).toBe('PASCAL_CASE');
+  });
+
+  it('should convert strings with whitespace to upper snake case', () => {
+    expect(upperSnakeCase('some whitespace')).toBe('SOME_WHITESPACE');
+  });
+
+  it('should convert hyphenated strings to upper snake case', () => {
+    expect(upperSnakeCase('hyphen-text')).toBe('HYPHEN_TEXT');
+  });
+
+  it('should convert strings with mixed delimiters to upper snake case', () => {
+    expect(upperSnakeCase('mixed-case_string withSpaces')).toBe('MIXED_CASE_STRING_WITH_SPACES');
+  });
+
+  it('should handle strings with consecutive uppercase letters', () => {
+    expect(upperSnakeCase('HTTPRequest')).toBe('HTTP_REQUEST');
+  });
+
+  it('should handle empty strings', () => {
+    expect(upperSnakeCase('')).toBe('');
+  });
+
+  it('should handle single words', () => {
+    expect(upperSnakeCase('word')).toBe('WORD');
+  });
+
+  it('should handle strings with numbers', () => {
+    expect(upperSnakeCase('version2')).toBe('VERSION_2');
+    expect(upperSnakeCase('getHTML5Parser')).toBe('GET_HTML_5_PARSER');
+  });
+
+  it('should handle strings with special characters', () => {
+    expect(upperSnakeCase('hello@world')).toBe('HELLO_WORLD');
+    expect(upperSnakeCase('test.file')).toBe('TEST_FILE');
+  });
+
+  it('should handle already upper snake case strings', () => {
+    expect(upperSnakeCase('ALREADY_UPPER_SNAKE')).toBe('ALREADY_UPPER_SNAKE');
+  });
+
+  it('should handle strings with unicode characters', () => {
+    expect(upperSnakeCase('Keep unicode 😅')).toBe('KEEP_UNICODE_😅');
+  });
+});

--- a/src/string/upperSnakeCase.ts
+++ b/src/string/upperSnakeCase.ts
@@ -1,0 +1,22 @@
+import { words as getWords } from './words.ts';
+
+/**
+ * Converts a string to upper snake case.
+ *
+ * Upper snake case is the naming convention in which each word is written in uppercase and separated by an underscore (_) character.
+ * Also known as SCREAMING_SNAKE_CASE or CONSTANT_CASE.
+ *
+ * @param {string} str - The string that is to be changed to upper snake case.
+ * @returns {string} - The converted string to upper snake case.
+ *
+ * @example
+ * const convertedStr1 = upperSnakeCase('camelCase') // returns 'CAMEL_CASE'
+ * const convertedStr2 = upperSnakeCase('some whitespace') // returns 'SOME_WHITESPACE'
+ * const convertedStr3 = upperSnakeCase('hyphen-text') // returns 'HYPHEN_TEXT'
+ * const convertedStr4 = upperSnakeCase('HTTPRequest') // returns 'HTTP_REQUEST'
+ */
+export function upperSnakeCase(str: string): string {
+  const words = getWords(str);
+
+  return words.map(word => word.toUpperCase()).join('_');
+}


### PR DESCRIPTION
# Add upperSnakeCase function for string case conversion

## Description

This PR adds a new `upperSnakeCase` function to the string utilities, which converts strings to upper snake case format (also known as SCREAMING_SNAKE_CASE or CONSTANT_CASE).

The function follows the same pattern as existing string case conversion utilities like `camelCase`, `snakeCase`, and `lowerCase`, using the shared `words` function for consistent word parsing.

## Usage Example

```typescript
import { upperSnakeCase } from 'es-toolkit/string';

upperSnakeCase('camelCase')        // 'CAMEL_CASE'
upperSnakeCase('some whitespace')  // 'SOME_WHITESPACE'
upperSnakeCase('hyphen-text')      // 'HYPHEN_TEXT'
upperSnakeCase('HTTPRequest')      // 'HTTP_REQUEST'
```

## Test
<img width="767" alt="Test" src="https://github.com/user-attachments/assets/20c436eb-52c7-4608-85df-e7d9cc232ea4" />

## Benchmark
<img width="1012" alt="Benchmark" src="https://github.com/user-attachments/assets/c56db171-acd0-4cc5-9f26-d3d8f905a3bc" />

