### PR TITLE
fix(compat/unset): Fix logic bug with nonexistent paths

### DIFF
--- a/src/compat/object/unset.spec.ts
+++ b/src/compat/object/unset.spec.ts
@@ -159,4 +159,11 @@ describe('unset', () => {
   it('should match the type of lodash', () => {
     expectTypeOf(unset).toEqualTypeOf<typeof unsetLodash>();
   });
+
+  it('should not delete root properties from nonexistent paths', () => {
+    const object = { b: null };
+
+    expect(unset(object, 'a.b')).toBe(true);
+    expect(object).toEqual({ b: null });
+  });
 });

--- a/src/compat/object/unset.ts
+++ b/src/compat/object/unset.ts
@@ -79,7 +79,7 @@ export function unset(obj: any, path: PropertyKey | readonly PropertyKey[]): boo
 }
 
 function unsetWithPath(obj: unknown, path: readonly PropertyKey[]): boolean {
-  const parent = get(obj, path.slice(0, -1), obj);
+  const parent = path.length === 1 ? obj : get(obj, path.slice(0, -1));
   const lastKey = path[path.length - 1];
 
   if (parent?.[lastKey] === undefined) {


### PR DESCRIPTION
## Relate Issue 
- resolve #1320 
## Changes
- remove `defaultValue` from `get()`, because it leads unwanted result when path is not matching on object.
- instead, use ternary operator for handling the case that `path.slice(0, -1)` return empty array.
- add a test `"does not delete root properties from nonexistent paths" `