### PR TITLE
fix(omit): add overload to support runtime-determined key arrays

### DIFF
--- a/docs/ja/reference/object/omit.md
+++ b/docs/ja/reference/object/omit.md
@@ -24,7 +24,7 @@ const result = omit(obj, ['b', 'c']);
 const safe = omit(obj, ['b', 'nonexistent']);
 // safeは{ a: 1, c: 3, d: 4 }になります
 
-// 動的な文字列配列も使用できます
+// 動的な配列も使用できます
 const keysToOmit = Object.keys({ b: true, c: true });
 const dynamic = omit(obj, keysToOmit);
 // dynamicは{ a: 1, d: 4 }になります
@@ -32,11 +32,11 @@ const dynamic = omit(obj, keysToOmit);
 
 #### パラメータ
 
-- `obj` (`T extends Record<string, any>`): キーを除外するオブジェクトです。
-- `keys` (`readonly K[]` または `readonly string[]`): オブジェクトから除外するキーの配列です。
+- `obj` (`T extends Record<PropertyKey, any>`): キーを除外するオブジェクトです。
+- `keys` (`readonly K[]` (`K extends keyof T`) または `readonly PropertyKey[]`): オブジェクトから除外するキーの配列です。
 
 #### 戻り値
 
 - `Omit<T, K>` または `Partial<T>` - 指定されたキーが除外された新しいオブジェクトを返します。
   - `keys`が `readonly K[]` の場合: `Omit<T, K>` でより厳密な型が返されます。
-  - `keys`が `readonly string[]` の場合: `Partial<T>` が返されます。
+  - `keys`が `readonly PropertyKey[]` の場合: `Partial<T>` が返されます。ランタイムで決定される動的なキー配列に便利です。

--- a/docs/ko/reference/object/omit.md
+++ b/docs/ko/reference/object/omit.md
@@ -24,7 +24,7 @@ const result = omit(obj, ['b', 'c']);
 const safe = omit(obj, ['b', 'nonexistent']);
 // safe는 { a: 1, c: 3, d: 4 }가 돼요
 
-// 동적 문자열 배열도 사용할 수 있어요
+// 동적 배열도 사용할 수 있어요
 const keysToOmit = Object.keys({ b: true, c: true });
 const dynamic = omit(obj, keysToOmit);
 // dynamic은 { a: 1, d: 4 }가 돼요
@@ -32,11 +32,11 @@ const dynamic = omit(obj, keysToOmit);
 
 #### 파라미터
 
-- `obj` (`T extends Record<string, any>`): 키를 제외할 객체예요.
-- `keys` (`readonly K[]` 또는 `readonly string[]`): 객체에서 제외할 키들의 배열이에요.
+- `obj` (`T extends Record<PropertyKey, any>`): 키를 제외할 객체예요.
+- `keys` (`readonly K[]` (`K extends keyof T`) 또는 `readonly PropertyKey[]`): 객체에서 제외할 키들의 배열이에요.
 
 #### 반환 값
 
 - `Omit<T, K>` 또는 `Partial<T>` - 지정된 키들이 제외된 새로운 객체를 반환해요.
   - `keys`가 `readonly K[]` 인 경우: `Omit<T, K>` 로 좀 더 엄격한 타입이 반환돼요.
-  - `keys`가 `readonly string[]` 인 경우: `Partial<T>` 로 반환돼요.
+  - `keys`가 `readonly PropertyKey[]` 인 경우: `Partial<T>` 로 반환돼요. 런타임에 결정되는 동적 키 배열에 유용해요.

--- a/docs/reference/object/omit.md
+++ b/docs/reference/object/omit.md
@@ -24,7 +24,7 @@ const result = omit(obj, ['b', 'c']);
 const safe = omit(obj, ['b', 'nonexistent']);
 // safe is { a: 1, c: 3, d: 4 }
 
-// Works with dynamic string arrays
+// Works with dynamic arrays
 const keysToOmit = Object.keys({ b: true, c: true });
 const dynamic = omit(obj, keysToOmit);
 // dynamic is { a: 1, d: 4 }
@@ -32,11 +32,11 @@ const dynamic = omit(obj, keysToOmit);
 
 #### Parameters
 
-- `obj` (`T extends Record<string, any>`): The object to exclude keys from.
-- `keys` (`readonly K[]` or `readonly string[]`): An array of keys to exclude from the object.
+- `obj` (`T extends Record<PropertyKey, any>`): The object to exclude keys from.
+- `keys` (`readonly K[]` (`K extends keyof T`) or `readonly PropertyKey[]`): An array of keys to exclude from the object.
 
 #### Returns
 
 - `Omit<T, K>` or `Partial<T>` - A new object with the specified keys excluded.
   - When `keys` is `readonly K[]`: Returns `Omit<T, K>` with stricter typing.
