### PR TITLE
fix(merge, mergeWith): Handle top-level type mismatch consistently

### DIFF
--- a/src/object/merge.spec.ts
+++ b/src/object/merge.spec.ts
@@ -118,4 +118,12 @@ describe('merge', () => {
     expect(result).toEqual({ a: 2 });
     expect(result.__proto__).toBe(Object.prototype);
   });
+
+  it('should handle top-level type mismatch consistently with nested behavior', () => {
+    const topLevelResult = merge(['1'] as any, { a: 2 });
+    const nestedResult = merge({ x: ['1'] }, { x: { a: 2 } } as any);
+
+    expect(topLevelResult).toEqual({ a: 2 });
+    expect(nestedResult.x).toEqual({ a: 2 });
+  });
 });

--- a/src/object/merge.ts
+++ b/src/object/merge.ts
@@ -45,6 +45,16 @@ export function merge<T extends Record<PropertyKey, any>, S extends Record<Prope
   target: T,
   source: S
 ): T & S {
+  if (Array.isArray(source)) {
+    if (!Array.isArray(target)) {
+      return merge([] as unknown as T, source);
+    }
+  } else if (isPlainObject(source)) {
+    if (!isPlainObject(target)) {
+      return merge({} as unknown as T, source);
+    }
+  }
+
   const sourceKeys = Object.keys(source) as Array<keyof S>;
 
   for (let i = 0; i < sourceKeys.length; i++) {

--- a/src/object/mergeWith.spec.ts
+++ b/src/object/mergeWith.spec.ts
@@ -125,4 +125,12 @@ describe('mergeWith', () => {
 
     expect(result).toEqual({ a: { b: { x: 1 }, c: { y: 2 }, d: { z: 3 } } });
   });
+
+  it('should handle top-level type mismatch consistently with nested behavior', () => {
+    const topLevelResult = mergeWith(['1'] as any, { a: 2 }, () => undefined);
+    const nestedResult = mergeWith({ x: ['1'] }, { x: { a: 2 } } as any, () => undefined);
+
+    expect(topLevelResult).toEqual({ a: 2 });
+    expect(nestedResult.x).toEqual({ a: 2 });
+  });
 });

--- a/src/object/mergeWith.ts
+++ b/src/object/mergeWith.ts
@@ -54,6 +54,16 @@ export function mergeWith<T extends Record<PropertyKey, any>, S extends Record<P
   source: S,
   merge: (targetValue: any, sourceValue: any, key: string, target: T, source: S) => any
 ): T & S {
+  if (Array.isArray(source)) {
+    if (!Array.isArray(target)) {
+      return mergeWith([] as unknown as T, source, merge);
+    }
+  } else if (isPlainObject(source)) {
+    if (!isPlainObject(target)) {
+      return mergeWith({} as unknown as T, source, merge);
+    }
+  }
+
   const sourceKeys = Object.keys(source) as Array<keyof T>;
 
   for (let i = 0; i < sourceKeys.length; i++) {


### PR DESCRIPTION
## Summary
Fixes #1394

`merge` and `mergeWith` now handle top-level type mismatches consistently with nested property behavior.

### Before  
```typescript
merge(["1"], {a: 2})             // [ '1', a: 2 ]
merge({x: ["1"]}, {x: {a: 2}}).x // { a: 2 }
// Inconsistent behavior
```

### After  
```typescript
merge(["1"], {a: 2})             // { a: 2 }
merge({x: ["1"]}, {x: {a: 2}}).x // { a: 2 }
// Consistent behavior - source type wins
```

## Changes
- Added top-level type checking in merge and mergeWith to match nested property logic from
PR #556
- Added test cases for top-level type mismatch scenarios