### PR TITLE
fix: simplified check for primitive

### DIFF
--- a/src/predicate/isPrimitive.ts
+++ b/src/predicate/isPrimitive.ts
@@ -27,5 +27,5 @@
  * isPrimitive([1, 2, 3]); // false
  */
 export function isPrimitive(value: unknown): value is null | undefined | string | number | boolean | symbol | bigint {
-  return value == null || (typeof value !== 'object' && typeof value !== 'function');
+  return Object(value) !== value;
 }


### PR DESCRIPTION
I simplified the primitive check using Object, which always returns the argument itself if it's not a primitive.
But the main point is that this approach even works with `document.all`