### PR TITLE
WIP: feat: add promises methods

### DIFF
--- a/docs/reference/promise/promisify.md
+++ b/docs/reference/promise/promisify.md
@@ -1,0 +1,82 @@
+# promisify
+
+Converts a callback-based function to a Promise-based function.
+
+Takes a function that accepts a Node.js-style callback `(error, result) => void` as its last argument and returns a new function that returns a Promise. This is useful for modernizing legacy codebases that use callback patterns.
+
+## Signature
+
+```typescript
+function promisify<Args extends unknown[], Result>(
+  fn: (...args: [...Args, Callback<Result>]) => void,
+  options?: PromisifyOptions
+): (...args: Args) => Promise<Result>;
+```
+
+### Parameters
+
+- `fn` (`(...args: [...Args, Callback<Result>]) => void`): A function that accepts a callback as its last argument. The callback should follow the Node.js convention: `(error, result) => void`.
+- `options` (`PromisifyOptions`, optional): Configuration options.
+  - `context` (`object`, optional): The `this` context to bind when calling the function. Useful for object methods.
+
+### Returns
+
+(`(...args: Args) => Promise<Result>`): A new function that returns a Promise. The Promise resolves with the callback's result value, or rejects with the callback's error.
+
+## Examples
+
+### Basic usage
+
+```typescript
+import { promisify } from 'es-toolkit/promise';
+
+function readFile(path: string, callback: (err: Error | null, data: string) => void) {
+  // simulate async file reading
+  setTimeout(() => callback(null, 'file content'), 100);
+}
+
+const readFileAsync = promisify(readFile);
+const data = await readFileAsync('example.txt');
+console.log(data); // 'file content'
+```
+
+### With context binding
+
+When working with object methods that depend on `this`, use the `context` option:
+
+```typescript
+import { promisify } from 'es-toolkit/promise';
+
+const redis = {
+  host: 'localhost',
+  get(key: string, callback: (err: Error | null, value: string) => void) {
+    // uses this.host
+    callback(null, `value from ${this.host}`);
+  },
+};
+
+// Without context, 'this' would be undefined
+const redisGet = promisify(redis.get, { context: redis });
+const value = await redisGet('myKey');
+console.log(value); // 'value from localhost'
+```
+
+### Error handling
+
+Errors passed to the callback are converted to Promise rejections:
+
+```typescript
+import { promisify } from 'es-toolkit/promise';
+
+function failingOperation(callback: (err: Error | null, result: string) => void) {
+  callback(new Error('Operation failed'), '');
+}
+
+const failingOperationAsync = promisify(failingOperation);
+
+try {
+  await failingOperationAsync();
+} catch (error) {
+  console.error(error.message); // 'Operation failed'
+}
+```

--- a/src/promise/asCallback.spec.ts
+++ b/src/promise/asCallback.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { asCallback, nodeify } from './asCallback';
+
+describe('asCallback', () => {
+  it('invokes callback with result on success', async () => {
+    const cb = vi.fn();
+    await asCallback(Promise.resolve(42), cb);
+    await Promise.resolve();
+    expect(cb).toHaveBeenCalledWith(null, 42);
+  });
+
+  it('invokes callback with error on rejection', async () => {
+    const cb = vi.fn();
+    const error = new Error('test error');
+    const promise = Promise.reject(error);
+
+    asCallback(promise, cb).catch(() => {
+      // Suppress unhandled rejection
+    });
+    await Promise.resolve();
+
+    expect(cb).toHaveBeenCalledWith(error, undefined);
+  });
+
+  it('converts non-Error rejections to Error instances', async () => {
+    const cb = vi.fn();
+    const promise = Promise.reject('string error');
+
+    asCallback(promise, cb).catch(() => {
+      // Suppress unhandled rejection
+    });
+    await Promise.resolve();
+
+    expect(cb).toHaveBeenCalled();
+    const [err] = cb.mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe('string error');
+  });
+
+  it('returns the original promise for chaining', async () => {
+    const cb = vi.fn();
+    const promise = Promise.resolve('value');
+    const result = asCallback(promise, cb);
+    expect(result).toBe(promise);
+  });
+
+  it('nodeify is an alias for asCallback', () => {
+    expect(nodeify).toBe(asCallback);
+  });
+});

--- a/src/promise/asCallback.ts
+++ b/src/promise/asCallback.ts
@@ -1,0 +1,74 @@
+/**
+ * A Node.js-style callback function type.
+ *
+ * @template Result - The type of the result value on success.
+ */
+export type NodeStyleCallback<Result> = (err: Error | null, result: Result) => void;
+
+/**
+ * Options for the asCallback function.
+ */
+export interface AsCallbackOptions {
+  /**
+   * If true, errors thrown in the callback won't be re-thrown.
+   * @default false
+   */
+  suppressErrors?: boolean;
+}
+
+/**
+ * Registers a Node.js-style callback on a promise.
+ *
+ * This function attaches a callback to a promise, invoking it when the promise
+ * settles. On success, the callback receives `(null, result)`. On failure, it
+ * receives `(error, undefined)`.
+ *
+ * @template Result - The type of the resolved value.
+ * @param {Promise<Result>} promise - The promise to attach the callback to.
+ * @param {NodeStyleCallback<Result>} callback - The Node.js-style callback function.
+ * @returns {Promise<Result>} The original promise (for chaining).
+ *
+ * @example
+ * // Basic usage
+ * import { asCallback } from 'es-toolkit/promise';
+ *
+ * const promise = Promise.resolve(42);
+ * asCallback(promise, (err, result) => {
+ *   if (err) {
+ *     console.error('Error:', err);
+ *   } else {
+ *     console.log('Result:', result); // Result: 42
+ *   }
+ * });
+ *
+ * @example
+ * // Error handling
+ * const failingPromise = Promise.reject(new Error('Something went wrong'));
+ * asCallback(failingPromise, (err, result) => {
+ *   if (err) {
+ *     console.error('Error:', err.message); // Error: Something went wrong
+ *   }
+ * });
+ */
+export function asCallback<Result>(
+  promise: Promise<Result>,
+  callback: NodeStyleCallback<Result>
+): Promise<Result> {
+  promise.then(
+    result => {
+      queueMicrotask(() => callback(null, result));
+    },
+    err => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      queueMicrotask(() => callback(error, undefined as Result));
+    }
+  );
+  return promise;
+}
+
+/**
+ * Alias for asCallback.
+ *
+ * @see {@link asCallback}
+ */
+export const nodeify = asCallback;

--- a/src/promise/asCallbackAll.spec.ts
+++ b/src/promise/asCallbackAll.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { asCallbackAll } from './asCallbackAll';
+
+describe('asCallbackAll', () => {
+  it('creates Callback methods from async methods', () =>
+    new Promise<void>(done => {
+      const api = {
+        async echo(msg: string): Promise<string> {
+          return msg;
+        },
+      };
+      const callbackApi = asCallbackAll(api);
+      callbackApi.echoCallback('hello', (err, result) => {
+        expect(err).toBeNull();
+        expect(result).toBe('hello');
+        done();
+      });
+    }));
+
+  it('preserves original async methods', async () => {
+    const api = {
+      async echo(msg: string): Promise<string> {
+        return msg;
+      },
+    };
+    const callbackApi = asCallbackAll(api);
+
+    // Original async method still works
+    await expect(callbackApi.echo('test')).resolves.toBe('test');
+  });
+
+  it('handles errors correctly', () =>
+    new Promise<void>(done => {
+      const api = {
+        async fail(): Promise<string> {
+          throw new Error('test error');
+        },
+      };
+      const callbackApi = asCallbackAll(api);
+      callbackApi.failCallback((err, _result) => {
+        expect(err).toBeInstanceOf(Error);
+        expect(err?.message).toBe('test error');
+        done();
+      });
+    }));
+
+  it('respects exclude option', () => {
+    const api = {
+      async included(): Promise<string> {
+        return 'included';
+      },
+      async excluded(): Promise<string> {
+        return 'excluded';
+      },
+    };
+    const callbackApi = asCallbackAll(api, { exclude: ['excluded'] });
+    expect('includedCallback' in callbackApi).toBe(true);
+    expect('excludedCallback' in callbackApi).toBe(false);
+  });
+
+  it('respects include option', () => {
+    const api = {
+      async included(): Promise<string> {
+        return 'included';
+      },
+      async notIncluded(): Promise<string> {
+        return 'not included';
+      },
+    };
+    const callbackApi = asCallbackAll(api, { include: ['included'] });
+    expect('includedCallback' in callbackApi).toBe(true);
+    expect('notIncludedCallback' in callbackApi).toBe(false);
+  });
+
+  it('uses custom suffix', () => {
+    const api = {
+      async echo(msg: string): Promise<string> {
+        return msg;
+      },
+    };
+    const callbackApi = asCallbackAll(api, { suffix: 'Cb' });
+    expect('echoCb' in callbackApi).toBe(true);
+    expect('echoCallback' in callbackApi).toBe(false);
+  });
+
+  it('preserves context', () =>
+    new Promise<void>(done => {
+      const api = {
+        value: 42,
+        async getValue(): Promise<number> {
+          return this.value;
+        },
+      };
+      const callbackApi = asCallbackAll(api);
+      callbackApi.getValueCallback((err, result) => {
+        expect(err).toBeNull();
+        expect(result).toBe(42);
+        done();
+      });
+    }));
+
+  it('works with multiple arguments', () =>
+    new Promise<void>(done => {
+      const api = {
+        async add(a: number, b: number): Promise<number> {
+          return a + b;
+        },
+      };
+      const callbackApi = asCallbackAll(api);
+      callbackApi.addCallback(5, 3, (err, result) => {
+        expect(err).toBeNull();
+        expect(result).toBe(8);
+        done();
+      });
+    }));
+});

