### PR TITLE
fix(findIndex): correct JSDoc return type to -1 instead of undefined

### DIFF
--- a/src/compat/array/findIndex.ts
+++ b/src/compat/array/findIndex.ts
@@ -11,7 +11,7 @@ import { matchesProperty } from '../predicate/matchesProperty.ts';
  * @param {((item: T, index: number, arr: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey} doesMatch - The criteria to match against the items in the array. This can be a function, a partial object, a key-value pair, or a property name.
  * @param {PropertyKey} propertyToCheck - The property name to check for in the items of the array.
  * @param {number} [fromIndex=0] - The index to start the search from, defaults to 0.
- * @returns {number} - The index of the first item that has the specified property, or -1 if no match is found.
+ * @returns {number} - The index of the first item that has the specified property, or `-1` if no match is found.
  *
  * @example
  * // Using a property name

--- a/src/compat/array/findIndex.ts
+++ b/src/compat/array/findIndex.ts
@@ -11,7 +11,7 @@ import { matchesProperty } from '../predicate/matchesProperty.ts';
  * @param {((item: T, index: number, arr: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey} doesMatch - The criteria to match against the items in the array. This can be a function, a partial object, a key-value pair, or a property name.
  * @param {PropertyKey} propertyToCheck - The property name to check for in the items of the array.
  * @param {number} [fromIndex=0] - The index to start the search from, defaults to 0.
- * @returns {number} - The index of the first item that has the specified property, or `undefined` if no match is found.
+ * @returns {number} - The index of the first item that has the specified property, or -1 if no match is found.
  *
  * @example
  * // Using a property name


### PR DESCRIPTION
[Tests](https://github.com/toss/es-toolkit/blob/main/src/compat/array/findIndex.spec.ts) and [implementation](https://github.com/toss/es-toolkit/blob/main/src/compat/array/findIndex.ts) show that `findIndex` returns -1 when no match is found, but the JSDoc incorrectly documented `undefined`. 

This commit fixes the JSDoc.