### PR TITLE
test(compat/{negate,add,set}): fix duplicate test titles and enable 'vitest/no-identical-title' error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,7 +55,6 @@ export default defineConfig(
       ...vitest.configs.recommended.rules,
       'vitest/no-commented-out-tests': 'warn',
       'vitest/valid-expect': 'warn',
-      'vitest/no-identical-title': 'warn',
     },
   },
   prettier,

--- a/src/compat/function/negate.spec.ts
+++ b/src/compat/function/negate.spec.ts
@@ -15,13 +15,6 @@ describe('negate', () => {
     expect(negateFn(2)).toBe(false);
   });
 
-  it('should create a function that negates the result of `func`', () => {
-    const negateFn = negate(isEven);
-
-    expect(negateFn(1)).toBe(true);
-    expect(negateFn(2)).toBe(false);
-  });
-
   it('should create a function that accepts multiple arguments', () => {
     let argCount: any;
     const count = 5;

--- a/src/compat/math/add.spec.ts
+++ b/src/compat/math/add.spec.ts
@@ -21,15 +21,15 @@ describe('add', () => {
     expect(add('x', 'y')).toBe('xy');
   });
 
-  it('should return the sum of two valid numbers', () => {
+  it('should return the sum of two positive numbers', () => {
     expect(add(2, 3)).toBe(5);
   });
 
-  it('should return the sum of two valid numbers', () => {
+  it('should return the sum of two negative numbers', () => {
     expect(add(-1, -5)).toBe(-6);
   });
 
-  it('should return the sum of two valid numbers', () => {
+  it('should return the sum of a negative and a positive number', () => {
     expect(add(-2, 3)).toBe(1);
   });
 

--- a/src/compat/object/set.spec.ts
+++ b/src/compat/object/set.spec.ts
@@ -30,7 +30,7 @@ describe('set', () => {
     expect(result).toEqual({ a: { b: 1 } });
   });
 
-  it('should set a value on an object with nested path', () => {
+  it('should set a value on an object with deeply nested path', () => {
     const result = set<{ a: { b: { c: { d: number } } } }>({} as { a: { b: { c: { d: number } } } }, 'a.b.c.d', 1);
     expect(result).toEqual({ a: { b: { c: { d: 1 } } } });
   });
@@ -44,18 +44,19 @@ describe('set', () => {
     expect(result[0]).toEqual(1);
   });
 
-  it('should set a value on an array with nested path', () => {
+  it('should set a value on an array with nested path of depth 2', () => {
     const result = set<number[][]>([] as number[][], '0.0', 1);
     expect(result).toEqual([[1]]);
     expect(result[0][0]).toEqual(1);
   });
 
-  it('should set a value on an array with nested path', () => {
+  it('should set a value on an array with nested path of depth 3', () => {
     const result = set<number[][][]>([], '0.0.0', 1);
     expect(result).toEqual([[[1]]]);
     expect(result[0][0][0]).toEqual(1);
   });
-  it('should set a value on an array with nested path', () => {
+
+  it('should set a value on an existing array at a specific index', () => {
     const arr = [1, 2, 3];
     set(arr, 1, 4);
     expect(arr).toEqual([1, 4, 3]);
@@ -65,25 +66,25 @@ describe('set', () => {
   //--------------------------------------------------------------------------------
   // object and array
   //--------------------------------------------------------------------------------
-  it('should set a value on an object and array', () => {
+  it('should set a value on an array containing an object', () => {
     const result = set<Array<{ a: number }>>([] as Array<{ a: number }>, '0.a', 1);
     expect(result).toEqual([{ a: 1 }]);
     expect(result[0].a).toEqual(1);
   });
 
-  it('should set a value on an object and array', () => {
+  it('should set a value on an object containing an array', () => {
     const result = set<{ a: number[] }>({} as { a: number[] }, 'a.0', 1);
     expect(result).toEqual({ a: [1] });
     expect(result.a[0]).toEqual(1);
   });
 
-  it('should set a value on an object and array', () => {
+  it('should set a value on an object containing nested arrays', () => {
     const result = set<{ a: number[][] }>({} as { a: number[][] }, 'a.0.0', 1);
     expect(result).toEqual({ a: [[1]] });
     expect(result.a[0][0]).toEqual(1);
   });
 
-  it('should set a value on an object and array', () => {
+  it('should set a value on an object containing deeply nested arrays with bracket notation', () => {
     const result = set<{ a: number[][][] }>({} as { a: number[][][] }, 'a[0][0][0]', 1);
     expect(result).toEqual({ a: [[[1]]] });
     expect(result.a[0][0][0]).toEqual(1);


### PR DESCRIPTION
## Summary
- Remove duplicate test cases in `negate.spec.ts`
- Rename duplicate test titles in `add.spec.ts` and `set.spec.ts` to be more specific
- Enable `vitest/no-identical-title` as error (remove from warn override)

## Changes
- `negate.spec.ts`: Remove duplicated test case
- `add.spec.ts`: Differentiate test titles for positive, negative, and mixed number cases
- `set.spec.ts`: Differentiate test titles for nested path depths and object/array combinations
- `eslint.config.mjs`: Remove `vitest/no-identical-title` from warn rules (defaults to error)

## Screenshot

### AS-IS

<img width="746" height="155" alt="image" src="https://github.com/user-attachments/assets/efe66d16-21a9-4a10-8028-6cb5d2007e46" />

### TO-BE

<img width="740" height="154" alt="image" src="https://github.com/user-attachments/assets/5e8066b7-5a8c-4981-9315-5b88230ed885" />
