### PR TITLE
docs[isElement]: fix Cyrillic character in Japanese doc

### DIFF
--- a/docs/ja/reference/compat/predicate/isElement.md
+++ b/docs/ja/reference/compat/predicate/isElement.md
@@ -24,7 +24,7 @@ const result = isElement(value);
 import { isElement } from 'es-toolkit/compat';
 
 // DOM要素
-исElement(document.body); // true
+isElement(document.body); // true
 isElement(document.createElement('div')); // true
 isElement(document.querySelector('p')); // true (要素が存在する場合)
 


### PR DESCRIPTION
Line 27 of `docs/ja/reference/compat/predicate/isElement.md` starts with Cyrillic `и` (U+0438) instead of Latin `i` (U+0069).

Visually identical, but copy-pasted code won't work.