### PR TITLE
fix(compat/merge): use isArrayLikeObject to match lodash merge behavior

### DIFF
--- a/src/compat/object/merge.spec.ts
+++ b/src/compat/object/merge.spec.ts
@@ -370,6 +370,14 @@ describe('merge', () => {
     expect(actual).toEqual({ a: ['x', 'y', 'z'] });
   });
 
+  it('should not preserve object properties when nested object is replaced by array', () => {
+    const actual = merge({ x: { a: 2 } }, { x: ['1'] });
+
+    expect(actual.x).toEqual(['1']);
+    expect(Object.keys(actual.x)).toEqual(['0']);
+    expect((actual.x as any).a).toBeUndefined();
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(merge).toEqualTypeOf<typeof mergeLodash>();
   });

--- a/src/compat/object/mergeWith.spec.ts
+++ b/src/compat/object/mergeWith.spec.ts
@@ -228,4 +228,12 @@ describe('mergeWith', () => {
     result = mergeWith({ a: 1 }, { a: undefined }, noop);
     expect(result.a).toBe(1);
   });
+
+  it('should not preserve object properties when nested object is replaced by array', () => {
+    const actual = mergeWith({ x: { a: 2 } }, { x: ['1'] }, noop);
+
+    expect(actual.x).toEqual(['1']);
+    expect(Object.keys(actual.x)).toEqual(['0']);
+    expect((actual.x as any).a).toBeUndefined();
+  });
 });

--- a/src/compat/object/mergeWith.ts
+++ b/src/compat/object/mergeWith.ts
@@ -4,6 +4,7 @@ import { clone } from '../../object/clone.ts';
 import { isPrimitive } from '../../predicate/isPrimitive.ts';
 import { getSymbols } from '../_internal/getSymbols.ts';
 import { isArguments } from '../predicate/isArguments.ts';
+import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 import { isObjectLike } from '../predicate/isObjectLike.ts';
 import { isPlainObject } from '../predicate/isPlainObject.ts';
 import { isTypedArray } from '../predicate/isTypedArray.ts';
@@ -292,13 +293,23 @@ function mergeWithDeep(
     }
 
     if (Array.isArray(sourceValue)) {
-      if (typeof targetValue === 'object' && targetValue != null) {
+      if (Array.isArray(targetValue)) {
         const cloned: any = [];
+        // for custom properties on arrays
         const targetKeys = Reflect.ownKeys(targetValue);
 
         for (let i = 0; i < targetKeys.length; i++) {
-          const targetKey = targetKeys[i];
+          const targetKey = targetKeys[i] as keyof typeof targetValue;
           cloned[targetKey] = targetValue[targetKey];
+        }
+
+        targetValue = cloned;
+      } else if (isArrayLikeObject(targetValue)) {
+        // array-like object: only copy numeric indices
+        const cloned: any = [];
+
+        for (let i = 0; i < targetValue.length; i++) {
+          cloned[i] = targetValue[i];
         }
 
         targetValue = cloned;


### PR DESCRIPTION
## PR Description

### Problem

es-toolkit/compat's merge() produces different results than Lodash when a nested object property is replaced by an array from the source.

```ts
import _ from 'lodash';
import { merge } from 'es-toolkit/compat';

// Lodash
_.merge({ x: { a: 2 } }, { x: ['1'] }).x    // => ['1']

// es-toolkit/compat (before fix)
merge({ x: { a: 2 } }, { x: ['1'] }).x      // => ['1', a: 2] ❌
```


###  Root Cause

In mergeWith.ts, when source is an array, the code treated all objects the same - copying every property to the new array:

```ts
// Before (Bug)
if (Array.isArray(sourceValue)) {
  if (typeof targetValue === 'object' && targetValue != null) {
    // Copies ALL keys from any object to array ❌
    const targetKeys = Reflect.ownKeys(targetValue);
    for (...) { cloned[targetKey] = targetValue[targetKey]; }
  }
}
```

Lodash (_baseMergeDeep.js lines 53-70) distinguishes three cases
using isArrayLikeObject:

```ts
// Lodash _baseMergeDeep.js
if (isArr || isBuff || isTyped) {
  if (isArray(objValue)) {
    newValue = objValue;              // Array: keep as-is
  } else if (isArrayLikeObject(objValue)) {
    newValue = copyArray(objValue);   // ArrayLikeObject: copy 
numeric indices only
  } else if (isBuff) {
    isCommon = false;
    newValue = cloneBuffer(srcValue, true);
  } else if (isTyped) {
    isCommon = false;
    newValue = cloneTypedArray(srcValue, true);
  } else {
    newValue = [];                    // Plain object: empty array
  }
}
```


### Solution

Use isArrayLikeObject to match Lodash's logic:

```ts
if (Array.isArray(sourceValue)) {
  if (Array.isArray(targetValue)) {
    // Array: copy all keys (preserves custom properties)
    const cloned: any = [];
    const targetKeys = Reflect.ownKeys(targetValue);
    for (...) { cloned[targetKey] = targetValue[targetKey]; }
    targetValue = cloned;
  } else if (isArrayLikeObject(targetValue)) {
    // ArrayLikeObject: copy numeric indices only
    const cloned: any = [];
    for (let i = 0; i < targetValue.length; i++) {
      cloned[i] = targetValue[i];
    }
    targetValue = cloned;
  } else {
    // Plain object: empty array
    targetValue = [];
  }
}
```

### Test

Added test cases in merge.spec.ts and mergeWith.spec.ts:

```ts
it('should not preserve object properties when nested object is 
replaced by array', () => {
  const actual = merge({ x: { a: 2 } }, { x: ['1'] });

  expect(actual.x).toEqual(['1']);
  expect(Object.keys(actual.x)).toEqual(['0']);
  expect((actual.x as any).a).toBeUndefined();
});
```
