### PR TITLE
test(object/mergeWith): add test cases for array merge with 'undefined' targetValue and skip overwrite when sourceValue is 'undefined' with 'merge' function returning 'undefined'

### DIFF
--- a/src/object/mergeWith.spec.ts
+++ b/src/object/mergeWith.spec.ts
@@ -89,4 +89,22 @@ describe('mergeWith', () => {
     expect(result).toEqual({ a: 2 });
     expect(result.__proto__).toBe(Object.prototype);
   });
+
+  it('should merge arrays when targetValue is undefined and merge function returns undefined', () => {
+    const target: { a?: number[] } = {};
+    const source = { a: [1, 2, 3] };
+
+    const result = mergeWith(target, source, () => undefined);
+
+    expect(result).toEqual({ a: [1, 2, 3] });
+  });
+
+  it('should not overwrite targetValue when sourceValue is undefined and merge function returns undefined', () => {
+    const target = { a: 1, b: 2 };
+    const source = { a: 3, b: undefined };
+
+    const result = mergeWith(target, source, () => undefined);
+
+    expect(result).toEqual({ a: 3, b: 2 });
+  });
 });


### PR DESCRIPTION
## AS-IS

<img width="596" height="172" alt="image" src="https://github.com/user-attachments/assets/12773d1b-7dc1-4143-8470-b736afae4005" />

## TO-BE

<img width="594" height="171" alt="image" src="https://github.com/user-attachments/assets/d9d24f57-38b0-47af-a27a-3a0f616b877d" />
