### PR TITLE
feat(median): add bigint support to median and medianBy

### DIFF
--- a/src/math/median.spec.ts
+++ b/src/math/median.spec.ts
@@ -37,4 +37,9 @@ describe('median', () => {
   it('returns the single element for bigint arrays with one element', () => {
     expect(median([42n])).toEqual(42n);
   });
+
+  it('returns NaN for empty bigint arrays', () => {
+    const empty: bigint[] = [];
+    expect(median(empty)).toEqual(NaN);
+  });
 });

--- a/src/math/median.spec.ts
+++ b/src/math/median.spec.ts
@@ -21,4 +21,20 @@ describe('median', () => {
   it('returns the single element for arrays with one element', () => {
     expect(median([42])).toEqual(42);
   });
+
+  it('returns the median for an odd number of bigint elements', () => {
+    expect(median([1n, 2n, 3n, 4n, 5n])).toEqual(3n);
+  });
+
+  it('returns the median for an even number of bigint elements (integer division)', () => {
+    expect(median([1n, 2n, 3n, 4n])).toEqual(2n);
+  });
+
+  it('returns the correct median for unsorted bigint arrays', () => {
+    expect(median([5n, 2n, 1n, 4n, 3n])).toEqual(3n);
+  });
+
+  it('returns the single element for bigint arrays with one element', () => {
+    expect(median([42n])).toEqual(42n);
+  });
 });

--- a/src/math/median.ts
+++ b/src/math/median.ts
@@ -30,7 +30,7 @@ export function median(nums: readonly number[]): number;
  * If the array has an even number of elements, it returns the average of the two middle values
  * using integer division.
  *
- * If the array is empty, this function returns `NaN`.
+ * If the array is empty, this function returns `0n`.
  *
  * @param {bigint[]} nums - An array of bigints to calculate the median.
  * @returns {bigint} The median of all the bigints in the array.
@@ -52,26 +52,30 @@ export function median(nums: readonly number[] | readonly bigint[]): number | bi
     return NaN;
   }
 
-  const isBigInt = typeof nums[0] === 'bigint';
+  if (typeof nums[0] === 'bigint') {
+    const sorted = (nums as bigint[]).slice().sort((a, b) => {
+      if (a < b) {
+        return -1;
+      }
+      if (a > b) {
+        return 1;
+      }
+      return 0;
+    });
 
-  const sorted = (nums as any[]).slice().sort((a, b) => {
-    if (a < b) {
-      return -1;
-    }
-    if (a > b) {
-      return 1;
-    }
-    return 0;
-  });
+    const middleIndex = Math.floor(sorted.length / 2);
 
+    if (sorted.length % 2 === 0) {
+      return (sorted[middleIndex - 1] + sorted[middleIndex]) / 2n;
+    }
+    return sorted[middleIndex];
+  }
+
+  const sorted = (nums as number[]).slice().sort((a, b) => a - b);
   const middleIndex = Math.floor(sorted.length / 2);
 
   if (sorted.length % 2 === 0) {
-    if (isBigInt) {
-      return (sorted[middleIndex - 1] + sorted[middleIndex]) / 2n;
-    }
     return (sorted[middleIndex - 1] + sorted[middleIndex]) / 2;
-  } else {
-    return sorted[middleIndex];
   }
+  return sorted[middleIndex];
 }

--- a/src/math/median.ts
+++ b/src/math/median.ts
@@ -20,15 +20,56 @@
  * const result = median(arrayWithEvenNumberOfElements);
  * // result will be 2.5
  */
