### PR TITLE
fix: incorrect function name in extendWith examples

### DIFF
--- a/docs/ko/reference/compat/object/extendWith.md
+++ b/docs/ko/reference/compat/object/extendWith.md
@@ -58,7 +58,7 @@ function extendWith(object: any, ...sources: any[]): any;
 
 ```typescript
 const target = { a: 1 };
-const result = assignInWith(target, { b: 2 }, { c: 3 }, function (objValue, srcValue) {
+const result = extendWith(target, { b: 2 }, { c: 3 }, function (objValue, srcValue) {
   return objValue === undefined ? srcValue : objValue;
 });
 console.log(result); // Output: { a: 1, b: 2, c: 3 }

--- a/docs/reference/compat/object/extendWith.md
+++ b/docs/reference/compat/object/extendWith.md
@@ -65,7 +65,7 @@ function extendWith(object: any, ...sources: any[]): any;
 
 ```typescript
 const target = { a: 1 };
-const result = assignInWith(target, { b: 2 }, { c: 3 }, function (objValue, srcValue) {
+const result = extendWith(target, { b: 2 }, { c: 3 }, function (objValue, srcValue) {
   return objValue === undefined ? srcValue : objValue;
 });
 console.log(result); // Output: { a: 1, b: 2, c: 3 }

--- a/docs/zh_hans/reference/compat/object/extendWith.md
+++ b/docs/zh_hans/reference/compat/object/extendWith.md
@@ -58,7 +58,7 @@ function extendWith(object: any, ...sources: any[]): any;
 
 ```typescript
 const target = { a: 1 };
-const result = assignInWith(target, { b: 2 }, { c: 3 }, function (objValue, srcValue) {
+const result = extendWith(target, { b: 2 }, { c: 3 }, function (objValue, srcValue) {
   return objValue === undefined ? srcValue : objValue;
 });
 console.log(result); // Output: { a: 1, b: 2, c: 3 }


### PR DESCRIPTION
## Summary
This PR fixes an error in the `extendWith` documentation examples (`en`, `ko`, `zh_hans`).  
The current examples incorrectly call `assignInWith` instead of `extendWith`.

## Changes
- Replaced `assignInWith` with `extendWith` in all `extendWith` examples.
- Applied the change consistently across English, Korean, Chinese