### PR TITLE
feat: Add Map support to flattenObject function  Fixes #1388

### DIFF
--- a/benchmarks/performance/flattenObject-map.bench.ts
+++ b/benchmarks/performance/flattenObject-map.bench.ts
@@ -1,0 +1,116 @@
+import { bench, describe } from 'vitest';
+import { flattenObject } from '../../src/object/flattenObject.ts';
+
+// Create nested objects for testing
+function createNestedObject(depth: number, width: number) {
+  const obj: any = {};
+
+  for (let i = 0; i < width; i++) {
+    const key = `key${i}`;
+
+    if (depth > 1) {
+      obj[key] = createNestedObject(depth - 1, width);
+    } else {
+      obj[key] = `value${i}`;
+    }
+  }
+
+  return obj;
+}
+
+// Real-world translation-like data structure
+const translationLikeData = {
+  welcome: {
+    title: 'Welcome to our app',
+    subtitle: 'Get started today',
+    buttons: {
+      login: 'Login',
+      signup: 'Sign Up',
+      forgot: 'Forgot Password',
+    },
+  },
+  navigation: {
+    home: 'Home',
+    about: 'About',
+    contact: 'Contact',
+    settings: {
+      profile: 'Profile',
+      preferences: 'Preferences',
+      security: 'Security',
+      notifications: {
+        email: 'Email',
+        push: 'Push',
+        sms: 'SMS',
+      },
+    },
+  },
+  errors: {
+    validation: {
+      required: 'This field is required',
+      email: 'Invalid email format',
+      password: 'Password too weak',
+      confirm: 'Passwords do not match',
+    },
+    network: ['Connection failed', 'Timeout error', 'Server error'],
+    auth: {
+      unauthorized: 'Unauthorized access',
+      forbidden: 'Access forbidden',
+      expired: 'Session expired',
+    },
+  },
+  features: {
+    premium: {
+      analytics: 'Advanced Analytics',
+      support: 'Priority Support',
+      storage: 'Unlimited Storage',
+    },
+    free: {
+      basic: 'Basic Features',
+      limited: 'Limited Storage',
+    },
+  },
+};
+
+describe('flattenObject Map conversion performance', () => {
+  bench('legacy: flattenObject + Object.entries + new Map', () => {
+    new Map(Object.entries(flattenObject(translationLikeData)));
+  });
+
+  bench('new: flattenObject with Map target', () => {
+    flattenObject(translationLikeData, new Map());
+  });
+});
+
+describe('flattenObject Map conversion - large data', () => {
+  const largeNestedObject = createNestedObject(4, 10); // depth 4, 10 keys per level
+
+  bench('legacy (large): flattenObject + Object.entries + new Map', () => {
+    new Map(Object.entries(flattenObject(largeNestedObject)));
+  });
+
+  bench('new (large): flattenObject with Map target', () => {
+    flattenObject(largeNestedObject, new Map());
+  });
+});
+
+describe('flattenObject Map conversion - very large data', () => {
+  const veryLargeNestedObject = createNestedObject(5, 20); // depth 5, 20 keys per level
+
+  bench('legacy (very large): flattenObject + Object.entries + new Map', () => {
+    new Map(Object.entries(flattenObject(veryLargeNestedObject)));
+  });
+
+  bench('new (very large): flattenObject with Map target', () => {
+    flattenObject(veryLargeNestedObject, new Map());
+  });
+});
+
+describe('flattenObject Map with custom delimiter', () => {
+  bench('legacy: flattenObject with delimiter + Object.entries + new Map', () => {
+    new Map(Object.entries(flattenObject(translationLikeData, { delimiter: '_' })));
+  });
+
+  bench('new: flattenObject with delimiter and Map target', () => {
+    flattenObject(translationLikeData, { delimiter: '_', target: new Map() });
+  });
+});

--- a/docs/ja/reference/object/flattenObject.md
+++ b/docs/ja/reference/object/flattenObject.md
@@ -1,6 +1,6 @@
 # flattenObject
 
-ネストされたオブジェクトを単純なオブジェクトに平坦化します。
+ネストされたオブジェクトを単純なオブジェクトに平坦化するか、Mapに直接変換します。
 
 - `Array`は平坦化されます。
 - `Buffer`や`TypedArray`のような純粋なオブジェクトでないものは平坦化されません。
