### PR TITLE
chore(eslint.config): enable 'vitest.typecheck' to recognize 'expectTypeOf' in tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,14 @@ export default defineConfig(
   {
     files: ['**/*.spec.ts*'],
     plugins: { vitest },
+    settings: { vitest: { typecheck: true } },
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {
       ...vitest.configs.recommended.rules,
       'vitest/no-commented-out-tests': 'warn',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src", ".scripts/**/*"],
+  "include": ["src", ".scripts/**/*", "**/*.spec.ts"],
   "exclude": [".scripts/docs/**/*"]
 }


### PR DESCRIPTION
## Summary

- Add `settings: { vitest: { typecheck: true } }` to vitest ESLint config to properly recognize `expectTypeOf` as a valid assertion
- Configure `parserOptions.project` for `**/*.spec.ts*` files to support type-aware linting
- Update `tsconfig.json` to include `**/*.spec.ts` files for ESLint type checking

## Impact

- Reduce `vitest/expect-expect` warnings from **285 to 1** by properly recognizing `expectTypeOf` as a valid assertion
- Improve linting accuracy for type-checking tests

## Changes

### `eslint.config.mjs`
- Add `settings: { vitest: { typecheck: true } }` to spec files configuration
- Add `languageOptions.parserOptions.project` for `**/*.spec.ts*` files to enable type-aware linting rules

### `tsconfig.json`
- Add `**/*.spec.ts` to `include` array to ensure all spec files (including those in `tests/` and `benchmarks/`) are covered by TypeScript compiler for ESLint type checking

## Screenshot

### AS-IS

<img width="754" height="160" alt="image" src="https://github.com/user-attachments/assets/0483da41-c73b-4107-832f-0a94fda4393e" />

### TO-BE

<img width="743" height="159" alt="image" src="https://github.com/user-attachments/assets/ee58593f-f2f5-4966-830b-8a95c01ecddb" />