### PR TITLE
perf(meanBy): reduce meanBy computation by removing intermediate array creation

### DIFF
--- a/src/math/meanBy.ts
+++ b/src/math/meanBy.ts
@@ -1,4 +1,4 @@
-import { mean } from './mean.ts';
+import { sumBy } from './sumBy';
 
 /**
  * Calculates the average of an array of numbers when applying
@@ -16,7 +16,5 @@ import { mean } from './mean.ts';
  * meanBy([], x => x.a); // Returns: NaN
  */
 export function meanBy<T>(items: readonly T[], getValue: (element: T) => number): number {
-  const nums = items.map(x => getValue(x));
-
-  return mean(nums);
+  return sumBy(items, item => getValue(item)) / items.length;
 }


### PR DESCRIPTION
<img width="908" height="466" alt="image" src="https://github.com/user-attachments/assets/ab9c3017-3d2e-482a-bf1d-f61e32712dd6" />

Replaced items.map(getValue) + mean() with sumBy(items, getValue) / items.length
to remove unnecessary array creation and reduce iteration overhead.

This change improves performance and memory efficiency without altering behavior.