### PR TITLE
fix(AbortError, TimeoutError): fall back to Error when DOMException is undefined

### DIFF
--- a/src/error/AbortError.spec.ts
+++ b/src/error/AbortError.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AbortError } from './AbortError';
 
 describe('AbortError', () => {
@@ -16,5 +16,21 @@ describe('AbortError', () => {
 
   it.skipIf(typeof DOMException === 'undefined')('extends DOMException when available', () => {
     expect(new AbortError()).toBeInstanceOf(DOMException);
+  });
+
+  describe('when DOMException is unavailable (e.g. Hermes)', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.resetModules();
+    });
+
+    it('loads without throwing and falls back to Error', async () => {
+      vi.stubGlobal('DOMException', undefined);
+      vi.resetModules();
+      const { AbortError: FallbackAbortError } = await import('./AbortError');
+      const err = new FallbackAbortError();
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe('The operation was aborted');
+    });
   });
 });

--- a/src/error/AbortError.spec.ts
+++ b/src/error/AbortError.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { AbortError } from './AbortError';
+
+describe('AbortError', () => {
+  it('is an instance of Error', () => {
+    expect(new AbortError()).toBeInstanceOf(Error);
+  });
+
+  it('uses the default message when none is provided', () => {
+    expect(new AbortError().message).toBe('The operation was aborted');
+  });
+
+  it('uses the provided message', () => {
+    expect(new AbortError('custom').message).toBe('custom');
+  });
+
+  it.skipIf(typeof DOMException === 'undefined')('extends DOMException when available', () => {
+    expect(new AbortError()).toBeInstanceOf(DOMException);
+  });
+});

--- a/src/error/AbortError.ts
+++ b/src/error/AbortError.ts
@@ -1,5 +1,7 @@
 // Falls back to `Error` on runtimes without `DOMException` (e.g. Hermes / React Native).
-const AbortErrorBase: { new (message?: string): Error } = typeof DOMException !== 'undefined' ? DOMException : Error;
+// Type stays `typeof DOMException` so the emitted `.d.ts` keeps `AbortError extends DOMException`.
+const AbortErrorBase: typeof DOMException =
+  typeof DOMException !== 'undefined' ? DOMException : (Error as unknown as typeof DOMException);
 
 /**
  * An error class representing an aborted operation.

--- a/src/error/AbortError.ts
+++ b/src/error/AbortError.ts
@@ -1,8 +1,21 @@
 /**
+ * Base constructor for {@link AbortError}. Uses `DOMException` when it is
+ * available on the global object (browsers, modern Node, Deno, Bun) so that
+ * `instanceof DOMException` checks keep working, and falls back to `Error`
+ * on runtimes that don't expose `DOMException` (notably Hermes, which powers
+ * React Native / Expo by default, as well as older Node versions).
+ */
+const AbortErrorBase: { new (message?: string): Error } = typeof DOMException !== 'undefined' ? DOMException : Error;
+
+/**
  * An error class representing an aborted operation.
+ *
+ * Extends `DOMException` on runtimes that provide it, otherwise extends `Error`.
+ * Either way, `instanceof Error` is always true.
+ *
  * @augments DOMException
  */
