### PR TITLE
fix(isObjectLike): Add type guard return type  

### DIFF
--- a/src/compat/predicate/isObjectLike.ts
+++ b/src/compat/predicate/isObjectLike.ts
@@ -6,7 +6,7 @@
  * This function can also serve as a type predicate in TypeScript, narrowing the type of the argument to an object-like value.
  *
  * @param {any} value - The value to test if it is an object-like.
- * @returns {boolean} `true` if the value is an object-like, `false` otherwise.
+ * @returns {value is object} `true` if the value is an object-like, `false` otherwise.
  *
  * @example
  * const value1 = { a: 1 };
@@ -22,6 +22,6 @@
  * console.log(isObjectLike(value5)); // false
  */
 
-export function isObjectLike(value?: any): boolean {
+export function isObjectLike(value?: any): value is object {
   return typeof value === 'object' && value !== null;
 }


### PR DESCRIPTION
## Summary  

Fixes #1383   
  
This PR fixes the return type of `isObjectLike` to enable proper TypeScript type guard functionality. Currently, the function returns `boolean`, which prevents it from narrowing types in conditional blocks.  
  
## Changes  
  
- Changed return type from `boolean` to `value is object` in `src/compat/predicate/isObjectLike.ts`
- Updated JSDoc `@returns` annotation to reflect the type guard return type
(The documentation already states that it returns `value is object`)
  
