### PR TITLE
docs: Rephrase isNotNil docs parameter description for better clarity

### DIFF
--- a/docs/ko/reference/predicate/isNotNil.md
+++ b/docs/ko/reference/predicate/isNotNil.md
@@ -18,7 +18,7 @@ function isNotNil<T>(x: T | null | undefined): x is T;
 
 ### 반환 값
 
-(`x is T`): 값이 `null`이나 `undefined`가 아니면 `true`, 맞으면 `false`.
+(`x is T`): 값이 `null`이나 `undefined`가 아니면 `true`, 그렇지 않으면 `false`를 반환해요.
 
 ## 예시
 

--- a/docs/ko/reference/predicate/isNotNil.md
+++ b/docs/ko/reference/predicate/isNotNil.md
@@ -14,11 +14,11 @@ function isNotNil<T>(x: T | null | undefined): x is T;
 
 ### 파라미터
 
-- `x` (`T | null | undefined`): 값null이나 undefined가 아님을 확인할 값.
+- `x` (`T | null | undefined`): `null`이나 `undefined`가 아님을 확인할 값.
 
 ### 반환 값
 
-(`x is T`): 값이 null이나 undefined가 아니면 true. 맞으면 false.
+(`x is T`): 값이 `null`이나 `undefined`가 아니면 `true`, 맞으면 `false`.
 
 ## 예시
 


### PR DESCRIPTION
## Summary
This PR updates the parameter description for the `isNotNil` function in the documentation.  

The previous description was:
- 값null이나 undefined가 아님을 확인할 값.

This phrase was slightly awkward and inconsistent with other docs, which use a more concise phrasing.  

## Changes
- Revised the parameter description to:
  - `null`이나 `undefined`가 아님을 확인할 값.
- This change improves clarity and aligns the style with other documentation entries.
