### PR TITLE
fix(compat/omitBy): do not treat plain objects with numeric `length` as array-like

### DIFF
--- a/src/compat/object/omitBy.spec.ts
+++ b/src/compat/object/omitBy.spec.ts
@@ -127,6 +127,26 @@ describe('omitBy', () => {
     expect(result).toEqual({});
   });
 
+  it('should not treat plain objects with a numeric `length` property as array-like', () => {
+    const obj = { level: 'error', message: 'hi', length: 104 };
+    const isNil = (value: unknown) => value == null;
+
+    expect(omitBy(obj, isNil)).toEqual({ level: 'error', message: 'hi', length: 104 });
+  });
+
+  it('should preserve symbol-keyed properties on objects with a numeric `length` property', () => {
+    const sym = Symbol('level');
+    const obj: Record<string | symbol, unknown> = { message: 'hi', length: 104 };
+    obj[sym] = 'error';
+    const isNil = (value: unknown) => value == null;
+
+    const actual = omitBy(obj, isNil);
+
+    expect(actual.message).toBe('hi');
+    expect(actual.length).toBe(104);
+    expect(actual[sym as any]).toBe('error');
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(omitBy).toEqualTypeOf<typeof omitByLodash>();
   });

--- a/src/compat/object/omitBy.spec.ts
+++ b/src/compat/object/omitBy.spec.ts
@@ -128,7 +128,7 @@ describe('omitBy', () => {
   });
 
   it('should not treat plain objects with a numeric `length` property as array-like', () => {
-    const obj = { level: 'error', message: 'hi', length: 104 };
+    const obj = { level: 'error', message: 'hi', length: 104, empty: undefined };
     const isNil = (value: unknown) => value == null;
 
     expect(omitBy(obj, isNil)).toEqual({ level: 'error', message: 'hi', length: 104 });
@@ -136,15 +136,14 @@ describe('omitBy', () => {
 
   it('should preserve symbol-keyed properties on objects with a numeric `length` property', () => {
     const sym = Symbol('level');
-    const obj: Record<string | symbol, unknown> = { message: 'hi', length: 104 };
-    obj[sym] = 'error';
+    const obj = { message: 'hi', length: 104, [sym]: 'error' };
     const isNil = (value: unknown) => value == null;
 
     const actual = omitBy(obj, isNil);
 
     expect(actual.message).toBe('hi');
     expect(actual.length).toBe(104);
-    expect(actual[sym as any]).toBe('error');
+    expect((actual as any)[sym]).toBe('error');
   });
 
   it('should match the type of lodash', () => {

--- a/src/compat/object/omitBy.ts
+++ b/src/compat/object/omitBy.ts
@@ -1,9 +1,7 @@
 import { keysIn } from './keysIn.ts';
-import { range } from '../../math/range.ts';
 import { getSymbolsIn } from '../_internal/getSymbolsIn.ts';
 import { ValueKeyIteratee } from '../_internal/ValueKeyIteratee.ts';
 import { identity } from '../function/identity.ts';
-import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { isSymbol } from '../predicate/isSymbol.ts';
 import { iteratee as createIteratee } from '../util/iteratee.ts';
 
@@ -89,9 +87,7 @@ export function omitBy<T, S extends T>(
 
   const predicate = createIteratee(shouldOmit ?? identity);
 
-  const keys = isArrayLike(object)
-    ? range(0, object.length)
-    : ([...keysIn(object), ...getSymbolsIn(object)] as Array<keyof T>);
+  const keys = [...keysIn(object), ...getSymbolsIn(object)] as Array<keyof T>;
   for (let i = 0; i < keys.length; i++) {
     const key = (isSymbol(keys[i]) ? keys[i] : keys[i].toString()) as keyof T;
     const value = object[key as keyof typeof object];


### PR DESCRIPTION
## Summary

Closes https://github.com/toss/es-toolkit/issues/1706

`omitBy` from `es-toolkit/compat` returned `{}` for any plain object that happened to have a numeric `length` property (e.g. `Error` instances, pg driver errors, winston `info` objects), because it treated array-likeness as authoritative. Lodash's `_.omitBy` does not — it operates on own enumerable keys regardless of `length`. This PR aligns the behavior with lodash.

Fixes the regression reported where `omitBy({ level: 'error', message: 'hi', length: 104 }, isNil)` returned `{}` instead of the original object, which also dropped symbol-keyed properties (e.g. winston's triple-beam routing key).

## Changes

- Drop the `isArrayLike` branch in `src/compat/object/omitBy.ts` and unconditionally walk `[...keysIn(object), ...getSymbolsIn(object)]`. `keysIn` already handles real arrays correctly (returns indices as string keys), so the branch was unnecessary and actively wrong for plain objects with a numeric `length`.
- Remove now-unused `range` and `isArrayLike` imports.
- Add two regression tests in `src/compat/object/omitBy.spec.ts`:
  - plain object with numeric `length` is preserved when no value is nil
  - symbol-keyed properties survive on objects that also carry a numeric `length`

## Test results

```
✓ src/compat/object/omitBy.spec.ts (11 tests) 3ms

Test Files  1 passed (1)
     Tests  11 passed (11)
```
