### PR TITLE
test(compat/mergeWith): add missing test cases for edge cases and improve coverage to 100%

### DIFF
--- a/src/compat/object/mergeWith.spec.ts
+++ b/src/compat/object/mergeWith.spec.ts
@@ -161,8 +161,12 @@ describe('mergeWith', () => {
   });
 
   it('should prevent prototype pollution by skipping __proto__ from source', () => {
-    const result = mergeWith({ a: 0, ['__proto__']: 0 }, { a: 1, ['__proto__']: 1 }, noop);
-    expect(result).toEqual({ a: 1, ['__proto__']: 0 });
+    const result = mergeWith(
+      { a: 0, ['__proto__']: { polluted: 'no' } },
+      { a: 1, ['__proto__']: { polluted: 'yes' } },
+      noop
+    );
+    expect(result).toEqual({ a: 1, ['__proto__']: { polluted: 'no' } });
   });
 
   it('should handle circular references in source object', () => {


### PR DESCRIPTION
## Summary  
  
This PR improves test coverage for `compat/mergeWith` function in the compat module from 85.41% to 100% by adding comprehensive test cases for previously uncovered edge cases.  
  
## Changes  
  
- Added test for prototype pollution prevention (`__proto__` handling)  
- Added test for circular reference handling in source objects  
- Added test for Arguments objects in both source and target  
- Added test for Buffer object cloning  
- Added test for TypedArray cloning  
- Added test for handling undefined values in both target and source  

## Impacts
| Before | After |
|:------:|:-----:|
|  <img width="774" height="472" alt="스크린샷 2025-11-15 오후 1 40 42" src="https://github.com/user-attachments/assets/f3b0dd41-00f1-4c65-98eb-d19a16b49384" />|  <img width="806" height="555" alt="스크린샷 2025-11-15 오후 1 39 51" src="https://github.com/user-attachments/assets/7fcd99ec-0481-41c4-a98e-a89a7f0e68fb" />|
