### PR TITLE
docs(memoize): fix incorrect variable name in JSDoc example

### DIFF
--- a/docs/ja/reference/function/memoize.md
+++ b/docs/ja/reference/function/memoize.md
@@ -138,5 +138,5 @@ const customCache = new CustomCache<string, number>();
 const memoizedSumWithCustomCache = memoize(sum, { cache: customCache });
 console.log(memoizedSumWithCustomCache([1, 2])); // 3
 console.log(memoizedSumWithCustomCache([1, 2])); // 3 (キャッシュされた結果)
-console.log(memoizedAddWithCustomCache.cache.size); // 1
+console.log(memoizedSumWithCustomCache.cache.size); // 1
 ```

--- a/src/function/memoize.ts
+++ b/src/function/memoize.ts
@@ -68,7 +68,7 @@
  * const memoizedSumWithCustomCache = memoize(sum, { cache: customCache });
  * console.log(memoizedSumWithCustomCache([1, 2])); // 3
  * console.log(memoizedSumWithCustomCache([1, 2])); // 3 (cached result)
- * console.log(memoizedAddWithCustomCache.cache.size); // 1
+ * console.log(memoizedSumWithCustomCache.cache.size); // 1
  */
 export function memoize<F extends (...args: any) => any>(
   fn: F,


### PR DESCRIPTION
The last line of the custom cache example references `memoizedAddWithCustomCache`, but the variable is defined as `memoizedSumWithCustomCache` three lines above.

Fixed in JSDoc (`src/function/memoize.ts:71`) and Japanese docs (`docs/ja/reference/function/memoize.md:141`).