### PR TITLE
fix: resolve circular import between isMatch and isMatchWith  

### DIFF
--- a/src/compat/predicate/isMatchWith.ts
+++ b/src/compat/predicate/isMatchWith.ts
@@ -1,4 +1,3 @@
-import { isMatch } from './isMatch.ts';
 import { isObject } from './isObject.ts';
 import { isPrimitive } from '../../predicate/isPrimitive.ts';
 import type { IsMatchWithCustomizer } from '../_internal/IsMatchWithCustomizer.ts';
@@ -112,7 +111,7 @@ export function isMatchWith(
   ) => boolean | undefined
 ): boolean {
   if (typeof compare !== 'function') {
-    return isMatch(target, source);
+    return isMatchWith(target, source, () => undefined);
   }
 
   return isMatchWithInternal(


### PR DESCRIPTION
## Summary  
  
Fixes #1392  
  
This PR resolves the circular import issue between `isMatch` and `isMatchWith` functions.  
  
## Changes  
  
- Removed the `import { isMatch }` statement from `src/compat/predicate/isMatchWith.ts`  
- Changed the fallback behavior in `isMatchWith` when no comparator is provided from calling `isMatch(target, source)` to calling `isMatchWith(target, source, () => undefined)`  
- This maintains the same functionality while breaking the circular dependency, as `isMatch` internally calls `isMatchWith` with a no-op comparator  
  
The change is functionally equivalent since `isMatch` simply delegates to `isMatchWith` with a comparator that always returns `undefined`, triggering the default matching behavior.