### PR TITLE
docs: Add error handling documentation for zero step value in range function

### DIFF
--- a/docs/ja/reference/math/range.md
+++ b/docs/ja/reference/math/range.md
@@ -22,6 +22,10 @@ function range(start: number, end: number, step: number): number[];
 
 - (`number[]`): `start`から始まり`end`の前で終わる、連続する数値が`step`だけ離れている配列。
 
+### エラー
+
+- `step`が0の場合、エラーをスローします。
+
 ## 例
 
 ```typescript

--- a/docs/ko/reference/math/range.md
+++ b/docs/ko/reference/math/range.md
@@ -22,6 +22,10 @@ function range(start: number, end: number, step: number): number[];
 
 - (`number[]`): `start`에서 시작해서 `end` 전에 끝나는, 연속한 숫자가 `step` 만큼 차이나는 배열.
 
+### 에러
+
+- `step`이 0이면 에러를 던져요.
+
 ## 예시
 
 ```typescript

--- a/docs/reference/math/range.md
+++ b/docs/reference/math/range.md
@@ -22,6 +22,10 @@ function range(start: number, end: number, step: number): number[];
 
 - (`number[]`): An array of numbers from `start` to `end` with the specified `step`.
 
+### Throws
+
+- Throws an error if `step` is 0.
+
 ## Examples
 
 ```typescript

--- a/docs/zh_hans/reference/math/range.md
+++ b/docs/zh_hans/reference/math/range.md
@@ -22,6 +22,10 @@ function range(start: number, end: number, step: number): number[];
 
 - (`number[]`): 从 `start` 到 `end` 的数字数组，使用指定的 `step`。
 
+### 抛出异常
+
+- 如果 `step` 为0，则抛出错误。
+
 ## 示例
 
 ```typescript

--- a/src/compat/math/range.ts
+++ b/src/compat/math/range.ts
@@ -64,10 +64,6 @@ export function range(start: number, end?: PropertyKey, step?: any): number[] {
   }
   step = step === undefined ? (start < end ? 1 : -1) : toFinite(step);
 
-  if (step === 0) {
-    throw new Error('The step value must be a non-zero integer.');
-  }
-
   const length = Math.max(Math.ceil((end - start) / (step || 1)), 0);
   const result = new Array(length);
   for (let index = 0; index < length; index++) {

--- a/src/compat/math/range.ts
+++ b/src/compat/math/range.ts
@@ -64,6 +64,10 @@ export function range(start: number, end?: PropertyKey, step?: any): number[] {
   }
   step = step === undefined ? (start < end ? 1 : -1) : toFinite(step);
 
+  if (step === 0) {
+    throw new Error('The step value must be a non-zero integer.');
+  }
+
   const length = Math.max(Math.ceil((end - start) / (step || 1)), 0);
   const result = new Array(length);
   for (let index = 0; index < length; index++) {


### PR DESCRIPTION
## Summary
This PR enhances the documentation for the `range` function by adding an error section to clarify behavior when `step` is 0.

- Previously, the documentation did not specify any error for a `step` value of 0.
- The documentation has been updated with a new **Error** section stating that:
  - Providing a `step` value of 0 will result in an error being thrown.

This update improves the clarity and reliability of the function's usage guidance.