### PR TITLE
fix(curry, curryRight): Remove unnecessary type assertions 

### DIFF
--- a/src/function/curry.ts
+++ b/src/function/curry.ts
@@ -163,7 +163,7 @@ export function curry(func: (...args: any[]) => any): (...args: any[]) => any {
 
   return function (arg: any) {
     return makeCurry(func, func.length, [arg]);
-  } as any;
+  };
 }
 
 function makeCurry<F extends (...args: any) => any>(origin: F, argsLength: number, args: any[]) {
@@ -174,6 +174,6 @@ function makeCurry<F extends (...args: any) => any>(origin: F, argsLength: numbe
       return makeCurry(origin, argsLength, [...args, arg]);
     };
 
-    return next as any;
+    return next;
   }
 }

--- a/src/function/curryRight.ts
+++ b/src/function/curryRight.ts
@@ -172,7 +172,7 @@ export function curryRight(func: (...args: any[]) => any): (...args: any[]) => a
 
   return function (arg: any) {
     return makeCurryRight(func, func.length, [arg]);
-  } as any;
+  };
 }
 
 function makeCurryRight<F extends (...args: any) => any>(origin: F, argsLength: number, args: any[]) {
@@ -182,6 +182,6 @@ function makeCurryRight<F extends (...args: any) => any>(origin: F, argsLength: 
     const next = function (arg: Parameters<F>[0]) {
       return makeCurryRight(origin, argsLength, [arg, ...args]);
     };
-    return next as any;
+    return next;
   }
 }


### PR DESCRIPTION
## Summary

This PR removes the unnecessary "as any" type assertion from the `curry` and `curryRight` functions in the core module. Since function overloading already provides adequate type safety for external APIs, I believe the type assertion is unnecessary.
  
## Changes  
  
- Removed `as any` type assertion from `curry` function implementation  
- Removed `as any` type assertion from `curryRight` function implementation  
- Removed `as any` type assertion from internal `makeCurry` helper function in both files  
  
The type overloads defined for these functions ensure that TypeScript correctly infers the return types based on the number of parameters. Since the internal implementation returns functions compatible with `(...args: any[]) => any`, the type assertions are redundant and can be safely removed.  
  
## Comment

I think the as any type assertion is unnecessary, but if there's something I'm missing, please let me know!