-export class AbortError extends DOMException {
+export class AbortError extends AbortErrorBase {
   constructor(message = 'The operation was aborted') {
     super(message);
   }

--- a/src/error/AbortError.ts
+++ b/src/error/AbortError.ts
@@ -1,18 +1,8 @@
-/**
- * Base constructor for {@link AbortError}. Uses `DOMException` when it is
- * available on the global object (browsers, modern Node, Deno, Bun) so that
- * `instanceof DOMException` checks keep working, and falls back to `Error`
- * on runtimes that don't expose `DOMException` (notably Hermes, which powers
- * React Native / Expo by default, as well as older Node versions).
- */
+// Falls back to `Error` on runtimes without `DOMException` (e.g. Hermes / React Native).
 const AbortErrorBase: { new (message?: string): Error } = typeof DOMException !== 'undefined' ? DOMException : Error;
 
 /**
  * An error class representing an aborted operation.
- *
- * Extends `DOMException` on runtimes that provide it, otherwise extends `Error`.
- * Either way, `instanceof Error` is always true.
- *
  * @augments DOMException
  */
 export class AbortError extends AbortErrorBase {

--- a/src/error/TimeoutError.spec.ts
+++ b/src/error/TimeoutError.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { TimeoutError } from './TimeoutError';
+
+describe('TimeoutError', () => {
+  it('is an instance of Error', () => {
+    expect(new TimeoutError()).toBeInstanceOf(Error);
+  });
+
+  it('uses the default message when none is provided', () => {
+    expect(new TimeoutError().message).toBe('The operation was timed out');
+  });
+
+  it('uses the provided message', () => {
+    expect(new TimeoutError('custom').message).toBe('custom');
+  });
+
+  it.skipIf(typeof DOMException === 'undefined')('extends DOMException when available', () => {
+    expect(new TimeoutError()).toBeInstanceOf(DOMException);
+  });
+});

--- a/src/error/TimeoutError.spec.ts
+++ b/src/error/TimeoutError.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TimeoutError } from './TimeoutError';
 
 describe('TimeoutError', () => {
@@ -16,5 +16,21 @@ describe('TimeoutError', () => {
 
   it.skipIf(typeof DOMException === 'undefined')('extends DOMException when available', () => {
     expect(new TimeoutError()).toBeInstanceOf(DOMException);
+  });
+
+  describe('when DOMException is unavailable (e.g. Hermes)', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.resetModules();
+    });
+
+    it('loads without throwing and falls back to Error', async () => {
+      vi.stubGlobal('DOMException', undefined);
+      vi.resetModules();
+      const { TimeoutError: FallbackTimeoutError } = await import('./TimeoutError');
+      const err = new FallbackTimeoutError();
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe('The operation was timed out');
+    });
   });
 });

--- a/src/error/TimeoutError.ts
+++ b/src/error/TimeoutError.ts
@@ -1,5 +1,7 @@
 // Falls back to `Error` on runtimes without `DOMException` (e.g. Hermes / React Native).
-const TimeoutErrorBase: { new (message?: string): Error } = typeof DOMException !== 'undefined' ? DOMException : Error;
+// Type stays `typeof DOMException` so the emitted `.d.ts` keeps `TimeoutError extends DOMException`.
+const TimeoutErrorBase: typeof DOMException =
+  typeof DOMException !== 'undefined' ? DOMException : (Error as unknown as typeof DOMException);
 
 /**
  * An error class representing a timeout operation.

--- a/src/error/TimeoutError.ts
+++ b/src/error/TimeoutError.ts
@@ -1,8 +1,21 @@
 /**
+ * Base constructor for {@link TimeoutError}. Uses `DOMException` when it is
+ * available on the global object (browsers, modern Node, Deno, Bun) so that
+ * `instanceof DOMException` checks keep working, and falls back to `Error`
+ * on runtimes that don't expose `DOMException` (notably Hermes, which powers
+ * React Native / Expo by default, as well as older Node versions).
+ */
+const TimeoutErrorBase: { new (message?: string): Error } = typeof DOMException !== 'undefined' ? DOMException : Error;
+
+/**
  * An error class representing a timeout operation.
+ *
+ * Extends `DOMException` on runtimes that provide it, otherwise extends `Error`.
+ * Either way, `instanceof Error` is always true.
+ *
  * @augments DOMException
  */
-export class TimeoutError extends DOMException {
+export class TimeoutError extends TimeoutErrorBase {
   constructor(message = 'The operation was timed out') {
     super(message);
   }

--- a/src/error/TimeoutError.ts
+++ b/src/error/TimeoutError.ts
@@ -1,18 +1,8 @@
-/**
- * Base constructor for {@link TimeoutError}. Uses `DOMException` when it is
- * available on the global object (browsers, modern Node, Deno, Bun) so that
- * `instanceof DOMException` checks keep working, and falls back to `Error`
- * on runtimes that don't expose `DOMException` (notably Hermes, which powers
- * React Native / Expo by default, as well as older Node versions).
- */
+// Falls back to `Error` on runtimes without `DOMException` (e.g. Hermes / React Native).
 const TimeoutErrorBase: { new (message?: string): Error } = typeof DOMException !== 'undefined' ? DOMException : Error;
 
 /**
  * An error class representing a timeout operation.
- *
- * Extends `DOMException` on runtimes that provide it, otherwise extends `Error`.
- * Either way, `instanceof Error` is always true.
- *
  * @augments DOMException
  */
 export class TimeoutError extends TimeoutErrorBase {


### PR DESCRIPTION
## Summary

Since 1.46.0 (#1660), `AbortError` and `TimeoutError` extend `DOMException`. This breaks on any JS runtime that does not expose `DOMException` as a global — most notably **Hermes** (the default engine for React Native and Expo), but also older Node versions, some workers, and QuickJS.

On those runtimes, merely importing the module throws at evaluation time:

```
ReferenceError: Property 'DOMException' doesn't exist
```

which cascades through every consumer (`es-toolkit/function` via `debounce` / `throttle`, `es-toolkit/promise` via `delay` / `timeout`, etc.), crashing the whole bundle at startup.

Fixes #1693.

## Fix

Pick the base constructor at module load — `DOMException` when it exists, `Error` otherwise:

```ts
const AbortErrorBase: { new (message?: string): Error } =
  typeof DOMException !== 'undefined' ? DOMException : Error;

export class AbortError extends AbortErrorBase {
  constructor(message = 'The operation was aborted') {
    super(message);
  }
}
```

- Browsers and modern Node keep extending `DOMException`, so `instanceof DOMException` checks and the AbortSignal-detection compatibility that motivated #1660 continue to work.
- Hermes / older Node / other runtimes without `DOMException` get a plain `Error` subclass instead of a crash.
- `instanceof Error` holds in both paths.

Same change applied to `TimeoutError`.

## Tests

Added `src/error/AbortError.spec.ts` and `src/error/TimeoutError.spec.ts` covering:

- default and custom messages
- `instanceof Error`
- `instanceof DOMException` when available (skipped via `it.skipIf` on runtimes without it)

Full suite passes locally (`yarn vitest run` — 504 files, 4342 tests). `yarn tsc --noEmit` and `yarn eslint src/error/` are clean.

## Test plan

- [x] `yarn vitest run src/error src/promise`
- [x] `yarn vitest run` (full suite)
- [x] `yarn tsc --noEmit`
- [x] `yarn eslint src/error/`
- [x] Verified that downgrading to this fix unblocks a real React Native / Expo (Hermes) app that was crashing on `import { debounce } from 'es-toolkit/function'`