### PR TITLE
fix: Fix incorrect lowerFirst examples

### DIFF
--- a/docs/ja/reference/string/lowerFirst.md
+++ b/docs/ja/reference/string/lowerFirst.md
@@ -19,7 +19,9 @@ function lowerFirst(str: string): string;
 ## 例
 
 ```typescript
-const convertedStr1 = lowerCase('fred'); // returns 'fred'
-const convertedStr2 = lowerCase('Fred'); // returns 'fred'
-const convertedStr3 = lowerCase('FRED'); // returns 'fRED'
+import { lowerFirst } from 'es-toolkit/string';
+
+lowerFirst('fred'); // 'fred' を返します
+lowerFirst('Fred'); // 'fred' を返します
+lowerFirst('FRED'); // 'fRED' を返します
 ```


### PR DESCRIPTION
## Summary
This PR fixes incorrect examples in the Japanese documentation for the `lowerFirst` function.  
The current examples mistakenly use the `lowerCase` function instead of `lowerFirst`.

## Changes
- Replaced all `lowerCase` calls with `lowerFirst` in the Japanese `lowerFirst` documentation examples.
- Ensured that the examples now accurately demonstrate how only the first character of a string is lowercased.
