### PR TITLE
add early return empty array

### DIFF
--- a/src/array/chunk.ts
+++ b/src/array/chunk.ts
@@ -26,6 +26,10 @@ export function chunk<T>(arr: readonly T[], size: number): T[][] {
     throw new Error('Size must be an integer greater than zero.');
   }
 
+  if (arr.length === 0) {
+    return [];
+  }
+
   const chunkLength = Math.ceil(arr.length / size);
   const result: T[][] = Array(chunkLength);
 


### PR DESCRIPTION
Adds an early return when the input array is empty to avoid unnecessary Math.ceil calculation and array allocation.

## Changes

- Added empty array check after size validation in `src/array/chunk.ts`

```typescript
if (arr.length === 0) {
  return [];
}
```

The existing test coverage already validates this behavior.