### PR TITLE
docs: Fix typo and add default value to precision parameter in ceil docs

### DIFF
--- a/docs/ja/reference/compat/math/ceil.md
+++ b/docs/ja/reference/compat/math/ceil.md
@@ -11,13 +11,13 @@
 ## インターフェース
 
 ```typescript
-function ceil(number: number | string, precision: number | string): number;
+function ceil(number: number | string, precision: number | string = 0): number;
 ```
 
 ### パラメータ
 
 - `number` (`number | string`): 切り上げる数値。
-- `precision` (`number | string`): 切り上げる精度。
+- `precision` (`number | string`, オプション): 切り上げる精度。 デフォルトは0です。
 
 ### 戻り値
 

--- a/docs/ko/reference/compat/math/ceil.md
+++ b/docs/ko/reference/compat/math/ceil.md
@@ -11,18 +11,17 @@
 ## 인터페이스
 
 ```typescript
-function ceil(number: number | string, precision: number | string): number;
+function ceil(number: number | string, precision: number | string = 0): number;
 ```
 
 ### 파라미터
 
 - `number` (`number | string`): 반올림할 숫자.
-- `precision` (`number | string`): 반올림할 자릿수.
+- `precision` (`number | string`, 선택 사항): 반올림할 자릿수. 기본값은 0이에요.
 
 ### 반환 값
 
 (`number`): 반올림된 숫자.
-문자열.
 
 ## 예시
 


### PR DESCRIPTION
## Summary
This PR improves the documentation for the `ceil` function:

- Removed an erroneous `문자열.` typo from the return value description.
- Updated the TypeScript interface to include a default value for the `precision` parameter:
```ts
function ceil(number: number | string, precision: number | string = 0): number;
```
- Clarified the `precision` parameter description by marking it as optional and explaining the default value of 0:
- `precision` (`number | string`, optional): The decimal place to round up to. Defaults to 0.

These changes enhance accuracy and clarity of the documentation.
