### PR TITLE
fix(startsWith): Fix startsWith docs return type from string to boolean

### DIFF
--- a/docs/ko/reference/compat/string/startsWith.md
+++ b/docs/ko/reference/compat/string/startsWith.md
@@ -11,7 +11,7 @@
 ## 인터페이스
 
 ```typescript
-function startsWith(str: string, target: string, position: number = 0): string;
+function startsWith(str: string, target: string, position: number = 0): boolean;
 ```
 
 ### 파라미터

--- a/docs/reference/compat/string/startsWith.md
+++ b/docs/reference/compat/string/startsWith.md
@@ -13,7 +13,7 @@ Checks if one string startsWith another string. Optional position parameter to s
 ## Signature
 
 ```typescript
-function startsWith(str: string, target: string, position: number = 0): string;
+function startsWith(str: string, target: string, position: number = 0): boolean;
 ```
 
 ### Parameters

--- a/docs/zh_hans/reference/compat/string/startsWith.md
+++ b/docs/zh_hans/reference/compat/string/startsWith.md
@@ -14,7 +14,7 @@
 ## 签名
 
 ```typescript
-function startsWith(str: string, target: string, position: number = 0): string;
+function startsWith(str: string, target: string, position: number = 0): boolean;
 ```
 
 ### 参数


### PR DESCRIPTION
## Summary
This PR fixes the incorrect return type in the documentation for the `startsWith` function.  
The original docs mistakenly specify the return type as `string` while the actual function returns a `boolean`.

## Changes
- Updated the function signature to:
```ts
function startsWith(str: string, target: string, position: number = 0): boolean;
```
- This update was applied to Korean, English, and Simplified Chinese (`zh_hans`) documentation only. The Japanese documentation was already correct.
