### PR TITLE
docs: localize darkModeSwitchLabel for i18n support

### DIFF
--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -11,7 +11,7 @@ export const en = defineConfig({
     'A state-of-the-art, high-performance JavaScript utility library with a small bundle size and strong type annotations.',
 
   themeConfig: {
-    darkModeSwitchLabel: 'Appearance',
+    darkModeSwitchLabel: 'Dark Mode',
 
     nav: nav(),
 

--- a/docs/.vitepress/ja.mts
+++ b/docs/.vitepress/ja.mts
@@ -10,7 +10,7 @@ export const ja = defineConfig({
   description: '高速なパフォーマンスと小さなバンドルサイズを持つ最先端のJavaScriptユーティリティライブラリ',
 
   themeConfig: {
-    darkModeSwitchLabel: 'テーマ',
+    darkModeSwitchLabel: 'ダークモード',
 
     nav: nav(),
 

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -10,7 +10,7 @@ export const ko = defineConfig({
   description: '빠른 성능, 작은 번들 사이즈를 가지는 현대적인 JavaScript 유틸리티 라이브러리',
 
   themeConfig: {
-    darkModeSwitchLabel: '테마',
+    darkModeSwitchLabel: '다크 모드',
 
     nav: nav(),
 

--- a/docs/.vitepress/zh_hans.mts
+++ b/docs/.vitepress/zh_hans.mts
@@ -11,7 +11,7 @@ export const zh_hans = defineConfig({
   description: '一款先进的高性能 JavaScript 实用库，具有小巧的包体积和强大的类型注解。',
 
   themeConfig: {
-    darkModeSwitchLabel: '主题',
+    darkModeSwitchLabel: '深色模式',
 
     nav: nav(),
 


### PR DESCRIPTION
## Summary

This PR adds localized `darkModeSwitchLabel` translations to the VitePress theme configuration, so the "Appearance" toggle label displays in the user's selected language on responsive/mobile views.

## issues

- https://github.com/toss/es-toolkit/issues/1605

## Changes

Added `darkModeSwitchLabel` property to `themeConfig` in each locale configuration file:

| Locale | File | Label |
|--------|------|-------|
| English | [en.mts](https://github.com/toss/es-toolkit/blob/main/docs/.vitepress/en.mts) | `Appearance` |
| Korean | [ko.mts](https://github.com/toss/es-toolkit/blob/main/docs/.vitepress/ko.mts) | `테마` |
| Japanese | [ja.mts](https://github.com/toss/es-toolkit/blob/main/docs/.vitepress/ja.mts) | `テーマ` |
| Chinese | [zh_hans.mts](https://github.com/toss/es-toolkit/blob/main/docs/.vitepress/zh_hans.mts) | `主題` |

## Before

The dark mode toggle label always showed "Appearance" in English regardless of the selected language.

## After

The label now displays the appropriate translation based on the selected locale.

- img
<img width="535" height="247" alt="toss local" src="https://github.com/user-attachments/assets/8fd61628-40c1-42f1-993a-179bcd0fa296" />
