### PR TITLE
test(compat/array/dropRightWhile): add test case for 'identity' function default 'predicate'

### DIFF
--- a/src/compat/array/dropRightWhile.spec.ts
+++ b/src/compat/array/dropRightWhile.spec.ts
@@ -69,6 +69,11 @@ describe('dropRightWhile', () => {
     expect(dropRightWhile(args, i => i > 1)).toEqual([1]);
   });
 
+  it('should use identity function when no predicate is provided', () => {
+    expect(dropRightWhile([1, 2, 0, 3])).toEqual([1, 2, 0]);
+    expect(dropRightWhile(['hello', '', 'world'])).toEqual(['hello', '']);
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(dropRightWhile).toEqualTypeOf<typeof dropRightWhileLodash>();
   });


### PR DESCRIPTION
## AS-IS

<img width="586" height="170" alt="image" src="https://github.com/user-attachments/assets/4c2f700c-b0bc-44a4-86a5-855f6a10e57a" />

## TO-BE

<img width="587" height="154" alt="image" src="https://github.com/user-attachments/assets/a2877fd9-f682-46a3-af4c-066539dafa43" />
