### PR TITLE
chore(intersection): simplify filter callback for consistency

### DIFF
--- a/src/array/intersection.ts
+++ b/src/array/intersection.ts
@@ -19,7 +19,5 @@
 export function intersection<T>(firstArr: readonly T[], secondArr: readonly T[]): T[] {
   const secondSet = new Set(secondArr);
 
-  return firstArr.filter(item => {
-    return secondSet.has(item);
-  });
+  return firstArr.filter(item => secondSet.has(item));
 }


### PR DESCRIPTION
## Summary

Simplified the filter callback in the [intersection](cci:1://file:///Users/eunwoo/Desktop/es-toolkit/src/array/intersection.ts:0:0-22:1) function by removing an unnecessary code block.

## Why

The [intersection](cci:1://file:///Users/eunwoo/Desktop/es-toolkit/src/array/intersection.ts:0:0-22:1) function had a redundant code block in its filter callback:


### Before
```ts
return firstArr.filter(item => {
  return secondSet.has(item);
});
```

### After
```ts
return firstArr.filter(item => secondSet.has(item));
```

This is unnecessarily verbose compared to the simpler arrow function syntax. Other similar functions in the codebase, such as [difference](https://es-toolkit.dev/reference/array/difference.html), already use the more concise pattern,

```ts
// difference.ts
return firstArr.filter(item => !secondSet.has(item));
```

This change improves code consistency and follows the project's simplicity principle.