--- a/src/promise/asCallbackAll.ts
+++ b/src/promise/asCallbackAll.ts
@@ -1,0 +1,159 @@
+import { asCallback, NodeStyleCallback } from './asCallback';
+
+/**
+ * Options for the asCallbackAll function.
+ */
+export interface AsCallbackAllOptions {
+  /**
+   * An array of method names to exclude from conversion.
+   */
+  exclude?: string[];
+  /**
+   * An array of method names to strictly include. If provided, only these will be converted.
+   */
+  include?: string[];
+  /**
+   * The suffix to append to the callback-style methods. Defaults to 'Callback'.
+   */
+  suffix?: string;
+  /**
+   * The `this` context to bind the methods to. Defaults to the object itself.
+   */
+  context?: object;
+}
+
+/**
+ * Extracts only the async function properties from a type.
+ */
+type AsyncFunctionKeys<T> = {
+  [K in keyof T]: T[K] extends (...args: infer _Args) => Promise<infer _R> ? K : never;
+}[keyof T];
+
+/**
+ * Creates the callback-style method type for a given async function.
+ */
+type AsCallbackMethod<T> = T extends (...args: infer Args) => Promise<infer R>
+  ? (...args: [...Args, NodeStyleCallback<R>]) => void
+  : never;
+
+/**
+ * The return type with appended callback methods.
+ */
+type AsCallbackAllResult<T extends object, S extends string> = T & {
+  [K in AsyncFunctionKeys<T> as `${string & K}${S}`]: AsCallbackMethod<T[K]>;
+};
+
+/**
+ * Converts all async methods in an object to callback-style methods using `asCallback`.
+ *
+ * For each async method in the object, a new method is created with the specified suffix
+ * (default: 'Callback') that accepts a Node.js-style callback as its last argument.
+ *
+ * This is similar to `callbackifyAll` but uses `asCallback` internally, which means
+ * the callback is attached to the promise rather than replacing the promise interface.
+ *
+ * @template T - The type of the input object.
+ * @template Suffix - The suffix string type.
+ * @param {T} object - The object containing async methods to convert.
+ * @param {AsCallbackAllOptions} [options] - Configuration options.
+ * @returns {AsCallbackAllResult<T, Suffix>} The object with added callback-style methods.
+ *
+ * @example
+ * // Basic usage
+ * import { asCallbackAll } from 'es-toolkit/promise';
+ *
+ * const api = {
+ *   async getUser(id: number) {
+ *     return { id, name: 'John' };
+ *   },
+ *   async saveUser(user: { name: string }) {
+ *     return { id: 1, ...user };
+ *   }
+ * };
+ *
+ * const callbackApi = asCallbackAll(api);
+ *
+ * // Original methods still work
+ * const user = await callbackApi.getUser(1);
+ *
+ * // New callback methods are available
+ * callbackApi.getUserCallback(1, (err, user) => {
+ *   if (err) {
+ *     console.error(err);
+ *   } else {
+ *     console.log(user); // { id: 1, name: 'John' }
+ *   }
+ * });
+ *
+ * @example
+ * // With custom suffix
+ * const callbackApi = asCallbackAll(api, { suffix: 'Cb' });
+ * callbackApi.getUserCb(1, (err, user) => {
+ *   console.log(user);
+ * });
+ */
+export function asCallbackAll<T extends object, Suffix extends string = 'Callback'>(
+  object: T,
+  options?: AsCallbackAllOptions
+): AsCallbackAllResult<T, Suffix> {
+  const suffix = options?.suffix ?? 'Callback';
+  const exclude = new Set(options?.exclude ?? []);
+  const include = options?.include ? new Set(options.include) : null;
+  const context = options?.context ?? object;
+
+  const processKey = (key: string) => {
+    if (include && !include.has(key)) {
+      return;
+    }
+    if (exclude.has(key)) {
+      return;
+    }
+    if (key === 'constructor') {
+      return;
+    }
+
+    const descriptor =
+      Object.getOwnPropertyDescriptor(object, key) ?? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(object), key);
+
+    if (!descriptor || typeof descriptor.value !== 'function') {
+      return;
+    }
+
+    const callbackKey = `${key}${suffix}`;
+
+    if (!(callbackKey in object)) {
+      const originalFn = descriptor.value;
+
+      // Create a callback-style version using asCallback
+      const callbackFn = function (...args: unknown[]): void {
+        const callback = args.pop() as NodeStyleCallback<unknown>;
+        const promise = originalFn.apply(context, args) as Promise<unknown>;
+        asCallback(promise, callback);
+      };
+
+      Object.defineProperty(object, callbackKey, {
+        value: callbackFn,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+  };
+
+  // Iterate own properties
+  for (const key in object) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) {
+      processKey(key);
+    }
+  }
+
+  // Iterate prototype properties (for class instances)
+  const prototype = Object.getPrototypeOf(object);
+  if (prototype && prototype !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(prototype)) {
+      processKey(key);
+    }
+  }
+
+  return object as AsCallbackAllResult<T, Suffix>;
+}

--- a/src/promise/callbackify.spec.ts
+++ b/src/promise/callbackify.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { callbackify } from './callbackify';
+
+describe('callbackify', () => {
+  it('calls callback on success', () =>
+    new Promise<void>(done => {
+      const add = async (a: number, b: number) => a + b;
+      callbackify(add)(10, 5, (err, res) => {
+        expect(err).toBeNull();
+        expect(res).toBe(15);
+        done();
+      });
+    }));
+
+  it('calls callback on error', () =>
+    new Promise<void>(done => {
+      const fail = async (): Promise<string> => {
+        throw new Error('Err');
+      };
+      callbackify(fail)((err, _res) => {
+        expect(err).toBeInstanceOf(Error);
+        expect(err?.message).toBe('Err');
+        done();
+      });
+    }));
+
+  it('converts non-Error rejections to Error instances', () =>
+    new Promise<void>(done => {
+      const fail = async (): Promise<string> => {
+        throw 'string error';
+      };
+      callbackify(fail)((err, _res) => {
+        expect(err).toBeInstanceOf(Error);
+        expect(err?.message).toBe('string error');
+        done();
+      });
+    }));
+
+  it('preserves this context when context option is provided', () =>
+    new Promise<void>(done => {
+      const obj = {
+        value: 42,
+        async getValue(): Promise<number> {
+          return this.value;
+        },
+      };
+
+      const callbackified = callbackify(obj.getValue, { context: obj });
+      callbackified((err, res) => {
+        expect(err).toBeNull();
+        expect(res).toBe(42);
+        done();
+      });
+    }));
+
+  it('passes multiple arguments correctly', () =>
+    new Promise<void>(done => {
+      const concat = async (a: string, b: string, c: string) => a + b + c;
+      callbackify(concat)('foo', 'bar', 'baz', (err, res) => {
+        expect(err).toBeNull();
+        expect(res).toBe('foobarbaz');
+        done();
+      });
+    }));
+});

