### PR TITLE
docs(remove): Fix incorrect return value description  

### DIFF
--- a/docs/ja/reference/array/remove.md
+++ b/docs/ja/reference/array/remove.md
@@ -18,7 +18,7 @@ function remove<T>(arr: T[], shouldRemoveElement: (value: T, index: number, arra
 
 ### 戻り値
 
-(`T[]`): 指定された要素が削除された修正済み配列です。
+(`T[]`): 削除された要素の配列。
 
 ## 例
 

--- a/docs/ko/reference/array/remove.md
+++ b/docs/ko/reference/array/remove.md
@@ -18,7 +18,7 @@ function remove<T>(arr: T[], shouldRemoveElement: (value: T, index: number, arra
 
 ### 반환 값
 
-(`T[]`): 지정된 요소가 제거된 수정된 배열.
+(`T[]`): 제거된 요소들의 배열.
 
 ## 예시
 

--- a/docs/reference/array/remove.md
+++ b/docs/reference/array/remove.md
@@ -18,7 +18,7 @@ function remove<T>(arr: T[], shouldRemoveElement: (value: T, index: number, arra
 
 ### Returns
 
-(`T[]`): The modified array with the specified elements removed.
+(`T[]`): Array of removed elements.
 
 ## Examples
 

--- a/docs/zh_hans/reference/array/remove.md
+++ b/docs/zh_hans/reference/array/remove.md
@@ -18,7 +18,7 @@ function remove<T>(arr: T[], shouldRemoveElement: (value: T, index: number, arra
 
 ### 返回值
 
-(`T[]`): 削除された要素の配列。
+(`T[]`): 被删除的元素数组。
 
 ## 示例
 

--- a/docs/zh_hans/reference/array/remove.md
+++ b/docs/zh_hans/reference/array/remove.md
@@ -18,7 +18,7 @@ function remove<T>(arr: T[], shouldRemoveElement: (value: T, index: number, arra
 
 ### 返回值
 
-(`T[]`): 移除指定元素后的修改数组。
+(`T[]`): 削除された要素の配列。
 
 ## 示例
 


### PR DESCRIPTION
## Summary  
  
Fixed incorrect return value description in the `remove` function documentation across all languages (English, Korean, Japanese, and Simplified Chinese).  
  
The documentation incorrectly stated that the function returns "the modified array with specified elements removed", when it actually returns "an array of removed elements". The original array is modified in-place, and the return value contains only the elements that were removed.  
  
## Changes  
  
- Updated English docs (`docs/reference/array/remove.md`): Changed return description to `Array of removed elements.`
- Updated Korean docs (`docs/ko/reference/array/remove.md`): Changed return description to `제거된 요소들의 배열.`
- Updated Japanese docs (`docs/ja/reference/array/remove.md`): Changed return description to `削除された要素の配列。` 
- Updated Simplified Chinese docs (`docs/zh_hans/reference/array/remove.md`): Changed return description to `被删除的元素数组。`