### PR TITLE
fix(split): Update split docs return type to string[] for consistency with interface

### DIFF
--- a/docs/ja/reference/compat/string/split.md
+++ b/docs/ja/reference/compat/string/split.md
@@ -24,7 +24,7 @@ function split(string: string, separator: RegExp | string, limit: number): strin
 
 ## 戻り値
 
-- (`Array`): 分割された文字列のセグメントの配列です。
+- (`string[]`): 分割された文字列のセグメントの配列です。
 
 ## 例
 

--- a/docs/ko/reference/compat/string/split.md
+++ b/docs/ko/reference/compat/string/split.md
@@ -24,7 +24,7 @@ function split(string: string, separator: RegExp | string, limit: number): strin
 
 ## 반환 값
 
-- (`Array`): 분할된 문자열 세그먼트들의 배열이에요.
+- (`string[]`): 분할된 문자열 세그먼트들의 배열이에요.
 
 ## 예시
 

--- a/docs/reference/compat/string/split.md
+++ b/docs/reference/compat/string/split.md
@@ -24,7 +24,7 @@ function split(string: string, separator: RegExp | string, limit: number): strin
 
 ## Returns
 
-- (`Array`): Returns the string segments.
+- (`string[]`): Returns the string segments.
 
 ## Examples
 

--- a/docs/zh_hans/reference/compat/string/split.md
+++ b/docs/zh_hans/reference/compat/string/split.md
@@ -24,7 +24,7 @@ function split(string: string, separator: RegExp | string, limit: number): strin
 
 ## 返回值
 
-- (`Array`): 返回分割后的字符串片段数组。
+- (`string[]`): 返回分割后的字符串片段数组。
 
 ## 示例
 


### PR DESCRIPTION
## Summary
This PR updates the return type description in the documentation for the `split` function.  
Previously, the return type was described as `Array`, which is less specific and inconsistent with the interface signature.

## Changes
- Changed the return type description from `Array` to `string[]` in all language documents.
- This clearly indicates that the function returns an array of strings.
- Improved the consistency between the documentation and the TypeScript interface signatures.
