### PR TITLE
fix(cloneDeep/cloneDeepWith): handle cloning of Boolean, Number and String objects

### DIFF
--- a/src/object/cloneDeep.spec.ts
+++ b/src/object/cloneDeep.spec.ts
@@ -402,4 +402,89 @@ describe('cloneDeep', () => {
     expect(clonedInstance.value).toBe(instance.value);
     expect(clonedInstance.getValue()).toBe(123);
   });
+
+  it('should clone arguments objects', () => {
+    function func() {
+      // eslint-disable-next-line prefer-rest-params
+      return cloneDeep(arguments);
+    }
+    // @ts-expect-error: arguments object allows calling with parameters despite no formal params
+    const args = func(1, 2, 3);
+    const cloned = cloneDeep(args);
+
+    expect(cloned).toEqual(args);
+    expect(cloned).not.toBe(args);
+  });
+
+  it('should clone Boolean objects', () => {
+    const boolObj = new Boolean(true);
+    const cloned = cloneDeep(boolObj);
+
+    expect(cloned).toEqual(boolObj);
+    expect(cloned).not.toBe(boolObj);
+    expect(cloned).toBeInstanceOf(Boolean);
+  });
+
+  it('should clone String objects', () => {
+    const strObj = new String('es-toolkit');
+    const cloned = cloneDeep(strObj);
+
+    expect(cloned).toEqual(strObj);
+    expect(cloned).not.toBe(strObj);
+    expect(cloned).toBeInstanceOf(String);
+  });
+
+  it('should clone Number objects', () => {
+    const numObj = new Number(42);
+    const cloned = cloneDeep(numObj);
+
+    expect(cloned).toEqual(numObj);
+    expect(cloned).not.toBe(numObj);
+    expect(cloned).toBeInstanceOf(Number);
+  });
+
+  it('should clone Float32Array', () => {
+    const arr = new Float32Array([1.1, 2.2, 3.3]);
+    const cloned = cloneDeep(arr);
+
+    expect(cloned).toEqual(arr);
+    expect(cloned).not.toBe(arr);
+    expect(cloned).toBeInstanceOf(Float32Array);
+  });
+
+  it('should clone Float64Array', () => {
+    const arr = new Float64Array([1.1, 2.2, 3.3]);
+    const cloned = cloneDeep(arr);
+
+    expect(cloned).toEqual(arr);
+    expect(cloned).not.toBe(arr);
+    expect(cloned).toBeInstanceOf(Float64Array);
+  });
+
+  it('should clone Int8Array', () => {
+    const arr = new Int8Array([1, 2, 3]);
+    const cloned = cloneDeep(arr);
+
+    expect(cloned).toEqual(arr);
+    expect(cloned).not.toBe(arr);
+    expect(cloned).toBeInstanceOf(Int8Array);
+  });
+
+  it('should clone Int16Array', () => {
+    const arr = new Int16Array([1, 2, 3]);
+    const cloned = cloneDeep(arr);
+
+    expect(cloned).toEqual(arr);
+    expect(cloned).not.toBe(arr);
+    expect(cloned).toBeInstanceOf(Int16Array);
+  });
+
+  it('should clone Int32Array', () => {
+    const arr = new Int32Array([1, 2, 3]);
+    const cloned = cloneDeep(arr);
+
+    expect(cloned).toEqual(arr);
+    expect(cloned).not.toBe(arr);
+    expect(cloned).toBeInstanceOf(Int32Array);
+  });
 });

--- a/src/object/cloneDeepWith.ts
+++ b/src/object/cloneDeepWith.ts
@@ -223,6 +223,27 @@ export function cloneDeepWithImpl<T>(
     return result as T;
   }
 
+  if (valueToClone instanceof Boolean) {
+    const result = new Boolean(valueToClone.valueOf()) as T;
+    stack.set(valueToClone, result);
+    copyProperties(result, valueToClone, objectToClone, stack, cloneValue);
+    return result;
+  }
+
+  if (valueToClone instanceof Number) {
+    const result = new Number(valueToClone.valueOf()) as T;
+    stack.set(valueToClone, result);
+    copyProperties(result, valueToClone, objectToClone, stack, cloneValue);
+    return result;
+  }
+
+  if (valueToClone instanceof String) {
+    const result = new String(valueToClone.valueOf()) as T;
+    stack.set(valueToClone, result);
+    copyProperties(result, valueToClone, objectToClone, stack, cloneValue);
+    return result;
+  }
+
   if (typeof valueToClone === 'object' && isCloneableObject(valueToClone)) {
     const result = Object.create(Object.getPrototypeOf(valueToClone));
 

--- a/src/object/merge.spec.ts
+++ b/src/object/merge.spec.ts
@@ -107,4 +107,15 @@ describe('merge', () => {
 
     expect(result).toEqual({ a: { b: { c: [2], d: 3 }, e: [4] } });
   });
+
+  it('should skip unsafe properties like __proto__', () => {
+    const target = { a: 1 };
+    const source = Object.create(null);
+    source.__proto__ = { b: 2 };
+    source.a = 2;
+    const result = merge(target, source);
+
+    expect(result).toEqual({ a: 2 });
+    expect(result.__proto__).toBe(Object.prototype);
+  });
 });

--- a/src/object/mergeWith.spec.ts
+++ b/src/object/mergeWith.spec.ts
@@ -76,4 +76,17 @@ describe('mergeWith', () => {
       })
     ).toEqual({ prop: null });
   });
+
+  it('should skip unsafe properties like __proto__', () => {
+    const target = { a: 1 };
+    const source = Object.create(null);
+    source.__proto__ = { b: 2 };
+    source.a = 2;
+    const result = mergeWith(target, source, (targetValue, sourceValue) => {
+      return sourceValue;
+    });
+
+    expect(result).toEqual({ a: 2 });
+    expect(result.__proto__).toBe(Object.prototype);
+  });
 });


### PR DESCRIPTION
before
```ts
cloneDeep(new Boolean(true)); // => Boolean{}
cloneDeep(new Number(42)); // => Number{}
cloneDeep(new String('123')); // => String {0: '1', 1: '2', 2: '3'}
```
after
```ts
cloneDeep(new Boolean(true)); // => Boolean{true}
cloneDeep(new Number(42)); // => Number{42}
cloneDeep(new String('123')); // => String {'123'}
```
Ensure that its behaviour is consistent with compat.