### PR TITLE
fix: Update reduce and reduceRight docs to use generic types for iteratee, initialValue, and return

### DIFF
--- a/docs/ja/reference/compat/array/reduce.md
+++ b/docs/ja/reference/compat/array/reduce.md
@@ -49,13 +49,13 @@ function reduce<T extends object>(
 
 ### パラメータ
 
-- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T>`): 反復処理を行うコレクション。
-- `iteratee` (`(accumulator: U, value: T, index, collection) => any)`): 反復ごとに呼び出される関数。
-- `initialValue` (`U`): 初期値。
+- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T> | null | undefined`): 反復処理を行うコレクション。
+- `iteratee` (`((accumulator: U, value: T, index: PropertyKey, collection: any) => any) | PropertyKey | object`): 反復ごとに呼び出される関数。
+- `initialValue` (`U`, オプション): 初期値。
 
 ### 戻り値
 
-(`any`): 蓄積された値。
+(`U`): 蓄積された値。 `initialValue` が指定されていない場合は、コレクションの要素型（`T`）が返されます。
 
 ## 例
 

--- a/docs/ja/reference/compat/array/reduceRight.md
+++ b/docs/ja/reference/compat/array/reduceRight.md
@@ -49,13 +49,13 @@ function reduceRight<T extends object>(
 
 ### パラメータ
 
-- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T>`): 反復処理を行うコレクション。
-- `iteratee` (`(accumulator: U, value: T, index, collection) => any)`): 反復ごとに呼び出される関数。
-- `initialValue` (`U`): 初期値。
+- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T> | null | undefined`): 反復処理を行うコレクション。
+- `iteratee` (`((accumulator: U, value: T, index: PropertyKey, collection: any) => any) | PropertyKey | object`): 反復ごとに呼び出される関数。
+- `initialValue` (`U`, オプション): 初期値。
 
 ### 戻り値
 
-(`any`): 蓄積された値。
+(`U`): 蓄積された値。 `initialValue` が指定されていない場合は、コレクションの要素型（`T`）が返されます。
 
 ## 例
 

--- a/docs/ja/reference/string/capitalize.md
+++ b/docs/ja/reference/string/capitalize.md
@@ -14,7 +14,7 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 戻り値
 
-(`Capitalize<string>`): 大文字に変換された文字列。
+(`Capitalize<T>`): 大文字に変換された文字列。
 
 ## 例
 

--- a/docs/ja/reference/string/capitalize.md
+++ b/docs/ja/reference/string/capitalize.md
@@ -10,11 +10,11 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### パラメータ
 
-`str` (`T`): 大文字に変換する文字列。
+`str` (`T`): 変換する文字列。
 
 ### 戻り値
 
-(`Capitalize<T>`): 大文字に変換された文字列。
+(`Capitalize<T>`): 最初の文字が大文字で、それ以降が小文字に変換された文字列。
 
 ## 例
 

--- a/docs/ko/reference/compat/array/reduce.md
+++ b/docs/ko/reference/compat/array/reduce.md
@@ -49,13 +49,13 @@ function reduce<T extends object>(
 
 ### 파라미터
 
-- `collection` (`T[] | ArrayLike<T> | Record<string, T> | null | undefined`): 반복할 컬렉션.
-- `iteratee` (`((accumulator: any, value: any, index: PropertyKey, collection: any) => any) | PropertyKey | object`): 반복할 때 호출되는 함수.
-- `initialValue` (`any`): 초기 값.
+- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T> | null | undefined`): 반복할 컬렉션.
+- `iteratee` (`((accumulator: U, value: T, index: PropertyKey, collection: any) => any) | PropertyKey | object`): 반복할 때 호출되는 함수.
+- `initialValue` (`U`, 선택 사항): 초기 값.
 
 ### 반환 값
 
-(`any`): 하나의 값으로 줄여진 값.
+(`U`): 하나의 값으로 줄여진 결과. `initialValue`를 제공하지 않은 경우 컬렉션의 원소 타입(`T`)이 반환돼요.
 
 ## 예시
 

--- a/docs/ko/reference/compat/array/reduceRight.md
+++ b/docs/ko/reference/compat/array/reduceRight.md
@@ -49,13 +49,13 @@ function reduceRight<T extends object>(
 
 ### 파라미터
 
-- `collection` (`T[] | ArrayLike<T> | Record<string, T> | null | undefined`): 반복할 컬렉션.
-- `iteratee` (`((accumulator: any, value: any, index: PropertyKey, collection: any) => any) | PropertyKey | object`): 반복할 때 호출되는 함수.
-- `initialValue` (`any`): 초기 값.
+- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T> | null | undefined`): 반복할 컬렉션.
+- `iteratee` (`((accumulator: U, value: T, index: PropertyKey, collection: any) => any) | PropertyKey | object`): 반복할 때 호출되는 함수.
+- `initialValue` (`any`, 선택 사항): 초기 값.
 
 ### 반환 값
 
