### PR TITLE
fix: Fixing errors when undefined is passed

### DIFF
--- a/src/array/remove.ts
+++ b/src/array/remove.ts
@@ -15,6 +15,10 @@
  * console.log(numbers); // [1, 3, 5]
  */
 export function remove<T>(arr: T[], shouldRemoveElement: (value: T, index: number, array: T[]) => boolean): T[] {
+  if (!(arr && arr.length)) {
+    return [];
+  }
+
   const originalArr = arr.slice();
   const removed = [];
 


### PR DESCRIPTION
An error occurs when `arr` is undefined and passed to `arr.slice()`.  
This fix adds a guard clause to return an empty array when `arr` is undefined.