### PR TITLE
docs: Simplify and clarify capitalize function parameter and return value descriptions

### DIFF
--- a/docs/ja/reference/string/capitalize.md
+++ b/docs/ja/reference/string/capitalize.md
@@ -14,7 +14,7 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 戻り値
 
-(`Capitalize<string>`): 大文字に変換された文字列。
+(`Capitalize<T>`): 大文字に変換された文字列。
 
 ## 例
 

--- a/docs/ja/reference/string/capitalize.md
+++ b/docs/ja/reference/string/capitalize.md
@@ -10,11 +10,11 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### パラメータ
 
-`str` (`T`): 大文字に変換する文字列。
+`str` (`T`): 変換する文字列。
 
 ### 戻り値
 
-(`Capitalize<T>`): 大文字に変換された文字列。
+(`Capitalize<T>`): 最初の文字が大文字で、それ以降が小文字に変換された文字列。
 
 ## 例
 

--- a/docs/ko/reference/string/capitalize.md
+++ b/docs/ko/reference/string/capitalize.md
@@ -14,7 +14,7 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 반환 값
 
-(`Capitalize<string>`): 대문자로 변환된 문자열.
+(`Capitalize<T>`): 대문자로 변환된 문자열.
 
 ## 예시
 

--- a/docs/ko/reference/string/capitalize.md
+++ b/docs/ko/reference/string/capitalize.md
@@ -10,11 +10,11 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 파라미터
 
-`str` (`T`): 대문자로 변환할 문자열.
+`str` (`T`): 변환할 문자열.
 
 ### 반환 값
 
-(`Capitalize<T>`): 대문자로 변환된 문자열.
+(`Capitalize<T>`): 첫 글자는 대문자, 나머지는 소문자로 변환된 문자열.
 
 ## 예시
 

--- a/docs/reference/string/capitalize.md
+++ b/docs/reference/string/capitalize.md
@@ -14,7 +14,7 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### Returns
 
-(`Capitalize<string>`): The capitalized string.
+(`Capitalize<T>`): The capitalized string.
 
 ## Examples
 

--- a/docs/reference/string/capitalize.md
+++ b/docs/reference/string/capitalize.md
@@ -10,11 +10,11 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### Parameters
 
-`str` (`T`): The string to be converted to uppercase.
+`str` (`T`): The string to be transformed.
 
 ### Returns
 
-(`Capitalize<T>`): The capitalized string.
+(`Capitalize<T>`): The string with the first character capitalized and the rest in lowercase.
 
 ## Examples
 

--- a/docs/zh_hans/reference/string/capitalize.md
+++ b/docs/zh_hans/reference/string/capitalize.md
@@ -10,11 +10,11 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 参数
 
-`str` (`T`): 要转换为大写的字符串。
+`str` (`T`): 需要转换的字符串。
 
 ### 返回值
 
-(`Capitalize<T>`): 转换后的大写字符串。
+(`Capitalize<T>`):首字母大写，其他字母小写的字符串。
 
 ## 示例
 

--- a/docs/zh_hans/reference/string/capitalize.md
+++ b/docs/zh_hans/reference/string/capitalize.md
@@ -14,7 +14,7 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 返回值
 
-(`Capitalize<string>`): 转换后的大写字符串。
+(`Capitalize<T>`): 转换后的大写字符串。
 
 ## 示例
 

--- a/docs/zh_hans/reference/string/capitalize.md
+++ b/docs/zh_hans/reference/string/capitalize.md
@@ -14,7 +14,7 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 返回值
 
-(`Capitalize<T>`):首字母大写，其他字母小写的字符串。
+(`Capitalize<T>`): 首字母大写，其他字母小写的字符串。
 
 ## 示例
 


### PR DESCRIPTION
## Summary
This PR updates the documentation for the `capitalize` function to provide clearer and more precise descriptions:

- The parameter `str` is described as the string to be transformed, using the generic type `T`.
- The return value is described as `Capitalize<T>`, indicating the string with the first character capitalized and the rest converted to lowercase.
- These descriptions better reflect the TypeScript interface and function behavior with clear and concise language.

## Changes
- Updated the parameter section to:
  - `str` (`T`): The string to be transformed.
- Updated the return value section to:
  - (`Capitalize<T>`): The string with the first letter capitalized and the rest in lowercase.
