### PR TITLE
fix(omit): Avoid unnecessary deep cloning in `omit`

### DIFF
--- a/src/compat/object/omit.spec.ts
+++ b/src/compat/object/omit.spec.ts
@@ -16,6 +16,10 @@ describe('omit', () => {
   const object = { a: 1, b: 2, c: 3, d: 4 };
   const nested = { a: 1, b: { c: 2, d: 3 } };
 
+  it('should avoid deep cloning if not omitting deep properties', () => {
+    expect(omit(nested, 'a').b).toBe(nested.b);
+  });
+
   it('should flatten `paths`', () => {
     expect(omit(object, 'a', 'c')).toEqual({ b: 2, d: 4 });
     expect(omit(object, ['a', 'd'], 'c')).toEqual({ b: 2 });


### PR DESCRIPTION
Some of our tests fail when using `import { omit } from 'es-toolkit/compat'` instead of `import { omit } from 'lodash'`. While investigating this, I found several incompatibilities with between es-toolkit and Lodash. I'm happy to open a PR to try and address these, but the various combinations and corner cases get tricky enough that I wanted guidance on the extent to which full Lodash compatibility is desired - Lodash's behavior seems odd in places. To the best of my ability, here's how compatibility currently works:

* Deep properties: Both Lodash and es-toolkit/compat allow omitting deep properties. E.g.: `omit({ a: { b: { one: 1, two: 2 }}, 'b.one')`.
* Deep vs. shallow copy: Lodash performs a deep copy (but not identical to `cloneDeep` - see below) if it detects that you're omitting deep properties. es-toolkit/compat always performs a deep copy (by calling `cloneDeep`). **This is the source of our failing test cases**, so it's the issue I'm most interested in fixing.
* Root object handling: Regardless of whether it's omitting deep properties, Lodash creates the new root object by copying all own and inherited string and symbol enumerable properties. es-toolkit/compat does a cloneDeep, meaning it copies the prototype and copies copies all own string and symbol enumerable properties. This should give similar results for plain objects, but for objects with prototypes, es-toolkit preserves the prototype, while Lodash doesn't.
* Nested object handling: If omitting deep properties, Lodash performs a `cloneDeep`, except that it only clones plain objects - other data types are assigned as is. (E.g., it copies a reference to an array, rather than cloning the array.) es-toolkit/compat does a full cloneDeep.

This PR attempts to bring es-toolkit/compat's omit more in line with Lodash's.