--- a/src/promise/callbackify.ts
+++ b/src/promise/callbackify.ts
@@ -1,0 +1,77 @@
+/**
+ * A Node.js-style callback function type.
+ *
+ * @template Result - The type of the result value on success.
+ */
+export type NodeCallback<Result> = (err: Error | null, result: Result) => void;
+
+/**
+ * Options for the callbackify function.
+ */
+export interface CallbackifyOptions {
+  /**
+   * The `this` context to bind the function to.
+   * If not provided, the context from the call site will be used.
+   */
+  context?: object;
+}
+
+/**
+ * Converts a function that returns a promise into a function that accepts a Node.js-style callback.
+ *
+ * This is the inverse of `promisify`. It takes an async function and returns a new function
+ * that accepts a callback `(error, result) => void` as its last argument.
+ *
+ * @template Args - The tuple type of the function's arguments.
+ * @template Result - The type of the resolved value.
+ * @param {(...args: Args) => Promise<Result>} fn - The async function to convert.
+ * @param {CallbackifyOptions} [options] - Configuration options.
+ * @returns {(...args: [...Args, NodeCallback<Result>]) => void} A new function that accepts a callback.
+ *
+ * @example
+ * // Basic usage
+ * import { callbackify } from 'es-toolkit/promise';
+ *
+ * async function fetchData(id: number): Promise<string> {
+ *   return `Data for ${id}`;
+ * }
+ *
+ * const fetchDataCallback = callbackify(fetchData);
+ *
+ * fetchDataCallback(123, (err, result) => {
+ *   if (err) {
+ *     console.error('Error:', err);
+ *   } else {
+ *     console.log('Result:', result); // Result: Data for 123
+ *   }
+ * });
+ *
+ * @example
+ * // With context binding
+ * const service = {
+ *   baseUrl: 'https://api.example.com',
+ *   async fetch(endpoint: string): Promise<string> {
+ *     return `${this.baseUrl}/${endpoint}`;
+ *   }
+ * };
+ *
+ * const fetchWithCallback = callbackify(service.fetch, { context: service });
+ *
+ * fetchWithCallback('users', (err, result) => {
+ *   console.log(result); // https://api.example.com/users
+ * });
+ */
+export function callbackify<Args extends unknown[], Result>(
+  fn: (...args: Args) => Promise<Result>,
+  options?: CallbackifyOptions
+): (...args: [...Args, NodeCallback<Result>]) => void {
+  return function (this: object, ...args: [...Args, NodeCallback<Result>]) {
+    const callback = args.pop() as NodeCallback<Result>;
+    const params = args as unknown as Args;
+    const context = options?.context ?? this;
+
+    fn.apply(context, params)
+      .then(val => callback(null, val))
+      .catch((err: unknown) => callback(err instanceof Error ? err : new Error(String(err)), undefined as Result));
+  };
+}

--- a/src/promise/callbackifyAll.spec.ts
+++ b/src/promise/callbackifyAll.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { callbackifyAll } from './callbackifyAll';
+
+describe('callbackifyAll', () => {
+  it('creates Callback methods', () =>
+    new Promise<void>(done => {
+      const api = {
+        async echo(msg: string): Promise<string> {
+          return msg;
+        },
+      };
+      const callbackApi = callbackifyAll(api);
+      callbackApi.echoCallback('hello', (err, result) => {
+        expect(err).toBeNull();
+        expect(result).toBe('hello');
+        done();
+      });
+    }));
+
+  it('preserves original async methods', async () => {
+    const api = {
+      async echo(msg: string): Promise<string> {
+        return msg;
+      },
+    };
+    const callbackApi = callbackifyAll(api);
+
+    // Original async method still works
+    await expect(callbackApi.echo('test')).resolves.toBe('test');
+  });
+
+  it('handles errors correctly', () =>
+    new Promise<void>(done => {
+      const api = {
+        async fail(): Promise<string> {
+          throw new Error('test error');
+        },
+      };
+      const callbackApi = callbackifyAll(api);
+      callbackApi.failCallback((err, _result) => {
+        expect(err).toBeInstanceOf(Error);
+        expect(err?.message).toBe('test error');
+        done();
+      });
+    }));
+
+  it('respects exclude option', () => {
+    const api = {
+      async included(): Promise<string> {
+        return 'included';
+      },
+      async excluded(): Promise<string> {
+        return 'excluded';
+      },
+    };
+    const callbackApi = callbackifyAll(api, { exclude: ['excluded'] });
+    expect('includedCallback' in callbackApi).toBe(true);
+    expect('excludedCallback' in callbackApi).toBe(false);
+  });
+
+  it('respects include option', () => {
+    const api = {
+      async included(): Promise<string> {
+        return 'included';
+      },
+      async notIncluded(): Promise<string> {
+        return 'not included';
+      },
+    };
+    const callbackApi = callbackifyAll(api, { include: ['included'] });
+    expect('includedCallback' in callbackApi).toBe(true);
+    expect('notIncludedCallback' in callbackApi).toBe(false);
+  });
+
+  it('uses custom suffix', () => {
+    const api = {
+      async echo(msg: string): Promise<string> {
+        return msg;
+      },
+    };
+    const callbackApi = callbackifyAll(api, { suffix: 'Cb' });
+    expect('echoCb' in callbackApi).toBe(true);
+    expect('echoCallback' in callbackApi).toBe(false);
+  });
+
+  it('preserves context', () =>
+    new Promise<void>(done => {
+      const api = {
+        value: 42,
+        async getValue(): Promise<number> {
+          return this.value;
+        },
+      };
+      const callbackApi = callbackifyAll(api);
+      callbackApi.getValueCallback((err, result) => {
+        expect(err).toBeNull();
+        expect(result).toBe(42);
+        done();
+      });
+    }));
+});

