### PR TITLE
fix: (flatten) prevent stack overflow in flatten for deeply nested arrays

### DIFF
--- a/src/array/flatten.spec.ts
+++ b/src/array/flatten.spec.ts
@@ -60,4 +60,13 @@ describe('flatten', () => {
 
     expect(flatten(originArr, 2)).toEqual([]);
   });
+  it('should handle deeply nested arrays without stack overflow', () => {
+    const createNestedArray = (depth: number): unknown[] => {
+      if (depth === 0) return [1];
+      return [createNestedArray(depth - 1)];
+    };
+
+    const arr = createNestedArray(10000);
+    expect(() => flatten(arr, Infinity)).not.toThrow();
+  });
 });

--- a/src/array/flatten.ts
+++ b/src/array/flatten.ts
@@ -14,21 +14,35 @@
  * const arr = flatten([1, [2, 3], [4, [5, 6]]], 2);
  * // Returns: [1, 2, 3, 4, 5, 6]
  */
+
+
 export function flatten<T, D extends number = 1>(arr: readonly T[], depth = 1 as D): Array<FlatArray<T[], D>> {
-  const result: Array<FlatArray<T[], D>> = [];
   const flooredDepth = Math.floor(depth);
 
-  const recursive = (arr: readonly T[], currentDepth: number) => {
-    for (let i = 0; i < arr.length; i++) {
-      const item = arr[i];
-      if (Array.isArray(item) && currentDepth < flooredDepth) {
-        recursive(item, currentDepth + 1);
-      } else {
-        result.push(item as FlatArray<T[], D>);
-      }
-    }
-  };
+  if (!(flooredDepth >= 1)) return Array.from(arr) as Array<FlatArray<T[], D>>;
 
-  recursive(arr, 0);
+  const result: Array<FlatArray<T[], D>> = [];
+  // Stack entries: [array, currentIndex, currentDepth]
+  const stack: [readonly unknown[], number, number][] = [[arr, 0, 0]];
+
+  while (stack.length > 0) {
+    const frame = stack[stack.length - 1]!;
+    const [current, index, currentDepth] = frame;
+
+    if (index >= current.length) {
+      stack.pop();
+      continue;
+    }
+
+    const item = current[index];
+    frame[1]++;
+
+    if (Array.isArray(item) && currentDepth < flooredDepth) {
+      stack.push([item, 0, currentDepth + 1]);
+    } else {
+      result.push(item as FlatArray<T[], D>);
+    }
+  }
+
   return result;
 }


### PR DESCRIPTION
**Problem**
**flatten** with `Infinity` depth uses recursion internally, causing 
RangeError: Maximum call stack size exceeded` for deeply nested arrays.

**Solution**
Replaced recursive approach with an iterative stack-based implementation.

**Changes**
- flatten.ts: converted recursive function to iterative using explicit stack
- flatten.spec.ts: added test for 10,000 depth nested array with `Infinity`