### PR TITLE
test(compat/string/truncate): add test case for 'separator' not found in truncated string

### DIFF
--- a/src/compat/string/truncate.spec.ts
+++ b/src/compat/string/truncate.spec.ts
@@ -112,6 +112,10 @@ describe('truncate', () => {
     expect(truncate('¥§✈✉🤓', { length: 4, omission: '…' })).toEqual('¥§✈…');
   });
 
+  it('should return base string with omission when separator is not found in truncated string', () => {
+    expect(truncate('hello world test', { length: 10, separator: 'xyz' })).toEqual('hello w...');
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(truncate).toEqualTypeOf<typeof truncateLodash>();
   });


### PR DESCRIPTION
## AS-IS

<img width="591" height="153" alt="image" src="https://github.com/user-attachments/assets/69eb8e7c-d7d3-4855-8efd-122966227422" />


## TO-BE

<img width="577" height="173" alt="image" src="https://github.com/user-attachments/assets/a36a75f5-b106-4a17-8def-f6ff46cb0259" />