### PR TITLE
fix: Fix incorrect isSafeInteger examples in English docs

### DIFF
--- a/docs/reference/compat/predicate/isSafeInteger.md
+++ b/docs/reference/compat/predicate/isSafeInteger.md
@@ -30,8 +30,8 @@ function isSafeInteger(value?: unknown): boolean;
 ## Examples
 
 ```typescript
-isInteger(3); // Returns: true
-isInteger(Number.MIN_SAFE_INTEGER - 1); // Returns: false
-isInteger(1n); // Returns: false
-isInteger('1'); // Returns: false
+isSafeInteger(3); // Returns: true
+isSafeInteger(Number.MIN_SAFE_INTEGER - 1); // Returns: false
+isSafeInteger(1n); // Returns: false
+isSafeInteger('1'); // Returns: false
 ```


### PR DESCRIPTION
## Summary
This PR fixes incorrect examples in the English documentation for the `isSafeInteger` function.  
The current examples incorrectly use the `isInteger` function instead of `isSafeInteger`.

## Changes
- Replaced all `isInteger` calls with `isSafeInteger` in the English `isSafeInteger` documentation examples.
- Ensured that the examples now reflect the correct intended usage and output.
