### PR TITLE
fix(isBuffer): use globalThis.Buffer to avoid webpack/turbopack polyfill injection

### DIFF
--- a/src/compat/object/mergeWith.ts
+++ b/src/compat/object/mergeWith.ts
@@ -9,12 +9,6 @@ import { isObjectLike } from '../predicate/isObjectLike.ts';
 import { isPlainObject } from '../predicate/isPlainObject.ts';
 import { isTypedArray } from '../predicate/isTypedArray.ts';
 
-declare let Buffer:
-  | {
-      isBuffer: (a: any) => boolean;
-    }
-  | undefined;
-
 type MergeWithCustomizer = (objValue: any, srcValue: any, key: string, object: any, source: any, stack: any) => any;
 
 /**
@@ -288,7 +282,9 @@ function mergeWithDeep(
       targetValue = { ...targetValue };
     }
 
-    if (typeof Buffer !== 'undefined' && Buffer.isBuffer(sourceValue)) {
+    // Access Buffer via globalThis so webpack/turbopack don't inject a Buffer polyfill into the browser bundle.
+    const B = (globalThis as { Buffer?: { isBuffer(a: any): boolean } }).Buffer;
+    if (B != null && B.isBuffer(sourceValue)) {
       sourceValue = cloneDeep(sourceValue);
     }
 

--- a/src/compat/predicate/isEmpty.ts
+++ b/src/compat/predicate/isEmpty.ts
@@ -4,12 +4,6 @@ import { isTypedArray } from './isTypedArray.ts';
 import type { EmptyObjectOf } from '../_internal/EmptyObjectOf.ts';
 import { isPrototype } from '../_internal/isPrototype.ts';
 
-declare let Buffer:
-  | {
-      isBuffer: (a: any) => boolean;
-    }
-  | undefined;
-
 export function isEmpty<T extends { __trapAny: any }>(value?: T): boolean;
 export function isEmpty(value: string): value is '';
 export function isEmpty(value: Map<any, any> | Set<any> | ArrayLike<any> | null | undefined): boolean;
@@ -50,10 +44,12 @@ export function isEmpty(value?: unknown): boolean {
 
   // Objects like { "length": 0 } are not empty in lodash
   if (isArrayLike(value)) {
+    // Access Buffer via globalThis so webpack/turbopack don't inject a Buffer polyfill into the browser bundle.
+    const B = (globalThis as { Buffer?: { isBuffer(a: any): boolean } }).Buffer;
     if (
       typeof (value as any).splice !== 'function' &&
       typeof value !== 'string' &&
-      (typeof Buffer === 'undefined' || !Buffer.isBuffer(value)) &&
+      (B == null || !B.isBuffer(value)) &&
       !isTypedArray(value) &&
       !isArguments(value)
     ) {

--- a/src/object/cloneDeepWith.ts
+++ b/src/object/cloneDeepWith.ts
@@ -152,12 +152,10 @@ export function cloneDeepWithImpl<T>(
     return result as T;
   }
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(valueToClone)) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return valueToClone.subarray() as T;
+  // Access Buffer via globalThis so webpack/turbopack don't inject a Buffer polyfill into the browser bundle.
+  const B = (globalThis as { Buffer?: { isBuffer(a: any): boolean } }).Buffer;
+  if (B != null && B.isBuffer(valueToClone)) {
+    return (valueToClone as { subarray(): unknown }).subarray() as T;
   }
 
   if (isTypedArray(valueToClone)) {

--- a/src/predicate/isBuffer.ts
+++ b/src/predicate/isBuffer.ts
@@ -1,9 +1,3 @@
-declare let Buffer:
-  | {
-      isBuffer: (a: any) => boolean;
-    }
-  | undefined;
-
 /**
  * Checks if the given value is a Buffer instance.
  *
@@ -23,7 +17,7 @@ declare let Buffer:
  * console.log(isBuffer(notBuffer)); // false
  */
 export function isBuffer(x: unknown): boolean {
-  // eslint-disable-next-line
-  // @ts-ignore
-  return typeof Buffer !== 'undefined' && Buffer.isBuffer(x);
+  // Access Buffer via globalThis so webpack/turbopack don't inject a Buffer polyfill into the browser bundle.
+  const B = (globalThis as { Buffer?: { isBuffer(a: any): boolean } }).Buffer;
+  return B != null && B.isBuffer(x);
 }

--- a/src/predicate/isEqualWith.ts
+++ b/src/predicate/isEqualWith.ts
@@ -31,12 +31,6 @@ import {
 } from '../compat/_internal/tags.ts';
 import { eq } from '../compat/util/eq.ts';
 
-declare let Buffer:
-  | {
-      isBuffer: (a: any) => boolean;
-    }
-  | undefined;
-
 /**
  * Compares two values for equality using a custom comparison function.
  *
@@ -255,7 +249,9 @@ function areObjectsEqual(
       case float32ArrayTag:
       case float64ArrayTag: {
         // Buffers are also treated as [object Uint8Array]s.
-        if (typeof Buffer !== 'undefined' && Buffer.isBuffer(a) !== Buffer.isBuffer(b)) {
+        // Access Buffer via globalThis so webpack/turbopack don't inject a Buffer polyfill into the browser bundle.
+        const B = (globalThis as { Buffer?: { isBuffer(a: any): boolean } }).Buffer;
+        if (B != null && B.isBuffer(a) !== B.isBuffer(b)) {
           return false;
         }
 


### PR DESCRIPTION
route every `Buffer.isBuffer` / `typeof Buffer` call through `globalThis.Buffer` so webpack & turbopack stop auto-injecting a ~20 KB Buffer polyfill into the browser bundle.

this is the lighter alternative to #1671 that @raon0211 suggested — no rollup alias plugin, no extra browser-build path, no `browser` export condition. single change: stop referencing the bare `Buffer` identifier.

closes #1670