### PR TITLE
docs: collapse sidebar items for improved navigation in multiple lang…

### DIFF
--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -52,6 +52,7 @@ function sidebar(): DefaultTheme.Sidebar {
       items: sortByText([
         {
           text: 'Array Utilities',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'reference', 'array'),
             ...getSidebarItems.compat('en', docsRoot, 'reference', 'compat', 'array'),
@@ -59,6 +60,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'Function Utilities',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'reference', 'function'),
             ...getSidebarItems.compat('en', docsRoot, 'reference', 'compat', 'function'),
@@ -66,6 +68,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'Math Utilities',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'reference', 'math'),
             ...getSidebarItems.compat('en', docsRoot, 'reference', 'compat', 'math'),
@@ -73,6 +76,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'Object Utilities',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'reference', 'object'),
             ...getSidebarItems.compat('en', docsRoot, 'reference', 'compat', 'object'),
@@ -80,6 +84,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'Predicates',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'reference', 'predicate'),
             ...getSidebarItems.compat('en', docsRoot, 'reference', 'compat', 'predicate'),
@@ -87,6 +92,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'Promise Utilities',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'reference', 'promise'),
             ...getSidebarItems.compat('en', docsRoot, 'reference', 'compat', 'promise'),
@@ -94,6 +100,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'String Utilities',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'reference', 'string'),
             ...getSidebarItems.compat('en', docsRoot, 'reference', 'compat', 'string'),
@@ -101,6 +108,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'Utility Functions',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'reference', 'util'),
             ...getSidebarItems.compat('en', docsRoot, 'reference', 'compat', 'util'),
@@ -108,6 +116,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'Errors',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'reference', 'error'),
             ...getSidebarItems.compat('en', docsRoot, 'reference', 'compat', 'error'),

