### PR TITLE
docs: Update isString docs return type from `x is string` to `value is string`

### DIFF
--- a/docs/ja/reference/predicate/isString.md
+++ b/docs/ja/reference/predicate/isString.md
@@ -16,7 +16,7 @@ function isString(value: unknown): value is string;
 
 ### 戻り値
 
-(`x is string`): 値が文字列であれば`true`、そうでなければ`false`。
+(`value is string`): 値が文字列であれば`true`、そうでなければ`false`。
 
 ## 例
 

--- a/docs/ko/reference/predicate/isString.md
+++ b/docs/ko/reference/predicate/isString.md
@@ -16,7 +16,7 @@ function isString(value: unknown): value is string;
 
 ### 반환 값
 
-(`x is string`): 값이 문자열이면 `true`, 아니면 `false`.
+(`value is string`): 값이 문자열이면 `true`, 아니면 `false`.
 
 ## 예시
 

--- a/docs/reference/predicate/isString.md
+++ b/docs/reference/predicate/isString.md
@@ -16,7 +16,7 @@ function isString(value: unknown): value is string;
 
 ### Returns
 
-- (`x is string`): True if the value is a string, otherwise false.
+(`value is string`): True if the value is a string, otherwise false.
 
 ## Examples
 

--- a/docs/zh_hans/reference/predicate/isString.md
+++ b/docs/zh_hans/reference/predicate/isString.md
@@ -16,7 +16,7 @@ function isString(value: unknown): value is string;
 
 ### 返回值
 
-- (`x is string`): 如果值是字符串，则返回 `true`，否则返回 `false`。
+(`value is string`): 如果值是字符串，则返回 `true`，否则返回 `false`。
 
 ## 示例
 


### PR DESCRIPTION
## Summary
This PR updates the return type description of the `isString` function in the documentation to match the TypeScript interface exactly.

## Interface

```typescript
function isString(value: unknown): value is string;
```

- Changed from:
(`x is string`): Returns true if the value is a string, false otherwise.


- To:
(`value is string`): Returns true if the value is a string, false otherwise.


This change improves consistency between the interface and documentation, reducing potential confusion.