### PR TITLE
fix(compat/merge): match lodash behavior for Date values

### DIFF
--- a/src/compat/object/merge.spec.ts
+++ b/src/compat/object/merge.spec.ts
@@ -9,6 +9,19 @@ import { isArguments } from '../predicate/isArguments';
 import { stubTrue } from '../util/stubTrue';
 
 describe('merge', () => {
+  it('should replace `source1` Date with `source2` Date instead of deep merging', () => {
+    const source1 = { a: 1, b: { x: 1, y: 2 }, c: new Date('2025-01-01') };
+    const source2 = { b: { y: 3, z: 4 }, c: new Date('2000-01-01') };
+
+    const actual = merge({}, source1, source2);
+
+    expect(actual).toEqual({
+      a: 1,
+      b: { x: 1, y: 3, z: 4 },
+      c: new Date('2000-01-01'),
+    });
+  });
+
   it('should merge `source` into `object`', () => {
     const names = {
       characters: [{ name: 'barney' }, { name: 'fred' }],

--- a/src/compat/object/mergeWith.spec.ts
+++ b/src/compat/object/mergeWith.spec.ts
@@ -7,6 +7,19 @@ import { identity } from '../../function/identity';
 import { noop } from '../../function/noop';
 
 describe('mergeWith', () => {
+  it('should replace `source1` Date with `source2` Date instead of deep merging', () => {
+    const source1 = { a: 1, b: { x: 1, y: 2 }, c: new Date('2025-01-01') };
+    const source2 = { b: { y: 3, z: 4 }, c: new Date('2000-01-01') };
+
+    const actual = mergeWith({}, source1, source2, noop);
+
+    expect(actual).toEqual({
+      a: 1,
+      b: { x: 1, y: 3, z: 4 },
+      c: new Date('2000-01-01'),
+    });
+  });
+
   it('should handle merging when `customizer` returns `undefined`', () => {
     let actual: any = mergeWith({ a: { b: [1, 1] } }, { a: { b: [0] } }, noop);
     expect(actual).toEqual({ a: { b: [0, 1] } });

--- a/src/compat/object/mergeWith.ts
+++ b/src/compat/object/mergeWith.ts
@@ -313,7 +313,14 @@ function mergeWithDeep(
       target[key] = merged;
     } else if (Array.isArray(sourceValue)) {
       target[key] = mergeWithDeep(targetValue, sourceValue, merge, stack);
-    } else if (isObjectLike(targetValue) && isObjectLike(sourceValue)) {
+    } else if (
+      isObjectLike(targetValue) &&
+      isObjectLike(sourceValue) &&
+      (isPlainObject(targetValue) ||
+        isPlainObject(sourceValue) ||
+        isTypedArray(targetValue) ||
+        isTypedArray(sourceValue))
+    ) {
       target[key] = mergeWithDeep(targetValue, sourceValue, merge, stack);
     } else if (targetValue == null && isPlainObject(sourceValue)) {
       target[key] = mergeWithDeep({}, sourceValue, merge, stack);


### PR DESCRIPTION
# PR Description

Fixes #1547 


`es-toolkit/compat`'s `merge()` produces different results than `lodash-es/merge` when merging objects that contain `Date` values.

Given the reproduction from [#1547](https://github.com/toss/es-toolkit/issues/1547):

```
import { merge as esMerge } from 'es-toolkit/compat';
import { merge as ldMerge } from 'lodash-es';

const target = { a: 1, b: { x: 1, y: 2 }, c: new Date('2025-01-01') };
const source = { b: { y: 3, z: 4 }, c: new Date('2000-01-01') };

const resultEs = esMerge({}, target, source);
const resultLd = ldMerge({}, target, source);

console.log('es-toolkit/compat', resultEs);
// { a: 1, b: { x: 1, y: 3, z: 4 }, c: 2025-01-01T00:00:00.000Z } ❌

console.log('lodash-es', resultLd);
// { a: 1, b: { x: 1, y: 3, z: 4 }, c: 2000-01-01T00:00:00.000Z } ✅**Actual:** `merge` from `es-toolkit/compat` keeps the `Date` from the target.  
```
**Expected:** it should use the `Date` from the source, like `lodash-es`.


---

## Root Cause

The compat implementation of `merge` is based on `mergeWith`:
-  `src/compat/object/merge.ts`
```
export function merge(object: any, ...sources: any[]): any {
  return mergeWith(object, ...sources, noop);
}Inside `mergeWithDeep` (`mergeWith.ts`), when both `targetValue` and `sourceValue` are “object-like”, the code recursively deep‑merges them regardless of their concrete type:

const merged = merge(targetValue, sourceValue, key, target, source, stack);

if (merged !== undefined) {
  target[key] = merged;
} else if (Array.isArray(sourceValue)) {
  target[key] = mergeWithDeep(targetValue, sourceValue, merge, stack);
} else if (isObjectLike(targetValue) && isObjectLike(sourceValue)) {
  // <-- this branch also handles Date / RegExp / other non-plain objects ❌
  target[key] = mergeWithDeep(targetValue, sourceValue, merge, stack);
} else {
  // ...
}
```
As a result, when both values are `Date` instances, the logic performs a deep merge instead of simply replacing the value, and the original `Date` from the target is preserved.

---

## Solution

Restrict the “deep merge” branch so that it only applies to mergeable types (plain objects / typed arrays), and let other object-like values (such as `Date`) fall through to the simple assignment path.

- `src/compat/object/mergeWith.ts`
```
const merged = merge(targetValue, sourceValue, key, target, source, stack);

if (merged !== undefined) {
  target[key] = merged;
} else if (Array.isArray(sourceValue)) {
  target[key] = mergeWithDeep(targetValue, sourceValue, merge, stack);
} else if (
  isObjectLike(targetValue) &&
  isObjectLike(sourceValue) &&
  (
    isPlainObject(targetValue) ||
    isPlainObject(sourceValue) ||
    isTypedArray(targetValue) ||
    isTypedArray(sourceValue)
  )
) {
  // Only deep-merge “mergeable” object-like values
  target[key] = mergeWithDeep(targetValue, sourceValue, merge, stack);
} else if (targetValue == null && isPlainObject(sourceValue)) {
  // ...
}
```
With this change:
- `Date` vs `Date` no longer goes through the deep‑merge branch.
- The value from the source is assigned in the final `else if (targetValue === undefined || sourceValue !== undefined)` branch.
- Existing behavior for plain objects, arrays, and typed arrays is preserved.

---


## Tests

I added tests for both `merge` and `mergeWith` to cover the reported scenario.

- **`src/compat/object/merge.spec.ts`**
```
it('should overwrite Date values from source like lodash-es', () => {
  const target = { a: 1, b: { x: 1, y: 2 }, c: new Date('2025-01-01') };
  const source = { b: { y: 3, z: 4 }, c: new Date('2000-01-01') };

  const actual = merge({}, target, source);

  expect(actual).toEqual({
    a: 1,
    b: { x: 1, y: 3, z: 4 },
    c: new Date('2000-01-01'),
  });
});
```
- **`src/compat/object/mergeWith.spec.ts`**
```
it('should overwrite Date values from source when customizer is noop', () => {
  const target = { a: 1, b: { x: 1, y: 2 }, c: new Date('2025-01-01') };
  const source = { b: { y: 3, z: 4 }, c: new Date('2000-01-01') };

  const actual = mergeWith({}, target, source, noop);

  expect(actual).toEqual({
    a: 1,
    b: { x: 1, y: 3, z: 4 },
    c: new Date('2000-01-01'),
  });
});
```
All existing tests continue to pass.
---