--- a/src/promise/callbackifyAll.ts
+++ b/src/promise/callbackifyAll.ts
@@ -1,0 +1,150 @@
+import { callbackify, NodeCallback } from './callbackify';
+
+/**
+ * Options for the callbackifyAll function.
+ */
+export interface CallbackifyAllOptions {
+  /**
+   * An array of method names to exclude from callbackification.
+   */
+  exclude?: string[];
+  /**
+   * An array of method names to strictly include. If provided, only these will be callbackified.
+   */
+  include?: string[];
+  /**
+   * The suffix to append to the callbackified methods. Defaults to 'Callback'.
+   */
+  suffix?: string;
+  /**
+   * The `this` context to bind the methods to. Defaults to the object itself.
+   */
+  context?: object;
+}
+
+/**
+ * Extracts only the function properties from a type.
+ */
+type FunctionKeys<T> = {
+  [K in keyof T]: T[K] extends (...args: infer _Args) => Promise<infer _R> ? K : never;
+}[keyof T];
+
+/**
+ * Creates the callbackified method type for a given async function.
+ */
+type CallbackifyMethod<T> = T extends (...args: infer Args) => Promise<infer R>
+  ? (...args: [...Args, NodeCallback<R>]) => void
+  : never;
+
+/**
+ * The return type with appended callback methods.
+ */
+type CallbackifyAllResult<T extends object, S extends string> = T & {
+  [K in FunctionKeys<T> as `${string & K}${S}`]: CallbackifyMethod<T[K]>;
+};
+
+/**
+ * Converts all async methods in an object to callback-style methods.
+ *
+ * For each async method in the object, a new method is created with the specified suffix
+ * (default: 'Callback') that accepts a Node.js-style callback as its last argument.
+ *
+ * @template T - The type of the input object.
+ * @template Suffix - The suffix string type.
+ * @param {T} object - The object containing async methods to convert.
+ * @param {CallbackifyAllOptions} [options] - Configuration options.
+ * @returns {CallbackifyAllResult<T, Suffix>} The object with added callback-style methods.
+ *
+ * @example
+ * // Basic usage
+ * import { callbackifyAll } from 'es-toolkit/promise';
+ *
+ * const api = {
+ *   async getUser(id: number) {
+ *     return { id, name: 'John' };
+ *   },
+ *   async saveUser(user: { name: string }) {
+ *     return { id: 1, ...user };
+ *   }
+ * };
+ *
+ * const callbackApi = callbackifyAll(api);
+ *
+ * // Original methods still work
+ * const user = await callbackApi.getUser(1);
+ *
+ * // New callback methods are available
+ * callbackApi.getUserCallback(1, (err, user) => {
+ *   if (err) {
+ *     console.error(err);
+ *   } else {
+ *     console.log(user); // { id: 1, name: 'John' }
+ *   }
+ * });
+ *
+ * @example
+ * // With custom suffix
+ * const callbackApi = callbackifyAll(api, { suffix: 'Cb' });
+ * callbackApi.getUserCb(1, (err, user) => {
+ *   console.log(user);
+ * });
+ *
+ * @example
+ * // With include filter
+ * const callbackApi = callbackifyAll(api, { include: ['getUser'] });
+ * // Only getUserCallback is created, saveUserCallback is not
+ */
+export function callbackifyAll<T extends object, Suffix extends string = 'Callback'>(
+  object: T,
+  options?: CallbackifyAllOptions
+): CallbackifyAllResult<T, Suffix> {
+  const suffix = options?.suffix ?? 'Callback';
+  const exclude = new Set(options?.exclude ?? []);
+  const include = options?.include ? new Set(options.include) : null;
+  const context = options?.context ?? object;
+
+  const processKey = (key: string) => {
+    if (include && !include.has(key)) {
+      return;
+    }
+    if (exclude.has(key)) {
+      return;
+    }
+    if (key === 'constructor') {
+      return;
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(object, key) ?? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(object), key);
+
+    if (!descriptor || typeof descriptor.value !== 'function') {
+      return;
+    }
+
+    const callbackKey = `${key}${suffix}`;
+    if (!(callbackKey in object)) {
+      Object.defineProperty(object, callbackKey, {
+        value: callbackify(descriptor.value, { context }),
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+  };
+
+  // Iterate own properties
+  for (const key in object) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) {
+      processKey(key);
+    }
+  }
+
+  // Iterate prototype properties (for class instances)
+  const prototype = Object.getPrototypeOf(object);
+  if (prototype && prototype !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(prototype)) {
+      processKey(key);
+    }
+  }
+
+  return object as CallbackifyAllResult<T, Suffix>;
+}

--- a/src/promise/fromCallback.spec.ts
+++ b/src/promise/fromCallback.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { fromCallback } from './fromCallback';
+
+describe('fromCallback', () => {
+  it('resolves with result on success', async () => {
+    const result = await fromCallback<string>(cb => cb(null, 'ok'));
+    expect(result).toBe('ok');
+  });
+
+  it('rejects with error on failure', async () => {
+    const error = new Error('test error');
+    await expect(fromCallback(cb => cb(error, null))).rejects.toThrow('test error');
+  });
+
+  it('works with async callbacks', async () => {
+    const result = await fromCallback<number>(cb => {
+      setTimeout(() => cb(null, 42), 10);
+    });
+    expect(result).toBe(42);
+  });
+
+  it('properly types the result', async () => {
+    interface User {
+      name: string;
+      age: number;
+    }
+    const user = await fromCallback<User>(cb => cb(null, { name: 'John', age: 30 }));
+    expect(user.name).toBe('John');
+    expect(user.age).toBe(30);
+  });
+});

