### PR TITLE
test(compat/array/partition): add test case for 'identity' function when no 'predicate' is provided

### DIFF
--- a/src/compat/array/partition.spec.ts
+++ b/src/compat/array/partition.spec.ts
@@ -149,6 +149,15 @@ describe('partition', () => {
     expect(partition(args, isEven)).toEqual([[2], [1, 3]]);
   });
 
+  it('should use identity function when no predicate is provided', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(partition([0, 1, 2, false, true, '', 'hello'])).toEqual([
+      [1, 2, true, 'hello'],
+      [0, false, ''],
+    ]);
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(partition).toEqualTypeOf<typeof partitionLodash>();
   });


### PR DESCRIPTION
## AS-IS

<img width="584" height="168" alt="image" src="https://github.com/user-attachments/assets/058145d3-91b6-42a2-bb31-198636f3e199" />

## TO-BE

<img width="589" height="171" alt="image" src="https://github.com/user-attachments/assets/f55a328b-ef74-42d5-af33-6c3d03e27ec2" />
