### PR TITLE
fix(pull): enhance pull function type definition

### DIFF
--- a/src/array/pull.ts
+++ b/src/array/pull.ts
@@ -4,9 +4,10 @@
  * This function changes `arr` in place.
  * If you want to remove values without modifying the original array, use `difference`.
  *
- * @template T, U
+ * @template T - The type of elements in the array.
+ * @template U - The type of values to remove from the array.
  * @param {T[]} arr - The array to modify.
- * @param {unknown[]} valuesToRemove - The values to remove from the array.
+ * @param {U[]} valuesToRemove - The values to remove from the array.
  * @returns {T[]} The modified array with the specified values removed.
  *
  * @example
@@ -14,12 +15,12 @@
  * pull(numbers, [2, 4]);
  * console.log(numbers); // [1, 3, 5]
  */
-export function pull<T>(arr: T[], valuesToRemove: readonly unknown[]): T[] {
+export function pull<T, U extends T>(arr: T[], valuesToRemove: readonly U[]): T[] {
   const valuesSet = new Set(valuesToRemove);
   let resultIndex = 0;
 
   for (let i = 0; i < arr.length; i++) {
-    if (valuesSet.has(arr[i])) {
+    if (valuesSet.has(arr[i] as U)) {
       continue;
     }
 


### PR DESCRIPTION
Improved the type of the pull function.

My opinion is that given the use case of `pull`, it is appropriate to define the type according to the type of the elements that make up the `arr`, rather than leaving it wide open with an `unknown` type for `valuesToRemove`

For example, I think it's unlikely that you'll actually use the following in practice

```ts
pull([1, 2, 3], [1, "str", true]); // ❌
```