### PR TITLE
docs: Clarify cond docs pairs parameter type from Array to any[][]

### DIFF
--- a/docs/ja/reference/compat/util/cond.md
+++ b/docs/ja/reference/compat/util/cond.md
@@ -21,7 +21,7 @@ function cond(pairs: any[][]): (...args: any[]) => unknown;
 
 ### パラメータ
 
-- `pairs` (`Array`): 条件をチェックする関数と実行する関数のペア。
+- `pairs` (`any[][]`): 条件をチェックする関数と実行する関数のペア。
 
 ### 戻り値
 

--- a/docs/ko/reference/compat/util/cond.md
+++ b/docs/ko/reference/compat/util/cond.md
@@ -21,7 +21,7 @@ function cond(pairs: any[][]): (...args: any[]) => unknown;
 
 ### 파라미터
 
-- `pairs` (`Array`): 조건을 검사하는 함수와 실행할 함수의 쌍.
+- `pairs` (`any[][]`): 조건을 검사하는 함수와 실행할 함수의 쌍.
 
 ### 반환 값
 

--- a/docs/reference/compat/util/cond.md
+++ b/docs/reference/compat/util/cond.md
@@ -21,7 +21,7 @@ function cond(pairs: any[][]): (...args: any[]) => unknown;
 
 ### Parameters
 
-- `pairs` (`Array`): Array of pairs. Each pair consists of a predicate function and a function to run.
+- `pairs` (`any[][]`): Array of pairs. Each pair consists of a predicate function and a function to run.
 
 ### Returns
 

--- a/docs/zh_hans/reference/compat/util/cond.md
+++ b/docs/zh_hans/reference/compat/util/cond.md
@@ -21,7 +21,7 @@ function cond(pairs: any[][]): (...args: any[]) => unknown;
 
 ### 参数
 
-- `pairs` (`Array`): 成对数组。每对包含一个断言函数和一个要运行的函数。
+- `pairs` (`any[][]`): 成对数组。每对包含一个断言函数和一个要运行的函数。
 
 ### 返回值
 


### PR DESCRIPTION
## Summary
This PR updates the documentation for the `cond` function by clarifying the `pairs` parameter type.

- Changed the parameter type from a generic `Array` to a two-dimensional array `any[][]` to explicitly indicate that `pairs` is an array of condition-function pairs.

This makes the documentation more precise and consistent with the TypeScript interface:

```ts
function cond(pairs: any[][]): (...args: any[]) => unknown;
```