### PR TITLE
fix(throttle, debounce): Fix throttle with `edges: ['trailing']` behaving like debounce

### DIFF
--- a/src/function/throttle.spec.ts
+++ b/src/function/throttle.spec.ts
@@ -166,4 +166,54 @@ describe('throttle', () => {
     await delay(throttleMs + 1);
     expect(capturedMsg).toBe('hello world');
   });
+
+  it('should invoke function periodically with trailing edge only', async () => {
+    const callback = vi.fn();
+    const throttleMs = 50;
+    const throttled = throttle(callback, throttleMs, { edges: ['trailing'] });
+
+    throttled();
+    expect(callback).toHaveBeenCalledTimes(0);
+
+    await delay(throttleMs + 1);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    throttled();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    await delay(throttleMs + 1);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('should invoke function periodically during continuous calls with trailing edge only', async () => {
+    const callback = vi.fn();
+    const throttleMs = 50;
+    const throttled = throttle(callback, throttleMs, { edges: ['trailing'] });
+
+    const intervalId = setInterval(() => {
+      throttled();
+    }, 10);
+
+    await delay(throttleMs * 3 + 10);
+    clearInterval(intervalId);
+
+    expect(callback.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should invoke function periodically with leading edge only', async () => {
+    const callback = vi.fn();
+    const throttleMs = 50;
+    const throttled = throttle(callback, throttleMs, { edges: ['leading'] });
+
+    throttled();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    await delay(throttleMs / 2);
+    throttled();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    await delay(throttleMs / 2 + 1);
+    throttled();
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/function/throttle.ts
+++ b/src/function/throttle.ts
@@ -53,25 +53,9 @@ export function throttle<F extends (...args: any[]) => void>(
   throttleMs: number,
   { signal, edges = ['leading', 'trailing'] }: ThrottleOptions = {}
 ): ThrottledFunction<F> {
-  let pendingAt: number | null = null;
-
-  const debounced = debounce(func, throttleMs, { signal, edges });
-
-  const throttled = function (this: any, ...args: Parameters<F>) {
-    if (pendingAt == null) {
-      pendingAt = Date.now();
-    } else {
-      if (Date.now() - pendingAt >= throttleMs) {
-        pendingAt = Date.now();
-        debounced.cancel();
-      }
-    }
-
-    debounced.apply(this, args);
-  };
-
-  throttled.cancel = debounced.cancel;
-  throttled.flush = debounced.flush;
-
-  return throttled;
+  return debounce(func, throttleMs, {
+    signal,
+    edges,
+    maxWait: throttleMs,
+  });
 }


### PR DESCRIPTION
## Summary
- Fix #1212
- `throttle` with `{ edges: ['trailing'] }` was behaving like `debounce` (only firing once at the end)

## Problem
The original `throttle` implementation tried to enforce periodic execution by calling `debounced.cancel()` after `throttleMs`, but `cancel()` only cancels without executing. This caused continuous calls to never fire.

## Solution
Added `maxWait` option to `debounce` to enforce periodic execution, then simplified `throttle` to use `debounce` with `maxWait: throttleMs`.

## Implementation Considerations
There were two possible approaches:

| Approach | Pros | Cons |
|----------|------|------|
| **1. Add `maxWait` to `debounce`** (chosen) | Simple `throttle` implementation, no code duplication | Extends `debounce` public API |
| **2. Implement `throttle` independently** | No `debounce` API change | Code duplication, separate logic to maintain |

I chose approach 1 because:
- `throttle = debounce + maxWait` is a common pattern (lodash does this)
- Avoids duplicating timer/invocation logic
- `maxWait` is a useful option for `debounce` users as well

**However**, I'd like maintainer feedback on whether `maxWait` should be:
- A public API option (current implementation)
- An internal-only option (e.g., `_maxWait`)

## Changes
- `src/function/debounce.ts`: Added `maxWait` option to `DebounceOptions`
- `src/function/throttle.ts`: Simplified to use `debounce` with `maxWait`
- `src/function/throttle.spec.ts`: Added test cases for `edges` options

## Test plan
- [x] New tests for `edges: ['trailing']` and `edges: ['leading']` options