### PR TITLE
docs: fix meanBy parameter description

### DIFF
--- a/docs/ja/reference/math/meanBy.md
+++ b/docs/ja/reference/math/meanBy.md
@@ -12,7 +12,7 @@ function meanBy<T>(items: T[], getValue: (item: T) => number): number;
 
 ### パラメータ
 
-- `items` (`T[]`): 平均を計算する数値配列です。
+- `items` (`T[]`): 平均を計算する配列です。
 - `getValue` (`(item: T) => number`): 各要素から数値を選択する関数です。
 
 ### 戻り値

--- a/docs/ko/reference/math/meanBy.md
+++ b/docs/ko/reference/math/meanBy.md
@@ -12,7 +12,7 @@ function meanBy<T>(items: T[], getValue: (item: T) => number): number;
 
 ### 파라미터
 
-- `items` (`T[]`): 평균을 계산할 숫자 배열이에요.
+- `items` (`T[]`): 평균을 계산할 배열이에요.
 - `getValue` (`(item: T) => number`): 각 요소에서 숫자 값을 선택하는 함수예요.
 
 ### 반환 값
@@ -25,3 +25,5 @@ function meanBy<T>(items: T[], getValue: (item: T) => number): number;
 meanBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // 2를 반환해요.
 meanBy([], x => x.a); // NaN을 반환해요.
 ```
+
+d

--- a/docs/ko/reference/math/meanBy.md
+++ b/docs/ko/reference/math/meanBy.md
@@ -25,5 +25,3 @@ function meanBy<T>(items: T[], getValue: (item: T) => number): number;
 meanBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // 2를 반환해요.
 meanBy([], x => x.a); // NaN을 반환해요.
 ```
-
-d


### PR DESCRIPTION
## Summary  
  
Fixed incorrect parameter description in the `meanBy` function documentation for Korean and Japanese languages.  
  
The documentation incorrectly described the `items` parameter as "an array of numbers" when it actually accepts a generic array of type `T[]`. The function extracts numeric values from each element using the `getValue` callback function, so the input array doesn't need to contain numbers directly.  
  
## Changes  
  
- Updated Korean docs (`docs/ko/reference/math/meanBy.md`): Changed parameter description from `평균을 계산할 숫자 배열이에요.` to `평균을 계산할 배열이에요.`  
- Updated Japanese docs (`docs/ja/reference/math/meanBy.md`): Changed parameter description from `平均を計算する数値の配列。` to `平均を計算する配列です。`  
  
## Rationale  
  
The function signature shows `items: T[]`, not `number[]`.
  
The example usage demonstrates this with an object array: `meanBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a)`. 
  
This aligns with similar functions like `sumBy` and `minBy` which also use generic type parameters and don't describe their input as "number arrays".