### PR TITLE
fix: forEach and each documentation callback function types and parameter names, corrected incorrect examples

### DIFF
--- a/docs/ja/reference/compat/array/each.md
+++ b/docs/ja/reference/compat/array/each.md
@@ -15,7 +15,7 @@
 ## インターフェース
 
 ```ts
-function each<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => void): T;
+function each<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => unknown): T;
 ```
 
 ### パラメータ

--- a/docs/ja/reference/compat/array/forEach.md
+++ b/docs/ja/reference/compat/array/forEach.md
@@ -13,7 +13,7 @@
 ## インターフェース
 
 ```ts
-function forEach<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => void): T;
+function forEach<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => unknown): T;
 ```
 
 ### パラメータ

--- a/docs/ja/reference/compat/array/forEach.md
+++ b/docs/ja/reference/compat/array/forEach.md
@@ -21,7 +21,7 @@ function forEach<T extends object>(object: T, callback: (value: T[keyof T], key:
 - `object` (`T`): 走査するオブジェクト。配列、文字列、またはオブジェクトである可能性があります。
 - `callback` (`(value: T[keyof T], key: keyof T, object: T)`): 各反復で呼び出される関数。
   - `value`: 配列で現在処理中の要素。
-  - `index`: 配列で現在処理中の要素のプロパティ名。
+  - `key`: 配列で現在処理中の要素のプロパティ名。
   - `object`: `forEach` 関数が呼び出されたオブジェクト。
 
 ### 戻り値

--- a/docs/ja/reference/compat/array/forEach.md
+++ b/docs/ja/reference/compat/array/forEach.md
@@ -40,5 +40,5 @@ forEach(array, value => {
   result.push(value);
 });
 
-console.log(result); // 出力: [3, 2, 1];
+console.log(result); // 出力: [1, 2, 3];
 ```

--- a/docs/ko/reference/compat/array/each.md
+++ b/docs/ko/reference/compat/array/each.md
@@ -15,7 +15,7 @@
 ## 인터페이스
 
 ```ts
-function each<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => void): T;
+function each<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => unknown): T;
 ```
 
 ### 파라미터

--- a/docs/ko/reference/compat/array/forEach.md
+++ b/docs/ko/reference/compat/array/forEach.md
@@ -13,7 +13,7 @@
 ## 인터페이스
 
 ```ts
-function forEach<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => void): T;
+function forEach<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => unknown): T;
 ```
 
 ### 파라미터

--- a/docs/ko/reference/compat/array/forEach.md
+++ b/docs/ko/reference/compat/array/forEach.md
@@ -21,7 +21,7 @@ function forEach<T extends object>(object: T, callback: (value: T[keyof T], key:
 - `object` (`T`): 순회할 객체, 배열 또는 문자열일 수 있어요.
 - `callback` (`(value: T[keyof T], key: keyof T, object: T)`): 각 반복마다 호출될 함수.
   - `value`: 배열에서 처리 중인 현재 요소.
-  - `index`: 배열에서 처리 중인 현재 요소의 프로퍼티 이름.
+  - `key`: 배열에서 처리 중인 현재 요소의 프로퍼티 이름.
   - `object`: `forEach` 함수가 호출된 객체.
 
 ### 반환 값

--- a/docs/reference/compat/array/each.md
+++ b/docs/reference/compat/array/each.md
@@ -15,7 +15,7 @@ This function is an alias for [forEach](./forEach.md).
 ## Signature
 
 ```ts
-function each<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => void): T;
+function each<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => unknown): T;
 ```
 
 ### Parameters

--- a/docs/reference/compat/array/forEach.md
+++ b/docs/reference/compat/array/forEach.md
@@ -21,7 +21,7 @@ function forEach<T extends object>(object: T, callback: (value: T[keyof T], key:
 - `object` (`T`): The object to iterate over.
 - `callback` (`(value: T[keyof T], key: keyof T, object: T)`): The function invoked per iteration.
   - `value`: The current property being processed in the object.
-  - `index`: The key of the current property being processed in the object.
+  - `key`: The key of the current property being processed in the object.
   - `object`: The object `forEach` was called upon.
 
 ### Returns

--- a/docs/reference/compat/array/forEach.md
+++ b/docs/reference/compat/array/forEach.md
@@ -13,7 +13,7 @@ The iteration stops if the `callback` function returns `false`.
 ## Signature
 
 ```ts
-function forEach<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => void): T;
+function forEach<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => unknown): T;
 ```
 
 ### Parameters

--- a/docs/zh_hans/reference/compat/array/each.md
+++ b/docs/zh_hans/reference/compat/array/each.md
@@ -15,7 +15,7 @@
 ### 参数
 
 ```ts
-function each<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => void): T;
+function each<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => unknown): T;
 ```
 
 ### 参数

--- a/docs/zh_hans/reference/compat/array/forEach.md
+++ b/docs/zh_hans/reference/compat/array/forEach.md
@@ -13,7 +13,7 @@
 ### 参数
 
 ```ts
-function forEach<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => void): T;
+function forEach<T extends object>(object: T, callback: (value: T[keyof T], key: keyof T, object: T) => unknown): T;
 ```
 
 ### 参数


### PR DESCRIPTION
## Summary
This PR addresses several issues in the documentation for the `forEach` and `each` functions:

1. The callback function’s return type was previously declared as `void`, which can cause confusion since the internal implementation stops iteration when the callback returns `false`.  
   To better reflect this behavior and align with the internal implementation, the callback return type has been changed to `unknown`.

2. Fixed an incorrect example in the Japanese `forEach` documentation, correcting the array from `[3, 2, 1,]` to `[1, 2, 3]`.

3. Corrected the parameter name for the callback function in the English, Japanese, and Korean `forEach` documentation.  
   Previously, the parameter was documented as `index` 
   
   This was changed to `key` to maintain consistency and accurately represent the property key in objects and arrays.
