### PR TITLE
fix: correct wrong output in each function example

### DIFF
--- a/docs/ja/reference/compat/array/each.md
+++ b/docs/ja/reference/compat/array/each.md
@@ -33,7 +33,7 @@ function each<T extends object>(object: T, callback: (value: T[keyof T], key: ke
 ## 例
 
 ```ts
-import { each } from 'es-toolkit/array';
+import { each } from 'es-toolkit/compat';
 
 const array = [1, 2, 3];
 const result: number[] = [];

--- a/docs/ja/reference/compat/array/each.md
+++ b/docs/ja/reference/compat/array/each.md
@@ -42,5 +42,5 @@ each(array, value => {
   result.push(value);
 });
 
-console.log(result); // 出力: [3, 2, 1];
+console.log(result); // 出力: [1, 2, 3];
 ```

--- a/docs/ko/reference/compat/array/each.md
+++ b/docs/ko/reference/compat/array/each.md
@@ -33,7 +33,7 @@ function each<T extends object>(object: T, callback: (value: T[keyof T], key: ke
 ## 예시
 
 ```ts
-import { each } from 'es-toolkit/array';
+import { each } from 'es-toolkit/compat';
 
 const array = [1, 2, 3];
 const result: number[] = [];

--- a/docs/ko/reference/compat/array/each.md
+++ b/docs/ko/reference/compat/array/each.md
@@ -43,5 +43,5 @@ each(array, value => {
   result.push(value);
 });
 
-console.log(result); // Output: [3, 2, 1];
+console.log(result); // Output: [1, 2, 3];
 ```


### PR DESCRIPTION
## Summary
This PR fixes incorrect example output for the `each` function in the documentation.
Currently, the output is `[3, 2, 1]`, but based on the provided loop logic, the correct value should be `[1, 2, 3]`.

Additionally, the `import` statement has been updated to use the correct module path.

## Changes
- Corrected the output of the Korean and Japanese documentation examples from `[3, 2, 1]` to `[1, 2, 3]`.
- Updated the `import` path in the Korean and Japanese documentation example from `es-toolkit/compat` to `es-toolkit/array`.

---

💬 Note: The Korean/Japanese and English/Chinese documentation currently use different example code for the `each` function.
Do you think the two examples should be aligned for consistency in a future update?