### PR TITLE
docs(before): update examples to use 'before' function instead of 'after' function

### DIFF
--- a/docs/ja/reference/function/before.md
+++ b/docs/ja/reference/function/before.md
@@ -33,19 +33,21 @@ function before<F extends (...args: any[]) => any>(
 ## 例
 
 ```typescript
-import { after } from 'es-toolkit/function';
+import { before } from 'es-toolkit/function';
 
 const mockFn = () => {
   console.log('実行されました');
 };
-const afterFn = after(3, mockFn);
+const beforeFn = before(3, mockFn);
+
+// '実行されました' がログに出力されます
+beforeFn();
+
+// '実行されました' がログに出力されます
+beforeFn();
 
 // 何もログに出力されません
-afterFn();
-// 何もログに出力されません
-afterFn();
-// '実行されました' がログに出力されます
-afterFn();
+beforeFn();
 ```
 
 ## Lodash 互換性

--- a/docs/ko/reference/function/before.md
+++ b/docs/ko/reference/function/before.md
@@ -33,19 +33,21 @@ function before<F extends (...args: any[]) => any>(
 ## 예시
 
 ```typescript
-import { after } from 'es-toolkit/function';
+import { before } from 'es-toolkit/function';
 
 const mockFn = () => {
   console.log('실행됨');
 };
-const afterFn = after(3, mockFn);
+const beforeFn = after(3, mockFn);
+
+// '실행됨'을 로깅해요.
+beforeFn();
+
+// '실행됨'을 로깅해요.
+beforeFn();
 
 // 아무것도 로깅하지 않아요.
-afterFn();
-// 아무것도 로깅하지 않아요.
-afterFn();
-// '실행됨'을 로깅해요.
-afterFn();
+beforeFn();
 ```
 
 ## Lodash와의 호환성


### PR DESCRIPTION
Fixed incorrect documentation example in the before function that was showing after function usage instead of proper before function examples.

(close #1246)

### KO

![image](https://github.com/user-attachments/assets/bf8bf872-3f4e-474d-a799-33464df7cdc9)

### JP

![image](https://github.com/user-attachments/assets/345f18ba-32e7-4aa1-a6a7-09c01607dd7b)