--- a/src/promise/fromCallback.ts
+++ b/src/promise/fromCallback.ts
@@ -1,0 +1,57 @@
+/**
+ * A Node.js-style callback function type used by fromCallback.
+ *
+ * @template T - The type of the result value on success.
+ */
+type FromCallbackCallback<T> = (err: Error | null, result: T) => void;
+
+/**
+ * Creates a Promise from a function that takes a Node.js-style callback.
+ *
+ * This utility function wraps callback-based APIs and returns a Promise that:
+ * - Resolves with the result when the callback is called with `(null, result)`
+ * - Rejects with the error when the callback is called with `(error, ...)`
+ *
+ * @template T - The type of the resolved value.
+ * @param {(callback: FromCallbackCallback<T>) => void} fn - A function that accepts a Node.js-style callback.
+ * @returns {Promise<T>} A Promise that resolves or rejects based on the callback invocation.
+ *
+ * @example
+ * // Basic usage
+ * import { fromCallback } from 'es-toolkit/promise';
+ *
+ * const result = await fromCallback<string>(callback => {
+ *   // Simulating an async operation
+ *   setTimeout(() => callback(null, 'success'), 100);
+ * });
+ * console.log(result); // 'success'
+ *
+ * @example
+ * // Error handling
+ * try {
+ *   await fromCallback(callback => {
+ *     callback(new Error('Something went wrong'), null);
+ *   });
+ * } catch (error) {
+ *   console.error(error.message); // 'Something went wrong'
+ * }
+ *
+ * @example
+ * // Wrapping Node.js-style APIs
+ * import { readFile } from 'fs';
+ *
+ * const content = await fromCallback<Buffer>(callback => {
+ *   readFile('example.txt', callback);
+ * });
+ */
+export function fromCallback<T>(fn: (callback: FromCallbackCallback<T>) => void): Promise<T> {
+  return new Promise((resolve, reject) => {
+    fn((err, result) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}

--- a/src/promise/fromCallbackAll.spec.ts
+++ b/src/promise/fromCallbackAll.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { fromCallbackAll } from './fromCallbackAll';
+
+describe('fromCallbackAll', () => {
+  it('creates Async methods from callback-style methods', async () => {
+    const api = {
+      echo(msg: string, cb: (err: Error | null, result: string) => void) {
+        cb(null, msg);
+      },
+    };
+    const asyncApi = fromCallbackAll(api);
+    await expect(asyncApi.echoAsync('hello')).resolves.toBe('hello');
+  });
+
+  it('preserves original methods', async () => {
+    const api = {
+      echo(msg: string, cb: (err: Error | null, result: string) => void) {
+        cb(null, msg);
+      },
+    };
+    const asyncApi = fromCallbackAll(api);
+
+    // Original callback method still works
+    await new Promise<void>(done => {
+      asyncApi.echo('test', (err, result) => {
+        expect(result).toBe('test');
+        done();
+      });
+    });
+  });
+
+  it('handles errors correctly', async () => {
+    const api = {
+      fail(cb: (err: Error | null, result: string) => void) {
+        cb(new Error('test error'), '');
+      },
+    };
+    const asyncApi = fromCallbackAll(api);
+    await expect(asyncApi.failAsync()).rejects.toThrow('test error');
+  });
+
+  it('respects exclude option', () => {
+    const api = {
+      included(cb: (err: Error | null, result: string) => void) {
+        cb(null, 'included');
+      },
+      excluded(cb: (err: Error | null, result: string) => void) {
+        cb(null, 'excluded');
+      },
+    };
+    const asyncApi = fromCallbackAll(api, { exclude: ['excluded'] });
+    expect('includedAsync' in asyncApi).toBe(true);
+    expect('excludedAsync' in asyncApi).toBe(false);
+  });
+
+  it('respects include option', () => {
+    const api = {
+      included(cb: (err: Error | null, result: string) => void) {
+        cb(null, 'included');
+      },
+      notIncluded(cb: (err: Error | null, result: string) => void) {
+        cb(null, 'not included');
+      },
+    };
+    const asyncApi = fromCallbackAll(api, { include: ['included'] });
+    expect('includedAsync' in asyncApi).toBe(true);
+    expect('notIncludedAsync' in asyncApi).toBe(false);
+  });
+
+  it('uses custom suffix', async () => {
+    const api = {
+      echo(msg: string, cb: (err: Error | null, result: string) => void) {
+        cb(null, msg);
+      },
+    };
+    const asyncApi = fromCallbackAll(api, { suffix: 'Promise' });
+    expect('echoPromise' in asyncApi).toBe(true);
+    expect('echoAsync' in asyncApi).toBe(false);
+  });
+
+  it('preserves context', async () => {
+    const api = {
+      value: 42,
+      getValue(cb: (err: Error | null, result: number) => void) {
+        cb(null, this.value);
+      },
+    };
+    const asyncApi = fromCallbackAll(api);
+    await expect(asyncApi.getValueAsync()).resolves.toBe(42);
+  });
+
+  it('works with multiple arguments', async () => {
+    const api = {
+      add(a: number, b: number, cb: (err: Error | null, result: number) => void) {
+        cb(null, a + b);
+      },
+    };
+    const asyncApi = fromCallbackAll(api);
+    await expect(asyncApi.addAsync(5, 3)).resolves.toBe(8);
+  });
+});

--- a/src/promise/fromCallbackAll.ts
+++ b/src/promise/fromCallbackAll.ts
@@ -1,0 +1,165 @@
+/**
+ * A Node.js-style callback function type used by fromCallbackAll.
+ */
+type FromCallbackAllCallback<T> = (err: Error | null, result: T) => void;
+
+/**
+ * Options for the fromCallbackAll function.
+ */
+export interface FromCallbackAllOptions {
+  /**
+   * An array of method names to exclude from conversion.
+   */
+  exclude?: string[];
+  /**
+   * An array of method names to strictly include. If provided, only these will be converted.
+   */
+  include?: string[];
+  /**
+   * The suffix to append to the converted methods. Defaults to 'Async'.
+   */
+  suffix?: string;
+  /**
+   * The `this` context to bind the methods to. Defaults to the object itself.
+   */
+  context?: object;
+}
+
+/**
+ * Extracts only the callback-style function properties from a type.
+ */
+type CallbackFunctionKeys<T> = {
+  [K in keyof T]: T[K] extends (...args: infer _Args) => void ? K : never;
+}[keyof T];
+
+/**
+ * Extracts the promisified return type from a callback-style function.
+ */
+type PromisifyFromCallbackMethod<T> = T extends (
+  ...args: [...infer Args, FromCallbackAllCallback<infer R>]
+) => void
+  ? (...args: Args) => Promise<R>
+  : never;
+
+/**
+ * The return type with appended async methods.
+ */
+type FromCallbackAllResult<T extends object, S extends string> = T & {
+  [K in CallbackFunctionKeys<T> as `${string & K}${S}`]: PromisifyFromCallbackMethod<T[K]>;
+};
+
+/**
+ * Converts all callback-style functions in an object to Promise-based functions.
+ *
+ * For each function in the object that follows the Node.js callback pattern
+ * `(args..., callback) => void`, a new method is created with the specified
+ * suffix (default: 'Async') that returns a Promise.
+ *
+ * This is similar to `promisifyAll` but uses the `fromCallback` pattern internally.
+ *
+ * @template T - The type of the input object.
+ * @template Suffix - The suffix string type.
+ * @param {T} object - The object containing callback-style functions to convert.
+ * @param {FromCallbackAllOptions} [options] - Configuration options.
+ * @returns {FromCallbackAllResult<T, Suffix>} The object with added Promise-based methods.
+ *
+ * @example
+ * // Basic usage
+ * import { fromCallbackAll } from 'es-toolkit/promise';
+ *
+ * const fs = {
+ *   readFile(path: string, callback: (err: Error | null, data: string) => void) {
+ *     callback(null, 'file content');
+ *   },
+ *   writeFile(path: string, data: string, callback: (err: Error | null) => void) {
+ *     callback(null);
+ *   }
+ * };
+ *
+ * const asyncFs = fromCallbackAll(fs);
+ *
+ * // Original methods still work
+ * asyncFs.readFile('test.txt', (err, data) => console.log(data));
+ *
+ * // New async methods are available
+ * const data = await asyncFs.readFileAsync('test.txt');
+ * console.log(data); // 'file content'
+ *
+ * @example
+ * // With custom suffix
+ * const asyncFs = fromCallbackAll(fs, { suffix: 'Promise' });
+ * const data = await asyncFs.readFilePromise('test.txt');
+ */
+export function fromCallbackAll<T extends object, Suffix extends string = 'Async'>(
+  object: T,
+  options?: FromCallbackAllOptions
+): FromCallbackAllResult<T, Suffix> {
+  const suffix = options?.suffix ?? 'Async';
+  const exclude = new Set(options?.exclude ?? []);
+  const include = options?.include ? new Set(options.include) : null;
+  const context = options?.context ?? object;
+
+  const processKey = (key: string) => {
+    if (include && !include.has(key)) {
+      return;
+    }
+    if (exclude.has(key)) {
+      return;
+    }
+    if (key === 'constructor') {
+      return;
+    }
+
+    const descriptor =
+      Object.getOwnPropertyDescriptor(object, key) ?? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(object), key);
+
+    if (!descriptor || typeof descriptor.value !== 'function') {
+      return;
+    }
+
+    const asyncKey = `${key}${suffix}`;
+
+    if (!(asyncKey in object)) {
+      const originalFn = descriptor.value;
+
+      // Create a promisified version using fromCallback pattern
+      const promisifiedFn = function (...args: unknown[]): Promise<unknown> {
+        return new Promise((resolve, reject) => {
+          const callback = (err: Error | null, result: unknown) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(result);
+            }
+          };
+
+          originalFn.call(context, ...args, callback);
+        });
+      };
+
+      Object.defineProperty(object, asyncKey, {
+        value: promisifiedFn,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+  };
+
+  // Iterate own properties
+  for (const key in object) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) {
+      processKey(key);
+    }
+  }
+
+  // Iterate prototype properties (for class instances)
+  const prototype = Object.getPrototypeOf(object);
+  if (prototype && prototype !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(prototype)) {
+      processKey(key);
+    }
+  }
+
+  return object as FromCallbackAllResult<T, Suffix>;
+}

--- a/src/promise/index.ts
+++ b/src/promise/index.ts
@@ -1,5 +1,15 @@
+export { asCallback, nodeify, type AsCallbackOptions, type NodeStyleCallback } from './asCallback.ts';
+export { asCallbackAll, type AsCallbackAllOptions } from './asCallbackAll.ts';
+export { callbackify, type CallbackifyOptions, type NodeCallback } from './callbackify.ts';
+export { callbackifyAll, type CallbackifyAllOptions } from './callbackifyAll.ts';
 export { delay } from './delay.ts';
+export { fromCallback } from './fromCallback.ts';
+export { fromCallbackAll, type FromCallbackAllOptions } from './fromCallbackAll.ts';
 export { Mutex } from './mutex.ts';
+export { promisify, type Callback, type PromisifyOptions } from './promisify.ts';
+export { promisifyAll, type PromisifyAllOptions } from './promisifyAll.ts';
 export { Semaphore } from './semaphore.ts';
 export { timeout } from './timeout.ts';
+export { withCallback, type DualModeFunction } from './withCallback.ts';
+export { withCallbackAll, type WithCallbackAllOptions } from './withCallbackAll.ts';
 export { withTimeout } from './withTimeout.ts';

--- a/src/promise/promisify.spec.ts
+++ b/src/promise/promisify.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { promisify } from './promisify';
+
+describe('promisify', () => {
+  it('resolves with value', async () => {
+    const fn = (cb: (err: Error | null, val: number) => void) => cb(null, 42);
+    await expect(promisify(fn)()).resolves.toBe(42);
+  });
+
+  it('rejects with error', async () => {
+    const err = new Error('Fail');
+    const fn = (cb: (err: Error | null, val: string) => void) => cb(err, '');
+    await expect(promisify(fn)()).rejects.toThrow(err);
+  });
+
+  it('preserves context with options', async () => {
+    const obj = {
+      val: 10,
+      run(cb: (err: Error | null, val: number) => void) {
+        cb(null, this.val);
+      },
+    };
+    await expect(promisify(obj.run, { context: obj })()).resolves.toBe(10);
+  });
+
+  it('passes arguments correctly', async () => {
+    const fn = (a: number, b: number, cb: (err: Error | null, val: number) => void) => {
+      cb(null, a + b);
+    };
+    await expect(promisify(fn)(5, 3)).resolves.toBe(8);
+  });
+
+  it('works with void callback', async () => {
+    const fn = (msg: string, cb: (err: Error | null, val: void) => void) => {
+      console.log(msg);
+      cb(null, undefined);
+    };
+    await expect(promisify(fn)('test')).resolves.toBeUndefined();
+  });
+
+  it('works with multiple arguments', async () => {
+    const fn = (a: string, b: string, c: string, cb: (err: Error | null, val: string) => void) => {
+      cb(null, a + b + c);
+    };
+    await expect(promisify(fn)('foo', 'bar', 'baz')).resolves.toBe('foobarbaz');
+  });
+});

