### PR TITLE
fix(clone): Fix error when cloning object with null prototype

### DIFF
--- a/src/object/clone.spec.ts
+++ b/src/object/clone.spec.ts
@@ -65,6 +65,14 @@ describe('clone', () => {
     expect(clonedObj).not.toBe(obj);
   });
 
+  it('should clone objects with a null prototype', () => {
+    const obj = Object.create(null);
+    const clonedObj = clone(obj);
+
+    expect(clonedObj).toEqual(obj);
+    expect(clonedObj).not.toBe(obj);
+  });
+
   it('should clone custom classes', () => {
     class Person {
       constructor(

--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -44,7 +44,7 @@ export function clone<T>(obj: T): T {
   }
 
   const prototype = Object.getPrototypeOf(obj);
-  const Constructor = prototype.constructor;
+  const Constructor = prototype?.constructor;
 
   if (obj instanceof Date || obj instanceof Map || obj instanceof Set) {
     return new Constructor(obj);


### PR DESCRIPTION
I experienced a crash when using `toMerged` with two objects in my project. Chasing this through, I discovered that it was because one of the values contained it in had a `null` prototype.

The crash was inside the `clone` method:

```
TypeError: Cannot read properties of null (reading 'constructor')
 ❯ Module.clone src/object/clone.ts:47:33
     45|
     46|   const prototype = Object.getPrototypeOf(obj);
     47|   const Constructor = prototype.constructor;
       |                                 ^
     48|
     49|   if (obj instanceof Date || obj instanceof Map || obj instanceof Set) {
```

The issue was that `Object.getPrototypeOf` can return `null` ([reference on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf#return_value)) but the code in `clone` does not check for `null` when accessing `prototype.constructor`.

I have added a test for this and resolved the issue by adding optional chaining to the property access.