### PR TITLE
fix(sortedIndexBy): fix default iteratee handling

### DIFF
--- a/src/compat/array/sortedIndexBy.spec.ts
+++ b/src/compat/array/sortedIndexBy.spec.ts
@@ -58,6 +58,16 @@ describe('sortedIndexBy', () => {
     });
   });
 
+  it('should use default iteratee (identity function) when no iteratee is provided', () => {
+    const numbers = [10, 30, 50];
+    const actual = sortedIndexBy(numbers, 40);
+    expect(actual).toBe(2);
+
+    const strings = ['apple', 'cherry'];
+    const actualString = sortedIndexBy(strings, 'banana');
+    expect(actualString).toBe(1);
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(sortedIndexBy).toEqualTypeOf<typeof sortedIndexByLodash>();
   });

--- a/src/compat/array/sortedIndexBy.ts
+++ b/src/compat/array/sortedIndexBy.ts
@@ -1,6 +1,7 @@
 import { isNull } from '../../predicate/isNull.ts';
 import { isUndefined } from '../../predicate/isUndefined.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
+import { identity } from '../function/identity.ts';
 import { isNaN } from '../predicate/isNaN.ts';
 import { isNil } from '../predicate/isNil.ts';
 import { isSymbol } from '../predicate/isSymbol.ts';
@@ -52,7 +53,7 @@ export function sortedIndexBy<T>(array: ArrayLike<T> | null | undefined, value: 
 export function sortedIndexBy<T, R>(
   array: ArrayLike<T> | null | undefined,
   value: T,
-  iteratee: Iteratee<T, R> = iterateeToolkit,
+  iteratee: Iteratee<T, R> = identity,
   retHighest?: boolean
 ): number {
   let low = 0;

--- a/src/compat/predicate/isUndefined.spec.ts
+++ b/src/compat/predicate/isUndefined.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { isUndefined as isUndefinedLodash } from 'lodash';
-import { isUndefined } from '../../predicate';
+import { isUndefined } from './isUndefined';
 import { falsey } from '../_internal/falsey';
 
 describe('isUndefined', () => {

--- a/src/compat/string/capitalize.spec.ts
+++ b/src/compat/string/capitalize.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { capitalize as capitalizeLodash } from 'lodash';
-import { capitalize } from '../../string/capitalize';
+import { capitalize } from './capitalize';
 
 describe('capitalize', () => {
   it('should capitalize the first character of a string', () => {


### PR DESCRIPTION
current behavior
<img width="299" height="111" alt="image" src="https://github.com/user-attachments/assets/151b45dd-d8c1-4a7d-a7f9-5e70552de0d4" />
<img width="353" height="135" alt="image" src="https://github.com/user-attachments/assets/8f415b1b-4f2b-47de-840c-99616f379aca" />
This PR try to fix this