--- a/src/promise/promisify.ts
+++ b/src/promise/promisify.ts
@@ -1,0 +1,76 @@
+/**
+ * A Node.js-style callback function type.
+ *
+ * @template Result - The type of the result value on success.
+ */
+export type Callback<Result> = (err: Error | null, result: Result) => void;
+
+/**
+ * Options for the promisify function.
+ */
+export interface PromisifyOptions {
+  /**
+   * The `this` context to bind when calling the function.
+   * Useful for object methods that depend on `this`.
+   */
+  context?: object;
+}
+
+/**
+ * Converts a callback-based function to a Promise-based function.
+ *
+ * Takes a function that accepts a Node.js-style callback `(error, result) => void` as its
+ * last argument and returns a new function that returns a Promise. This is useful for
+ * modernizing legacy codebases that use callback patterns.
+ *
+ * @template Args - The tuple type of the function's arguments (excluding the callback).
+ * @template Result - The type of the result value.
+ * @param {(...args: [...Args, Callback<Result>]) => void} fn - The callback-based function to convert.
+ * @param {PromisifyOptions} [options] - Configuration options.
+ * @returns {(...args: Args) => Promise<Result>} A new function that returns a Promise.
+ *
+ * @example
+ * // Basic usage
+ * import { promisify } from 'es-toolkit/promise';
+ *
+ * function readFile(path: string, callback: (err: Error | null, data: string) => void) {
+ *   setTimeout(() => callback(null, 'file content'), 100);
+ * }
+ *
+ * const readFileAsync = promisify(readFile);
+ * const data = await readFileAsync('example.txt');
+ * console.log(data); // 'file content'
+ *
+ * @example
+ * // With context binding
+ * const redis = {
+ *   host: 'localhost',
+ *   get(key: string, callback: (err: Error | null, value: string) => void) {
+ *     callback(null, `value from ${this.host}`);
+ *   },
+ * };
+ *
+ * const redisGet = promisify(redis.get, { context: redis });
+ * const value = await redisGet('myKey');
+ * console.log(value); // 'value from localhost'
+ */
+export function promisify<Args extends unknown[], Result>(
+  fn: (...args: [...Args, Callback<Result>]) => void,
+  options?: PromisifyOptions
+): (...args: Args) => Promise<Result> {
+  return function (this: object, ...args: Args): Promise<Result> {
+    const context = options?.context ?? this;
+
+    return new Promise<Result>((resolve, reject) => {
+      const callback: Callback<Result> = (err: Error | null, result: Result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      };
+
+      fn.call(context, ...args, callback);
+    });
+  };
+}

--- a/src/promise/promisifyAll.spec.ts
+++ b/src/promise/promisifyAll.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { promisifyAll } from './promisifyAll';
+
+describe('promisifyAll', () => {
+  it('creates Async methods', async () => {
+    const api = {
+      echo(msg: string, cb: (err: Error | null, result: string) => void) {
+        cb(null, msg);
+      },
+    };
+    const promisifiedApi = promisifyAll(api);
+    await expect(promisifiedApi.echoAsync('hello')).resolves.toBe('hello');
+  });
+
+  it('preserves original methods', async () => {
+    const api = {
+      echo(msg: string, cb: (err: Error | null, result: string) => void) {
+        cb(null, msg);
+      },
+    };
+    const promisifiedApi = promisifyAll(api);
+
+    // Original callback method still works
+    await new Promise<void>(done => {
+      promisifiedApi.echo('test', (err, result) => {
+        expect(result).toBe('test');
+        done();
+      });
+    });
+  });
+
+  it('handles errors correctly', async () => {
+    const api = {
+      fail(cb: (err: Error | null, result: string) => void) {
+        cb(new Error('test error'), '');
+      },
+    };
+    const promisifiedApi = promisifyAll(api);
+    await expect(promisifiedApi.failAsync()).rejects.toThrow('test error');
+  });
+
+  it('respects exclude option', () => {
+    const api = {
+      included(cb: (err: Error | null, result: string) => void) {
+        cb(null, 'included');
+      },
+      excluded(cb: (err: Error | null, result: string) => void) {
+        cb(null, 'excluded');
+      },
+    };
+    const promisifiedApi = promisifyAll(api, { exclude: ['excluded'] });
+    expect('includedAsync' in promisifiedApi).toBe(true);
+    expect('excludedAsync' in promisifiedApi).toBe(false);
+  });
+
+  it('respects include option', () => {
+    const api = {
+      included(cb: (err: Error | null, result: string) => void) {
+        cb(null, 'included');
+      },
+      notIncluded(cb: (err: Error | null, result: string) => void) {
+        cb(null, 'not included');
+      },
+    };
+    const promisifiedApi = promisifyAll(api, { include: ['included'] });
+    expect('includedAsync' in promisifiedApi).toBe(true);
+    expect('notIncludedAsync' in promisifiedApi).toBe(false);
+  });
+
+  it('uses custom suffix', async () => {
+    const api = {
+      echo(msg: string, cb: (err: Error | null, result: string) => void) {
+        cb(null, msg);
+      },
+    };
+    const promisifiedApi = promisifyAll(api, { suffix: 'Promise' });
+    expect('echoPromise' in promisifiedApi).toBe(true);
+    expect('echoAsync' in promisifiedApi).toBe(false);
+  });
+});

--- a/src/promise/promisifyAll.ts
+++ b/src/promise/promisifyAll.ts
@@ -1,0 +1,152 @@
+import { promisify, Callback } from './promisify';
+
+/**
+ * Options for the promisifyAll function.
+ */
+export interface PromisifyAllOptions {
+  /**
+   * An array of method names to exclude from promisification.
+   */
+  exclude?: string[];
+  /**
+   * An array of method names to strictly include. If provided, only these will be promisified.
+   */
+  include?: string[];
+  /**
+   * The suffix to append to the promisified methods. Defaults to 'Async'.
+   */
+  suffix?: string;
+  /**
+   * The `this` context to bind the methods to. Defaults to the object itself.
+   */
+  context?: object;
+}
+
+/**
+ * Extracts only the function properties from a type that follow the callback pattern.
+ */
+type CallbackFunctionKeys<T> = {
+  [K in keyof T]: T[K] extends (...args: infer _Args) => void ? K : never;
+}[keyof T];
+
+/**
+ * Extracts the promisified return type from a callback-style function.
+ */
+type PromisifyMethod<T> = T extends (...args: [...infer Args, Callback<infer R>]) => void
+  ? (...args: Args) => Promise<R>
+  : T extends (...args: [...infer Args, (err: Error | null) => void]) => void
+    ? (...args: Args) => Promise<void>
+    : never;
+
+/**
+ * The return type with appended async methods.
+ */
+type PromisifyAllResult<T extends object, S extends string> = T & {
+  [K in CallbackFunctionKeys<T> as `${string & K}${S}`]: PromisifyMethod<T[K]>;
+};
+
+/**
+ * Promisifies all callback-style functions in an object.
+ *
+ * For each function in the object that follows the Node.js callback pattern
+ * `(args..., callback) => void`, a new method is created with the specified
+ * suffix (default: 'Async') that returns a Promise.
+ *
+ * @template T - The type of the input object.
+ * @template Suffix - The suffix string type.
+ * @param {T} object - The object containing callback-style functions to promisify.
+ * @param {PromisifyAllOptions} [options] - Configuration options.
+ * @returns {PromisifyAllResult<T, Suffix>} The object with added Promise-based methods.
+ *
+ * @example
+ * // Basic usage
+ * import { promisifyAll } from 'es-toolkit/promise';
+ *
+ * const fs = {
+ *   readFile(path: string, callback: (err: Error | null, data: string) => void) {
+ *     callback(null, 'file content');
+ *   },
+ *   writeFile(path: string, data: string, callback: (err: Error | null) => void) {
+ *     callback(null);
+ *   }
+ * };
+ *
+ * const asyncFs = promisifyAll(fs);
+ *
+ * // Original methods still work
+ * asyncFs.readFile('test.txt', (err, data) => console.log(data));
+ *
+ * // New async methods are available
+ * const data = await asyncFs.readFileAsync('test.txt');
+ * console.log(data); // 'file content'
+ *
+ * @example
+ * // With custom suffix
+ * const asyncFs = promisifyAll(fs, { suffix: 'Promise' });
+ * const data = await asyncFs.readFilePromise('test.txt');
+ *
+ * @example
+ * // With include filter
+ * const asyncFs = promisifyAll(fs, { include: ['readFile'] });
+ * // Only readFileAsync is created, writeFileAsync is not
+ */
+export function promisifyAll<T extends object, Suffix extends string = 'Async'>(
+  object: T,
+  options?: PromisifyAllOptions
+): PromisifyAllResult<T, Suffix> {
+  const suffix = options?.suffix ?? 'Async';
+  const exclude = new Set(options?.exclude ?? []);
+  const include = options?.include ? new Set(options.include) : null;
+  const context = options?.context ?? object;
+
+  const processKey = (key: string) => {
+    // 1. Check Filters
+    if (include && !include.has(key)) {
+      return;
+    }
+    if (exclude.has(key)) {
+      return;
+    }
+    if (key === 'constructor') {
+      return;
+    }
+
+    // 2. Check value type
+    const descriptor =
+      Object.getOwnPropertyDescriptor(object, key) ?? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(object), key);
+
+    if (!descriptor || typeof descriptor.value !== 'function') {
+      return;
+    }
+
+    // 3. Generate new key
+    const asyncKey = `${key}${suffix}`;
+
+    // 4. Promisify if not exists
+    if (!(asyncKey in object)) {
+      Object.defineProperty(object, asyncKey, {
+        value: promisify(descriptor.value, { context }),
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+  };
+
+  // Iterate own properties
+  for (const key in object) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) {
+      processKey(key);
+    }
+  }
+
+  // Iterate prototype properties (for class instances)
+  const prototype = Object.getPrototypeOf(object);
+  if (prototype && prototype !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(prototype)) {
+      processKey(key);
+    }
+  }
+
+  return object as PromisifyAllResult<T, Suffix>;
+}

