### PR TITLE
fix(groupBy): Use more accurate return type

### DIFF
--- a/src/array/groupBy.ts
+++ b/src/array/groupBy.ts
@@ -9,7 +9,7 @@
  * @template K - The type of keys.
  * @param {T[]} arr - The array to group.
  * @param {(item: T) => K} getKeyFromItem - A function that generates a key from an element.
- * @returns {Record<K, T[]>} An object where each key is associated with an array of elements that
+ * @returns {Partial<Record<K, [T, ...T[]]>>} An object where each key is associated with an array of elements that
  * share that key.
  *
  * @example
@@ -30,18 +30,22 @@
  * //   ]
  * // }
  */
-export function groupBy<T, K extends PropertyKey>(arr: readonly T[], getKeyFromItem: (item: T) => K): Record<K, T[]> {
-  const result = {} as Record<K, T[]>;
+export function groupBy<T, K extends PropertyKey>(
+  arr: readonly T[],
+  getKeyFromItem: (item: T) => K
+): Partial<Record<K, [T, ...T[]]>> {
+  const result = {} as Partial<Record<K, [T, ...T[]]>>;
 
   for (let i = 0; i < arr.length; i++) {
     const item = arr[i];
     const key = getKeyFromItem(item);
 
     if (!Object.hasOwn(result, key)) {
+      // @ts-expect-error - first item is added below
       result[key] = [];
     }
 
-    result[key].push(item);
+    result[key]!.push(item);
   }
 
   return result;

--- a/src/compat/array/groupBy.ts
+++ b/src/compat/array/groupBy.ts
@@ -89,5 +89,6 @@ export function groupBy<T, K extends PropertyKey>(
   const items = isArrayLike(source) ? Array.from(source) : Object.values(source);
   const getKeyFromItem = createIteratee(_getKeyFromItem ?? identity);
 
+  // @ts-expect-error - lodash types assume all keys exist in result
   return groupByToolkit<T, K>(items, getKeyFromItem);
 }


### PR DESCRIPTION
## Summary

Updates the return type of `groupBy` to reflect that properties need not exist in the output but that if they do, their value has at least length 1. It prevents users from having to suppress unnecessary condition warnings when trying to safely access properties in `groupBy` results.

## Changes

* Wraps `groupBy` return type with `Partial`
* Changes values in `groupBy` return type from `T[]` to `[T, ...T[]]`

## Comments

The compat function is still using `Record` type here instead of `Partial<Record>`