### PR TITLE
docs: improve return value explanation of template function including source property

### DIFF
--- a/docs/ja/reference/compat/string/template.md
+++ b/docs/ja/reference/compat/string/template.md
@@ -29,7 +29,7 @@ function template(string: string, options?: TemplateOptions): ((data?: object) =
 
 ### 戻り値
 
-(`(data?: object) => string`): コンパイルされたテンプレート関数を返します。
+(`((data?: object) => string) & { source: string }`): 返された関数は呼び出すことができ、`source` プロパティにコンパイル済みテンプレートのソースコードが含まれます。
 
 ## 例
 

--- a/docs/ko/reference/compat/string/template.md
+++ b/docs/ko/reference/compat/string/template.md
@@ -29,7 +29,7 @@ function template(string: string, options?: TemplateOptions): ((data?: object) =
 
 ### 반환 값
 
-(`(data?: object) => string`): 컴파일된 템플릿 함수를 반환합니다.
+(`((data?: object) => string) & { source: string }`): 반환된 함수는 호출할 수 있고, `source` 속성으로 컴파일된 템플릿 소스 코드를 포함합니다.
 
 ## 예시
 

--- a/docs/reference/compat/string/template.md
+++ b/docs/reference/compat/string/template.md
@@ -30,7 +30,7 @@ function template(string: string, options?: TemplateOptions): ((data?: object) =
 
 ### Returns
 
-(`(data?: object) => string`): Returns the compiled template function.
+(`((data?: object) => string) & { source: string }`): The returned function can be called and includes a `source` property containing the compiled template source code.
 
 ## Examples
 

--- a/docs/zh_hans/reference/compat/string/template.md
+++ b/docs/zh_hans/reference/compat/string/template.md
@@ -29,7 +29,7 @@ function template(string: string, options?: TemplateOptions): ((data?: object) =
 
 ### 返回值
 
-(`(data?: object) => string`): 返回编译的模板函数。
+(`((data?: object) => string) & { source: string }`): 返回的函数可以被调用，并包含一个 `source` 属性，里面包含编译后的模板源代码。
 
 ## 示例
 


### PR DESCRIPTION
## Summary
This PR updates the return value description of the `template` function documentation in multiple languages (ko, en, ja, zh_hans).

- Specifies that the returned function is callable and includes a `source` property containing the compiled template source code.
- Improves clarity and completeness of the documentation for better developer understanding.
- Applies consistent wording across all supported languages.

This refinement helps users better understand the capabilities of the returned template function.