@@ -8,19 +8,30 @@
 ## インターフェース
 
 ```typescript
-function flattenObject(object: object, { delimiter = '.' }: FlattenObjectOptions = {}): Record<string, any>;
+// Record<string, any>を返す
+function flattenObject(object: object, options?: { delimiter?: string }): Record<string, any>;
+
+// Map<string, any>を返す（レガシー構文）
+function flattenObject(object: object, target: Map<string, any>): Map<string, any>;
+
+// Map<string, any>を返す（区切り文字付き）
+function flattenObject(object: object, options: { delimiter?: string; target: Map<string, any> }): Map<string, any>;
 ```
 
 ### パラメータ
 
 - `object` (`object`): 平坦化するオブジェクト。
-- `delimiter` (`string`): ネストされたキーの区切り文字。デフォルトは `'.'`。
+- `options` (`object`, オプション): オプションオブジェクト。
+  - `delimiter` (`string`): ネストされたキーの区切り文字。デフォルトは `'.'`。
+  - `target` (`Map<string, any>`): 平坦化されたキーと値のペアで満たすMap。
 
 ### 戻り値
 
-(`T`): 平坦化されたオブジェクト。
+(`Record<string, any> | Map<string, any>`): 平坦化されたオブジェクトまたはMap。
 
 ## 例
+
+### 基本的な使用法（Record）
 
 ```typescript
 const nestedObject = {
@@ -42,6 +53,8 @@ console.log(flattened);
 // }
 ```
 
+### カスタム区切り文字（Record）
+
 ```typescript
 const flattened = flattenObject(nestedObject, { delimiter: '/' });
 console.log(flattened);
@@ -51,4 +64,27 @@ console.log(flattened);
 //   'd/0': 2,
 //   'd/1': 3
 // }
+```
+
+### Mapターゲット（レガシー構文）
+
+```typescript
+const map = flattenObject(nestedObject, new Map());
+console.log(map);
+// 出力: Map { 'a.b.c' => 1, 'd.0' => 2, 'd.1' => 3 }
+
+// 値へのアクセス
+console.log(map.get('a.b.c')); // 1
+console.log(map.size); // 3
+```
+
+### Map + カスタム区切り文字
+
+```typescript
+const customMap = flattenObject(nestedObject, {
+  delimiter: '_',
+  target: new Map(),
+});
+console.log(customMap);
+// 出力: Map { 'a_b_c' => 1, 'd_0' => 2, 'd_1' => 3 }
 ```

--- a/docs/ko/reference/object/flattenObject.md
+++ b/docs/ko/reference/object/flattenObject.md
@@ -1,6 +1,6 @@
 # flattenObject
 
-중첩된 객체를 단순한 객체로 평탄화해요.
+중첩된 객체를 단순한 객체로 평탄화하거나 Map으로 직접 변환해요.
 
 - `Array`는 평탄화돼요.
 - 순수 객체가 아닌 `Buffer`나 `TypedArray`는 평탄화되지 않아요.
@@ -8,19 +8,30 @@
 ## 인터페이스
 
 ```typescript
-function flattenObject(object: object, { delimiter = '.' }: FlattenObjectOptions = {}): Record<string, any>;
+// Record<string, any> 반환
+function flattenObject(object: object, options?: { delimiter?: string }): Record<string, any>;
+
+// Map<string, any> 반환 (기존 문법)
+function flattenObject(object: object, target: Map<string, any>): Map<string, any>;
+
+// Map<string, any> 반환 (구분자 포함)
+function flattenObject(object: object, options: { delimiter?: string; target: Map<string, any> }): Map<string, any>;
 ```
 
 ### 파라미터
 
 - `object` (`object`): 평탄화할 객체.
-- `delimiter` (`string`): 중첩된 키의 구분자. 기본값은 `.`.
+- `options` (`object`, 선택): 옵션 객체.
+  - `delimiter` (`string`): 중첩된 키의 구분자. 기본값은 `.`.
+  - `target` (`Map<string, any>`): 평탄화된 키-값 쌍으로 채울 Map.
 
 ### 반환 값
 
-(`T`): 평탄화된 객체.
+(`Record<string, any> | Map<string, any>`): 평탄화된 객체 또는 Map.
 
 ## 예시
+
+### 기본 사용법 (Record)
 
 ```typescript
 const nestedObject = {
@@ -42,6 +53,8 @@ console.log(flattened);
 // }
 ```
 
