### PR TITLE
chore(tests): fixes inconsistent capitalization in test suite description

### DIFF
--- a/src/string/pascalCase.spec.ts
+++ b/src/string/pascalCase.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { pascalCase } from './pascalCase';
 
-describe('PascalCase', () => {
+describe('pascalCase', () => {
   it('should change space to pascal case', () => {
     expect(pascalCase('some whitespace')).toEqual('SomeWhitespace');
   });


### PR DESCRIPTION
Replaces `"PascalCase"` w/ `"pascalCase"` to be consistent with other specs in the repo.