### PR TITLE
docs: Update zipObject and zipObjectDeep docs to use PropertyKey and Record for better readability

### DIFF
--- a/docs/ja/reference/array/zipObject.md
+++ b/docs/ja/reference/array/zipObject.md
@@ -7,7 +7,7 @@
 ## インターフェース
 
 ```typescript
-function zipObject<P extends string | number | symbol, V>(keys: P[], values: V[]): { [K in P]: V };
+function zipObject<P extends PropertyKey, V>(keys: P[], values: V[]): Record<P, V>;
 ```
 
 ### パラメータ
@@ -17,7 +17,7 @@ function zipObject<P extends string | number | symbol, V>(keys: P[], values: V[]
 
 ### 戻り値
 
-(`{ [K in P]: V }`): 与えられたプロパティ名と値で構成される新しいオブジェクトです。
+(`Record<P, V>`): 与えられたプロパティ名と値で構成される新しいオブジェクトです。
 
 ## 例
 

--- a/docs/ja/reference/compat/array/zipObjectDeep.md
+++ b/docs/ja/reference/compat/array/zipObjectDeep.md
@@ -13,7 +13,7 @@
 ## インターフェース
 
 ```typescript
-function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, values: ArrayLike<V>): { [K in P]: V };
+function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, values: ArrayLike<V>): Record<P, V>;
 ```
 
 ### パラメータ
@@ -23,7 +23,7 @@ function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, value
 
 ### 戻り値
 
-(`{ [K in P]: V }`): 与えられたプロパティ名と値で構成される新しいオブジェクトです。
+(`Record<P, V>`): 与えられたプロパティ名と値で構成される新しいオブジェクトです。
 
 ## 例
 

--- a/docs/ko/reference/array/zipObject.md
+++ b/docs/ko/reference/array/zipObject.md
@@ -7,7 +7,7 @@
 ## 인터페이스
 
 ```typescript
-function zipObject<P extends string | number | symbol, V>(keys: P[], values: V[]): { [K in P]: V };
+function zipObject<P extends PropertyKey, V>(keys: P[], values: V[]): Record<P, V>;
 ```
 
 ### 파라미터
@@ -17,7 +17,7 @@ function zipObject<P extends string | number | symbol, V>(keys: P[], values: V[]
 
 ### 반환 값
 
-(`{ [K in P]: V }`): 주어진 속성 이름과 값으로 구성된 새로운 객체예요.
+(`Record<P, V>`): 주어진 속성 이름과 값으로 구성된 새로운 객체예요.
 
 ## 예시
 

--- a/docs/ko/reference/compat/array/zipObjectDeep.md
+++ b/docs/ko/reference/compat/array/zipObjectDeep.md
@@ -13,7 +13,7 @@
 ## 인터페이스
 
 ```typescript
-function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, values: ArrayLike<V>): { [K in P]: V };
+function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, values: ArrayLike<V>): Record<P, V>;
 ```
 
 ### 파라미터
@@ -23,7 +23,7 @@ function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, value
 
 ### 반환 값
 
-(`{ [K in P]: V }`): 주어진 속성 이름과 값으로 구성된 새로운 객체예요.
+(`Record<P, V>`): 주어진 속성 이름과 값으로 구성된 새로운 객체예요.
 
 ## 예시
 

--- a/docs/reference/array/zipObject.md
+++ b/docs/reference/array/zipObject.md
@@ -7,7 +7,7 @@ This function takes two arrays: one containing property names and another contai
 ## Signature
 
 ```typescript
-function zipObject<P extends string | number | symbol, V>(keys: P[], values: V[]): { [K in P]: V };
+function zipObject<P extends PropertyKey, V>(keys: P[], values: V[]): Record<P, V>;
 ```
 
 ### Parameters
@@ -17,7 +17,7 @@ function zipObject<P extends string | number | symbol, V>(keys: P[], values: V[]
 
 ### Returns
 
-(`{ [K in P]: V }`): A new object composed of the given property names and values.
+(`Record<P, V>`): A new object composed of the given property names and values.
 
 ## Examples
 

--- a/docs/reference/compat/array/zipObjectDeep.md
+++ b/docs/reference/compat/array/zipObjectDeep.md
@@ -15,7 +15,7 @@ Paths can be dot-separated strings or arrays of property names. If the `keys` ar
 ## Signature
 
 ```typescript
-function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, values: ArrayLike<V>): { [K in P]: V };
+function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, values: ArrayLike<V>): Record<P, V>;
 ```
 
 ### Parameters
@@ -25,7 +25,7 @@ function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, value
 
 ### Returns
 
-(`{ [K in P]: V }`): A new object composed of the given property names and values.
+(`Record<P, V>`): A new object composed of the given property names and values.
 
 ## Examples
 

--- a/docs/zh_hans/reference/array/zipObject.md
+++ b/docs/zh_hans/reference/array/zipObject.md
@@ -9,7 +9,7 @@
 ## 签名
 
 ```typescript
-function zipObject<P extends string | number | symbol, V>(keys: P[], values: V[]): { [K in P]: V };
+function zipObject<P extends PropertyKey, V>(keys: P[], values: V[]): Record<P, V>;
 ```
 
 ### 参数
@@ -19,7 +19,7 @@ function zipObject<P extends string | number | symbol, V>(keys: P[], values: V[]
 
 ### 返回值
 
-(`{ [K in P]: V }`): 由给定的属性名称和值组成的新对象。
+(`Record<P, V>`): 由给定的属性名称和值组成的新对象。
 
 ## 示例
 

--- a/docs/zh_hans/reference/compat/array/zipObjectDeep.md
+++ b/docs/zh_hans/reference/compat/array/zipObjectDeep.md
@@ -14,7 +14,7 @@
 ## 签名
 
 ```typescript
-function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, values: ArrayLike<V>): { [K in P]: V };
+function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, values: ArrayLike<V>): Record<P, V>;
 ```
 
 ### 参数
@@ -24,7 +24,7 @@ function zipObjectDeep<P extends PropertyKey, V>(keys: ArrayLike<P | P[]>, value
 
 ### 返回值
 
-(`{ [K in P]: V }`): 由给定的属性名称和值组成的新对象。
+(`Record<P, V>`): 由给定的属性名称和值组成的新对象。
 
 ## 示例
 


### PR DESCRIPTION
## Summary
This PR improves the documentation for `zipObject` and `zipObjectDeep` by aligning their TypeScript generics and return types with other related documents:

- Modified the generic constraint from `P extends string | number | symbol` to `P extends PropertyKey` for clarity and uniformity.
- Updated the return type from mapped type `{ [K in P]: V }` to `Record<P, V>` to improve readability and maintain consistency across documents.

These changes enhance the clarity and uniformity of the documentation, making it easier to read and understand for users.
