### PR TITLE
fix[zip]: include undefined in tuple return types for arrays of different lenghts

### DIFF
--- a/src/array/zip.spec.ts
+++ b/src/array/zip.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { zip } from './zip';
 
 describe('zip', () => {
@@ -26,5 +26,18 @@ describe('zip', () => {
 
   it('supports spread operators', () => {
     expect(zip(...[[1], ['s'], [{ a: 2 }]])).toEqual([[1, 's', { a: 2 }]]);
+  });
+
+  it('should include undefined in return types for arrays of different lengths', () => {
+    const result2 = zip([1, 2, 3], ['a', 'b']);
+    expectTypeOf(result2).toEqualTypeOf<Array<[number | undefined, string | undefined]>>();
+
+    const result3 = zip([1], [true], ['x']);
+    expectTypeOf(result3).toEqualTypeOf<Array<[number | undefined, boolean | undefined, string | undefined]>>();
+
+    const result4 = zip([1], ['a'], [true], [null]);
+    expectTypeOf(result4).toEqualTypeOf<
+      Array<[number | undefined, string | undefined, boolean | undefined, null | undefined]>
+    >();
   });
 });

--- a/src/array/zip.ts
+++ b/src/array/zip.ts
@@ -15,7 +15,7 @@
  * const result = zip(arr1);
  * // result will be [[1], [2], [3]]
  */
-export function zip<T>(arr1: readonly T[]): Array<[T]>;
+export function zip<T>(arr1: readonly T[]): Array<[T | undefined]>;
 
 /**
  * Combines multiple arrays into a single array of tuples.
@@ -36,7 +36,7 @@ export function zip<T>(arr1: readonly T[]): Array<[T]>;
  * const result = zip(arr1, arr2);
  * // result will be [[1, 'a'], [2, 'b'], [3, 'c']]
  */
-export function zip<T, U>(arr1: readonly T[], arr2: readonly U[]): Array<[T, U]>;
+export function zip<T, U>(arr1: readonly T[], arr2: readonly U[]): Array<[T | undefined, U | undefined]>;
 
 /**
  * Combines multiple arrays into a single array of tuples.
@@ -59,7 +59,11 @@ export function zip<T, U>(arr1: readonly T[], arr2: readonly U[]): Array<[T, U]>
  * const result = zip(arr1, arr2, arr3);
  * // result will be [[1, 'a', true], [2, 'b', false], [3, 'c', undefined]]
  */
-export function zip<T, U, V>(arr1: readonly T[], arr2: readonly U[], arr3: readonly V[]): Array<[T, U, V]>;
+export function zip<T, U, V>(
+  arr1: readonly T[],
+  arr2: readonly U[],
+  arr3: readonly V[]
+): Array<[T | undefined, U | undefined, V | undefined]>;
 
 /**
  * Combines multiple arrays into a single array of tuples.
@@ -89,7 +93,7 @@ export function zip<T, U, V, W>(
   arr2: readonly U[],
   arr3: readonly V[],
   arr4: readonly W[]
-): Array<[T, U, V, W]>;
+): Array<[T | undefined, U | undefined, V | undefined, W | undefined]>;
 
 /**
  * Combines multiple arrays into a single array of tuples.


### PR DESCRIPTION
# Summary

This PR improves type safety for the `zip` function by adding `| undefined` to all tuple element positions in the overload return types. When arrays of different lengths are zipped, the resulting tuples contain `undefined` for missing elements, but the types did not reflect this.

# Changes

- **[`src/array/zip.ts`](src/array/zip.ts)**
  - Updated all 4 overload return types to include `| undefined` in each tuple position
  - Runtime implementation remains unchanged

- **[`src/array/zip.spec.ts`](src/array/zip.spec.ts)**
  - Added type-level test cases using `expectTypeOf` for 2-arg, 3-arg, and 4-arg overloads

# Motivation

- Using the current types causes loss of type information and can hide obvious runtime errors.

```ts
// zip with arrays of different lengths
const result = zip([1, 2, 3], ['a', 'b']);
// result at runtime: [[1, 'a'], [2, 'b'], [3, undefined]]

// TypeScript infers result as [number, string][]
// No TypeScript error, but accessing result[2][1] could be undefined
result[2][1].toUpperCase();
// No TypeScript error, but will crash at runtime because result[2][1] is undefined
```

- The compat version (`src/compat/array/zip.ts`) already correctly uses `| undefined`, so the core version should be consistent.

```ts
// With the fix, TypeScript correctly infers:
const result = zip([1, 2, 3], ['a', 'b']);
// Type: [number | undefined, string | undefined][]

result[2][1]?.toUpperCase(); // TypeScript now requires optional chaining
```

By including `| undefined` in the return types, the function now preserves type information and provides better safety for downstream consumers.

This change aligns with the project's design principles:

- Strong typing
- Clear and predictable API
- Consistency between `es-toolkit` and `es-toolkit/compat`

# Example

```ts
// 2 arrays of different lengths
const a = zip([1, 2, 3], ['a', 'b']);
// Type: Array<[number | undefined, string | undefined]>

// 3 arrays
const b = zip([1], [true], ['x']);
// Type: Array<[number | undefined, boolean | undefined, string | undefined]>

// 4 arrays
const c = zip([1], ['a'], [true], [null]);
// Type: Array<[number | undefined, string | undefined, boolean | undefined, null | undefined]>
```

Fixes #1609