-(`U`): 하나의 값으로 줄여진 값.
+(`U`): 하나의 값으로 줄여진 결과. `initialValue`를 제공하지 않은 경우 컬렉션의 원소 타입(`T`)이 반환돼요.
 
 ## 예시
 

--- a/docs/ko/reference/string/capitalize.md
+++ b/docs/ko/reference/string/capitalize.md
@@ -14,7 +14,7 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 반환 값
 
-(`Capitalize<string>`): 대문자로 변환된 문자열.
+(`Capitalize<T>`): 대문자로 변환된 문자열.
 
 ## 예시
 

--- a/docs/ko/reference/string/capitalize.md
+++ b/docs/ko/reference/string/capitalize.md
@@ -10,11 +10,11 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 파라미터
 
-`str` (`T`): 대문자로 변환할 문자열.
+`str` (`T`): 변환할 문자열.
 
 ### 반환 값
 
-(`Capitalize<T>`): 대문자로 변환된 문자열.
+(`Capitalize<T>`): 첫 글자는 대문자, 나머지는 소문자로 변환된 문자열.
 
 ## 예시
 

--- a/docs/reference/compat/array/reduce.md
+++ b/docs/reference/compat/array/reduce.md
@@ -49,13 +49,13 @@ function reduce<T extends object>(
 
 ### Parameters
 
-- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T>`): The collection to iterate over.
-- `iteratee` (`(accumulator: U, value: T, index, collection) => any)`): The function invoked per iteration.
-- `initialValue` (`U`): The initial value.
+- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T> | null | undefined`): The collection to iterate over.
+- `iteratee` (`((accumulator: U, value: T, index: PropertyKey, collection: any) => any) | PropertyKey | object`): The function invoked per iteration.
+- `initialValue` (`U`, Optional): The initial value.
 
 ### Returns
 
-(`any`): Returns the accumulated value.
+(`U`): Returns the accumulated value. If `initialValue` is not provided, the element type (`T`) of the collection is returned.
 
 ## Examples
 

--- a/docs/reference/compat/array/reduceRight.md
+++ b/docs/reference/compat/array/reduceRight.md
@@ -49,13 +49,13 @@ function reduceRight<T extends object>(
 
 ### Parameters
 
-- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T>`): The collection to iterate over.
-- `iteratee` (`(accumulator: U, value: T, index, collection) => any)`): The function invoked per iteration.
-- `initialValue` (`U`): The initial value.
+- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T> | null | undefined`): The collection to iterate over.
+- `iteratee` (`((accumulator: U, value: T, index: PropertyKey, collection: any) => any) | PropertyKey | object`): The function invoked per iteration.
+- `initialValue` (`U`, Optional): The initial value.
 
 ### Returns
 
-(`any`): Returns the accumulated value.
+(`U`): Returns the accumulated value. If `initialValue` is not provided, the element type (`T`) of the collection is returned.
 
 ## Examples
 

--- a/docs/reference/string/capitalize.md
+++ b/docs/reference/string/capitalize.md
@@ -14,7 +14,7 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### Returns
 
-(`Capitalize<string>`): The capitalized string.
+(`Capitalize<T>`): The capitalized string.
 
 ## Examples
 

