### PR TITLE
docs(set): update type annotations to match implementation

### DIFF
--- a/docs/ja/reference/compat/object/set.md
+++ b/docs/ja/reference/compat/object/set.md
@@ -26,7 +26,7 @@ function set<T extends object>(
 
 ### 戻り値
 
-(`T`): 修正されたオブジェクトを返します。T を指定しない場合は unknown です。
+(`T`): 修正されたオブジェクトを返します。T を指定しない場合は object です。
 
 ## 例
 

--- a/docs/ja/reference/compat/object/set.md
+++ b/docs/ja/reference/compat/object/set.md
@@ -14,7 +14,7 @@
 function set<T extends object>(
   obj: T,
   path: string | number | symbol | Array<string | number | symbol>,
-  value: unknown
+  value: any
 ): T;
 ```
 
@@ -22,7 +22,7 @@ function set<T extends object>(
 
 - `obj` (`T`): 値を設定するオブジェクト。
 - `path` (`string | number | symbol | Array<string | number | symbol>`): 値を設定するプロパティのパス。
-- `value` (`unknown`): 設定する値。
+- `value` (`any`): 設定する値。
 
 ### 戻り値
 

--- a/docs/ko/reference/compat/object/set.md
+++ b/docs/ko/reference/compat/object/set.md
@@ -26,7 +26,7 @@ function set<T extends object>(
 
 ### 반환 값
 
-(`T`): 수정된 객체를 반환해요. T를 지정하지 않으면 unknown이에요.
+(`T`): 수정된 객체를 반환해요. T를 지정하지 않으면 object이에요.
 
 ## 예시
 

--- a/docs/ko/reference/compat/object/set.md
+++ b/docs/ko/reference/compat/object/set.md
@@ -14,7 +14,7 @@
 function set<T extends object>(
   obj: T,
   path: string | number | symbol | Array<string | number | symbol>,
-  value: unknown
+  value: any
 ): T;
 ```
 
@@ -22,7 +22,7 @@ function set<T extends object>(
 
 - `obj` (`T`): 값을 설정할 객체.
 - `path` (`string | number | symbol | Array<string | number | symbol>`): 값을 설정할 프로퍼티 경로.
-- `value` (`unknown`): 설정할 값.
+- `value` (`any`): 설정할 값.
 
 ### 반환 값
 

--- a/docs/reference/compat/object/set.md
+++ b/docs/reference/compat/object/set.md
@@ -14,7 +14,7 @@ Sets the given value at the specified path of the object. If any part of the pat
 function set<T extends object>(
   obj: T,
   path: string | number | symbol | Array<string | number | symbol>,
-  value: unknown
+  value: any
 ): T;
 ```
 
@@ -22,7 +22,7 @@ function set<T extends object>(
 
 - `obj` (`T`): The object to modify.
 - `path` (`string | number | symbol | Array<string | number | symbol>`): The path of the property to set.
-- `value` (`unknown`): The value to set.
+- `value` (`any`): The value to set.
 
 ### Returns
 

--- a/docs/reference/compat/object/set.md
+++ b/docs/reference/compat/object/set.md
@@ -26,7 +26,7 @@ function set<T extends object>(
 
 ### Returns
 
-(`T`): Returns the modified object. If T is not specified, it defaults to unknown.
+(`T`): Returns the modified object. If T is not specified, it defaults to object.
 
 ## Examples
 

--- a/docs/zh_hans/reference/compat/object/set.md
+++ b/docs/zh_hans/reference/compat/object/set.md
@@ -15,7 +15,7 @@
 function set<T extends object>(
   obj: T,
   path: string | number | symbol | Array<string | number | symbol>,
-  value: unknown
+  value: any
 ): T;
 ```
 
@@ -23,7 +23,7 @@ function set<T extends object>(
 
 - `obj` (`T`): 要修改的对象。
 - `path` (`string | number | symbol | Array<string | number | symbol>`): 要设置的属性路径。
-- `value` (`unknown`): 要设置的值。
+- `value` (`any`): 要设置的值。
 
 ### 返回值
 

--- a/docs/zh_hans/reference/compat/object/set.md
+++ b/docs/zh_hans/reference/compat/object/set.md
@@ -27,7 +27,7 @@ function set<T extends object>(
 
 ### 返回值
 
-(`T`): 返回修改后的对象。如果未指定 T，默认值为 unknown。
+(`T`): 返回修改后的对象。如果未指定 T，默认值为 object。
 
 ## 示例
 


### PR DESCRIPTION
# Summary

This PR updates the documentation for the set function to reflect the actual implementation

# Changes

- Changed the value parameter type from `unknown` to `any` for consistency with the implementation and lodash behavior.
- Corrected the return type description: if `T` is not specified, it defaults to `object` instead of `unknown`.



These changes ensure the documentation accurately matches the function’s behavior.