### PR TITLE
test(compat/array/intersectionBy): add test case for invalid iteratee type handling

### DIFF
--- a/src/compat/array/intersectionBy.spec.ts
+++ b/src/compat/array/intersectionBy.spec.ts
@@ -139,6 +139,14 @@ describe('intersectionBy', () => {
     ]);
   });
 
+  it('should handle non-function, non-string, non-array iteratee', () => {
+    const array1 = [1, 2, 3];
+    const array2 = [2, 3, 4];
+
+    const actual = intersectionBy(array1, array2, 123);
+    expect(actual).toEqual([1, 2, 3]);
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(intersectionBy).toEqualTypeOf<typeof intersectionByLodash>();
   });


### PR DESCRIPTION
## AS-IS

<img width="595" height="155" alt="image" src="https://github.com/user-attachments/assets/0c4ef7e1-1464-46e9-8a29-30f6bf4fac5b" />

## TO-BE

<img width="620" height="156" alt="image" src="https://github.com/user-attachments/assets/5597bf47-c050-457f-89ee-86908c212a01" />