--- a/src/promise/withCallback.spec.ts
+++ b/src/promise/withCallback.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { withCallback } from './withCallback';
+
+describe('withCallback', () => {
+  const add = async (a: number, b: number): Promise<number> => a + b;
+  const dualAdd = withCallback(add);
+
+  it('works as promise', async () => {
+    await expect(dualAdd(1, 2)).resolves.toBe(3);
+  });
+
+  it('works as callback', () =>
+    new Promise<void>(done => {
+      dualAdd(1, 2, (err, res) => {
+        expect(err).toBeNull();
+        expect(res).toBe(3);
+        done();
+      });
+    }));
+
+  it('handles errors in promise mode', async () => {
+    const fail = async (): Promise<string> => {
+      throw new Error('test error');
+    };
+    const dualFail = withCallback(fail);
+    await expect(dualFail()).rejects.toThrow('test error');
+  });
+
+  it('handles errors in callback mode', () =>
+    new Promise<void>(done => {
+      const fail = async (): Promise<string> => {
+        throw new Error('test error');
+      };
+      const dualFail = withCallback(fail);
+      dualFail((err, _res) => {
+        expect(err).toBeInstanceOf(Error);
+        expect(err?.message).toBe('test error');
+        done();
+      });
+    }));
+
+  it('preserves this context', () =>
+    new Promise<void>(done => {
+      const obj = {
+        value: 42,
+        getValue: withCallback(async function (this: { value: number }): Promise<number> {
+          return this.value;
+        }),
+      };
+
+      obj.getValue((err, res) => {
+        expect(err).toBeNull();
+        expect(res).toBe(42);
+        done();
+      });
+    }));
+
+  it('works with no arguments in promise mode', async () => {
+    const noArgs = async (): Promise<string> => 'hello';
+    const dualNoArgs = withCallback(noArgs);
+    await expect(dualNoArgs()).resolves.toBe('hello');
+  });
+
+  it('works with no arguments in callback mode', () =>
+    new Promise<void>(done => {
+      const noArgs = async (): Promise<string> => 'hello';
+      const dualNoArgs = withCallback(noArgs);
+      dualNoArgs((err, res) => {
+        expect(err).toBeNull();
+        expect(res).toBe('hello');
+        done();
+      });
+    }));
+});

--- a/src/promise/withCallback.ts
+++ b/src/promise/withCallback.ts
@@ -1,0 +1,89 @@
+import { asCallback, NodeStyleCallback } from './asCallback';
+
+/**
+ * A dual-mode function that can be called with either a Promise return or a callback.
+ *
+ * @template Args - The tuple type of the function's arguments.
+ * @template Result - The type of the resolved value.
+ */
+export interface DualModeFunction<Args extends unknown[], Result> {
+  /**
+   * Call without callback to get a Promise.
+   */
+  (...args: Args): Promise<Result>;
+  /**
+   * Call with callback for Node.js-style callback API.
+   */
+  (...args: [...Args, NodeStyleCallback<Result>]): void;
+}
+
+/**
+ * Wraps a Promise-returning function to allow it to be called with an optional callback.
+ *
+ * This enables a Dual API where the function can be used either with Promises or
+ * with Node.js-style callbacks. When called without a callback as the last argument,
+ * it returns a Promise. When called with a callback, it invokes the callback with
+ * the result.
+ *
+ * @template Args - The tuple type of the function's arguments.
+ * @template Result - The type of the resolved value.
+ * @param {(...args: Args) => Promise<Result>} fn - The async function to wrap.
+ * @returns {DualModeFunction<Args, Result>} A function that supports both Promise and callback patterns.
+ *
+ * @example
+ * // Basic usage
+ * import { withCallback } from 'es-toolkit/promise';
+ *
+ * async function fetchUser(id: number): Promise<{ name: string }> {
+ *   return { name: 'John' };
+ * }
+ *
+ * const fetchUserDual = withCallback(fetchUser);
+ *
+ * // Use as Promise
+ * const user = await fetchUserDual(1);
+ * console.log(user.name); // 'John'
+ *
+ * // Use with callback
+ * fetchUserDual(1, (err, user) => {
+ *   if (err) {
+ *     console.error(err);
+ *   } else {
+ *     console.log(user.name); // 'John'
+ *   }
+ * });
+ *
+ * @example
+ * // Creating a library with dual API support
+ * class UserService {
+ *   private async fetchFromDb(id: number): Promise<User> {
+ *     return db.users.find(id);
+ *   }
+ *
+ *   getUser = withCallback(this.fetchFromDb.bind(this));
+ * }
+ *
+ * const service = new UserService();
+ *
+ * // Consumers can use either style
+ * const user = await service.getUser(1);
+ * service.getUser(1, (err, user) => { ... });
+ */
+export function withCallback<Args extends unknown[], Result>(
+  fn: (...args: Args) => Promise<Result>
+): DualModeFunction<Args, Result> {
+  function dualMode(this: object, ...args: [...Args] | [...Args, NodeStyleCallback<Result>]): Promise<Result> | void {
+    const lastArg = args[args.length - 1];
+
+    if (typeof lastArg === 'function') {
+      const callback = args.pop() as NodeStyleCallback<Result>;
+      const promise = fn.apply(this, args as unknown as Args);
+      asCallback(promise, callback);
+      return;
+    }
+
+    return fn.apply(this, args as Args);
+  }
+
+  return dualMode as DualModeFunction<Args, Result>;
+}

