### PR TITLE
fix: Fix incorrect function titles in uniqueId docs

### DIFF
--- a/docs/reference/compat/util/uniqueId.md
+++ b/docs/reference/compat/util/uniqueId.md
@@ -1,4 +1,4 @@
-# constant
+# uniqueId
 
 ::: info
 This function is only available in `es-toolkit/compat` for compatibility reasons. It either has alternative native JavaScript APIs or isn’t fully optimized yet.

--- a/docs/zh_hans/reference/compat/util/uniqueId.md
+++ b/docs/zh_hans/reference/compat/util/uniqueId.md
@@ -1,4 +1,4 @@
-# toString
+# uniqueId
 
 ::: info
 出于兼容性原因，此函数仅在 `es-toolkit/compat` 中提供。它可能具有替代的原生 JavaScript API，或者尚未完全优化。


### PR DESCRIPTION
## Summary
This PR fixes incorrect function titles in the English and Simplified Chinese documentation for the `uniqueId` function.

In both translations, the title did not match the function being documented:
- English doc: `# constant` → `# uniqueId`
- Simplified Chinese doc: `# toString` → `# uniqueId`

## Changes
- Updated the function title in the English doc from `# constant` to `# uniqueId`.
- Updated the function title in the Simplified Chinese doc from `# toString` to `# uniqueId`.
- Verified that the rest of the content, signature, parameters, returns, and examples already correctly describe `uniqueId`.