--- a/docs/reference/string/capitalize.md
+++ b/docs/reference/string/capitalize.md
@@ -10,11 +10,11 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### Parameters
 
-`str` (`T`): The string to be converted to uppercase.
+`str` (`T`): The string to be transformed.
 
 ### Returns
 
-(`Capitalize<T>`): The capitalized string.
+(`Capitalize<T>`): The string with the first character capitalized and the rest in lowercase.
 
 ## Examples
 

--- a/docs/zh_hans/reference/compat/array/reduce.md
+++ b/docs/zh_hans/reference/compat/array/reduce.md
@@ -49,13 +49,13 @@ function reduce<T extends object>(
 
 ### 参数
 
-- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T>`): 要迭代的集合。
-- `iteratee` (`(accumulator: U, value: T, index, collection) => any)`): 每次迭代时调用的函数。
-- `initialValue` (`U`): 初始值。
+- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T> | null | undefined`): 要迭代的集合。
+- `iteratee` (`((accumulator: U, value: T, index: PropertyKey, collection: any) => any) | PropertyKey | object`): 每次迭代时调用的函数。
+- `initialValue` (`U`, 可选): 初始值。
 
 ### 返回值
 
-(`any`): 返回累积值。
+(`U`): 返回累积值。 如果未提供 `initialValue`，则返回集合的元素类型（`T`）。
 
 ## 示例
 

--- a/docs/zh_hans/reference/compat/array/reduceRight.md
+++ b/docs/zh_hans/reference/compat/array/reduceRight.md
@@ -49,13 +49,13 @@ function reduceRight<T extends object>(
 
 ### 参数
 
-- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T>`): 要迭代的集合。
-- `iteratee` (`(accumulator: U, value: T, index, collection) => any)`): 每次迭代时调用的函数。
-- `initialValue` (`U`): 初始值。
+- `collection` (`T[] | ArrayLike<T> | Record<PropertyKey, T> | null | undefined`): 要迭代的集合。
+- `iteratee` (`((accumulator: U, value: T, index: PropertyKey, collection: any) => any) | PropertyKey | object`): 每次迭代时调用的函数。
+- `initialValue` (`U`, 可选): 初始值。
 
 ### 返回值
 
-(`any`): 返回累积值。
+(`U`): 返回累积值。 如果未提供 `initialValue`，则返回集合的元素类型（`T`）。
 
 ## 示例
 

--- a/docs/zh_hans/reference/string/capitalize.md
+++ b/docs/zh_hans/reference/string/capitalize.md
@@ -10,11 +10,11 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 参数
 
-`str` (`T`): 要转换为大写的字符串。
+`str` (`T`): 需要转换的字符串。
 
 ### 返回值
 
-(`Capitalize<T>`): 转换后的大写字符串。
+(`Capitalize<T>`):首字母大写，其他字母小写的字符串。
 
 ## 示例
 

--- a/docs/zh_hans/reference/string/capitalize.md
+++ b/docs/zh_hans/reference/string/capitalize.md
@@ -14,7 +14,7 @@ function capitalize<T extends string>(str: T): Capitalize<T>;
 
 ### 返回值
 
-(`Capitalize<string>`): 转换后的大写字符串。
+(`Capitalize<T>`): 转换后的大写字符串。
 
 ## 示例
 


### PR DESCRIPTION
## Summary
This PR updates the documentation for both `reduce` and `reduceRight` functions by replacing broad `any` types with more precise generic types (`T` and `U`).  

### Changes:
- Updated `collection` type to include `Record<PropertyKey, T>` for object collections.
- Changed `iteratee` function parameter and return types from `any` to generic `U` for the accumulator, and `T` for value.
- Changed `initialValue` type from `any` to generic `U`, marking it as optional.
- Clarified the return type as `U`, explaining that if `initialValue` is omitted, the return type is the element type `T`.

### Reason:
Using generic types improves type safety and better reflects the functions' TypeScript signatures and runtime behavior. The previous `any` types were too broad and could cause confusion or loss of type information.

These changes ensure more accurate and helpful documentation for TypeScript users.
