### PR TITLE
Fix: correct method name from toNumber to toFinite in JSDoc and official documentation

### DIFF
--- a/docs/ja/reference/compat/util/toFinite.md
+++ b/docs/ja/reference/compat/util/toFinite.md
@@ -25,10 +25,10 @@ function toFinite(value?: unknown): number;
 ## 例
 
 ```typescript
-toNumber(3.2); // => 3.2
-toNumber(Number.MIN_VALUE); // => 5e-324
-toNumber(Infinity); // => 1.7976931348623157e+308
-toNumber('3.2'); // => 3.2
-toNumber(Symbol.iterator); // => 0
-toNumber(NaN); // => 0
+toFinite(3.2); // => 3.2
+toFinite(Number.MIN_VALUE); // => 5e-324
+toFinite(Infinity); // => 1.7976931348623157e+308
+toFinite('3.2'); // => 3.2
+toFinite(Symbol.iterator); // => 0
+toFinite(NaN); // => 0
 ```

--- a/docs/ko/reference/compat/util/toFinite.md
+++ b/docs/ko/reference/compat/util/toFinite.md
@@ -25,10 +25,10 @@ function toFinite(value?: unknown): number;
 ## 예시
 
 ```typescript
-toNumber(3.2); // => 3.2
-toNumber(Number.MIN_VALUE); // => 5e-324
-toNumber(Infinity); // => 1.7976931348623157e+308
-toNumber('3.2'); // => 3.2
-toNumber(Symbol.iterator); // => 0
-toNumber(NaN); // => 0
+toFinite(3.2); // => 3.2
+toFinite(Number.MIN_VALUE); // => 5e-324
+toFinite(Infinity); // => 1.7976931348623157e+308
+toFinite('3.2'); // => 3.2
+toFinite(Symbol.iterator); // => 0
+toFinite(NaN); // => 0
 ```

--- a/docs/reference/compat/util/toFinite.md
+++ b/docs/reference/compat/util/toFinite.md
@@ -25,10 +25,10 @@ function toFinite(value?: unknown): number;
 ## Examples
 
 ```typescript
-toNumber(3.2); // => 3.2
-toNumber(Number.MIN_VALUE); // => 5e-324
-toNumber(Infinity); // => 1.7976931348623157e+308
-toNumber('3.2'); // => 3.2
-toNumber(Symbol.iterator); // => 0
-toNumber(NaN); // => 0
+toFinite(3.2); // => 3.2
+toFinite(Number.MIN_VALUE); // => 5e-324
+toFinite(Infinity); // => 1.7976931348623157e+308
+toFinite('3.2'); // => 3.2
+toFinite(Symbol.iterator); // => 0
+toFinite(NaN); // => 0
 ```

--- a/docs/zh_hans/reference/compat/util/toFinite.md
+++ b/docs/zh_hans/reference/compat/util/toFinite.md
@@ -25,10 +25,10 @@ function toFinite(value?: unknown): number;
 ## 示例
 
 ```typescript
-toNumber(3.2); // => 3.2
-toNumber(Number.MIN_VALUE); // => 5e-324
-toNumber(Infinity); // => 1.7976931348623157e+308
-toNumber('3.2'); // => 3.2
-toNumber(Symbol.iterator); // => 0
-toNumber(NaN); // => 0
+toFinite(3.2); // => 3.2
+toFinite(Number.MIN_VALUE); // => 5e-324
+toFinite(Infinity); // => 1.7976931348623157e+308
+toFinite('3.2'); // => 3.2
+toFinite(Symbol.iterator); // => 0
+toFinite(NaN); // => 0
 ```

--- a/src/compat/util/toFinite.ts
+++ b/src/compat/util/toFinite.ts
@@ -7,12 +7,12 @@ import { toNumber } from './toNumber.ts';
  * @returns {number} Returns the number.
  *
  * @example
- * toNumber(3.2); // => 3.2
- * toNumber(Number.MIN_VALUE); // => 5e-324
- * toNumber(Infinity); // => 1.7976931348623157e+308
- * toNumber('3.2'); // => 3.2
- * toNumber(Symbol.iterator); // => 0
- * toNumber(NaN); // => 0
+ * toFinite(3.2); // => 3.2
+ * toFinite(Number.MIN_VALUE); // => 5e-324
+ * toFinite(Infinity); // => 1.7976931348623157e+308
+ * toFinite('3.2'); // => 3.2
+ * toFinite(Symbol.iterator); // => 0
+ * toFinite(NaN); // => 0
  */
 export function toFinite(value: any): number {
   if (!value) {


### PR DESCRIPTION
### Summary
This pull request fixes a typo where `toFinite` function examples were incorrectly labeled as `toNumber` in both the JSDoc comments and the official documentation.

### Changes
- Replaced all occurrences of `toNumber` with `toFinite` in the examples within JSDoc comments.
- Corrected method name references in the official documentation/tutorials to reflect toFinite usage.
- No changes were made to example outputs or function implementations.


### Before
```ts
toNumber(3.2); // => 3.2
toNumber(Number.MIN_VALUE); // => 5e-324
toNumber(Infinity); // => 1.7976931348623157e+308
toNumber('3.2'); // => 3.2
toNumber(Symbol.iterator); // => 0
toNumber(NaN); // => 0
```

### After
```ts
toFinite(3.2); // => 3.2
toFinite(Number.MIN_VALUE); // => 5e-324
toFinite(Infinity); // => 1.7976931348623157e+308
toFinite('3.2'); // => 3.2
toFinite(Symbol.iterator); // => 0
toFinite(NaN); // => 0
```
