### PR TITLE
Fix/korean spelling and typescript casing

### DIFF
--- a/docs/ko/reference/compat/array/reverse.md
+++ b/docs/ko/reference/compat/array/reverse.md
@@ -30,7 +30,7 @@ function reverse<T>(array: T[]): T[];
 const array = [1, 2, 3, 4, 5];
 const reversedArray = reverse(array);
 console.log(reversedArray); // [5, 4, 3, 2, 1]
-console.log(array); // [5, 4, 3, 2, 1] (원본 배열이 수정되요)
+console.log(array); // [5, 4, 3, 2, 1] (원본 배열이 수정돼요)
 
 const emptyArray = reverse([]);
 console.log(emptyArray); // []

--- a/docs/ko/reference/math/median.md
+++ b/docs/ko/reference/math/median.md
@@ -31,5 +31,5 @@ const result = median(arrayWithOddNumberOfElements);
 
 const arrayWithEvenNumberOfElements = [1, 2, 3, 4];
 const result = median(arrayWithEvenNumberOfElements);
-// result는 2.5가 되요.
+// result는 2.5가 되어요.
 ```

--- a/src/predicate/isBoolean.spec.ts
+++ b/src/predicate/isBoolean.spec.ts
@@ -15,7 +15,7 @@ describe('isBoolean', () => {
     expect(isBoolean([1, 2, 3])).toBe(false);
   });
 
-  it('can be used with Typescript as a type predicate', () => {
+  it('can be used with TypeScript as a type predicate', () => {
     const arr = [1, 2, true, 4, false];
 
     const result = arr.filter(isBoolean);


### PR DESCRIPTION
# Fix Korean spelling and TypeScript capitalization

## Summary
Fixed Korean spelling and TypeScript capitalization issues in Korean documentation to maintain consistency and proper conventions throughout the codebase.

## Changes
- Updated Korean spelling: changed "되요" to "돼요" and "되어요" where appropriate
  - "되요" → "돼요" (standard Korean spelling)
  - "되요" → "되어요" (to match existing usage in files that already use "되어요")
- Fixed TypeScript capitalization: changed "Typescript" to "TypeScript" for proper brand naming

## Type of Change
- [x] Documentation/Test improvement 
## Testing
No additional testing required as this is a documentation/naming fix only.

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Changes generate no new warnings
- [x] No functional code changes made

## Question for Maintainers
I noticed an inconsistency in Korean documentation that I'd like to get your opinion on:

- "되어요" is currently used in **24 locations**
- "돼요" is currently used in **244 locations**

Both forms are grammatically correct, but "돼요" is more commonly used and appears to be the preferred form in this codebase. Since this doesn't affect functionality and isn't technically an error, I didn't include these changes in this PR.

**Would you be interested in standardizing to "돼요" for consistency?** If so, I'd be happy to submit an additional PR to unify these 24 instances across the documentation.

This is purely for consistency and readability - no pressure if you'd prefer to leave it as is!