### PR TITLE
fix(some): update predicate check to handle null and undefined cases

### DIFF
--- a/src/compat/array/some.spec.ts
+++ b/src/compat/array/some.spec.ts
@@ -127,6 +127,7 @@ describe('some', () => {
     expect(some(objects, 'b')).toBe(true);
 
     expect(some(objects, 0)).toBe(true);
+    expect(some(objects, '')).toBe(false);
     expect(some(objects, Symbol.for('a'))).toBe(true);
   });
 

--- a/src/compat/array/some.ts
+++ b/src/compat/array/some.ts
@@ -87,7 +87,7 @@ export function some<T>(
     predicate = undefined;
   }
 
-  if (!predicate) {
+  if (predicate == null) {
     predicate = identity;
   }
 


### PR DESCRIPTION
current behavior: 
<img width="395" height="173" alt="{254F5C39-E25C-4B33-92E8-5EA3C10D5E5A}" src="https://github.com/user-attachments/assets/578d933f-884e-4f9e-80ae-b58072049560" />

<img width="409" height="169" alt="{74A51D4E-7768-4BA6-A7E7-31D7A0CDE091}" src="https://github.com/user-attachments/assets/6b30aa34-b4b5-4d29-96e7-5624cca9956b" />

This PR prevents "" and 0 from being converted to `identity`.