### PR TITLE
fix(throttle): avoid multiple Date.now() calls

### DIFF
--- a/src/function/throttle.ts
+++ b/src/function/throttle.ts
@@ -58,11 +58,13 @@ export function throttle<F extends (...args: any[]) => void>(
   const debounced = debounce(func, throttleMs, { signal, edges });
 
   const throttled = function (...args: Parameters<F>) {
+    const now = Date.now();
+
     if (pendingAt == null) {
-      pendingAt = Date.now();
+      pendingAt = now;
     } else {
-      if (Date.now() - pendingAt >= throttleMs) {
-        pendingAt = Date.now();
+      if (now - pendingAt >= throttleMs) {
+        pendingAt = now;
         debounced.cancel();
       }
     }


### PR DESCRIPTION
## Description

Cache `Date.now()` result in a variable to avoid repeated system calls and ensure time consistency within the throttle function execution.

## Changes
- Cache `Date.now()` result in now variable at the beginning of throttle execution
- Replace all subsequent `Date.now()` calls with the cached now variable

## Test
<img width="818" alt="Test" src="https://github.com/user-attachments/assets/77c75f5a-954c-46b6-abda-edc07bef9138" />

## Benchmark
<img width="992" alt="Benchmark" src="https://github.com/user-attachments/assets/d7a793f3-1495-497a-a482-4e3d57d7cf9e" />