### PR TITLE
test(promise/semaphore): add test case for 'release' beyond 'capacity' validation

### DIFF
--- a/src/promise/semaphore.spec.ts
+++ b/src/promise/semaphore.spec.ts
@@ -98,4 +98,16 @@ describe('Semaphore', () => {
     expect(spy1).toHaveBeenCalledTimes(1);
     expect(spy2).not.toHaveBeenCalled();
   });
+
+  it('should not increase available permits beyond capacity when releasing without pending tasks', () => {
+    const semaphore = new Semaphore(2);
+
+    expect(semaphore.available).toBe(2);
+
+    semaphore.release();
+    expect(semaphore.available).toBe(2);
+
+    semaphore.release();
+    expect(semaphore.available).toBe(2);
+  });
 });


### PR DESCRIPTION
## AS-IS

<img width="617" height="106" alt="image" src="https://github.com/user-attachments/assets/72644b4d-bc4d-40cc-b0c0-41ded39e4824" />

## TO-BE

<img width="608" height="106" alt="image" src="https://github.com/user-attachments/assets/dc64ab44-33f3-4447-b589-e2b7905b9dd2" />
