### PR TITLE
fix: some function example issues in Korean docs and variable name mismatches in all languages

### DIFF
--- a/docs/ja/reference/compat/array/some.md
+++ b/docs/ja/reference/compat/array/some.md
@@ -104,7 +104,7 @@ import { some } from 'es-toolkit/compat';
 
 // 検査関数を使う場合
 let obj = { a: 1, b: 2, c: 3 };
-let result = some(object, value => value > 2);
+let result = some(obj, value => value > 2);
 console.log(result); // true
 
 // 部分オブジェクトを使う場合

--- a/docs/ko/reference/compat/array/some.md
+++ b/docs/ko/reference/compat/array/some.md
@@ -82,60 +82,60 @@ lodash와 완벽하게 호환되도록 `every` 함수는 `object`를 다음과 �
 ### 배열의 경우
 
 ```typescript
-import { every } from 'es-toolkit/compat';
+import { some } from 'es-toolkit/compat';
 
 // 검사 함수를 쓰는 경우
-const items = [1, 2, 3, 4, 5];
-const result = every(items, item => item > 0);
+let items = [1, 2, 3, 4, 5];
+let result = some(items, item => item > 3);
 console.log(result); // true
 
 // 부분 객체를 쓰는 경우
-const items = [
+items = [
   { id: 1, name: 'Alice' },
   { id: 2, name: 'Bob' },
 ];
-const result = every(items, { name: 'Bob' });
-console.log(result); // false
+result = some(items, { name: 'Bob' });
+console.log(result); // true
 
 // 프로퍼티-값 쌍을 쓰는 경우
-const items = [
+items = [
   { id: 1, name: 'Alice' },
   { id: 2, name: 'Bob' },
 ];
-const result = every(items, ['name', 'Alice']);
-console.log(result); // false
+result = some(items, ['name', 'Bob']);
+console.log(result); // true
 
 // 프로퍼티 이름을 쓰는 경우
-const items = [
+items = [
   { id: 1, name: 'Alice' },
   { id: 2, name: 'Bob' },
 ];
-const result = every(items, 'name');
+result = some(items, 'name');
 console.log(result); // true
 ```
 
 ### 객체의 경우
 
 ```typescript
-import { every } from 'es-toolkit/compat';
+import { some } from 'es-toolkit/compat';
 
 // 검사 함수를 쓰는 경우
-const obj = { a: 1, b: 2, c: 3 };
-const result = every(obj, value => value > 0);
+let obj = { a: 1, b: 2, c: 3 };
+let result = some(obj, value => value > 2);
 console.log(result); // true
 
 // 부분 객체를 쓰는 경우
-const obj = { a: { id: 1, name: 'Alice' }, b: { id: 2, name: 'Bob' } };
-const result = every(obj, { name: 'Bob' });
-console.log(result); // false
+obj = { a: { id: 1, name: 'Alice' }, b: { id: 2, name: 'Bob' } };
+result = some(obj, { name: 'Bob' });
+console.log(result); // true
 
 // 프로퍼티-값 쌍을 쓰는 경우
-const obj = { alice: { id: 1, name: 'Alice' }, bob: { id: 2, name: 'Bob' } };
-const result = every(obj, ['name', 'Alice']);
-console.log(result); // false
+obj = { alice: { id: 1, name: 'Alice' }, bob: { id: 2, name: 'Bob' } };
+result = some(obj, ['name', 'Bob']);
+console.log(result); // true
 
 // 프로퍼티 이름을 쓰는 경우
-const obj = { a: { id: 1, name: 'Alice' }, b: { id: 2, name: 'Bob' } };
-const result = every(obj, 'name');
+obj = { a: { id: 1, name: 'Alice' }, b: { id: 2, name: 'Bob' } };
+result = some(obj, 'name');
 console.log(result); // true
 ```

--- a/docs/reference/compat/array/some.md
+++ b/docs/reference/compat/array/some.md
@@ -120,7 +120,7 @@ import { some } from 'es-toolkit/compat';
 
 // Using a predicate function
 let obj = { a: 1, b: 2, c: 3 };
-let result = some(object, value => value > 2);
+let result = some(obj, value => value > 2);
 console.log(result); // true
 
 // Using a partial value

--- a/docs/zh_hans/reference/compat/array/some.md
+++ b/docs/zh_hans/reference/compat/array/some.md
@@ -121,7 +121,7 @@ import { some } from 'es-toolkit/compat';
 
 // 使用谓词函数
 let obj = { a: 1, b: 2, c: 3 };
-let result = some(object, value => value > 2);
+let result = some(obj, value => value > 2);
 console.log(result); // true
 
 // 使用部分对象


### PR DESCRIPTION
## Summary
This PR addresses issues in the documentation examples for the `some` function, making them consistent and executable as intended.

## Changes
1. Korean documentation (`ko`):
   - Replaced incorrect `every` calls with `some` in both array and object examples.
   - Updated expected outputs in the object examples to match the actual behavior of `some`.

2. All language documentation (`en`, `ko`, `zh_hans`, `zh_hant`):
   - Fixed variable name mismatches in examples where `obj` was declared but `object` was used in function calls.