### PR TITLE
fix(toCamelCaseKeys): Add a type for PascalCase

### DIFF
--- a/src/object/toCamelCaseKeys.spec.ts
+++ b/src/object/toCamelCaseKeys.spec.ts
@@ -8,6 +8,12 @@ describe('camelizeKeys', () => {
     expect(toCamelCaseKeys(input)).toEqual(expected);
   });
 
+  it('should convert PascalCase keys to camelCase in a flat object', () => {
+    const input = { UserId: 1, FirstName: 'John', LastName: 'Doe' };
+    const expected = { userId: 1, firstName: 'John', lastName: 'Doe' };
+    expect(toCamelCaseKeys(input)).toEqual(expected);
+  });
+
   it('should convert keys recursively in nested objects', () => {
     const input = {
       user_data: {

--- a/src/object/toCamelCaseKeys.ts
+++ b/src/object/toCamelCaseKeys.ts
@@ -2,14 +2,19 @@ import { isArray } from '../compat/predicate/isArray.ts';
 import { isPlainObject } from '../predicate/isPlainObject.ts';
 import { camelCase } from '../string/camelCase.ts';
 
-type CamelCase<S extends string> = S extends `${infer P1}_${infer P2}${infer P3}`
-  ? `${Lowercase<P1>}${Uppercase<P2>}${CamelCase<P3>}`
+type SnakeToCamel<S extends string> = S extends `${infer H}_${infer T}`
+  ? `${Lowercase<H>}${Capitalize<SnakeToCamel<T>>}`
   : Lowercase<S>;
+
+type PascalToCamel<S extends string> = S extends `${infer F}${infer R}` ? `${Lowercase<F>}${R}` : S;
+
+/** If it's snake_case, apply the snake_case rule; otherwise, just lowercase the first letter (including PascalCase → camelCase). */
+type AnyToCamel<S extends string> = S extends `${string}_${string}` ? SnakeToCamel<S> : PascalToCamel<S>;
 
 type ToCamelCaseKeys<T> = T extends any[]
   ? Array<ToCamelCaseKeys<T[number]>>
   : T extends Record<string, any>
-    ? { [K in keyof T as CamelCase<string & K>]: ToCamelCaseKeys<T[K]> }
+    ? { [K in keyof T as AnyToCamel<Extract<K, string>>]: ToCamelCaseKeys<T[K]> }
     : T;
 
 /**


### PR DESCRIPTION
## Problem
When object keys were written in **PascalCase**, the inferred type was not properly converted to the expected `camelCase` form.  
This caused inconsistent typing results compared to `snake_case`.

## Solution
- Added explicit handling for `PascalCase` keys in the type transformation.
- Now both `PascalCase` and `snake_case` keys are correctly converted to `camelCase`.

## Before Result
```ts
const pascal: { referenceid: string; };
const snake: { referenceId: string };
```
## After Result
```ts
const pascal: { referenceId: string; };
const snake: { referenceId: string };
```
## Related Issue
Fixes [#1355](https://github.com/toss/es-toolkit/issues/1355)

## Notes
This change ensures consistent type conversion rules regardless of whether the input key is PascalCase or snake_case.

No breaking changes expected.