-  - When `keys` is `readonly string[]`: Returns `Partial<T>`.
+  - When `keys` is `readonly PropertyKey[]`: Returns `Partial<T>`. Useful for dynamic key arrays determined at runtime.

--- a/docs/zh_hans/reference/object/omit.md
+++ b/docs/zh_hans/reference/object/omit.md
@@ -24,7 +24,7 @@ const result = omit(obj, ['b', 'c']);
 const safe = omit(obj, ['b', 'nonexistent']);
 // safe 是 { a: 1, c: 3, d: 4 }
 
-// 也可以使用动态字符串数组
+// 也可以使用动态键数组
 const keysToOmit = Object.keys({ b: true, c: true });
 const dynamic = omit(obj, keysToOmit);
 // dynamic 是 { a: 1, d: 4 }
@@ -32,11 +32,11 @@ const dynamic = omit(obj, keysToOmit);
 
 #### 参数
 
-- `obj` (`T extends Record<string, any>`):要排除键的对象。
-- `keys` (`readonly K[]` 或 `readonly string[]`):要从对象中排除的键的数组。
+- `obj` (`T extends Record<PropertyKey, any>`):要排除键的对象。
+- `keys` (`readonly K[]` (`K extends keyof T`) 或 `readonly PropertyKey[]`):要从对象中排除的键的数组。
 
 #### 返回值
 
 - `Omit<T, K>` 或 `Partial<T>` - 返回排除了指定键的新对象。
   - 当 `keys` 为 `readonly K[]` 时: 返回 `Omit<T, K>`,类型更严格。
-  - 当 `keys` 为 `readonly string[]` 时: 返回 `Partial<T>`。
+  - 当 `keys` 为 `readonly PropertyKey[]` 时: 返回 `Partial<T>`。对于在运行时确定的动态键数组很有用。

--- a/src/object/omit.ts
+++ b/src/object/omit.ts
@@ -15,27 +15,27 @@
  * const result = omit(obj, ['b', 'c']);
  * // result will be { a: 1 }
  */
-export function omit<T extends Record<string, any>, K extends keyof T>(obj: T, keys: readonly K[]): Omit<T, K>;
+export function omit<T extends Record<PropertyKey, any>, K extends keyof T>(obj: T, keys: readonly K[]): Omit<T, K>;
 
 /**
  * Creates a new object with specified keys omitted.
  *
- * This overload allows passing a string array without strict type checking,
- * useful when working with dynamic key lists.
+ * This overload supports dynamic key arrays determined at runtime,
+ * useful when working with keys from Object.keys() or similar operations.
  *
  * @template T - The type of object.
  * @param {T} obj - The object to omit keys from.
- * @param {string[]} keys - An array of keys to be omitted from the object.
+ * @param {PropertyKey[]} keys - An array of keys to be omitted from the object. Supports dynamic arrays.
  * @returns {Partial<T>} A new object with the specified keys omitted.
  *
  * @example
  * const obj = { a: 1, b: 2, c: 3 };
- * const keysToOmit = ['b', 'c']; // string[]
+ * const keysToOmit = Object.keys({ b: true, c: true }); // string[]
  * const result = omit(obj, keysToOmit);
  * // result will be { a: 1 }
  */
-export function omit<T extends Record<string, any>>(obj: T, keys: readonly string[]): Partial<T>;
-export function omit<T extends Record<string, any>>(obj: T, keys: readonly string[]): Partial<T> {
+export function omit<T extends Record<PropertyKey, any>>(obj: T, keys: readonly PropertyKey[]): Partial<T>;
+export function omit<T extends Record<PropertyKey, any>>(obj: T, keys: readonly PropertyKey[]): Partial<T> {
   const result = { ...obj };
 
   for (let i = 0; i < keys.length; i++) {


### PR DESCRIPTION
This pull request enhances the `omit` utility function to support dynamic arrays of string keys, making it more flexible when omitting keys from objects. It also updates the documentation in English, Japanese, Korean, and Simplified Chinese to reflect this new overload and clarify the return types based on the input.

**Core functionality improvements:**

* Added an overload to the `omit` function in `omit.ts` that accepts a `readonly string[]` as keys, returning a `Partial<T>` for cases where keys are not strictly typed, such as when using dynamic key lists.

**Documentation updates:**

* Updated the English documentation (`omit.md`) to describe the new overload, show usage with dynamic string arrays, and clarify the difference in return types (`Omit<T, K>` vs `Partial<T>`).
* Updated the Japanese documentation to include dynamic key usage and explain the stricter vs looser return types.
* Updated the Korean documentation to include dynamic key usage and clarify return types.
* Updated the Simplified Chinese documentation to show dynamic key usage and explain the return type differences.