--- a/docs/.vitepress/ja.mts
+++ b/docs/.vitepress/ja.mts
@@ -51,6 +51,7 @@ function sidebar(): DefaultTheme.Sidebar {
       items: sortByText([
         {
           text: '配列',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ja', 'reference', 'array'),
             ...getSidebarItems.compat('ja', docsRoot, 'ja', 'reference', 'compat', 'array'),
@@ -58,6 +59,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '関数',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ja', 'reference', 'function'),
             ...getSidebarItems.compat('ja', docsRoot, 'ja', 'reference', 'compat', 'function'),
@@ -65,6 +67,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '数学',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ja', 'reference', 'math'),
             ...getSidebarItems.compat('ja', docsRoot, 'ja', 'reference', 'compat', 'math'),
@@ -72,6 +75,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'オブジェクト',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ja', 'reference', 'object'),
             ...getSidebarItems.compat('ja', docsRoot, 'ja', 'reference', 'compat', 'object'),
@@ -79,6 +83,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '述語',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ja', 'reference', 'predicate'),
             ...getSidebarItems.compat('ja', docsRoot, 'ja', 'reference', 'compat', 'predicate'),
@@ -86,6 +91,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'Promise',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ja', 'reference', 'promise'),
             ...getSidebarItems.compat('ja', docsRoot, 'ja', 'reference', 'compat', 'promise'),
@@ -93,6 +99,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '文字列',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ja', 'reference', 'string'),
             ...getSidebarItems.compat('ja', docsRoot, 'ja', 'reference', 'compat', 'string'),
@@ -100,6 +107,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'ユーティリティ',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ja', 'reference', 'util'),
             ...getSidebarItems.compat('ja', docsRoot, 'ja', 'reference', 'compat', 'util'),
@@ -107,6 +115,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'エラー',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ja', 'reference', 'error'),
             ...getSidebarItems.compat('ja', docsRoot, 'ja', 'reference', 'compat', 'error'),

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -51,6 +51,7 @@ function sidebar(): DefaultTheme.Sidebar {
       items: sortByText([
         {
           text: '배열',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ko', 'reference', 'array'),
             ...getSidebarItems.compat('ko', docsRoot, 'ko', 'reference', 'compat', 'array'),
@@ -58,6 +59,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '함수',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ko', 'reference', 'function'),
             ...getSidebarItems.compat('ko', docsRoot, 'ko', 'reference', 'compat', 'function'),
@@ -65,6 +67,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '숫자',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ko', 'reference', 'math'),
             ...getSidebarItems.compat('ko', docsRoot, 'ko', 'reference', 'compat', 'math'),
@@ -72,6 +75,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '객체',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ko', 'reference', 'object'),
             ...getSidebarItems.compat('ko', docsRoot, 'ko', 'reference', 'compat', 'object'),
@@ -79,6 +83,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '타입 가드',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ko', 'reference', 'predicate'),
             ...getSidebarItems.compat('ko', docsRoot, 'ko', 'reference', 'compat', 'predicate'),
@@ -86,6 +91,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'Promise',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ko', 'reference', 'promise'),
             ...getSidebarItems.compat('ko', docsRoot, 'ko', 'reference', 'compat', 'promise'),
@@ -93,6 +99,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '문자열',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ko', 'reference', 'string'),
             ...getSidebarItems.compat('ko', docsRoot, 'ko', 'reference', 'compat', 'string'),
@@ -100,6 +107,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '유틸리티',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ko', 'reference', 'util'),
             ...getSidebarItems.compat('ko', docsRoot, 'ko', 'reference', 'compat', 'util'),
@@ -107,6 +115,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '에러',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'ko', 'reference', 'error'),
             ...getSidebarItems.compat('ko', docsRoot, 'ko', 'reference', 'compat', 'error'),

--- a/docs/.vitepress/zh_hans.mts
+++ b/docs/.vitepress/zh_hans.mts
@@ -52,6 +52,7 @@ function sidebar(): DefaultTheme.Sidebar {
       items: sortByText([
         {
           text: '数组工具',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'zh_hans', 'reference', 'array'),
             ...getSidebarItems.compat('zh_hans', docsRoot, 'zh_hans', 'reference', 'compat', 'array'),
@@ -59,6 +60,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '函数工具',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'zh_hans', 'reference', 'function'),
             ...getSidebarItems.compat('zh_hans', docsRoot, 'zh_hans', 'reference', 'compat', 'function'),
@@ -66,6 +68,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '数学工具',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'zh_hans', 'reference', 'math'),
             ...getSidebarItems.compat('zh_hans', docsRoot, 'zh_hans', 'reference', 'compat', 'math'),
@@ -73,6 +76,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '对象工具',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'zh_hans', 'reference', 'object'),
             ...getSidebarItems.compat('zh_hans', docsRoot, 'zh_hans', 'reference', 'compat', 'object'),
@@ -80,6 +84,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '谓词',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'zh_hans', 'reference', 'predicate'),
             ...getSidebarItems.compat('zh_hans', docsRoot, 'zh_hans', 'reference', 'compat', 'predicate'),
@@ -87,6 +92,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: 'Promise 工具',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'zh_hans', 'reference', 'promise'),
             ...getSidebarItems.compat('zh_hans', docsRoot, 'zh_hans', 'reference', 'compat', 'promise'),
@@ -94,6 +100,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '字符串工具',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'zh_hans', 'reference', 'string'),
             ...getSidebarItems.compat('zh_hans', docsRoot, 'zh_hans', 'reference', 'compat', 'string'),
@@ -101,6 +108,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '工具函数',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'zh_hans', 'reference', 'util'),
             ...getSidebarItems.compat('zh_hans', docsRoot, 'zh_hans', 'reference', 'compat', 'util'),
@@ -108,6 +116,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: '错误',
+          collapsed: true,
           items: [
             ...getSidebarItems(docsRoot, 'zh_hans', 'reference', 'error'),
             ...getSidebarItems.compat('zh_hans', docsRoot, 'zh_hans', 'reference', 'compat', 'error'),


### PR DESCRIPTION
While checking the es-toolkit site documentation, I applied collapsed because there were many functions.


<img width="821" height="1374" alt="스크린샷 2025-09-02 10 33 01" src="https://github.com/user-attachments/assets/83282d8b-7ead-488e-98da-4206e7f19ffa" />
