### PR TITLE
fix: add missing full-application overloads for partial with 2/3/4 args

### DIFF
--- a/src/function/partial.spec.ts
+++ b/src/function/partial.spec.ts
@@ -111,4 +111,25 @@ describe('partial', () => {
     expect(partialed(5)).toBe(15);
     expect(typeof partialed.prototype).toBe('object');
   });
+
+  it('fully applies a 2-argument function and returns a zero-argument function', () => {
+    const add = (a: number, b: number) => a + b;
+    const addThree = partial(add, 1, 2);
+
+    expect(addThree()).toBe(3);
+  });
+
+  it('fully applies a 3-argument function and returns a zero-argument function', () => {
+    const sum = (a: number, b: number, c: number) => a + b + c;
+    const sumAll = partial(sum, 1, 2, 3);
+
+    expect(sumAll()).toBe(6);
+  });
+
+  it('fully applies a 4-argument function and returns a zero-argument function', () => {
+    const sumFour = (a: number, b: number, c: number, d: number) => a + b + c + d;
+    const sumAll = partial(sumFour, 1, 2, 3, 4);
+
+    expect(sumAll()).toBe(10);
+  });
 });

--- a/src/function/partial.ts
+++ b/src/function/partial.ts
@@ -74,6 +74,28 @@ export function partial<T1, T2, R>(
  *
  * @template T1 The type of the first argument.
  * @template T2 The type of the second argument.
+ * @template R The return type of the function.
+ * @param {function(arg1: T1, arg2: T2): R} func The function to partially apply.
+ * @param {T1} arg1 The first argument to apply.
+ * @param {T2} arg2 The second argument to apply.
+ * @returns {function(): R} A new function that takes no arguments and returns the result of the original function.
+ *
+ * @example
+ * const add = (x: number, y: number) => x + y;
+ * const addThree = partial(add, 1, 2);
+ * console.log(addThree()); // => 3
+ */
+export function partial<T1, T2, R>(func: (arg1: T1, arg2: T2) => R, arg1: T1, arg2: T2): () => R;
+
+/**
+ * Creates a function that invokes `func` with `partialArgs` prepended to the arguments it receives. This method is like `bind` except it does not alter the `this` binding.
+ *
+ * The partial.placeholder value, which defaults to a `symbol`, may be used as a placeholder for partially applied arguments.
+ *
+ * Note: This method doesn't set the `length` property of partially applied functions.
+ *
+ * @template T1 The type of the first argument.
+ * @template T2 The type of the second argument.
  * @template T3 The type of the third argument.
  * @template R The return type of the function.
  * @param {function(arg1: T1, arg2: T2, arg3: T3): R} func The function to partially apply.
@@ -200,6 +222,30 @@ export function partial<T1, T2, T3, R>(
   arg2: T2,
   arg3: T3
 ): (arg1: T1) => R;
+
+/**
+ * Creates a function that invokes `func` with `partialArgs` prepended to the arguments it receives. This method is like `bind` except it does not alter the `this` binding.
+ *
+ * The partial.placeholder value, which defaults to a `symbol`, may be used as a placeholder for partially applied arguments.
+ *
+ * Note: This method doesn't set the `length` property of partially applied functions.
+ *
+ * @template T1 The type of the first argument.
+ * @template T2 The type of the second argument.
+ * @template T3 The type of the third argument.
+ * @template R The return type of the function.
+ * @param {function(arg1: T1, arg2: T2, arg3: T3): R} func The function to partially apply.
+ * @param {T1} arg1 The first argument to apply.
+ * @param {T2} arg2 The second argument to apply.
+ * @param {T3} arg3 The third argument to apply.
+ * @returns {function(): R} A new function that takes no arguments and returns the result of the original function.
+ *
+ * @example
+ * const sum = (a: number, b: number, c: number) => a + b + c;
+ * const sumAll = partial(sum, 1, 2, 3);
+ * console.log(sumAll()); // => 6
+ */
+export function partial<T1, T2, T3, R>(func: (arg1: T1, arg2: T2, arg3: T3) => R, arg1: T1, arg2: T2, arg3: T3): () => R;
 
 /**
  * Creates a function that invokes `func` with `partialArgs` prepended to the arguments it receives. This method is like `bind` except it does not alter the `this` binding.
@@ -512,6 +558,38 @@ export function partial<T1, T2, T3, T4, R>(
   arg3: T3,
   arg4: T4
 ): (arg1: T1) => R;
+
+/**
+ * Creates a function that invokes `func` with `partialArgs` prepended to the arguments it receives. This method is like `bind` except it does not alter the `this` binding.
+ *
+ * The partial.placeholder value, which defaults to a `symbol`, may be used as a placeholder for partially applied arguments.
+ *
+ * Note: This method doesn't set the `length` property of partially applied functions.
+ *
+ * @template T1 The type of the first argument.
+ * @template T2 The type of the second argument.
+ * @template T3 The type of the third argument.
+ * @template T4 The type of the fourth argument.
+ * @template R The return type of the function.
+ * @param {function(arg1: T1, arg2: T2, arg3: T3, arg4: T4): R} func The function to partially apply.
+ * @param {T1} arg1 The first argument to apply.
+ * @param {T2} arg2 The second argument to apply.
+ * @param {T3} arg3 The third argument to apply.
+ * @param {T4} arg4 The fourth argument to apply.
+ * @returns {function(): R} A new function that takes no arguments and returns the result of the original function.
+ *
+ * @example
+ * const sumFour = (a: number, b: number, c: number, d: number) => a + b + c + d;
+ * const sumAll = partial(sumFour, 1, 2, 3, 4);
+ * console.log(sumAll()); // => 10
+ */
+export function partial<T1, T2, T3, T4, R>(
+  func: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => R,
+  arg1: T1,
+  arg2: T2,
+  arg3: T3,
+  arg4: T4
+): () => R;
 
 /**
  * Creates a function that invokes `func` with `partialArgs` prepended to the arguments it receives. This method is like `bind` except it does not alter the `this` binding.

--- a/src/function/partial.ts
+++ b/src/function/partial.ts
@@ -245,7 +245,12 @@ export function partial<T1, T2, T3, R>(
  * const sumAll = partial(sum, 1, 2, 3);
  * console.log(sumAll()); // => 6
  */
-export function partial<T1, T2, T3, R>(func: (arg1: T1, arg2: T2, arg3: T3) => R, arg1: T1, arg2: T2, arg3: T3): () => R;
+export function partial<T1, T2, T3, R>(
+  func: (arg1: T1, arg2: T2, arg3: T3) => R,
+  arg1: T1,
+  arg2: T2,
+  arg3: T3
+): () => R;
 
 /**
  * Creates a function that invokes `func` with `partialArgs` prepended to the arguments it receives. This method is like `bind` except it does not alter the `this` binding.


### PR DESCRIPTION
## Summary

Fixes #1667

The `partial` function was missing type overloads for fully applying all arguments of a 2-, 3-, or 4-argument function.

**Root cause:** When passing all arguments (e.g. `partial(add, 1, 2)`), TypeScript would fall through to a variadic overload like `partial<TS extends any[], T1, T2, R>(func: (arg1: T1, arg2: T2, ...args: TS) => R, t1: T1, arg2: T2): (...args: TS) => R`, failing to infer `TS = []`. This resulted in a wrong return type of `(arg3: unknown, arg4: unknown) => number` instead of `() => number`.

**Before:**
```ts
const add = (a: number, b: number): number => a + b;
const addBoth = partial(add, 1, 2);
// Type: (arg3: unknown, arg4: unknown) => number  ❌
```

**After:**
```ts
const addBoth = partial(add, 1, 2);
// Type: () => number  ✅
addBoth(); // => 3
```

## Changes

- Added explicit full-application overloads for 2-, 3-, and 4-argument functions
- Placed before variadic fallback overloads so TypeScript picks the more specific signatures
- Added 3 tests covering all new overloads