### PR TITLE
test: improve test assertions and remove 'vitest/expect-expect', 'vitest/valid-title' from ESLint warn rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,10 +54,8 @@ export default defineConfig(
     rules: {
       ...vitest.configs.recommended.rules,
       'vitest/no-commented-out-tests': 'warn',
-      'vitest/expect-expect': 'warn',
       'vitest/valid-expect': 'warn',
       'vitest/no-identical-title': 'warn',
-      'vitest/valid-title': 'warn',
     },
   },
   prettier,

--- a/src/compat/array/some.spec.ts
+++ b/src/compat/array/some.spec.ts
@@ -37,7 +37,7 @@ describe('some', () => {
         count++;
         return value;
       })
-    );
+    ).toBe(true);
 
     expect(count).toBe(2);
   });

--- a/src/compat/function/attempt.spec.ts
+++ b/src/compat/function/attempt.spec.ts
@@ -66,7 +66,7 @@ describe('attempt', () => {
     const actual = attempt(() => {
       throw new CustomError('x');
     });
-    expect(actual instanceof CustomError);
+    expect(actual instanceof CustomError).toBe(true);
   });
 
   it('should match the type of lodash', () => {

--- a/src/compat/function/bind.spec.ts
+++ b/src/compat/function/bind.spec.ts
@@ -37,19 +37,19 @@ describe('bind', () => {
     const bound = bind(fn, null);
     const actual = bound('a');
 
-    expect(actual[0] === null);
+    expect(actual[0]).toBe(null);
     expect(actual[1]).toBe('a');
 
     const bound2 = bind(fn, undefined);
     const actual2 = bound2('b');
 
-    expect(actual2[0] === undefined);
+    expect(actual2[0]).toBe(undefined);
     expect(actual2[1]).toBe('b');
 
     const bound3 = (bind as any)(fn);
     const actual3 = bound3('b');
 
-    expect(actual3[0] === undefined);
+    expect(actual3[0]).toBe(undefined);
     expect(actual3[1]).toBe('b');
   });
 
@@ -100,7 +100,7 @@ describe('bind', () => {
 
     expect(bound().a).toBe(1);
     expect(newBound.a).toBe(undefined);
-    expect(newBound instanceof Foo);
+    expect(newBound instanceof Foo).toBe(true);
   });
 
   it('should handle a number of arguments when called with the `new` operator', () => {
@@ -135,7 +135,7 @@ describe('bind', () => {
     const bound = (bind as any)(Foo) as any;
     const object = {};
 
-    expect(new bound() instanceof Foo);
+    expect(new bound() instanceof Foo).toBe(true);
     expect(new bound(true)).toBe(object);
   });
 

--- a/src/compat/function/curry.spec.ts
+++ b/src/compat/function/curry.spec.ts
@@ -90,7 +90,7 @@ describe('curry', () => {
     const object = {};
 
     // @ts-expect-error - curried is a constructor
-    expect(new curried(false) instanceof Foo);
+    expect(new curried(false) instanceof Foo).toBe(true);
 
     // @ts-expect-error - curried is a constructor
     expect(new curried(true)).toBe(object);

--- a/src/compat/function/curryRight.spec.ts
+++ b/src/compat/function/curryRight.spec.ts
@@ -88,7 +88,7 @@ describe('curryRight', () => {
     const object = {};
 
     // @ts-expect-error - curried is a constructor
-    expect(new curried(false) instanceof Foo);
+    expect(new curried(false) instanceof Foo).toBe(true);
 
     // @ts-expect-error - curried is a constructor
     expect(new curried(true)).toBe(object);

--- a/src/compat/function/debounce.spec.ts
+++ b/src/compat/function/debounce.spec.ts
@@ -439,8 +439,7 @@ describe('debounce', () => {
   const methodName = 'debounce';
 
   it(`\`_.${methodName}\` should not error for non-object \`options\` values`, () => {
-    func(noop, 32, 1 as any);
-    expect(true);
+    expect(() => func(noop, 32, 1 as any)).not.toThrow();
   });
 
   it(`\`_.${methodName}\` should use a default \`wait\` of \`0\``, async () => {

--- a/src/compat/function/defer.spec.ts
+++ b/src/compat/function/defer.spec.ts
@@ -31,7 +31,7 @@ describe('defer', () => {
     clearTimeout(timerId);
 
     setTimeout(() => {
-      expect(pass);
+      expect(pass).toBe(true);
       done();
     }, 32);
   });

--- a/src/compat/function/throttle.spec.ts
+++ b/src/compat/function/throttle.spec.ts
@@ -211,8 +211,7 @@ describe('throttle', () => {
   const methodName = 'throttle';
 
   it(`\`_.${methodName}\` should not error for non-object \`options\` values`, () => {
-    func(noop, 32, 1 as any);
-    expect(true);
+    expect(() => func(noop, 32, 1 as any)).not.toThrow();
   });
 
   it(`\`_.${methodName}\` should use a default \`wait\` of \`0\``, async () => {

--- a/src/compat/math/random.spec.ts
+++ b/src/compat/math/random.spec.ts
@@ -56,9 +56,9 @@ describe('random', () => {
         const result = random(min, max);
         return result >= min && result <= max;
       })
-    ).toBeTruthy();
+    ).toBe(true);
 
-    expect(array.some(() => random(Number.MAX_SAFE_INTEGER)));
+    expect(array.some(() => random(Number.MAX_SAFE_INTEGER))).toBe(true);
   });
 
   it('should coerce arguments to finite numbers', () => {

--- a/src/compat/object/cloneDeepWith.spec.ts
+++ b/src/compat/object/cloneDeepWith.spec.ts
@@ -75,7 +75,7 @@ describe('cloneDeepWith', function () {
       actual = last(arguments);
     });
 
-    expect(actual instanceof Map);
+    expect(actual instanceof Map).toBe(true);
   });
 
   const methodName = 'cloneDeepWith';

--- a/src/compat/object/create.spec.ts
+++ b/src/compat/object/create.spec.ts
@@ -24,8 +24,8 @@ describe('create', () => {
 
     const actual = new Circle();
 
-    expect(actual instanceof Circle);
-    expect(actual instanceof Shape);
+    expect(actual instanceof Circle).toBe(true);
+    expect(actual instanceof Shape).toBe(true);
     expect(Circle.prototype).not.toBe(Shape.prototype);
     // assert.notStrictEqual(Circle.prototype, Shape.prototype);
   });
@@ -37,8 +37,8 @@ describe('create', () => {
 
     const actual = new Circle();
 
-    expect(actual instanceof Circle);
-    expect(actual instanceof Shape);
+    expect(actual instanceof Circle).toBe(true);
+    expect(actual instanceof Shape).toBe(true);
     expect(Object.keys(Circle.prototype)).toEqual(properties);
     properties.forEach(property => {
       expect(Circle.prototype[property]).toBe(expected[property]);
@@ -75,7 +75,7 @@ describe('create', () => {
     const actual = map(falsey, (prototype, index) => (index ? create(prototype) : create()));
 
     actual.forEach(value => {
-      expect(isObject(value));
+      expect(isObject(value)).toBe(true);
     });
   });
 
@@ -84,7 +84,7 @@ describe('create', () => {
     const actual = map(primitives, (value, index) => (index ? create(value) : create()));
 
     actual.forEach(value => {
-      expect(isObject(value));
+      expect(isObject(value)).toBe(true);
     });
   });
 

--- a/src/compat/object/forInRight.spec.ts
+++ b/src/compat/object/forInRight.spec.ts
@@ -15,6 +15,8 @@ describe('forInRight', () => {
     forInRight(new Foo(), (_, key) => {
       keys.push(key);
     });
+
+    expect(keys).toEqual(['b', 'a']);
   });
 
   it('returns `null` if `object` is `null`', () => {

--- a/src/compat/object/merge.spec.ts
+++ b/src/compat/object/merge.spec.ts
@@ -280,7 +280,7 @@ describe('merge', () => {
     // @ts-ignore
     let actual = merge(new Foo(), object);
 
-    expect(actual instanceof Foo);
+    expect(actual instanceof Foo).toBe(true);
     // eslint-disable-next-line
     // @ts-ignore
     expect(actual).toEqual(new Foo(object));
@@ -288,7 +288,7 @@ describe('merge', () => {
     // eslint-disable-next-line
     // @ts-ignore
     actual = merge([new Foo()], [object]);
-    expect(actual[0] instanceof Foo);
+    expect(actual[0] instanceof Foo).toBe(true);
     // eslint-disable-next-line
     // @ts-ignore
     expect(actual).toEqual([new Foo(object)]);

--- a/src/compat/object/set.spec.ts
+++ b/src/compat/object/set.spec.ts
@@ -254,7 +254,7 @@ describe('set', () => {
       });
 
       set(object, 'a', updater);
-      expect(pass);
+      expect(pass).toBe(true);
     });
   });
 

--- a/src/compat/object/setWith.spec.ts
+++ b/src/compat/object/setWith.spec.ts
@@ -187,7 +187,7 @@ describe('setWith', () => {
       });
 
       update(object, 'a', updater);
-      expect(pass);
+      expect(pass).toBe(true);
     });
   });
 

--- a/src/compat/object/transform.spec.ts
+++ b/src/compat/object/transform.spec.ts
@@ -116,7 +116,7 @@ describe('transform', () => {
     forEach([[], {}], accumulator => {
       const actual = map(values, value => transform(value, noop, accumulator));
 
-      expect(every(actual, result => result === accumulator));
+      expect(every(actual, result => result === accumulator)).toBe(true);
 
       // @ts-expect-error - Just for testing
       expect(transform(null, null, accumulator)).toBe(accumulator);
@@ -133,7 +133,7 @@ describe('transform', () => {
 
   it('should work without an `iteratee`', () => {
     // @ts-expect-error - Just for testing
-    expect(transform(new Foo()) instanceof Foo);
+    expect(transform(new Foo()) instanceof Foo).toBe(true);
   });
 
   it('should ensure `object` is an object before using its `[[Prototype]]`', () => {

--- a/src/compat/object/update.spec.ts
+++ b/src/compat/object/update.spec.ts
@@ -175,7 +175,7 @@ describe('update', () => {
       });
 
       update(object, 'a', updater);
-      expect(pass);
+      expect(pass).toBe(true);
     });
   });
 

--- a/src/compat/object/updateWith.spec.ts
+++ b/src/compat/object/updateWith.spec.ts
@@ -182,7 +182,7 @@ describe('updateWith', () => {
       });
 
       updateWith(object, 'a', updater, noop);
-      expect(pass);
+      expect(pass).toBe(true);
     });
   });
 

--- a/src/compat/string/template.spec.ts
+++ b/src/compat/string/template.spec.ts
@@ -308,7 +308,7 @@ describe('template', () => {
     );
 
     const data = { a: 'A' };
-    expect(compiled(data), '\'a\').toBe("A"');
+    expect(compiled(data)).toBe('\'a\',"A"');
   });
 
   it('should work with templates containing newlines and comments', () => {
@@ -416,11 +416,8 @@ describe('template', () => {
   });
 
   it('should not error for non-object `data` and `options` values', () => {
-    template('')(1 as any);
-    expect(true, '`data` value');
-
-    template('', 1 as any)(1 as any);
-    expect(true, '`options` value');
+    expect(() => template('')(1 as any)).not.toThrow();
+    expect(() => template('', 1 as any)(1 as any)).not.toThrow();
   });
 
   it('should expose the source on compiled templates', () => {

--- a/src/compat/string/truncate.spec.ts
+++ b/src/compat/string/truncate.spec.ts
@@ -9,7 +9,7 @@ describe('truncate', () => {
   const string = 'hi-diddly-ho there, neighborino';
 
   it('should use a default `length` of `30`', () => {
-    expect(truncate(string), 'hi-diddly-ho there).toBe(neighbo...');
+    expect(truncate(string)).toBe('hi-diddly-ho there, neighbo...');
   });
 
   it('should not truncate if `string` is <= `length`', () => {
@@ -18,7 +18,7 @@ describe('truncate', () => {
   });
 
   it('should truncate string the given length', () => {
-    expect(truncate(string, { length: 24 }), 'hi-diddly-ho there).toBe(n...');
+    expect(truncate(string, { length: 24 })).toBe('hi-diddly-ho there, n...');
   });
 
   it('should support a `omission` option', () => {
@@ -28,7 +28,7 @@ describe('truncate', () => {
   it('should coerce nullish `omission` values to strings', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
-    expect(truncate(string, { omission: null }), 'hi-diddly-ho there).toBe(neighbnull');
+    expect(truncate(string, { omission: null })).toBe('hi-diddly-ho there, neighbnull');
     expect(truncate(string, { omission: undefined })).toBe('hi-diddly-ho there, nundefined');
   });
 

--- a/src/compat/util/now.spec.ts
+++ b/src/compat/util/now.spec.ts
@@ -12,7 +12,7 @@ describe('now', () => {
 
     await delay(32);
 
-    expect(now() > actual);
+    expect(now()).toBeGreaterThan(actual);
   });
 
   it('should match the type of lodash', () => {

--- a/src/object/clone.spec.ts
+++ b/src/object/clone.spec.ts
@@ -176,7 +176,7 @@ describe('clone', () => {
     expect(clonedDataView).toBeInstanceOf(DataView);
   });
 
-  it('should clone File', () => {
+  it('should clone File', async () => {
     if (typeof File === 'undefined') {
       return;
     }
@@ -190,10 +190,10 @@ describe('clone', () => {
 
     expect(clonedFile.size).toBe(file.size);
     expect(clonedFile.type).toBe(file.type);
-    expect(clonedFile.text()).resolves.toBe('Hello');
+    await expect(clonedFile.text()).resolves.toBe('Hello');
   });
 
-  it('should clone Blob', () => {
+  it('should clone Blob', async () => {
     const blob = new Blob(['Hello'], { type: 'text/plain' });
     const clonedBlob = clone(blob);
 
@@ -203,7 +203,7 @@ describe('clone', () => {
 
     expect(clonedBlob.size).toBe(blob.size);
     expect(clonedBlob.type).toBe(blob.type);
-    expect(clonedBlob.text()).resolves.toBe('Hello');
+    await expect(clonedBlob.text()).resolves.toBe('Hello');
   });
 
   it('should clone Error', () => {

--- a/src/promise/withTimeout.spec.ts
+++ b/src/promise/withTimeout.spec.ts
@@ -13,6 +13,6 @@ describe('withTimeout', () => {
   });
 
   it('returns a reason if a response is received after the specified wait time', () => {
-    expect(withTimeout(() => delay(1000), 50)).rejects.toThrow('The operation was timed out');
+    return expect(withTimeout(() => delay(1000), 50)).rejects.toThrow('The operation was timed out');
   });
 });


### PR DESCRIPTION
## Summary

This PR improves test assertions by replacing inefficient patterns with proper Vitest matchers and removes unused ESLint rules.

## Changes

### Test Assertion Improvements

1. **Replace comparison patterns with direct matchers**
   - `expect(value === null).toBe(true)` → `expect(value).toBe(null)`
   - `expect(value === undefined).toBe(true)` → `expect(value).toBe(undefined)`
   - `expect(value > other).toBe(true)` → `expect(value).toBeGreaterThan(other)`

2. **Replace meaningless expects with proper error testing**
   - `expect(true).toBe(true)` → `expect(() => fn()).not.toThrow()`

3. **Replace verbose truthy checks**
   - `expect(result).toBeTruthy()` → `expect(result).toBe(true)` (where boolean is expected)

4. **Add missing assertion**
   - Add assertion to `forInRight` test that was missing expect statement

### ESLint Configuration

- Remove `vitest/expect-expect` rule (0 warnings)
- Remove `vitest/valid-title` rule (0 warnings)

## Test Results

- ✅ All 480 test files passed
- ✅ 4019 tests passed (2 skipped)
- ✅ 0 failures

## Files Modified

- 23 test files improved
- 1 ESLint configuration updated

## Screenshot

### AS-IS

<img width="738" height="158" alt="image" src="https://github.com/user-attachments/assets/6e6f7e28-f624-4291-a065-1a30d4a3306c" />

### TO-BE

<img width="742" height="157" alt="image" src="https://github.com/user-attachments/assets/146ba0b7-9b85-4556-95de-2062c774a67d" />
