### PR TITLE
test(compat/unset): add comprehensive prototype pollution tests

### DIFF
--- a/src/compat/object/unset.spec.ts
+++ b/src/compat/object/unset.spec.ts
@@ -171,4 +171,14 @@ describe('unset', () => {
     expect(unset({ ['__proto__']: {} }, '__proto__')).toBe(false);
     expect(unset({ ['__proto__']: {} }, ['__proto__'])).toBe(false);
   });
+
+  it('should not be polluted in compat/unset', () => {
+    unset({}, '__proto__.toString');
+    expect({}.toString).not.toBeUndefined();
+
+    const object = { a: 1 };
+    expect(unset(object, '__proto__')).toBe(false);
+    expect(unset(object, { toString: () => '__proto__' } as any)).toBe(false);
+    expect(unset(object, ['a', '__proto__'])).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary  
  
This PR adds comprehensive test coverage for `__proto__` property handling in the `unset` function to verify prototype pollution prevention mechanisms work correctly.  
  
## Changes  
  
- **Added prototype pollution prevention test**: Verifies that `unset` returns `false` when attempting to delete `__proto__` property via both string and array path formats  

## Impacts

| Before | After |
|:------:|:-----:|
| <img width="748" height="447" alt="스크린샷 2025-11-15 오후 6 52 16" src="https://github.com/user-attachments/assets/e7acba3d-275e-4a24-bc5e-07ee753e1458" />|   <img width="755" height="454" alt="스크린샷 2025-11-15 오후 6 51 14" src="https://github.com/user-attachments/assets/4f0eb078-aea2-476a-bc07-d01137e8024e" />|

## Comment

if there's something I'm missing, please let me know!