### PR TITLE
fix: Fix incorrect callback key parameter type in each docs

### DIFF
--- a/docs/ja/reference/compat/array/each.md
+++ b/docs/ja/reference/compat/array/each.md
@@ -23,7 +23,7 @@ function each<T extends object>(object: T, callback: (value: T[keyof T], key: ke
 - `object` (`T`): 走査するオブジェクト。配列、文字列、またはオブジェクトである可能性があります。
 - `callback` (`(value: T[keyof T], key: keyof T, object: T)`): 各反復で呼び出される関数。
   - `value`: 配列で現在処理中の要素。
-  - `index`: 配列で現在処理中の要素のプロパティ名。
+  - `key`: 配列で現在処理中の要素のプロパティ名。
   - `object`: `each` 関数が呼び出されたオブジェクト。
 
 ### 戻り値

--- a/docs/ko/reference/compat/array/each.md
+++ b/docs/ko/reference/compat/array/each.md
@@ -23,7 +23,7 @@ function each<T extends object>(object: T, callback: (value: T[keyof T], key: ke
 - `object` (`T`): 순회할 객체. 배열, 문자열, 또는 객체일 수 있어요.
 - `callback` (`(value: T[keyof T], key: keyof T, object: T)`): 각 반복마다 호출될 함수.
   - `value`: 배열에서 처리 중인 현재 요소.
-  - `index`: 배열에서 처리 중인 현재 요소의 프로퍼티 이름.
+  - `key`: 배열에서 처리 중인 현재 요소의 프로퍼티 이름.
   - `object`: `each` 함수가 호출된 객체.
 
 ### 반환 값

--- a/docs/ko/reference/compat/array/each.md
+++ b/docs/ko/reference/compat/array/each.md
@@ -21,7 +21,7 @@ function each<T extends object>(object: T, callback: (value: T[keyof T], key: ke
 ### 파라미터
 
 - `object` (`T`): 순회할 객체. 배열, 문자열, 또는 객체일 수 있어요.
-- `callback` (`(value: T[keyof T], key: T, object: T)`): 각 반복마다 호출될 함수.
+- `callback` (`(value: T[keyof T], key: keyof T, object: T)`): 각 반복마다 호출될 함수.
   - `value`: 배열에서 처리 중인 현재 요소.
   - `index`: 배열에서 처리 중인 현재 요소의 프로퍼티 이름.
   - `object`: `each` 함수가 호출된 객체.

--- a/docs/reference/compat/array/each.md
+++ b/docs/reference/compat/array/each.md
@@ -23,7 +23,7 @@ function each<T extends object>(object: T, callback: (value: T[keyof T], key: ke
 - `object` (`T`): The object to iterate over.
 - `callback` (`(value: T[keyof T], key: keyof T, object: T)`): The function invoked per iteration.
   - `value`: The current property being processed in the object.
-  - `index`: The key of the current property being processed in the object.
+  - `key`: The key of the current property being processed in the object.
   - `object`: The object `each` was called upon.
 
 ### Returns

--- a/docs/reference/compat/array/each.md
+++ b/docs/reference/compat/array/each.md
@@ -21,7 +21,7 @@ function each<T extends object>(object: T, callback: (value: T[keyof T], key: ke
 ### Parameters
 
 - `object` (`T`): The object to iterate over.
-- `callback` (`(value: T[keyof T], key: T, object: T)`): The function invoked per iteration.
+- `callback` (`(value: T[keyof T], key: keyof T, object: T)`): The function invoked per iteration.
   - `value`: The current property being processed in the object.
   - `index`: The key of the current property being processed in the object.
   - `object`: The object `each` was called upon.


### PR DESCRIPTION
## Summary
This PR fixes a documentation error in the `each` function for the English and Korean docs.  
The `callback` parameter type for the key was incorrectly documented as `T` instead of `keyof T`.

## Changes
- Updated the `callback` parameter type in English and Korean docs:
  - Incorrect: `(value: T[keyof T], key: T, object: T)`
  - Corrected: `(value: T[keyof T], key: keyof T, object: T)`
- Adjusted the parameter description so that:
  - `key` is described as the **current element's key (index or property name)**, matching the actual function signature.

This change aligns the documentation with the correct TypeScript definition and clarifies the role of the `key` parameter.

Additionally, updated the callback parameter names in the examples to match the interface.(`ko`, `en`, `ja`)
