### PR TITLE
docs(words): fix typo

### DIFF
--- a/docs/ko/reference/string/words.md
+++ b/docs/ko/reference/string/words.md
@@ -31,7 +31,7 @@ words('Lunedì 18 Set');
 
 ## Lodash 호환성
 
-`es-toolkit/compat`에서 `chunk`를 가져오면 lodash와 호환돼요.
+`es-toolkit/compat`에서 `words`를 가져오면 lodash와 호환돼요.
 
 - `words`에서 문자열을 분리하는 정규식을 바꾸기 위해서 두 번째 인자 `pattern`을 제공할 수 있어요.
 - `words`는 첫 번째 인자가 문자열이 아닌 경우, 자동으로 문자열로 바꿔요.


### PR DESCRIPTION
Nice to meet you!  
Since I became a web-frontend developer, toss's open source libraries have been really helpful for me.
Thank you for all the services. 😄 

While reading the `es-toolkit` document, I noticed a small bug in `words` chapter and made a quick fix.
I double-checked other languages, but the typo only exist on Korean document.

Actually, this is my first contribution on open source community, 
so if there’s anything here that doesn’t follow the contribution guidelines, please let me know!