### PR TITLE
fix: Fix incorrect return type of isInteger docs

### DIFF
--- a/docs/ja/reference/compat/predicate/isInteger.md
+++ b/docs/ja/reference/compat/predicate/isInteger.md
@@ -22,7 +22,7 @@ function isInteger(value?: unknown): value is number;
 
 ### 戻り値
 
-(`boolean`): `value`が整数の場合は`true`、それ以外の場合は`false`です。
+(`value is number`): `value`が整数の場合は`true`、それ以外の場合は`false`です。
 
 ## 例
 

--- a/docs/ko/reference/compat/predicate/isInteger.md
+++ b/docs/ko/reference/compat/predicate/isInteger.md
@@ -22,7 +22,7 @@ function isInteger(value?: unknown): value is number;
 
 ### 반환 값
 
-(`boolean`): `value`가 정수면 `true`, 그렇지 않으면 `false`.
+(`value is number`): `value`가 정수면 `true`, 그렇지 않으면 `false`.
 
 ## 예시
 

--- a/docs/reference/compat/predicate/isInteger.md
+++ b/docs/reference/compat/predicate/isInteger.md
@@ -22,7 +22,7 @@ function isInteger(value?: unknown): value is number;
 
 ### Returns
 
-(`boolean`): `true` if `value` is integer, otherwise `false`.
+(`value is number`): `true` if `value` is integer, otherwise `false`.
 
 ## Examples
 

--- a/docs/zh_hans/reference/compat/predicate/isInteger.md
+++ b/docs/zh_hans/reference/compat/predicate/isInteger.md
@@ -22,7 +22,7 @@ function isInteger(value?: unknown): value is number;
 
 ### 返回值
 
-(`boolean`): `value`是整数则返回`true`，否则返回`false`。
+(`value is number`): `value`是整数则返回`true`，否则返回`false`。
 
 ## 示例
 


### PR DESCRIPTION
## Summary
This PR corrects the return type description of the `isInteger` function in all documentation translations (`en`, `ko`, `zh_hans`, `zh_hant`).

Previously, the docs stated the return type as `boolean`.  
In TypeScript, `isInteger` is a type guard, so the proper return type is `value is number`.

## Changes
- Updated the return type description in all languages:
  - Incorrect: (`boolean`)
  - Correct: (`value is number`)
- Ensured that the narrative explanation still clarifies: returns `true` if the value is an integer, otherwise `false`.