+### 구분자 지정 (Record)
+
 ```typescript
 const flattened = flattenObject(nestedObject, { delimiter: '/' });
 console.log(flattened);
@@ -51,4 +64,27 @@ console.log(flattened);
 //   'd/0': 2,
 //   'd/1': 3
 // }
+```
+
+### Map 대상 (기존 문법)
+
+```typescript
+const map = flattenObject(nestedObject, new Map());
+console.log(map);
+// Output: Map { 'a.b.c' => 1, 'd.0' => 2, 'd.1' => 3 }
+
+// 값 접근
+console.log(map.get('a.b.c')); // 1
+console.log(map.size); // 3
+```
+
+### Map + 구분자 지정
+
+```typescript
+const customMap = flattenObject(nestedObject, {
+  delimiter: '_',
+  target: new Map(),
+});
+console.log(customMap);
+// Output: Map { 'a_b_c' => 1, 'd_0' => 2, 'd_1' => 3 }
 ```

--- a/docs/reference/object/flattenObject.md
+++ b/docs/reference/object/flattenObject.md
@@ -1,6 +1,6 @@
 # flattenObject
 
-Flattens a nested object into a single-level object with dot-separated keys.
+Flattens a nested object into a single-level object with dot-separated keys or directly into a Map.
 
 - `Array`s are flattened.
 - Non-plain objects, like `Buffer`s or `TypedArray`s, are not flattened.
@@ -8,19 +8,30 @@ Flattens a nested object into a single-level object with dot-separated keys.
 ## Signature
 
 ```typescript
-function flattenObject(object: object, { delimiter = '.' }: FlattenObjectOptions = {}): Record<string, any>;
+// Return Record<string, any>
+function flattenObject(object: object, options?: { delimiter?: string }): Record<string, any>;
+
+// Return Map<string, any> (legacy syntax)
+function flattenObject(object: object, target: Map<string, any>): Map<string, any>;
+
+// Return Map<string, any> (with custom delimiter)
+function flattenObject(object: object, options: { delimiter?: string; target: Map<string, any> }): Map<string, any>;
 ```
 
 ### Parameters
 
 - `object` (`object`): The object to flatten.
-- `delimiter` (`string`): The delimiter to use between nested keys. Defaults to `'.'`.
+- `options` (`object`, optional): The options object.
+  - `delimiter` (`string`): The delimiter to use between nested keys. Defaults to `'.'`.
+  - `target` (`Map<string, any>`): The target Map to populate with flattened key-value pairs.
 
 ### Returns
 
-(`T`): The flattened object.
+(`Record<string, any> | Map<string, any>`): The flattened object or Map.
 
 ## Examples
+
+### Basic Usage (Record)
 
 ```typescript
 const nestedObject = {
@@ -42,6 +53,8 @@ console.log(flattened);
 // }
 ```
 
+### Custom Delimiter (Record)
+
 ```typescript
 const flattened = flattenObject(nestedObject, { delimiter: '/' });
 console.log(flattened);
@@ -51,4 +64,39 @@ console.log(flattened);
 //   'd/0': 2,
 //   'd/1': 3
 // }
+```
+
+### Map Target (Legacy Syntax)
+
+```typescript
+const map = flattenObject(nestedObject, new Map());
+console.log(map);
+// Output: Map { 'a.b.c' => 1, 'd.0' => 2, 'd.1' => 3 }
+
+// Access values
+console.log(map.get('a.b.c')); // 1
+console.log(map.size); // 3
+```
+
+### Map with Custom Delimiter
+
+```typescript
+const customMap = flattenObject(nestedObject, {
+  delimiter: '_',
+  target: new Map(),
+});
+console.log(customMap);
+// Output: Map { 'a_b_c' => 1, 'd_0' => 2, 'd_1' => 3 }
+```
+
+### Performance Comparison
+
+Using Map targets provides better performance compared to converting Records to Maps:
+
+```typescript
+// Slower: Object → Array → Map (3 steps)
+const slowMap = new Map(Object.entries(flattenObject(largeObject)));
+
+// Faster: Object → Map (1 step)
+const fastMap = flattenObject(largeObject, new Map());
 ```

--- a/src/object/flattenObject.spec.ts
+++ b/src/object/flattenObject.spec.ts
@@ -281,4 +281,37 @@ describe('flattenObject', function () {
       });
     });
   });
