### PR TITLE
fix: rename loop-local variables to singular in toCamelCaseKeys and toSnakeCaseKeys

### DIFF
--- a/src/object/toCamelCaseKeys.ts
+++ b/src/object/toCamelCaseKeys.ts
@@ -71,8 +71,8 @@ export function toCamelCaseKeys<T>(obj: T): ToCamelCaseKeys<T> {
       const key = keys[i];
 
       const camelKey = camelCase(key) as keyof typeof result;
-      const camelCaseKeys = toCamelCaseKeys(obj[key]);
-      result[camelKey] = camelCaseKeys as ToCamelCaseKeys<T>[keyof ToCamelCaseKeys<T>];
+      const convertedValue = toCamelCaseKeys(obj[key]);
+      result[camelKey] = convertedValue as ToCamelCaseKeys<T>[keyof ToCamelCaseKeys<T>];
     }
 
     return result;

--- a/src/object/toSnakeCaseKeys.ts
+++ b/src/object/toSnakeCaseKeys.ts
@@ -73,8 +73,8 @@ export function toSnakeCaseKeys<T>(obj: T): ToSnakeCaseKeys<T> {
       const key = keys[i];
 
       const snakeKey = snakeCase(key) as keyof typeof result;
-      const snakeCaseKeys = toSnakeCaseKeys((obj as Record<PropertyKey, any>)[key]);
-      result[snakeKey] = snakeCaseKeys as ToSnakeCaseKeys<T>[keyof ToSnakeCaseKeys<T>];
+      const convertedValue = toSnakeCaseKeys((obj as Record<PropertyKey, any>)[key]);
+      result[snakeKey] = convertedValue as ToSnakeCaseKeys<T>[keyof ToSnakeCaseKeys<T>];
     }
 
     return result;


### PR DESCRIPTION
## Overview
Rename loop-local variables from plural to singular to avoid implying a collection. This is a readability-only change; no behavior, public API, or types are affected.

## Changes
- src/object/toCamelCaseKeys.ts
  - camelCaseKeys → convertedValue
- src/object/toSnakeCaseKeys.ts
  - snakeCaseKeys → convertedValue

## Rationale
Each loop iteration stores a single transformed value. Singular naming better communicates the intent and avoids confusion.

## Impact
- No behavior change
- No public API/type changes
- No docs updates required
- No bundle-size impact

## Verification
- Typecheck passed
- Unit tests for both files passed

## Checklist
- [x] No user-facing changes
- [x] Tests/typecheck pass
- [x] Follows repo commit/PR conventions

---

Notes:
First-time open source contribution. Feedback welcome!

Korean summary:
루프에서 단일 값을 담는 로컬 변수를 복수형에서 단수형으로 바꿔 가독성을 개선했어요. 동작/공개 API/타입 변화는 없습니다. 타입체크와 테스트 통과했습니다. 

