### PR TITLE
fix(invariant): update `invariant` to accept error functions instead of error objects

### DIFF
--- a/docs/ja/reference/util/invariant.md
+++ b/docs/ja/reference/util/invariant.md
@@ -1,18 +1,18 @@
 # invariant
 
-与えられた条件が真であることを主張します。条件が偽の場合は、指定されたメッセージでエラーが投げられますます。
+与えられた条件が真であることを主張します。条件が偽の場合は、指定されたメッセージまたはエラー関数でエラーが投げられます。
 
 ## インターフェース
 
 ```typescript
 function invariant(condition: unknown, message: string): asserts condition;
-function invariant(condition: unknown, error: Error): asserts condition;
+function invariant(condition: unknown, error: () => Error): asserts condition;
 ```
 
 ### パラメータ
 
 - `condition` (`unknown`): 評価する条件。
-- `message` (`string` | `Error`): 条件が偽である場合に投げるエラーメッセージ。
+- `message` (`string` | `() => Error`): 条件が偽である場合に投げるエラーメッセージまたはエラー関数。
 
 ### 戻り値
 
@@ -40,14 +40,14 @@ invariant(value !== null && value !== undefined, 'Value should not be null or un
 // Example of using invariant to check if a number is positive
 invariant(number > 0, 'Number must be positive');
 
-// Example of using invariant with an error
-invariant(false, new Error('This should throw'));
+// Example of using invariant with an error function
+invariant(false, () => new Error('This should throw'));
 
-// Example of using invariant with a custom error
+// Example of using invariant with a custom error function
 class CustomError extends Error {
   constructor(message: string) {
     super(message);
   }
 }
-invariant(false, new CustomError('This should throw'));
+invariant(false, () => new CustomError('This should throw'));
 ```

--- a/docs/ko/reference/util/invariant.md
+++ b/docs/ko/reference/util/invariant.md
@@ -1,18 +1,18 @@
 # invariant
 
-주어진 조건이 참임을 단언해요. 조건이 거짓이면 제공된 메시지와 함께 오류를 던져요.
+주어진 조건이 참임을 단언해요. 조건이 거짓이면 제공된 메시지나 오류 함수와 함께 오류를 던져요.
 
 ## 인터페이스
 
 ```typescript
 function invariant(condition: unknown, message: string): asserts condition;
-function invariant(condition: unknown, error: Error): asserts condition;
+function invariant(condition: unknown, error: () => Error): asserts condition;
 ```
 
 ### 파라미터
 
 - `condition` (`unknown`): 평가할 조건.
-- `message` (`string` | `Error`): 조건이 거짓일 때 발생할 오류 메시지.
+- `message` (`string` | `() => Error`): 조건이 거짓일 때 발생할 오류 메시지나 오류 함수.
 
 ### 반환 값
 
@@ -40,14 +40,14 @@ invariant(value !== null && value !== undefined, 'Value should not be null or un
 // Example of using invariant to check if a number is positive
 invariant(number > 0, 'Number must be positive');
 
-// Example of using invariant with an error
-invariant(false, new Error('This should throw'));
+// Example of using invariant with an error function
+invariant(false, () => new Error('This should throw'));
 
-// Example of using invariant with a custom error
+// Example of using invariant with a custom error function
 class CustomError extends Error {
   constructor(message: string) {
     super(message);
   }
 }
-invariant(false, new CustomError('This should throw'));
+invariant(false, () => new CustomError('This should throw'));
 ```

--- a/docs/reference/util/invariant.md
+++ b/docs/reference/util/invariant.md
@@ -1,18 +1,18 @@
 # invariant
 
-Asserts that a given condition is true. If the condition is false, an error is thrown with the provided message or error.
+Asserts that a given condition is true. If the condition is false, an error is thrown with the provided message or error function.
 
 ## Signature
 
 ```typescript
 function invariant(condition: unknown, message: string): asserts condition;
-function invariant(condition: unknown, error: Error): asserts condition;
+function invariant(condition: unknown, error: () => Error): asserts condition;
 ```
 
 ### Parameters
 
 - `condition` (`unknown`): The condition to evaluate.
-- `message` (`string` | `Error`): The error message to throw if the condition is false.
+- `message` (`string` | `() => Error`): The error message or error function to throw if the condition is false.
 
 ### Returns
 
@@ -40,15 +40,15 @@ invariant(value !== null && value !== undefined, 'Value should not be null or un
 // Example of using invariant to check if a number is positive
 invariant(number > 0, 'Number must be positive');
 
-// Example of using invariant with an error
-invariant(false, new Error('This should throw'));
+// Example of using invariant with an error function
+invariant(false, () => new Error('This should throw'));
 
-// Example of using invariant with a custom error
+// Example of using invariant with a custom error function
 class CustomError extends Error {
   constructor(message: string) {
     super(message);
   }
 }
 
-invariant(false, new CustomError('This should throw'));
+invariant(false, () => new CustomError('This should throw'));
 ```

--- a/docs/zh_hans/reference/util/invariant.md
+++ b/docs/zh_hans/reference/util/invariant.md
@@ -1,18 +1,18 @@
 # invariant
 
-断言给定条件为真。如果条件为假，则抛出提供的错误信息。
+断言给定条件为真。如果条件为假，则抛出提供的错误信息或错误函数。
 
 ## 签名
 
 ```typescript
 function invariant(condition: unknown, message: string): asserts condition;
-function invariant(condition: unknown, error: Error): asserts condition;
+function invariant(condition: unknown, error: () => Error): asserts condition;
 ```
 
 ### 参数
 
 - `condition` (`unknown`): 要评估的条件。
-- `message` (`string` | `Error`): 如果条件为假，则抛出的错误信息。
+- `message` (`string` | `() => Error`): 如果条件为假，则抛出的错误信息或错误函数。
 
 ### 返回值
 
@@ -40,14 +40,14 @@ invariant(value !== null && value !== undefined, 'Value should not be null or un
 // 使用 invariant 检查数字是否为正
 invariant(number > 0, 'Number must be positive');
 
-// 使用 invariant 抛出错误
-invariant(false, new Error('This should throw'));
+// 使用 invariant 抛出错误函数
+invariant(false, () => new Error('This should throw'));
 
-// 使用 invariant 抛出自定义错误
+// 使用 invariant 抛出自定义错误函数
 class CustomError extends Error {
   constructor(message: string) {
     super(message);
   }
 }
-invariant(false, new CustomError('This should throw'));
+invariant(false, () => new CustomError('This should throw'));
 ```

--- a/src/util/invariant.spec.ts
+++ b/src/util/invariant.spec.ts
@@ -41,17 +41,17 @@ describe('invariant', () => {
     expectTypeOf(value).toEqualTypeOf<string>();
   });
 
-  it('should throw an error when the condition is false and the message is an error', () => {
-    expect(() => invariant(false, new Error('This should throw'))).toThrow('This should throw');
+  it('should throw an error when the condition is false and the message is an error function', () => {
+    expect(() => invariant(false, () => new Error('This should throw'))).toThrow('This should throw');
   });
 
-  it('should throw a custom error when the condition is false and the message is an error', () => {
+  it('should throw a custom error when the condition is false and the message is a custom error function', () => {
     class CustomError extends Error {
       constructor(message: string) {
         super(message);
       }
     }
 
-    expect(() => invariant(false, new CustomError('This should throw'))).toThrow(CustomError);
+    expect(() => invariant(false, () => new CustomError('This should throw'))).toThrow(CustomError);
   });
 });

--- a/src/util/invariant.ts
+++ b/src/util/invariant.ts
@@ -16,16 +16,16 @@
 export function invariant(condition: unknown, message: string): asserts condition;
 
 /**
- * Asserts that a given condition is true. If the condition is false, an error is thrown with the provided error.
+ * Asserts that a given condition is true. If the condition is false, an error is thrown with the provided error function.
  *
  * @param {unknown} condition - The condition to evaluate.
- * @param {Error} error - The error to throw if the condition is false.
+ * @param {() => Error} error - The error function to throw if the condition is false.
  * @returns {void} Returns void if the condition is true.
  * @throws {Error} Throws an error if the condition is false.
  *
  * @example
  * // This call will succeed without any errors
- * invariant(true, new Error('This should not throw'));
+ * invariant(true, () => new Error('This should not throw'));
  *
  * class CustomError extends Error {
  *   constructor(message: string) {
@@ -34,15 +34,15 @@ export function invariant(condition: unknown, message: string): asserts conditio
  * }
  *
  * // This call will fail and throw an error with the message 'This should throw'
- * invariant(false, new CustomError('This should throw'));
+ * invariant(false, () => new CustomError('This should throw'));
  */
-export function invariant(condition: unknown, error: Error): asserts condition;
+export function invariant(condition: unknown, error: () => Error): asserts condition;
 
 /**
  * Asserts that a given condition is true. If the condition is false, an error is thrown with the provided message.
  *
  * @param {unknown} condition - The condition to evaluate.
- * @param {string | Error} [message] - The error message to throw if the condition is false.
+ * @param {string | () => Error} [message] - The error message or error function to throw if the condition is false.
  * @returns {void} Returns void if the condition is true.
  * @throws {Error} Throws an error if the condition is false.
  *
@@ -62,7 +62,7 @@ export function invariant(condition: unknown, error: Error): asserts condition;
  * // Example of using invariant to check if a number is positive
  * invariant(number > 0, 'Number must be positive');
  */
-export function invariant(condition: unknown, message: string | Error): asserts condition {
+export function invariant(condition: unknown, message: string | (() => Error)): asserts condition {
   if (condition) {
     return;
   }
@@ -71,5 +71,5 @@ export function invariant(condition: unknown, message: string | Error): asserts 
     throw new Error(message);
   }
 
-  throw message;
+  throw message();
 }


### PR DESCRIPTION
This could be considered as BC, but I think it is not BC.
I think we can just see this as fixing a bug.

### AS-IS

```ts
const example = (id: number | null) => {
  invariant(id, new Error('id is requiered')) // An Error object should be created only when the condition is incorrect, but currently an Error object is created every time the example function executes.
}

example(1) // Error object will be created, even if id is just 1
example(2) // Error object will be created, even if id is just 2
```

### TO-BE

```ts
const example = (id: number | null) => {
  invariant(id, () => new Error('id is requiered')) // An Error object should be created only when the condition is incorrect, and this will be fine
}

example(1) // Error object won't be created, because id is just 1
example(2) // Error object won't be created, because id is just 2
```