### PR TITLE
Fix: correct forEach example import path, parameter type, and description in documentation

### DIFF
--- a/docs/ko/reference/compat/array/forEach.md
+++ b/docs/ko/reference/compat/array/forEach.md
@@ -18,7 +18,7 @@ function forEach<T extends object>(object: T, callback: (value: T[keyof T], key:
 
 ### 파라미터
 
-- `object` (`T`): 순회할 객체. 배열, 문자열, 또는 객체일 수 있어요.
+- `object` (`T`): 순회할 객체, 배열 또는 문자열일 수 있어요.
 - `callback` (`(value: T[keyof T], key: keyof T, object: T)`): 각 반복마다 호출될 함수.
   - `value`: 배열에서 처리 중인 현재 요소.
   - `index`: 배열에서 처리 중인 현재 요소의 프로퍼티 이름.

--- a/docs/ko/reference/compat/array/forEach.md
+++ b/docs/ko/reference/compat/array/forEach.md
@@ -31,7 +31,7 @@ function forEach<T extends object>(object: T, callback: (value: T[keyof T], key:
 ## 예시
 
 ```ts
-import { forEach } from 'es-toolkit/array';
+import { forEach } from 'es-toolkit/compat';
 
 const array = [1, 2, 3];
 const result: number[] = [];
@@ -41,5 +41,5 @@ forEach(array, value => {
   result.push(value);
 });
 
-console.log(result); // Output: [3, 2, 1];
+console.log(result); // Output: [1, 2, 3];
 ```

--- a/docs/ko/reference/compat/array/forEach.md
+++ b/docs/ko/reference/compat/array/forEach.md
@@ -19,7 +19,7 @@ function forEach<T extends object>(object: T, callback: (value: T[keyof T], key:
 ### 파라미터
 
 - `object` (`T`): 순회할 객체. 배열, 문자열, 또는 객체일 수 있어요.
-- `callback` (`(value: T[keyof T], key: T, object: T)`): 각 반복마다 호출될 함수.
+- `callback` (`(value: T[keyof T], key: keyof T, object: T)`): 각 반복마다 호출될 함수.
   - `value`: 배열에서 처리 중인 현재 요소.
   - `index`: 배열에서 처리 중인 현재 요소의 프로퍼티 이름.
   - `object`: `forEach` 함수가 호출된 객체.

--- a/docs/reference/compat/array/forEach.md
+++ b/docs/reference/compat/array/forEach.md
@@ -19,7 +19,7 @@ function forEach<T extends object>(object: T, callback: (value: T[keyof T], key:
 ### Parameters
 
 - `object` (`T`): The object to iterate over.
-- `callback` (`(value: T[keyof T], key: T, object: T)`): The function invoked per iteration.
+- `callback` (`(value: T[keyof T], key: keyof T, object: T)`): The function invoked per iteration.
   - `value`: The current property being processed in the object.
   - `index`: The key of the current property being processed in the object.
   - `object`: The object `forEach` was called upon.


### PR DESCRIPTION
### Summary
This pull request updates the forEach documentation to correct examples, fix type annotations, and improve parameter descriptions for clarity and accuracy.

### Changes
- Fixed import path in example code from `es-toolkit/array` to `es-toolkit/compat`.
- Corrected array iteration output in example from `[3, 2, 1]` to `[1, 2, 3]`.
- Updated `key` parameter type in function signature from `T` to `keyof T`.
- Simplified the `object` parameter description for conciseness and readability.