-export function median(nums: readonly number[]): number {
+export function median(nums: readonly number[]): number;
+
+/**
+ * Calculates the median of an array of bigints.
+ *
+ * The median is the middle value of a sorted array.
+ * If the array has an odd number of elements, the median is the middle value.
+ * If the array has an even number of elements, it returns the average of the two middle values
+ * using integer division.
+ *
+ * If the array is empty, this function returns `NaN`.
+ *
+ * @param {bigint[]} nums - An array of bigints to calculate the median.
+ * @returns {bigint} The median of all the bigints in the array.
+ *
+ * @example
+ * const arrayWithOddNumberOfElements = [1n, 2n, 3n, 4n, 5n];
+ * const result = median(arrayWithOddNumberOfElements);
+ * // result will be 3n
+ *
+ * @example
+ * const arrayWithEvenNumberOfElements = [1n, 2n, 3n, 4n];
+ * const result = median(arrayWithEvenNumberOfElements);
+ * // result will be 2n (integer division)
+ */
+export function median(nums: readonly bigint[]): bigint;
+
+export function median(nums: readonly number[] | readonly bigint[]): number | bigint {
   if (nums.length === 0) {
     return NaN;
   }
 
-  const sorted = nums.slice().sort((a, b) => a - b);
+  const isBigInt = typeof nums[0] === 'bigint';
+
+  const sorted = (nums as any[]).slice().sort((a, b) => {
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+    return 0;
+  });
+
   const middleIndex = Math.floor(sorted.length / 2);
 
   if (sorted.length % 2 === 0) {
+    if (isBigInt) {
+      return (sorted[middleIndex - 1] + sorted[middleIndex]) / 2n;
+    }
     return (sorted[middleIndex - 1] + sorted[middleIndex]) / 2;
   } else {
     return sorted[middleIndex];

--- a/src/math/medianBy.spec.ts
+++ b/src/math/medianBy.spec.ts
@@ -36,4 +36,10 @@ describe('medianBy', () => {
     const result = medianBy([{ a: 1n }, { a: 2n }, { a: 3n }, { a: 4n }], x => x.a);
     expect(result).toEqual(2n);
   });
+
+  it('returns NaN for empty bigint arrays', () => {
+    type Item = { a: bigint };
+    const items: Item[] = [];
+    expect(medianBy(items, x => x.a)).toEqual(NaN);
+  });
 });

--- a/src/math/medianBy.spec.ts
+++ b/src/math/medianBy.spec.ts
@@ -26,4 +26,14 @@ describe('medianBy', () => {
   it('returns the single element for arrays with one element', () => {
     expect(medianBy([{ a: 42 }], x => x.a)).toEqual(42);
   });
+
+  it('calculates the median of bigint values extracted from objects with odd number of elements', () => {
+    const result = medianBy([{ a: 1n }, { a: 2n }, { a: 3n }, { a: 4n }, { a: 5n }], x => x.a);
+    expect(result).toEqual(3n);
+  });
+
+  it('calculates the median of bigint values extracted from objects with even number of elements', () => {
+    const result = medianBy([{ a: 1n }, { a: 2n }, { a: 3n }, { a: 4n }], x => x.a);
+    expect(result).toEqual(2n);
+  });
 });

--- a/src/math/medianBy.ts
+++ b/src/math/medianBy.ts
@@ -26,6 +26,8 @@ export function medianBy<T>(items: readonly T[], getValue: (element: T) => numbe
  * Calculates the median of an array of elements when applying
  * the `getValue` function to each element, returning a bigint.
  *
+ * If the array is empty, this function returns `NaN`.
+ *
  * @template T - The type of elements in the array.
  * @param {T[]} items An array to calculate the median.
  * @param {(element: T) => bigint} getValue A function that selects a bigint value from each element.
@@ -39,5 +41,8 @@ export function medianBy<T>(items: readonly T[], getValue: (element: T) => bigin
 export function medianBy<T>(items: readonly T[], getValue: (element: T) => number | bigint): number | bigint {
   const nums = items.map(x => getValue(x));
 
-  return median(nums as any);
+  if (nums.length > 0 && typeof nums[0] === 'bigint') {
+    return median(nums as bigint[]);
+  }
+  return median(nums as number[]);
 }

--- a/src/math/medianBy.ts
+++ b/src/math/medianBy.ts
@@ -20,8 +20,24 @@ import { median } from './median.ts';
  * medianBy([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }], x => x.a); // Returns: 2.5
  * medianBy([], x => x.a); // Returns: NaN
  */
-export function medianBy<T>(items: readonly T[], getValue: (element: T) => number): number {
+export function medianBy<T>(items: readonly T[], getValue: (element: T) => number): number;
+
+/**
+ * Calculates the median of an array of elements when applying
+ * the `getValue` function to each element, returning a bigint.
+ *
+ * @template T - The type of elements in the array.
+ * @param {T[]} items An array to calculate the median.
+ * @param {(element: T) => bigint} getValue A function that selects a bigint value from each element.
+ * @returns {bigint} The median of all the bigints as determined by the `getValue` function.
+ *
+ * @example
+ * medianBy([{ a: 1n }, { a: 2n }, { a: 3n }, { a: 4n }, { a: 5n }], x => x.a); // Returns: 3n
+ */
+export function medianBy<T>(items: readonly T[], getValue: (element: T) => bigint): bigint;
+
+export function medianBy<T>(items: readonly T[], getValue: (element: T) => number | bigint): number | bigint {
   const nums = items.map(x => getValue(x));
 
-  return median(nums);
+  return median(nums as any);
 }


### PR DESCRIPTION
## Summary

- Add `bigint[]` overload to `median()` — uses `2n` for integer division instead of `2`
- Add `bigint[]` overload to `medianBy()` to match
- Use comparison-based sorting (`< >`) instead of subtraction (`a - b`) to support both `number` and `bigint`

## Motivation

`median()` currently throws a runtime error when called with `bigint[]` because it divides by `2` (a `number`), which cannot be mixed with `bigint`. This follows the same pattern as #742 (`sum()` bigint support).

Closes #1588

## Test plan

- [x] `median([1n, 2n, 3n, 4n, 5n])` returns `3n`
- [x] `median([1n, 2n, 3n, 4n])` returns `2n` (integer division)
- [x] Unsorted bigint arrays return correct median
- [x] Single-element bigint arrays work
- [x] `medianBy()` works with bigint getValue
- [x] All existing 68 math tests still pass