### PR TITLE
docs(cloneDeep): fix incorrect function names and output in JSDoc

### DIFF
--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -10,37 +10,37 @@ import { cloneDeepWithImpl } from './cloneDeepWith.ts';
  * @example
  * // Clone a primitive values
  * const num = 29;
- * const clonedNum = clone(num);
+ * const clonedNum = cloneDeep(num);
  * console.log(clonedNum); // 29
  * console.log(clonedNum === num); // true
  *
  * @example
  * // Clone an array
  * const arr = [1, 2, 3];
- * const clonedArr = clone(arr);
+ * const clonedArr = cloneDeep(arr);
  * console.log(clonedArr); // [1, 2, 3]
  * console.log(clonedArr === arr); // false
  *
  * @example
  * // Clone an array with nested objects
  * const arr = [1, { a: 1 }, [1, 2, 3]];
- * const clonedArr = clone(arr);
+ * const clonedArr = cloneDeep(arr);
  * arr[1].a = 2;
- * console.log(arr); // [2, { a: 2 }, [1, 2, 3]]
+ * console.log(arr); // [1, { a: 2 }, [1, 2, 3]]
  * console.log(clonedArr); // [1, { a: 1 }, [1, 2, 3]]
  * console.log(clonedArr === arr); // false
  *
  * @example
  * // Clone an object
  * const obj = { a: 1, b: 'es-toolkit', c: [1, 2, 3] };
- * const clonedObj = clone(obj);
+ * const clonedObj = cloneDeep(obj);
  * console.log(clonedObj); // { a: 1, b: 'es-toolkit', c: [1, 2, 3] }
  * console.log(clonedObj === obj); // false
  *
  * @example
  * // Clone an object with nested objects
  * const obj = { a: 1, b: { c: 1 } };
- * const clonedObj = clone(obj);
+ * const clonedObj = cloneDeep(obj);
  * obj.b.c = 2;
  * console.log(obj); // { a: 1, b: { c: 2 } }
  * console.log(clonedObj); // { a: 1, b: { c: 1 } }


### PR DESCRIPTION
### Summary
Fixed documentation errors in the JSDoc comments of [cloneDeep.ts](cci:7://file:///Users/eunwoo/Desktop/es-toolkit/src/object/cloneDeep.ts:0:0-0:0) where function names were incorrectly written as [clone](cci:1://file:///Users/eunwoo/Desktop/es-toolkit/src/object/cloneDeep.ts:2:0-50:1) instead of [cloneDeep](cci:1://file:///Users/eunwoo/Desktop/es-toolkit/src/object/cloneDeep.ts:2:0-50:1), and one example had an incorrect expected output value.

### Changes

**1. Fixed function names (5 instances)**
```diff
- const clonedNum = clone(num);
+ const clonedNum = cloneDeep(num);
```

**2. Fixed incorrect output**
```diff
  arr[1].a = 2;
- console.log(arr); // [2, { a: 2 }, [1, 2, 3]]
+ console.log(arr); // [1, { a: 2 }, [1, 2, 3]]
```

The first element is a primitive value, so it shouldn't change when mutating the nested object.


