### PR TITLE
docs(mapValues): Improve return value description across all languages 

### DIFF
--- a/docs/ja/reference/object/mapValues.md
+++ b/docs/ja/reference/object/mapValues.md
@@ -2,7 +2,7 @@
 
 値を `getNewValue` 関数が返す値に置き換えた新しいオブジェクトを返します。キーは元のオブジェクトのキーと同じです。
 
-## Signature
+## インターフェース
 
 ```typescript
 function mapValues<T extends object, K extends keyof T, V>(
@@ -11,16 +11,16 @@ function mapValues<T extends object, K extends keyof T, V>(
 ): Record<K, V>;
 ```
 
-### Parameters
+### パラメータ
 
 - `obj` (`T extends object`): 値を置き換えるオブジェクト。
 - `getNewValue`: (`(value: T[K], key: K, object: T) => V`): 新しい値を生成する関数。
 
-### Return Value
+### 戻り値
 
 (`Record<K, V>`): `getNewValue` 関数が返す値に置き換えた新しいオブジェクト。
 
-## Examples
+## 例
 
 ```typescript
 const obj = { a: 1, b: 2 };

--- a/docs/ja/reference/object/mapValues.md
+++ b/docs/ja/reference/object/mapValues.md
@@ -18,7 +18,7 @@ function mapValues<T extends object, K extends keyof T, V>(
 
 ### Return Value
 
-(`Record<K, V>`): 新しくマッピングされたオブジェクト。
+(`Record<K, V>`): `getNewValue` 関数が返す値に置き換えた新しいオブジェクト。
 
 ## Examples
 

--- a/docs/ko/reference/object/mapValues.md
+++ b/docs/ko/reference/object/mapValues.md
@@ -18,7 +18,7 @@ function mapValues<T extends object, K extends keyof T, V>(
 
 ### 반환 값
 
-(`Record<K, V>`): The new mapped object.
+(`Record<K, V>`): `getNewValue` 함수가 반환한 값으로 바꾼 새로운 객체
 
 ## 예시
 

--- a/docs/ko/reference/object/mapValues.md
+++ b/docs/ko/reference/object/mapValues.md
@@ -2,7 +2,7 @@
 
 값을 `getNewValue` 함수가 반환한 값으로 바꾼 새로운 객체를 반환해요. 키는 원래 객체의 키와 동일해요.
 
-## Signature
+## 인터페이스
 
 ```typescript
 function mapValues<T extends object, K extends keyof T, V>(

--- a/docs/reference/object/mapValues.md
+++ b/docs/reference/object/mapValues.md
@@ -19,7 +19,7 @@ function mapValues<T extends object, K extends keyof T, V>(
 
 ### Returns
 
-(`Record<K, V>`): The new mapped object.
+(`Record<K, V>`): A new object with values transformed by the `getNewValue` function.
 
 ## Examples
 

--- a/docs/zh_hans/reference/object/mapValues.md
+++ b/docs/zh_hans/reference/object/mapValues.md
@@ -18,7 +18,7 @@ function mapValues<T extends object, K extends keyof T, V>(
 
 ### 返回值
 
-(`Record<K, V>`): 新映射的对象。
+(`Record<K, V>`): 由 `getNewValue` 函数返回的值转换后的新对象。
 
 ## 示例
 


### PR DESCRIPTION
## Summary  
  
This PR improves the return value description for the `mapValues` function across all language documentation (English, Korean, Japanese, and Simplified Chinese). The Korean documentation previously had the return value description in English, and all language versions now provide more specific descriptions that explicitly mention the `getNewValue` function.  
  
## Changes  
  
- Updated Korean documentation to use Korean language for the return value description  
- Enhanced all language versions to explicitly reference the `getNewValue` function in the return value description  
- Made descriptions more specific and clear about how values are transformed  
  