### PR TITLE
test(compat/get): add prototype pollution tests and undefined value handling test  

### DIFF
--- a/src/compat/object/get.spec.ts
+++ b/src/compat/object/get.spec.ts
@@ -153,4 +153,15 @@ describe('get', () => {
   it('should match the type of lodash', () => {
     expectTypeOf(get<unknown>).toEqualTypeOf<typeof getLodash<unknown>>();
   });
+
+  it('should prevent prototype pollution by returning defaultValue for __proto__ access', () => {
+    expect(get({ ['__proto__']: {} }, '__proto__', 'defaultValue')).toBe('defaultValue');
+    expect(get({ ['__proto__']: {} }, ['__proto__'], 'defaultValue')).toBe('defaultValue');
+    expect(get({ ['__proto__']: {} }, { toString: () => '__proto__' } as any, 'defaultValue')).toBe('defaultValue');
+  });
+
+  it('should return defaultValue when property value is undefined', () => {
+    const object = { '-0': undefined };
+    expect(get(object, Object(-0), 'defaultValue')).toBe('defaultValue');
+  });
 });


### PR DESCRIPTION
## Summary  
  
This PR adds comprehensive test coverage for the `get` function in the compat module to verify prototype pollution prevention mechanisms and proper handling of edge cases with undefined values.  
  
## Changes  
  
- **Added prototype pollution prevention test**: Verifies that `get` returns `defaultValue` when attempting to access `__proto__` property:  
  - String path (`'__proto__'`)  
  - Array path (`['__proto__']`)  
  - Objects with custom `toString()` methods returning `'__proto__'`  
  
- **Added undefined value handling test**: Validates that `get` correctly returns `defaultValue` when accessing a property that exists but has an `undefined` value

## Impacts

| Before | After |
|:------:|:-----:|
| <img width="759" height="574" alt="스크린샷 2025-11-15 오후 7 29 29" src="https://github.com/user-attachments/assets/6be82d04-7bc1-4a7d-8f19-6e7b54778c53" />| <img width="768" height="600" alt="스크린샷 2025-11-15 오후 7 28 26" src="https://github.com/user-attachments/assets/1f3b098a-fe72-423d-a6a8-20843f8824f2" />|

## Comment

if there's something I'm missing, please let me know!