### PR TITLE
feat(partition): Type guard support

### DIFF
--- a/src/array/partition.spec.ts
+++ b/src/array/partition.spec.ts
@@ -45,7 +45,7 @@ describe('partition', () => {
     expect(evens).toEqual([2, 4]);
     expect(odds).toEqual([1, 3, 5]);
 
-    expectTypeOf(evens).toEqualTypeOf<Array<1 | 2 | 3 | 4 | 5>>();
+    expectTypeOf(evens).toEqualTypeOf<Array<2 | 4>>();
     expectTypeOf(odds).toEqualTypeOf<Array<1 | 3 | 5>>();
   });
 });

--- a/src/array/partition.ts
+++ b/src/array/partition.ts
@@ -11,20 +11,20 @@
  * @param {(value: T) => value is U} isInTruthy - A type guard that determines whether an
  * element should be placed in the truthy array. The function is called with each element
  * of the array.
- * @returns {[U[], T[]]} A tuple containing two arrays: the first array contains elements for
+ * @returns {[U[], Exclude<T, U>[]]} A tuple containing two arrays: the first array contains elements for
  * which the predicate returned true, and the second array contains elements for which the
  * predicate returned false.
  *
  * @example
  * const array = [1, 2, 3, 4] as const;
  * const isEven = (x: number): x is 2 | 4 => x % 2 === 0;
- * const [even, odd]: [(2 | 4)[], (1 | 2 | 3 | 4)[]] = partition(array, isEven);
+ * const [even, odd]: [(2 | 4)[], (2 | 4)[]] = partition(array, isEven);
  * // even will be [2, 4], and odd will be [1, 3]
  */
 export function partition<T, U extends T>(
   arr: readonly T[],
   isInTruthy: (value: T) => value is U
-): [truthy: U[], falsy: T[]];
+): [truthy: U[], falsy: Array<Exclude<T, U>>];
 
 /**
  * Splits an array into two groups based on a predicate function.


### PR DESCRIPTION
## Summary

This adds a function overload to `partition` to support type guards, narrowing the type of the output truthy and falsy arrays.

## Changes

* Adds JSDoc and type signature for `partition` where `isInTruthy` is a type guard
* Adds a `partition` test case using a type guard with a type assertion on the narrowed output arrays
