### PR TITLE
fix(defaultsDeep): defaultsDeep can now deep merge objects in from arrays

### DIFF
--- a/src/compat/object/defaultsDeep.spec.ts
+++ b/src/compat/object/defaultsDeep.spec.ts
@@ -224,6 +224,24 @@ describe('defaultsDeep', () => {
     });
   });
 
+  it('should work with objects in arrays', () => {
+    const target = { a: [{ foo: 1 }] };
+    const source = { a: [{ bar: 2 }] };
+
+    const expected = { a: [{ foo: 1, bar: 2 }] };
+
+    expect(defaultsDeep(target, source)).toEqual(expected);
+  });
+
+  it('should append additional elements from the source array to the target array if the source array is longer than the target array', () => {
+    const target = { a: [{ foo: 1 }] };
+    const source = { a: [{ foo: 2 }, { some: 'hello' }] };
+
+    const expected = { a: [{ foo: 1 }, { some: 'hello' }] };
+
+    expect(defaultsDeep(target, source)).toEqual(expected);
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(defaultsDeep).toEqualTypeOf<typeof defaultsDeepLodash>();
   });


### PR DESCRIPTION
### Greetings!

First of all I wanted to say thank you for such a miraculous project, my colleagues and me really appreciate your work!

During migration from lodash I noticed that `es-toolkit/defaultsDeep` works slightly different from `lodash/defaultsDeep`. To be exactly, objects in arrays are treated in different ways: `es-toolkit/defaultsDeep` just  copies array from the field and `lodash/defaultsDeep` merges objects deeply. Moreover, `lodash/defaultsDeep` append additional elements from the source array to the target array if the source array is longer than the target array. And that's why I suggest you these fixes.

I also attached benchmark screenshot just like your contribution guide says. Thank you for your time!

<img width="1058" height="222" alt="Снимок экрана 2025-08-15 в 19 27 40" src="https://github.com/user-attachments/assets/f192ebc4-3d43-40ec-a064-aca304837794" />