+
+  describe('Map functionality', () => {
+    it('flattens into a provided Map', () => {
+      const nestedObject = {
+        a: {
+          b: {
+            c: 1,
+          },
+        },
+        d: [2, 3],
+      };
+
+      const map = new Map();
+      const result = flattenObject(nestedObject, map);
+
+      expect(result).toBe(map);
+      expect(map.get('a.b.c')).toBe(1);
+      expect(map.get('d.0')).toBe(2);
+      expect(map.get('d.1')).toBe(3);
+      expect(map.size).toBe(3);
+    });
+
+    it('works with pre-populated Map', () => {
+      const map = new Map([['existing', 'value']]);
+
+      flattenObject({ a: { b: 1 } }, map);
+
+      expect(map.get('existing')).toBe('value');
+      expect(map.get('a.b')).toBe(1);
+      expect(map.size).toBe(2);
+    });
+
+  });
 });

--- a/src/object/flattenObject.spec.ts
+++ b/src/object/flattenObject.spec.ts
@@ -313,5 +313,33 @@ describe('flattenObject', function () {
       expect(map.size).toBe(2);
     });
 
+    it('supports custom delimiter with Map using new syntax', () => {
+      const nestedObject = {
+        a: {
+          b: {
+            c: 1,
+          },
+        },
+        d: [2, 3],
+      };
+
+      const map = new Map();
+      const result = flattenObject(nestedObject, { delimiter: '_', target: map });
+
+      expect(result).toBe(map);
+      expect(map.get('a_b_c')).toBe(1);
+      expect(map.get('d_0')).toBe(2);
+      expect(map.get('d_1')).toBe(3);
+    });
+
+    it('supports custom delimiter with Map using forward slash', () => {
+      const map = flattenObject(
+        { user: { profile: { name: 'John' }, settings: { theme: 'dark' } } },
+        { delimiter: '/', target: new Map() }
+      );
+
+      expect(map.get('user/profile/name')).toBe('John');
+      expect(map.get('user/settings/theme')).toBe('dark');
+    });
   });
 });

--- a/src/object/flattenObject.ts
+++ b/src/object/flattenObject.ts
@@ -8,12 +8,23 @@ interface FlattenObjectOptions {
   delimiter?: string;
 }
 
