### PR TITLE
docs: add SameValueZero spec link to eq and includes documentation

### DIFF
--- a/docs/ja/reference/compat/array/includes.md
+++ b/docs/ja/reference/compat/array/includes.md
@@ -8,7 +8,7 @@
 
 指定された値が、与えられた配列、オブジェクト、または文字列に含まれているかどうかを確認します。
 
-比較演算にはSameValueZeroを使用します。
+比較演算には[SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero)を使用します。
 
 ## インターフェース
 

--- a/docs/ja/reference/compat/util/eq.md
+++ b/docs/ja/reference/compat/util/eq.md
@@ -6,7 +6,7 @@
 `es-toolkit/compat` からこの関数をインポートすると、[lodash と完全に同じように動作](../../../compatibility.md)します。
 :::
 
-2つの値の間で`SameValueZero`比較を行い、それらが同等であるかどうかを判定します。
+2つの値の間で[SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero)比較を行い、それらが同等であるかどうかを判定します。
 
 ## インターフェース
 

--- a/docs/ko/reference/compat/array/includes.md
+++ b/docs/ko/reference/compat/array/includes.md
@@ -8,7 +8,7 @@
 
 값이 주어진 배열, 객체 또는 문자열에 포함되어 있는지 확인해요.
 
-비교 연산은 SameValueZero를 사용해요.
+비교 연산은 [SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero)를 사용해요.
 
 ## 인터페이스
 

--- a/docs/ko/reference/compat/util/eq.md
+++ b/docs/ko/reference/compat/util/eq.md
@@ -6,7 +6,7 @@
 `es-toolkit/compat`에서 이 함수를 가져오면, [lodash와 완전히 똑같이 동작](../../../compatibility.md)해요.
 :::
 
-두 값이 동등한지 여부를 결정하기 위해 `SameValueZero` 비교를 수행해요.
+두 값이 동등한지 여부를 결정하기 위해 [SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero) 비교를 수행해요.
 
 ## 인터페이스
 

--- a/docs/reference/compat/array/includes.md
+++ b/docs/reference/compat/array/includes.md
@@ -8,7 +8,7 @@ When imported from `es-toolkit/compat`, it behaves exactly like lodash and provi
 
 Checks if a specified value exists within a given source, which can be an array, an object, or a string.
 
-The comparison uses SameValueZero to check for inclusion.
+The comparison uses [SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero) to check for inclusion.
 
 ## Signature
 

--- a/docs/reference/compat/util/eq.md
+++ b/docs/reference/compat/util/eq.md
@@ -6,7 +6,7 @@ This function is only available in `es-toolkit/compat` for compatibility reasons
 When imported from `es-toolkit/compat`, it behaves exactly like lodash and provides the same functionalities, as detailed [here](../../../compatibility.md).
 :::
 
-Performs a `SameValueZero` comparison between two values to determine if they are equivalent.
+Performs a [SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero) comparison between two values to determine if they are equivalent.
 
 ## Signature
 

--- a/docs/zh_hans/reference/compat/array/includes.md
+++ b/docs/zh_hans/reference/compat/array/includes.md
@@ -8,7 +8,7 @@
 
 检查给定的值是否包含在数组、对象或字符串中。
 
-比较运算使用 SameValueZero。
+比较运算使用 [SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero)。
 
 ## 签名
 

--- a/docs/zh_hans/reference/compat/util/eq.md
+++ b/docs/zh_hans/reference/compat/util/eq.md
@@ -6,7 +6,7 @@
 从 `es-toolkit/compat` 导入时，它的行为与 lodash 完全一致，并提供相同的功能，详情请见 [这里](../../../compatibility.md)。
 :::
 
-执行 `SameValueZero` 比较，以确定两个值是否相等。
+执行 [SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero) 比较，以确定两个值是否相等。
 
 ## 签名
 


### PR DESCRIPTION
## Summary
This PR improves the documentation for the `eq` and `includes` functions by adding a link to the ECMAScript SameValueZero specification:

- Updated the descriptions to include a direct link to [SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero), so users can quickly reference the exact algorithm used for equality comparisons.
- This change increases transparency and clarity about value comparison semantics, aligning with how the `without` function is documented.

This ensures consistency across documentation and helps users better understand how equality checks are performed, especially regarding edge cases like `NaN`.