--- a/src/promise/withCallbackAll.spec.ts
+++ b/src/promise/withCallbackAll.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { withCallbackAll } from './withCallbackAll';
+
+describe('withCallbackAll', () => {
+  it('wraps async methods to support both Promise and callback', async () => {
+    const api = {
+      async echo(msg: string): Promise<string> {
+        return msg;
+      },
+    };
+    const dualApi = withCallbackAll(api);
+
+    // Test as Promise
+    await expect(dualApi.echo('hello')).resolves.toBe('hello');
+
+    // Test as callback
+    await new Promise<void>(done => {
+      dualApi.echo('world', (err, result) => {
+        expect(err).toBeNull();
+        expect(result).toBe('world');
+        done();
+      });
+    });
+  });
+
+  it('handles errors in Promise mode', async () => {
+    const api = {
+      async fail(): Promise<string> {
+        throw new Error('test error');
+      },
+    };
+    const dualApi = withCallbackAll(api);
+    await expect(dualApi.fail()).rejects.toThrow('test error');
+  });
+
+  it('handles errors in callback mode', () =>
+    new Promise<void>(done => {
+      const api = {
+        async fail(): Promise<string> {
+          throw new Error('test error');
+        },
+      };
+      const dualApi = withCallbackAll(api);
+      dualApi.fail((err, _result) => {
+        expect(err).toBeInstanceOf(Error);
+        expect(err?.message).toBe('test error');
+        done();
+      });
+    }));
+
+  it('respects exclude option', async () => {
+    const api = {
+      async included(): Promise<string> {
+        return 'included';
+      },
+      async excluded(): Promise<string> {
+        return 'excluded';
+      },
+    };
+    const dualApi = withCallbackAll(api, { exclude: ['excluded'] });
+
+    // included should work with callback
+    await new Promise<void>(done => {
+      dualApi.included((err, result) => {
+        expect(result).toBe('included');
+        done();
+      });
+    });
+
+    // excluded should only work as Promise (no callback support)
+    await expect(dualApi.excluded()).resolves.toBe('excluded');
+  });
+
+  it('respects include option', async () => {
+    const api = {
+      async included(): Promise<string> {
+        return 'included';
+      },
+      async notIncluded(): Promise<string> {
+        return 'not included';
+      },
+    };
+    const dualApi = withCallbackAll(api, { include: ['included'] });
+
+    // included should work with callback
+    await new Promise<void>(done => {
+      dualApi.included((err, result) => {
+        expect(result).toBe('included');
+        done();
+      });
+    });
+  });
+
+  it('preserves context', async () => {
+    const api = {
+      value: 42,
+      async getValue(): Promise<number> {
+        return this.value;
+      },
+    };
+    const dualApi = withCallbackAll(api);
+
+    await new Promise<void>(done => {
+      dualApi.getValue((err, result) => {
+        expect(err).toBeNull();
+        expect(result).toBe(42);
+        done();
+      });
+    });
+  });
+
+  it('works with multiple arguments', async () => {
+    const api = {
+      async add(a: number, b: number): Promise<number> {
+        return a + b;
+      },
+    };
+    const dualApi = withCallbackAll(api);
+
+    await new Promise<void>(done => {
+      dualApi.add(5, 3, (err, result) => {
+        expect(err).toBeNull();
+        expect(result).toBe(8);
+        done();
+      });
+    });
+  });
+});

--- a/src/promise/withCallbackAll.ts
+++ b/src/promise/withCallbackAll.ts
@@ -1,0 +1,122 @@
+import { withCallback, DualModeFunction } from './withCallback';
+
+/**
+ * Options for the withCallbackAll function.
+ */
+export interface WithCallbackAllOptions {
+  /**
+   * An array of method names to exclude from wrapping.
+   */
+  exclude?: string[];
+  /**
+   * An array of method names to strictly include. If provided, only these will be wrapped.
+   */
+  include?: string[];
+}
+
+/**
+ * The return type with wrapped dual-mode methods.
+ */
+type WithCallbackAllResult<T extends object> = {
+  [K in keyof T]: T[K] extends (...args: infer Args) => Promise<infer R> ? DualModeFunction<Args, R> : T[K];
+};
+
+/**
+ * Wraps all async methods in an object with `withCallback` to support both Promise and callback APIs.
+ *
+ * Each async method will be replaced with a dual-mode function that can be called either:
+ * - Without a callback: returns a Promise
+ * - With a callback as the last argument: invokes the callback with the result
+ *
+ * @template T - The type of the input object.
+ * @param {T} object - The object containing async methods to wrap.
+ * @param {WithCallbackAllOptions} [options] - Configuration options.
+ * @returns {WithCallbackAllResult<T>} The object with wrapped dual-mode methods.
+ *
+ * @example
+ * // Basic usage
+ * import { withCallbackAll } from 'es-toolkit/promise';
+ *
+ * const api = {
+ *   async getUser(id: number) {
+ *     return { id, name: 'John' };
+ *   },
+ *   async saveUser(user: { name: string }) {
+ *     return { id: 1, ...user };
+ *   }
+ * };
+ *
+ * const dualApi = withCallbackAll(api);
+ *
+ * // Use as Promise
+ * const user = await dualApi.getUser(1);
+ *
+ * // Use with callback
+ * dualApi.getUser(1, (err, user) => {
+ *   if (err) {
+ *     console.error(err);
+ *   } else {
+ *     console.log(user); // { id: 1, name: 'John' }
+ *   }
+ * });
+ *
+ * @example
+ * // With exclude filter
+ * const dualApi = withCallbackAll(api, { exclude: ['saveUser'] });
+ * // Only getUser is wrapped, saveUser remains Promise-only
+ */
+export function withCallbackAll<T extends object>(
+  object: T,
+  options?: WithCallbackAllOptions
+): WithCallbackAllResult<T> {
+  const exclude = new Set(options?.exclude ?? []);
+  const include = options?.include ? new Set(options.include) : null;
+
+  const processKey = (key: string) => {
+    if (include && !include.has(key)) {
+      return;
+    }
+    if (exclude.has(key)) {
+      return;
+    }
+    if (key === 'constructor') {
+      return;
+    }
+
+    const descriptor =
+      Object.getOwnPropertyDescriptor(object, key) ?? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(object), key);
+
+    if (!descriptor || typeof descriptor.value !== 'function') {
+      return;
+    }
+
+    const originalFn = descriptor.value;
+
+    // Wrap the method with withCallback, binding to the object
+    const wrappedFn = withCallback(originalFn.bind(object));
+
+    Object.defineProperty(object, key, {
+      value: wrappedFn,
+      writable: true,
+      enumerable: descriptor.enumerable,
+      configurable: true,
+    });
+  };
+
+  // Iterate own properties
+  for (const key in object) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) {
+      processKey(key);
+    }
+  }
+
+  // Iterate prototype properties (for class instances)
+  const prototype = Object.getPrototypeOf(object);
+  if (prototype && prototype !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(prototype)) {
+      processKey(key);
+    }
+  }
+
+  return object as WithCallbackAllResult<T>;
+}


### PR DESCRIPTION
Fixes: https://github.com/toss/es-toolkit/issues/1549

This PR adds a set of utilities for converting between Promise-based and callback-based APIs. These are especially useful when working with legacy Node.js code or when you need to support both styles.

Inspired on:
http://bluebirdjs.com/docs/api/promisification.html
https://googleapis.dev/nodejs/promisify/latest/global.html

### What's included

**Converting callbacks to promises:**
- `promisify(fn)` - Takes a function that uses a callback and returns one that returns a Promise
- `promisifyAll(obj)` - Does the same for all methods in an object, adding `*Async` suffix
- `fromCallback(fn)` - Creates a Promise from a one-shot callback operation
- `fromCallbackAll(obj)` - Adds `*Async` methods for callback-based objects

**Converting promises to callbacks:**
- `callbackify(fn)` - Takes an async function and returns one that accepts a callback
- `callbackifyAll(obj)` - Does the same for all async methods, adding `*Callback` suffix
- `asCallback(promise, cb)` - Attaches a callback to an existing promise (also exported as `nodeify`)
- `asCallbackAll(obj)` - Adds `*Callback` methods for async objects

**Supporting both styles at once:**
- `withCallback(fn)` - Wraps an async function so it can be called either way
- `withCallbackAll(obj)` - Does the same for all async methods in an object

### Why these exist

When maintaining libraries or working with mixed codebases, you often need to support both Promise and callback patterns. Instead of writing boilerplate for each conversion, these utilities handle it in a type-safe way.

The "All" variants are particularly useful for wrapping entire modules (like `fs`) or class instances without touching each method individually.

This is still a WIP and I'm still testing this.