+interface FlattenObjectMapOptions {
+  /**
+   * The delimiter to use between nested keys.
+   * @default '.'
+   */
+  delimiter?: string;
+  /**
+   * The target Map to populate with flattened key-value pairs.
+   */
+  target: Map<string, any>;
+}
 
 /**
  * Flattens a nested object into a single level object with delimiter-separated keys.
  *
  * @param {object} object - The object to flatten.
- * @param {FlattenObjectOptions | Map<string, any>} [optionsOrTarget] - Options for flattening or target Map.
+ * @param {FlattenObjectOptions | FlattenObjectMapOptions | Map<string, any>} [options] - Options for flattening.
  * @returns {Record<string, any> | Map<string, any>} - The flattened object or Map.
  *
  * @example
@@ -39,17 +50,31 @@ interface FlattenObjectOptions {
  * const map = flattenObject(nestedObject, new Map());
  * console.log(map);
  * // Output: Map { 'a.b.c' => 1, 'd.0' => 2, 'd.1' => 3 }
+ *
+ * // Or flatten into a Map with custom delimiter
+ * const customMap = flattenObject(nestedObject, { delimiter: '_', target: new Map() });
+ * console.log(customMap);
+ * // Output: Map { 'a_b_c' => 1, 'd_0' => 2, 'd_1' => 3 }
  */
 export function flattenObject(
   object: object,
-  optionsOrTarget?: FlattenObjectOptions | Map<string, any>
+  options?: FlattenObjectOptions | FlattenObjectMapOptions | Map<string, any>
 ): Record<string, any> | Map<string, any> {
-  if (optionsOrTarget instanceof Map) {
-    flattenObjectIntoMap(object, optionsOrTarget, '', '.');
-    return optionsOrTarget;
+  // Legacy support: Map as second parameter
+  if (options instanceof Map) {
+    flattenObjectIntoMap(object, options, '', '.');
+    return options;
   }
 
-  const { delimiter = '.' } = optionsOrTarget || {};
+  // New syntax: { delimiter, target }
+  if (options && 'target' in options) {
+    const { delimiter = '.', target } = options;
+    flattenObjectIntoMap(object, target, '', delimiter);
+    return target;
+  }
+
+  // Original syntax: { delimiter }
+  const { delimiter = '.' } = options || {};
   return flattenObjectImpl(object, '', delimiter);
 }
 


### PR DESCRIPTION
# Add Map support to flattenObject function

Fixes #1388

## Summary

This PR adds Map support to the `flattenObject` function as requested in issue #1388, allowing users to flatten objects directly into Map instances for improved performance and cleaner syntax.

However, during implementation, we discovered that simply adding Map support would break the existing delimiter customization feature. To maintain feature parity and ensure users don't lose functionality, we implemented an enhanced solution that supports both Map targets and custom delimiters simultaneously.

## Changes

### 🆕 New Features

1. **Direct Map Support** - Users can now pass a Map as the second parameter
2. **Map + Custom Delimiter** - New syntax for using Maps with custom delimiters
3. **Performance Optimization** - Eliminates intermediate object/array creation

### 🔧 Implementation Details

- Added `FlattenObjectMapOptions` interface for Map-specific options
- Enhanced function signature to support multiple parameter types
- Added `flattenObjectIntoMap` function for direct Map operations
- Maintained full backward compatibility with existing API

## Usage Examples

The `flattenObject` function now supports **4 different usage patterns**:

### 1. Original Object Return (unchanged)
```typescript
const result = flattenObject(nestedObject);
// Returns: { "a.b.c": 1, "d.0": 2, "d.1": 3 }
```

### 2. Object with Custom Delimiter (unchanged)
```typescript
const result = flattenObject(nestedObject, { delimiter: '_' });
// Returns: { "a_b_c": 1, "d_0": 2, "d_1": 3 }
```

### 3. Map Target (new - addresses #1388)
```typescript
const map = flattenObject(nestedObject, new Map());
// Returns: Map { 'a.b.c' => 1, 'd.0' => 2, 'd.1' => 3 }
```

### 4. Map with Custom Delimiter (new - enhancement)
```typescript
const customMap = flattenObject(nestedObject, { 
  delimiter: '_', 
  target: new Map() 
});
// Returns: Map { 'a_b_c' => 1, 'd_0' => 2, 'd_1' => 3 }
```

## Performance Benchmarks

Comprehensive performance testing shows significant improvements:

<img width="1274" height="451" alt="image" src="https://github.com/user-attachments/assets/260f78cf-3c0a-47a9-86ce-db2913c6081e" />


| Test Case | Legacy Method (ops/sec) | New Method (ops/sec) | Performance Gain |
|-----------|-------------------------|---------------------|------------------|
| **Normal Data** | 137,671 | 204,929 | **1.49x faster** |
| **Large Data** | 125 | 716 | **5.7x faster** |
| **Very Large Data** | 0.096 | 0.677 | **7.08x faster** |
| **With Custom Delimiter** | 140,104 | 281,763 | **2.01x faster** |

### Why is it faster?

**Legacy approach (3 steps)**:
```typescript
// 1. Create flattened object
const flattened = flattenObject(contents);
// 2. Convert to entries array  
const entries = Object.entries(flattened);
// 3. Create Map from array
const map = new Map(entries);
```

**New approach (1 step)**:
```typescript
// Direct Map creation
const map = flattenObject(contents, new Map());
```

The new approach eliminates intermediate object and array creation, resulting in significant memory and CPU savings.

## Testing

- ✅ All existing tests pass (17 tests)
- ✅ Added comprehensive Map functionality tests (4 new tests)
- ✅ TypeScript compilation successful
- ✅ Performance benchmarks included
- ✅ Backward compatibility maintained

## Commit History

1. **feat: add Map support to flattenObject function (#1388)** - Core Map functionality
2. **feat: add delimiter support for Map target in flattenObject** - Enhanced delimiter support
3. **test: add performance benchmark for flattenObject Map support** - Performance validation

---

## 한국어 요약

이슈 #1388 요구사항대로 `flattenObject` 함수에 Map 지원 기능을 추가했습니다. 7ac4f06eb566177c44ac9bcf8a64f303be6fd942
그러나 구현 중 기존 delimiter 커스터마이징 기능이 누락되는 문제를 발견하여, Map 지원과 delimiter 지정을 모두 가능하도록 코드를 보완하였습니다. eba49dffabe436e52e738db5f98e3b932ec291fb

**주요 개선사항**:
- ✅ 이슈 요구사항: Map 직접 지원 추가
- 성능 1.5~7배 향상 (데이터 크기에 따라)  
- delimiter 커스터마이징 + Map 동시 사용 가능
- 완전한 하위 호환성 유지
 