### PR TITLE
Revise isEmpty function documentation

### DIFF
--- a/src/compat/predicate/isEmpty.ts
+++ b/src/compat/predicate/isEmpty.ts
@@ -24,7 +24,7 @@ export function isEmpty(value?: any): boolean;
  * - If the given value is an array, `Map`, or `Set`, checks if its size is 0.
  * - If the given value is an [array-like object](../predicate/isArrayLike.md), checks if its length is 0.
  * - If the given value is an object, checks if it is an empty object with no properties.
- * - Primitive values (strings, booleans, numbers, or bigints) are considered empty.
+ * - Primitive values (booleans, numbers, or bigints) are considered empty.
  *
  * @param {unknown} [value] - The value to check.
  * @returns {boolean} `true` if the value is empty, `false` otherwise.


### PR DESCRIPTION
Updated documentation to remove 'strings' from the list of primitive values considered empty.
It does align with the actually tests.