### PR TITLE
fix: Update stubFalse and stubTrue docs to use literal return types false and true

### DIFF
--- a/docs/ja/reference/compat/util/stubFalse.md
+++ b/docs/ja/reference/compat/util/stubFalse.md
@@ -11,12 +11,12 @@
 ## インターフェース
 
 ```typescript
-function stubFalse(): boolean;
+function stubFalse(): false;
 ```
 
 ### 戻り値
 
-(`boolean`): false。
+(`false`): 常に`false`を返します。
 
 ## 例
 

--- a/docs/ja/reference/compat/util/stubTrue.md
+++ b/docs/ja/reference/compat/util/stubTrue.md
@@ -11,12 +11,12 @@
 ## インターフェース
 
 ```typescript
-function stubTrue(): boolean;
+function stubTrue(): true;
 ```
 
 ### 戻り値
 
-(`boolean`): `true`。
+(`true`): 常に`true`を返します。
 
 ## 例
 

--- a/docs/ko/reference/compat/util/stubFalse.md
+++ b/docs/ko/reference/compat/util/stubFalse.md
@@ -11,12 +11,12 @@
 ## 인터페이스
 
 ```typescript
-function stubFalse(): boolean;
+function stubFalse(): false;
 ```
 
 ### 반환 값
 
-(`boolean`): `false`.
+(`false`): 항상 `false`를 반환합니다.
 
 ## 예시
 

--- a/docs/ko/reference/compat/util/stubTrue.md
+++ b/docs/ko/reference/compat/util/stubTrue.md
@@ -11,12 +11,12 @@
 ## 인터페이스
 
 ```typescript
-function stubTrue(): boolean;
+function stubTrue(): true;
 ```
 
 ### 반환 값
 
-(`boolean`): `true`.
+(`true`): 항상 `true`를 반환합니다.
 
 ## 예시
 

--- a/docs/reference/compat/util/stubFalse.md
+++ b/docs/reference/compat/util/stubFalse.md
@@ -11,12 +11,12 @@ Returns false.
 ## Signature
 
 ```typescript
-function stubFalse(): boolean;
+function stubFalse(): false;
 ```
 
 ### Returns
 
-(`boolean`): false.
+(`false`): Returns `false` always.
 
 ## Examples
 

--- a/docs/reference/compat/util/stubTrue.md
+++ b/docs/reference/compat/util/stubTrue.md
@@ -11,12 +11,12 @@ Returns true.
 ## Signature
 
 ```typescript
-function stubTrue(): boolean;
+function stubTrue(): true;
 ```
 
 ### Returns
 
-(`boolean`): true.
+(`true`): Returns `true` always.
 
 ## Examples
 

--- a/docs/zh_hans/reference/compat/util/stubFalse.md
+++ b/docs/zh_hans/reference/compat/util/stubFalse.md
@@ -11,12 +11,12 @@
 ## 签名
 
 ```typescript
-function stubFalse(): boolean;
+function stubFalse(): false;
 ```
 
 ### 返回值
 
-(`false`): `false`。
+(`false`): 始终返回`false`。
 
 ## 示例
 

--- a/docs/zh_hans/reference/compat/util/stubTrue.md
+++ b/docs/zh_hans/reference/compat/util/stubTrue.md
@@ -11,12 +11,12 @@
 ## 签名
 
 ```typescript
-function stubTrue(): boolean;
+function stubTrue(): true;
 ```
 
 ### 返回值
 
-(`boolean`): true。
+(`true`): 始终返回`true`。
 
 ## 示例
 


### PR DESCRIPTION
## Summary
This PR updates the documentation for the `stubFalse` and `stubTrue` functions to reflect their precise return types.  

Both functions always return a constant literal value (`false` and `true` respectively), so the return types are changed from the broad `boolean` to the literal types `false` and `true`.  

## Changes
- Changed `stubFalse` return type from `boolean` to `false`.
- Changed `stubTrue` return type from `boolean` to `true`.
