### PR TITLE
fix: Fix incorrect return type description for isFunction docs

### DIFF
--- a/docs/ja/reference/predicate/isFunction.md
+++ b/docs/ja/reference/predicate/isFunction.md
@@ -18,7 +18,7 @@ function isFunction(value: unknown): value is (...args: never[]) => unknown;
 
 ### 戻り値
 
-(`value is number`): 与えられた値が関数であれば`true`、そうでなければ`false`を返します。
+(`value is (...args: never[]) => unknown`): 与えられた値が関数であれば`true`、そうでなければ`false`を返します。
 
 ## 例
 

--- a/docs/ko/reference/predicate/isFunction.md
+++ b/docs/ko/reference/predicate/isFunction.md
@@ -18,7 +18,7 @@ function isFunction(value: unknown): value is (...args: never[]) => unknown;
 
 ### 반환 값
 
-(`value is number`): 주어진 값이 함수이면 `true`, 아니면 `false`를 반환해요.
+(`value is (...args: never[]) => unknown`): 주어진 값이 함수이면 `true`, 아니면 `false`를 반환해요.
 
 ## 예시
 


### PR DESCRIPTION
## Summary
This PR fixes incorrect return type descriptions in the Korean and Japanese documentation for the `isFunction` function.  
Both docs incorrectly stated the return type as `value is number`.

## Changes
- Updated the return type in Korean and Japanese docs:
  - Incorrect: (value is number)
  - Corrected: (value is (...args: never[]) => unknown)
- Ensured the description now matches the actual TypeScript interface and type guard behavior.
