### PR TITLE
fix(set): remove duplicate arg from set utils

### DIFF
--- a/docs/reference/set/countBy.md
+++ b/docs/reference/set/countBy.md
@@ -63,7 +63,7 @@ const ageGroups = countBy(ages, age => {
 #### Parameters
 
 - `set` (`Set<T>`): The Set to count occurrences from.
-- `mapper` (`(value: T, value2: T, set: Set<T>) => K`): The function to produce a key for counting.
+- `mapper` (`(value: T, set: Set<T>) => K`): The function to produce a key for counting.
 
 #### Returns
 

--- a/docs/reference/set/every.md
+++ b/docs/reference/set/every.md
@@ -58,7 +58,7 @@ const allActive = every(users, user => user.active);
 #### Parameters
 
 - `set` (`Set<T>`): The Set to test.
-- `doesMatch` (`(value: T, value2: T, set: Set<T>) => boolean`): A predicate function that tests each element.
+- `doesMatch` (`(value: T, set: Set<T>) => boolean`): A predicate function that tests each element.
 
 #### Returns
 

--- a/docs/reference/set/filter.md
+++ b/docs/reference/set/filter.md
@@ -52,7 +52,7 @@ const availableProducts = filter(products, product => product.available);
 #### Parameters
 
 - `set` (`Set<T>`): The Set to filter.
-- `callback` (`(value: T, value2: T, set: Set<T>) => boolean`): A predicate function that tests each element.
+- `callback` (`(value: T, set: Set<T>) => boolean`): A predicate function that tests each element.
 
 #### Returns
 

--- a/docs/reference/set/find.md
+++ b/docs/reference/set/find.md
@@ -56,7 +56,7 @@ const adminEmail = find(emails, email => email.startsWith('admin'));
 #### Parameters
 
 - `set` (`Set<T>`): The Set to search.
-- `doesMatch` (`(value: T, value2: T, set: Set<T>) => boolean`): A predicate function that tests each element.
+- `doesMatch` (`(value: T, set: Set<T>) => boolean`): A predicate function that tests each element.
 
 #### Returns
 

--- a/docs/reference/set/forEach.md
+++ b/docs/reference/set/forEach.md
@@ -85,7 +85,7 @@ forEach(users, user => {
 #### Parameters
 
 - `set` (`Set<T>`): The Set to iterate over.
-- `callback` (`(value: T, value2: T, set: Set<T>) => void`): A function to execute for each element.
+- `callback` (`(value: T, set: Set<T>) => void`): A function to execute for each element.
 
 #### Returns
 

--- a/docs/reference/set/keyBy.md
+++ b/docs/reference/set/keyBy.md
@@ -69,7 +69,7 @@ const byParity = keyBy(numbers, num => (num % 2 === 0 ? 'even' : 'odd'));
 #### Parameters
 
 - `set` (`Set<T>`): The set of elements to be mapped.
-- `getKeyFromValue` (`(value: T, value2: T, set: Set<T>) => K`): A function that generates a key from a value.
+- `getKeyFromValue` (`(value: T, set: Set<T>) => K`): A function that generates a key from a value.
 
 #### Returns
 

--- a/docs/reference/set/map.md
+++ b/docs/reference/set/map.md
@@ -57,7 +57,7 @@ const ids = map(users, user => user.id);
 #### Parameters
 
 - `set` (`Set<T>`): The Set to transform.
-- `getNewValue` (`(value: T, value2: T, set: Set<T>) => U`): A function that generates a new value from an element.
+- `getNewValue` (`(value: T, set: Set<T>) => U`): A function that generates a new value from an element.
 
 #### Returns
 

--- a/docs/reference/set/reduce.md
+++ b/docs/reference/set/reduce.md
@@ -54,7 +54,7 @@ const nameList = reduce(uniqueNames, (acc, name) => [...acc, name.toUpperCase()]
 #### Parameters
 
 - `set` (`Set<T>`): The Set to reduce.
-- `callback` (`(accumulator: A, value: T, value2: T, set: Set<T>) => A`): A function that processes each element and updates the accumulator.
+- `callback` (`(accumulator: A, value: T, set: Set<T>) => A`): A function that processes each element and updates the accumulator.
 - `initialValue` (`A`, optional): The initial value for the accumulator. If not provided, the first element in the Set is used.
 
 #### Returns

--- a/docs/reference/set/some.md
+++ b/docs/reference/set/some.md
@@ -58,7 +58,7 @@ const hasAdmin = some(users, user => user.admin);
 #### Parameters
 
 - `set` (`Set<T>`): The Set to test.
-- `doesMatch` (`(value: T, value2: T, set: Set<T>) => boolean`): A predicate function that tests each element.
+- `doesMatch` (`(value: T, set: Set<T>) => boolean`): A predicate function that tests each element.
 
 #### Returns
 

--- a/src/set/countBy.spec.ts
+++ b/src/set/countBy.spec.ts
@@ -18,7 +18,7 @@ describe('countBy', () => {
   it('should pass the original set to the mapper function', () => {
     const set = new Set([1, 2, 3]);
 
-    const result = countBy(set, (value, value2, originalSet) => {
+    const result = countBy(set, (value, originalSet) => {
       expect(originalSet).toBe(set);
       return value >= originalSet.size ? 'large' : 'small';
     });

--- a/src/set/countBy.ts
+++ b/src/set/countBy.ts
@@ -8,7 +8,7 @@
  * @template T - The type of elements in the Set.
  * @template K - The type of keys produced by the transformation function.
  * @param {Set<T>} set - The Set to count occurrences from.
- * @param {(value: T, value2: T, set: Set<T>) => K} mapper - The function to produce a key for counting.
+ * @param {(value: T, set: Set<T>) => K} mapper - The function to produce a key for counting.
  * @returns {Map<K, number>} A Map containing the mapped keys and their counts.
  *
  * @example
@@ -21,11 +21,11 @@
  * const result = countBy(set, (value) => value.length);
  * // result will be Map(2) { 5 => 1, 6 => 2 }
  */
-export function countBy<T, K>(set: Set<T>, mapper: (value: T, value2: T, set: Set<T>) => K): Map<K, number> {
+export function countBy<T, K>(set: Set<T>, mapper: (value: T, set: Set<T>) => K): Map<K, number> {
   const result = new Map<K, number>();
 
   for (const value of set) {
-    const mappedKey = mapper(value, value, set);
+    const mappedKey = mapper(value, set);
     result.set(mappedKey, (result.get(mappedKey) ?? 0) + 1);
   }
 

--- a/src/set/every.spec.ts
+++ b/src/set/every.spec.ts
@@ -23,7 +23,7 @@ describe('every', () => {
   it('should pass the set to the predicate function', () => {
     const set = new Set([1, 2, 3]);
 
-    expect(every(set, (value, value2, originalSet) => originalSet.has(value) && value > 0)).toBe(true);
+    expect(every(set, (value, originalSet) => originalSet.has(value) && value > 0)).toBe(true);
   });
 
   it('should return false immediately when predicate returns false', () => {

--- a/src/set/every.ts
+++ b/src/set/every.ts
@@ -7,7 +7,7 @@
  *
  * @template T - The type of elements in the Set.
  * @param {Set<T>} set - The Set to test.
- * @param {(value: T, value2: T, set: Set<T>) => boolean} doesMatch - A predicate function that tests each element.
+ * @param {(value: T, set: Set<T>) => boolean} doesMatch - A predicate function that tests each element.
  * @returns {boolean} true if all elements satisfy the predicate, false otherwise.
  *
  * @example
@@ -18,9 +18,9 @@
  * const result2 = every(set, (value) => value > 15);
  * // result2 will be: false
  */
-export function every<T>(set: Set<T>, doesMatch: (value: T, value2: T, set: Set<T>) => boolean): boolean {
+export function every<T>(set: Set<T>, doesMatch: (value: T, set: Set<T>) => boolean): boolean {
   for (const value of set) {
-    if (!doesMatch(value, value, set)) {
+    if (!doesMatch(value, set)) {
       return false;
     }
   }

--- a/src/set/filter.spec.ts
+++ b/src/set/filter.spec.ts
@@ -13,7 +13,7 @@ describe('filter', () => {
   it('should pass the original set to the predicate function', () => {
     const set = new Set([1, 2, 3]);
 
-    const result = filter(set, (value, value2, originalSet) => {
+    const result = filter(set, (value, originalSet) => {
       expect(originalSet).toBe(set);
       return value >= originalSet.size;
     });

--- a/src/set/filter.ts
+++ b/src/set/filter.ts
@@ -6,7 +6,7 @@
  *
  * @template T - The type of elements in the Set.
  * @param {Set<T>} set - The Set to filter.
- * @param {(value: T, value2: T, set: Set<T>) => boolean} callback - A predicate function that tests each element.
+ * @param {(value: T, set: Set<T>) => boolean} callback - A predicate function that tests each element.
  * @returns {Set<T>} A new Set containing only the elements that satisfy the predicate.
  *
  * @example
@@ -15,11 +15,11 @@
  * // result will be:
  * // Set(3) { 3, 4, 5 }
  */
-export function filter<T>(set: Set<T>, callback: (value: T, value2: T, set: Set<T>) => boolean): Set<T> {
+export function filter<T>(set: Set<T>, callback: (value: T, set: Set<T>) => boolean): Set<T> {
   const result = new Set<T>();
 
   for (const value of set) {
-    if (callback(value, value, set)) {
+    if (callback(value, set)) {
       result.add(value);
     }
   }

--- a/src/set/find.spec.ts
+++ b/src/set/find.spec.ts
@@ -50,7 +50,7 @@ describe('find', () => {
       { age: 40, active: false },
     ]);
 
-    expect(find(set, (value, value2, originalSet) => value.active && originalSet.has(value))).toEqual({
+    expect(find(set, (value, originalSet) => value.active && originalSet.has(value))).toEqual({
       age: 36,
       active: true,
     });

--- a/src/set/find.ts
+++ b/src/set/find.ts
@@ -7,7 +7,7 @@
  *
  * @template T - The type of elements in the Set.
  * @param {Set<T>} set - The Set to search.
- * @param {(value: T, value2: T, set: Set<T>) => boolean} doesMatch - A predicate function that tests each element.
+ * @param {(value: T, set: Set<T>) => boolean} doesMatch - A predicate function that tests each element.
  * @returns {T | undefined} The first element that satisfies the predicate, or undefined if none found.
  *
  * @example
@@ -19,9 +19,9 @@
  * const result = find(set, (value) => value.quantity > 10);
  * // result will be: { name: 'grape', quantity: 15 }
  */
-export function find<T>(set: Set<T>, doesMatch: (value: T, value2: T, set: Set<T>) => boolean): T | undefined {
+export function find<T>(set: Set<T>, doesMatch: (value: T, set: Set<T>) => boolean): T | undefined {
   for (const value of set) {
-    if (doesMatch(value, value, set)) {
+    if (doesMatch(value, set)) {
       return value;
     }
   }

--- a/src/set/forEach.spec.ts
+++ b/src/set/forEach.spec.ts
@@ -15,20 +15,19 @@ describe('forEach', () => {
 
   it('should pass the value twice and the set to the callback', () => {
     const set = new Set(['a', 'b', 'c']);
-    const results: Array<{ value1: string; value2: string; hasValue: boolean }> = [];
+    const results: Array<{ value1: string; hasValue: boolean }> = [];
 
-    forEach(set, (value, value2, originalSet) => {
+    forEach(set, (value, originalSet) => {
       results.push({
         value1: value,
-        value2: value2,
         hasValue: originalSet.has(value),
       });
     });
 
     expect(results).toEqual([
-      { value1: 'a', value2: 'a', hasValue: true },
-      { value1: 'b', value2: 'b', hasValue: true },
-      { value1: 'c', value2: 'c', hasValue: true },
+      { value1: 'a', hasValue: true },
+      { value1: 'b', hasValue: true },
+      { value1: 'c', hasValue: true },
     ]);
   });
 

--- a/src/set/forEach.ts
+++ b/src/set/forEach.ts
@@ -7,7 +7,7 @@
  *
  * @template T - The type of elements in the Set.
  * @param {Set<T>} set - The Set to iterate over.
- * @param {(value: T, value2: T, set: Set<T>) => void} callback - A function to execute for each element.
+ * @param {(value: T, set: Set<T>) => void} callback - A function to execute for each element.
  * @returns {void}
  *
  * @example
@@ -20,8 +20,8 @@
  * // 4
  * // 6
  */
-export function forEach<T>(set: Set<T>, callback: (value: T, value2: T, set: Set<T>) => void): void {
+export function forEach<T>(set: Set<T>, callback: (value: T, set: Set<T>) => void): void {
   for (const value of set) {
-    callback(value, value, set);
+    callback(value, set);
   }
 }

--- a/src/set/keyBy.spec.ts
+++ b/src/set/keyBy.spec.ts
@@ -23,7 +23,7 @@ describe('keyBy', () => {
   it('should pass the original set to the key function', () => {
     const set = new Set([1, 2, 3]);
 
-    const result = keyBy(set, (value, value2, originalSet) => {
+    const result = keyBy(set, (value, originalSet) => {
       expect(originalSet).toBe(set);
       return value >= originalSet.size ? 'large' : 'small';
     });

--- a/src/set/keyBy.ts
+++ b/src/set/keyBy.ts
@@ -9,7 +9,7 @@
  * @template T - The type of elements in the Set.
  * @template K - The type of keys to produce in the returned Map.
  * @param {Set<T>} set - The set of elements to be mapped.
- * @param {(value: T, value2: T, set: Set<T>) => K} getKeyFromValue - A function that generates a key from a value.
+ * @param {(value: T, set: Set<T>) => K} getKeyFromValue - A function that generates a key from a value.
  * @returns {Map<K, T>} A Map where the generated keys are mapped to each element's value.
  *
  * @example
@@ -25,11 +25,11 @@
  * //   'vegetable' => { type: 'vegetable', name: 'carrot' }
  * // }
  */
-export function keyBy<T, K>(set: Set<T>, getKeyFromValue: (value: T, value2: T, set: Set<T>) => K): Map<K, T> {
+export function keyBy<T, K>(set: Set<T>, getKeyFromValue: (value: T, set: Set<T>) => K): Map<K, T> {
   const result = new Map<K, T>();
 
   for (const value of set) {
-    const newKey = getKeyFromValue(value, value, set);
+    const newKey = getKeyFromValue(value, set);
     result.set(newKey, value);
   }
 

--- a/src/set/map.spec.ts
+++ b/src/set/map.spec.ts
@@ -13,7 +13,7 @@ describe('map', () => {
   it('should pass the set to the transform function', () => {
     const set = new Set([1, 2, 3]);
 
-    const result = map(set, (value, value2, originalSet) => {
+    const result = map(set, (value, originalSet) => {
       expect(originalSet).toBe(set);
       return value + originalSet.size;
     });

--- a/src/set/map.ts
+++ b/src/set/map.ts
@@ -7,7 +7,7 @@
  * @template T - The type of elements in the input Set.
  * @template U - The type of elements in the output Set.
  * @param {Set<T>} set - The Set to transform.
- * @param {(value: T, value2: T, set: Set<T>) => U} getNewValue - A function that generates a new value from an element.
+ * @param {(value: T, set: Set<T>) => U} getNewValue - A function that generates a new value from an element.
  * @returns {Set<U>} A new Set with transformed elements.
  *
  * @example
@@ -16,11 +16,11 @@
  * // result will be:
  * // Set(3) { 2, 4, 6 }
  */
-export function map<T, U>(set: Set<T>, getNewValue: (value: T, value2: T, set: Set<T>) => U): Set<U> {
+export function map<T, U>(set: Set<T>, getNewValue: (value: T, set: Set<T>) => U): Set<U> {
   const result = new Set<U>();
 
   for (const value of set) {
-    const newValue = getNewValue(value, value, set);
+    const newValue = getNewValue(value, set);
     result.add(newValue);
   }
 

--- a/src/set/reduce.spec.ts
+++ b/src/set/reduce.spec.ts
@@ -37,7 +37,7 @@ describe('reduce', () => {
 
     const result = reduce(
       set,
-      (acc, value, value2, originalSet) => {
+      (acc, value, originalSet) => {
         expect(originalSet).toBe(set);
         return acc + value;
       },

--- a/src/set/reduce.ts
+++ b/src/set/reduce.ts
@@ -8,7 +8,7 @@
  * @template T - The type of elements in the Set.
  * @template A - The type of the accumulator.
  * @param {Set<T>} set - The Set to reduce.
- * @param {(accumulator: A, value: T, value2: T, set: Set<T>) => A} callback - A function that processes each element and updates the accumulator.
+ * @param {(accumulator: A, value: T, set: Set<T>) => A} callback - A function that processes each element and updates the accumulator.
  * @param {A} [initialValue] - The initial value for the accumulator. If not provided, the first element in the Set is used.
  * @returns {A} The final accumulated value.
  * @throws {TypeError} If the Set is empty and no initial value is provided.
@@ -25,7 +25,7 @@
  */
 export function reduce<T, A = T>(
   set: Set<T>,
-  callback: (accumulator: A, value: T, value2: T, set: Set<T>) => A,
+  callback: (accumulator: A, value: T, set: Set<T>) => A,
   initialValue?: A
 ): A {
   if (initialValue == null && set.size === 0) {
@@ -38,7 +38,7 @@ export function reduce<T, A = T>(
     if (accumulator == null) {
       accumulator = value as any as A;
     } else {
-      accumulator = callback(accumulator, value, value, set);
+      accumulator = callback(accumulator, value, set);
     }
   }
 

--- a/src/set/some.spec.ts
+++ b/src/set/some.spec.ts
@@ -23,7 +23,7 @@ describe('some', () => {
   it('should pass the set to the predicate function', () => {
     const set = new Set([1, 2, 3]);
 
-    expect(some(set, (value, value2, originalSet) => originalSet.has(value) && value === 2)).toBe(true);
+    expect(some(set, (value, originalSet) => originalSet.has(value) && value === 2)).toBe(true);
   });
 
   it('should return true immediately when predicate returns true', () => {

--- a/src/set/some.ts
+++ b/src/set/some.ts
@@ -7,7 +7,7 @@
  *
  * @template T - The type of elements in the Set.
  * @param {Set<T>} set - The Set to test.
- * @param {(value: T, value2: T, set: Set<T>) => boolean} doesMatch - A predicate function that tests each element.
+ * @param {(value: T, set: Set<T>) => boolean} doesMatch - A predicate function that tests each element.
  * @returns {boolean} true if at least one element satisfies the predicate, false otherwise.
  *
  * @example
@@ -18,9 +18,9 @@
  * const result2 = some(set, (value) => value > 5);
  * // result2 will be: false
  */
-export function some<T>(set: Set<T>, doesMatch: (value: T, value2: T, set: Set<T>) => boolean): boolean {
+export function some<T>(set: Set<T>, doesMatch: (value: T, set: Set<T>) => boolean): boolean {
   for (const value of set) {
-    if (doesMatch(value, value, set)) {
+    if (doesMatch(value, set)) {
       return true;
     }
   }


### PR DESCRIPTION
All Set utilities pass a duplicate value argument to the predicate.

For example:
```ts
find(new Set([1,2,3]), (value, value2, originalSet) => ...) // value and value2 are the same
```

This seems rather unnecessary and the reasoning for this is not documented properly. Moreover, the `value2` property will need to be mentioned if you want to access the `originalSet`.

I'm proposing that we remove the duplicate argument `value2` from all Set utils. This change also updates their related tests and documentation.

This is a breaking change.