### PR TITLE
feat(math): add percentile

### DIFF
--- a/docs/ja/reference/math/percentile.md
+++ b/docs/ja/reference/math/percentile.md
@@ -1,0 +1,52 @@
+# percentile
+
+数値配列から指定されたパーセンタイルの値を計算します。
+
+```typescript
+const value = percentile(arr, p);
+```
+
+## インターフェース
+
+```typescript
+function percentile(arr: readonly number[], percentile: number): number;
+```
+
+### パラメータ
+
+- `arr` (`readonly number[]`): パーセンタイルを計算する数値配列です。
+- `percentile` (`number`): 計算するパーセンタイルです。`[0, 100]` の範囲の値である必要があります。
+
+### 戻り値
+
+(`number`): 指定されたパーセンタイルに対応する値を返します。空の配列の場合は `NaN` を返します。
+
+### エラー
+
+`percentile` が `NaN` の場合、`0` より小さい場合、または `100` より大きい場合は `Error` をスローします。
+
+## 例
+
+```typescript
+import { percentile } from 'es-toolkit/math';
+
+// 配列の中央値(50パーセンタイル)を返します
+percentile([1, 2, 3, 4, 5], 50);
+// 3を返します
+
+// 75パーセンタイルを計算します
+percentile([1, 2, 3, 4, 5], 75);
+// 4を返します
+
+// ソートされていない配列も自動的にソートします
+percentile([50, 10, 30, 20, 40], 50);
+// 30を返します
+
+// 0パーセンタイルでは最小値を返します
+percentile([5, 1, 4, 2, 3], 0);
+// 1を返します
+
+// 空の配列の場合はNaNを返します
+percentile([], 50);
+// NaNを返します
+```

--- a/docs/ja/reference/math/percentile.md
+++ b/docs/ja/reference/math/percentile.md
@@ -8,47 +8,40 @@
 const value = percentile(arr, p);
 ```
 
-## インターフェース
+## 使用法
 
-```typescript
-function percentile(arr: readonly number[], percentile: number): number;
-```
+### `percentile(arr, percentile)`
 
-### パラメータ
-
-- `arr` (`readonly number[]`): パーセンタイルを計算する数値配列です。
-- `percentile` (`number`): 計算するパーセンタイルです。`[0, 100]` の範囲の値である必要があります。
-
-### 戻り値
-
-(`number`): 指定されたパーセンタイルに対応する値を返します。空の配列の場合は `NaN` を返します。
-
-### エラー
-
-`percentile` が `NaN` の場合、`0` より小さい場合、または `100` より大きい場合は `Error` をスローします。
-
-## 例
+数値配列から特定のパーセンタイルに対応する値を求めたい場合は `percentile` を使用してください。例えば、50パーセンタイルは中央値であり、75パーセンタイルはデータ全体の75%がその値以下になる位置です。
 
 ```typescript
 import { percentile } from 'es-toolkit/math';
 
-// 配列の中央値(50パーセンタイル)を返します
-percentile([1, 2, 3, 4, 5], 50);
-// 3を返します
+// 配列の中央値(50パーセンタイル)を求めます
+const median = percentile([1, 2, 3, 4, 5], 50); // medianは3になります
 
-// 75パーセンタイルを計算します
-percentile([1, 2, 3, 4, 5], 75);
-// 4を返します
+// 75パーセンタイルを求めます
+const p75 = percentile([1, 2, 3, 4, 5], 75); // p75は4になります
 
 // ソートされていない配列も自動的にソートします
-percentile([50, 10, 30, 20, 40], 50);
-// 30を返します
+const result = percentile([50, 10, 30, 20, 40], 50); // resultは30になります
 
-// 0パーセンタイルでは最小値を返します
-percentile([5, 1, 4, 2, 3], 0);
-// 1を返します
+// 0パーセンタイルは最小値を返します
+const min = percentile([5, 1, 4, 2, 3], 0); // minは1になります
 
 // 空の配列の場合はNaNを返します
-percentile([], 50);
-// NaNを返します
+const empty = percentile([], 50); // emptyはNaNになります
 ```
+
+#### パラメータ
+
+- `arr` (`readonly number[]`): パーセンタイルを計算する数値配列です。
+- `percentile` (`number`): 計算するパーセンタイルです。`[0, 100]` の範囲の値である必要があります。
+
+#### 戻り値
+
+(`number`): 指定されたパーセンタイルに対応する値を返します。空の配列の場合は `NaN` を返します。
+
+#### エラー
+
+`percentile` が `NaN` の場合、`0` より小さい場合、または `100` より大きい場合は、エラーをスローします。

--- a/docs/ja/reference/math/percentile.md
+++ b/docs/ja/reference/math/percentile.md
@@ -25,6 +25,24 @@ function percentile(arr: readonly number[], percentile: number): number;
 
 `percentile` が `NaN` の場合、`0` より小さい場合、または `100` より大きい場合は `Error` をスローします。
 
+## 仕組み
+
+配列を昇順にソートした後、次の位置にある要素を返します。
+
+```typescript
+const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
+return sorted[index];
+```
+
+これは **nearest-rank**(最近順位)方式です。配列の長さに `percentile / 100` を掛けると 1 始まりの順位(rank)が得られます。`Math.ceil` で切り上げることで、要求された割合以上を含む最小の順位が選ばれ、`1` を引いて 0 始まりの配列インデックスに変換します。
+
+例えば、長さ 100 のソート済み配列で `percentile = 75` の場合:
+
+- `Math.ceil(100 * 0.75) - 1` → `74`
+- 75 番目に小さい値(`sorted[74]`)を返します。
+
+`percentile = 0` は上記の式だと `-1` になってしまうため、特別扱いして最小値を返します。
+
 ## 例
 
 ```typescript

--- a/docs/ja/reference/math/percentile.md
+++ b/docs/ja/reference/math/percentile.md
@@ -2,6 +2,8 @@
 
 数値配列から指定されたパーセンタイルの値を計算します。
 
+`percentile` 関数は配列を昇順にソートし、最も近い順位の要素を返します ([Nearest rank method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method))。
+
 ```typescript
 const value = percentile(arr, p);
 ```
@@ -24,24 +26,6 @@ function percentile(arr: readonly number[], percentile: number): number;
 ### エラー
 
 `percentile` が `NaN` の場合、`0` より小さい場合、または `100` より大きい場合は `Error` をスローします。
-
-## 仕組み
-
-配列を昇順にソートした後、次の位置にある要素を返します。
-
-```typescript
-const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
-return sorted[index];
-```
-
-これは **nearest-rank**(最近順位)方式です。配列の長さに `percentile / 100` を掛けると 1 始まりの順位(rank)が得られます。`Math.ceil` で切り上げることで、要求された割合以上を含む最小の順位が選ばれ、`1` を引いて 0 始まりの配列インデックスに変換します。
-
-例えば、長さ 100 のソート済み配列で `percentile = 75` の場合:
-
-- `Math.ceil(100 * 0.75) - 1` → `74`
-- 75 番目に小さい値(`sorted[74]`)を返します。
-
-`percentile = 0` は上記の式だと `-1` になってしまうため、特別扱いして最小値を返します。
 
 ## 例
 

--- a/docs/ko/reference/math/percentile.md
+++ b/docs/ko/reference/math/percentile.md
@@ -25,6 +25,24 @@ function percentile(arr: readonly number[], percentile: number): number;
 
 `percentile`이 `NaN`이거나, `0`보다 작거나, `100`보다 크면 `Error`를 던져요.
 
+## 동작 방식
+
+배열을 오름차순으로 정렬한 다음, 아래 위치의 요소를 반환해요.
+
+```typescript
+const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
+return sorted[index];
+```
+
+이건 **nearest-rank**(가장 가까운 순위) 방식이에요. 배열 길이에 `percentile / 100`을 곱하면 1부터 시작하는 순위(rank)가 나와요. `Math.ceil`로 올림하면 요청한 비율 이상을 포함하는 가장 작은 순위가 선택되고, 거기에 `1`을 빼서 0부터 시작하는 배열 인덱스로 변환해요.
+
+예를 들어, 길이가 100인 정렬된 배열에서 `percentile = 75`이면:
+
+- `Math.ceil(100 * 0.75) - 1` → `74`
+- 75번째로 작은 값(`sorted[74]`)을 반환해요.
+
+`percentile = 0`은 위 공식대로면 `-1`이 되기 때문에, 별도로 처리해서 가장 작은 값을 반환해요.
+
 ## 예시
 
 ```typescript

--- a/docs/ko/reference/math/percentile.md
+++ b/docs/ko/reference/math/percentile.md
@@ -1,0 +1,52 @@
+# percentile
+
+숫자 배열에서 주어진 백분위수에 해당하는 값을 계산해요.
+
+```typescript
+const value = percentile(arr, p);
+```
+
+## 인터페이스
+
+```typescript
+function percentile(arr: readonly number[], percentile: number): number;
+```
+
+### 파라미터
+
+- `arr` (`readonly number[]`): 백분위수를 계산할 숫자 배열이에요.
+- `percentile` (`number`): 계산할 백분위수예요. `[0, 100]` 범위의 값이어야 해요.
+
+### 반환 값
+
+(`number`): 주어진 백분위수에 해당하는 값을 반환해요. 빈 배열이면 `NaN`을 반환해요.
+
+### 에러
+
+`percentile`이 `NaN`이거나, `0`보다 작거나, `100`보다 크면 `Error`를 던져요.
+
+## 예시
+
+```typescript
+import { percentile } from 'es-toolkit/math';
+
+// 배열의 중앙값(50번째 백분위수)을 반환해요
+percentile([1, 2, 3, 4, 5], 50);
+// 3을 반환해요
+
+// 75번째 백분위수를 계산해요
+percentile([1, 2, 3, 4, 5], 75);
+// 4를 반환해요
+
+// 정렬되지 않은 배열도 자동으로 정렬해요
+percentile([50, 10, 30, 20, 40], 50);
+// 30을 반환해요
+
+// 0번째 백분위수에서는 가장 작은 값을 반환해요
+percentile([5, 1, 4, 2, 3], 0);
+// 1을 반환해요
+
+// 빈 배열의 경우 NaN을 반환해요
+percentile([], 50);
+// NaN을 반환해요
+```

--- a/docs/ko/reference/math/percentile.md
+++ b/docs/ko/reference/math/percentile.md
@@ -8,47 +8,40 @@
 const value = percentile(arr, p);
 ```
 
-## 인터페이스
+## 사용법
 
-```typescript
-function percentile(arr: readonly number[], percentile: number): number;
-```
+### `percentile(arr, percentile)`
 
-### 파라미터
-
-- `arr` (`readonly number[]`): 백분위수를 계산할 숫자 배열이에요.
-- `percentile` (`number`): 계산할 백분위수예요. `[0, 100]` 범위의 값이어야 해요.
-
-### 반환 값
-
-(`number`): 주어진 백분위수에 해당하는 값을 반환해요. 빈 배열이면 `NaN`을 반환해요.
-
-### 에러
-
-`percentile`이 `NaN`이거나, `0`보다 작거나, `100`보다 크면 `Error`를 던져요.
-
-## 예시
+숫자 배열에서 특정 백분위수에 해당하는 값을 찾고 싶을 때 `percentile`을 사용하세요. 예를 들어 50번째 백분위수는 중앙값이고, 75번째 백분위수는 전체 데이터의 75%가 그 아래에 있는 값이에요.
 
 ```typescript
 import { percentile } from 'es-toolkit/math';
 
-// 배열의 중앙값(50번째 백분위수)을 반환해요
-percentile([1, 2, 3, 4, 5], 50);
-// 3을 반환해요
+// 배열의 중앙값(50번째 백분위수)을 구해요
+const median = percentile([1, 2, 3, 4, 5], 50); // median은 3이 돼요
 
-// 75번째 백분위수를 계산해요
-percentile([1, 2, 3, 4, 5], 75);
-// 4를 반환해요
+// 75번째 백분위수를 구해요
+const p75 = percentile([1, 2, 3, 4, 5], 75); // p75는 4가 돼요
 
 // 정렬되지 않은 배열도 자동으로 정렬해요
-percentile([50, 10, 30, 20, 40], 50);
-// 30을 반환해요
+const result = percentile([50, 10, 30, 20, 40], 50); // result는 30이 돼요
 
-// 0번째 백분위수에서는 가장 작은 값을 반환해요
-percentile([5, 1, 4, 2, 3], 0);
-// 1을 반환해요
+// 0번째 백분위수는 가장 작은 값을 반환해요
+const min = percentile([5, 1, 4, 2, 3], 0); // min은 1이 돼요
 
 // 빈 배열의 경우 NaN을 반환해요
-percentile([], 50);
-// NaN을 반환해요
+const empty = percentile([], 50); // empty는 NaN이 돼요
 ```
+
+#### 파라미터
+
+- `arr` (`readonly number[]`): 백분위수를 계산할 숫자 배열이에요.
+- `percentile` (`number`): 계산할 백분위수예요. `[0, 100]` 범위의 값이어야 해요.
+
+#### 반환 값
+
+(`number`): 주어진 백분위수에 해당하는 값을 반환해요. 빈 배열이면 `NaN`을 반환해요.
+
+#### 에러
+
+`percentile`이 `NaN`이거나, `0`보다 작거나, `100`보다 크면 에러를 던져요.

--- a/docs/ko/reference/math/percentile.md
+++ b/docs/ko/reference/math/percentile.md
@@ -2,6 +2,8 @@
 
 숫자 배열에서 주어진 백분위수에 해당하는 값을 계산해요.
 
+`percentile` 함수는 배열을 오름차순으로 정렬하고, 가장 가까운 순위에 있는 요소를 반환해요 ([Nearest rank method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method)).
+
 ```typescript
 const value = percentile(arr, p);
 ```
@@ -24,24 +26,6 @@ function percentile(arr: readonly number[], percentile: number): number;
 ### 에러
 
 `percentile`이 `NaN`이거나, `0`보다 작거나, `100`보다 크면 `Error`를 던져요.
-
-## 동작 방식
-
-배열을 오름차순으로 정렬한 다음, 아래 위치의 요소를 반환해요.
-
-```typescript
-const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
-return sorted[index];
-```
-
-이건 **nearest-rank**(가장 가까운 순위) 방식이에요. 배열 길이에 `percentile / 100`을 곱하면 1부터 시작하는 순위(rank)가 나와요. `Math.ceil`로 올림하면 요청한 비율 이상을 포함하는 가장 작은 순위가 선택되고, 거기에 `1`을 빼서 0부터 시작하는 배열 인덱스로 변환해요.
-
-예를 들어, 길이가 100인 정렬된 배열에서 `percentile = 75`이면:
-
-- `Math.ceil(100 * 0.75) - 1` → `74`
-- 75번째로 작은 값(`sorted[74]`)을 반환해요.
-
-`percentile = 0`은 위 공식대로면 `-1`이 되기 때문에, 별도로 처리해서 가장 작은 값을 반환해요.
 
 ## 예시
 

--- a/docs/reference/math/percentile.md
+++ b/docs/reference/math/percentile.md
@@ -8,47 +8,40 @@ Calculates the value at the given percentile of an array of numbers.
 const value = percentile(arr, p);
 ```
 
-## Signature
+## Usage
 
-```typescript
-function percentile(arr: readonly number[], percentile: number): number;
-```
+### `percentile(arr, percentile)`
 
-### Parameters
-
-- `arr` (`readonly number[]`): An array of numbers to calculate the percentile from.
-- `percentile` (`number`): The percentile to compute, in the range `[0, 100]`.
-
-### Returns
-
-(`number`): The value at the given percentile. Returns `NaN` if the array is empty.
-
-### Throws
-
-Throws an `Error` if `percentile` is `NaN`, less than `0`, or greater than `100`.
-
-## Examples
+Use `percentile` when you want to find the value at a specific percentile of a numeric array. For example, the 50th percentile is the median, and the 75th percentile is the value below which 75% of the data falls.
 
 ```typescript
 import { percentile } from 'es-toolkit/math';
 
-// Return the median (50th percentile) of an array
-percentile([1, 2, 3, 4, 5], 50);
-// Returns 3
+// Find the median (50th percentile) of an array
+const median = percentile([1, 2, 3, 4, 5], 50); // median is 3
 
-// Compute the 75th percentile
-percentile([1, 2, 3, 4, 5], 75);
-// Returns 4
+// Find the 75th percentile
+const p75 = percentile([1, 2, 3, 4, 5], 75); // p75 is 4
 
 // Unsorted arrays are automatically sorted
-percentile([50, 10, 30, 20, 40], 50);
-// Returns 30
+const result = percentile([50, 10, 30, 20, 40], 50); // result is 30
 
-// Returns the smallest value at the 0th percentile
-percentile([5, 1, 4, 2, 3], 0);
-// Returns 1
+// The 0th percentile returns the smallest value
+const min = percentile([5, 1, 4, 2, 3], 0); // min is 1
 
 // Returns NaN for an empty array
-percentile([], 50);
-// Returns NaN
+const empty = percentile([], 50); // empty is NaN
 ```
+
+#### Parameters
+
+- `arr` (`readonly number[]`): An array of numbers to calculate the percentile from.
+- `percentile` (`number`): The percentile to compute, in the range `[0, 100]`.
+
+#### Returns
+
+(`number`): Returns the value at the given percentile. Returns `NaN` if the array is empty.
+
+#### Throws
+
+Throws an error if `percentile` is `NaN`, less than `0`, or greater than `100`.

--- a/docs/reference/math/percentile.md
+++ b/docs/reference/math/percentile.md
@@ -1,0 +1,52 @@
+# percentile
+
+Calculates the value at the given percentile of an array of numbers.
+
+```typescript
+const value = percentile(arr, p);
+```
+
+## Signature
+
+```typescript
+function percentile(arr: readonly number[], percentile: number): number;
+```
+
+### Parameters
+
+- `arr` (`readonly number[]`): An array of numbers to calculate the percentile from.
+- `percentile` (`number`): The percentile to compute, in the range `[0, 100]`.
+
+### Returns
+
+(`number`): The value at the given percentile. Returns `NaN` if the array is empty.
+
+### Throws
+
+Throws an `Error` if `percentile` is `NaN`, less than `0`, or greater than `100`.
+
+## Examples
+
+```typescript
+import { percentile } from 'es-toolkit/math';
+
+// Return the median (50th percentile) of an array
+percentile([1, 2, 3, 4, 5], 50);
+// Returns 3
+
+// Compute the 75th percentile
+percentile([1, 2, 3, 4, 5], 75);
+// Returns 4
+
+// Unsorted arrays are automatically sorted
+percentile([50, 10, 30, 20, 40], 50);
+// Returns 30
+
+// Returns the smallest value at the 0th percentile
+percentile([5, 1, 4, 2, 3], 0);
+// Returns 1
+
+// Returns NaN for an empty array
+percentile([], 50);
+// Returns NaN
+```

--- a/docs/reference/math/percentile.md
+++ b/docs/reference/math/percentile.md
@@ -25,6 +25,24 @@ function percentile(arr: readonly number[], percentile: number): number;
 
 Throws an `Error` if `percentile` is `NaN`, less than `0`, or greater than `100`.
 
+## How it works
+
+After sorting the array in ascending order, the result is the element at:
+
+```typescript
+const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
+return sorted[index];
+```
+
+This is the **nearest-rank** method. Multiplying the array length by `percentile / 100` gives a 1-indexed rank; `Math.ceil` rounds up to the smallest rank that covers at least the requested fraction of values, and subtracting `1` converts the rank into a 0-indexed array position.
+
+For example, given a sorted array of length 100 with `percentile = 75`:
+
+- `Math.ceil(100 * 0.75) - 1` → `74`
+- The 75th-smallest value (`sorted[74]`) is returned.
+
+`percentile = 0` is special-cased to return the smallest element, since the formula above would otherwise produce `-1`.
+
 ## Examples
 
 ```typescript

--- a/docs/reference/math/percentile.md
+++ b/docs/reference/math/percentile.md
@@ -2,6 +2,8 @@
 
 Calculates the value at the given percentile of an array of numbers.
 
+`percentile` sorts the array in ascending order and returns the element at the nearest rank ([Nearest rank method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method)).
+
 ```typescript
 const value = percentile(arr, p);
 ```
@@ -24,24 +26,6 @@ function percentile(arr: readonly number[], percentile: number): number;
 ### Throws
 
 Throws an `Error` if `percentile` is `NaN`, less than `0`, or greater than `100`.
-
-## How it works
-
-After sorting the array in ascending order, the result is the element at:
-
-```typescript
-const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
-return sorted[index];
-```
-
-This is the **nearest-rank** method. Multiplying the array length by `percentile / 100` gives a 1-indexed rank; `Math.ceil` rounds up to the smallest rank that covers at least the requested fraction of values, and subtracting `1` converts the rank into a 0-indexed array position.
-
-For example, given a sorted array of length 100 with `percentile = 75`:
-
-- `Math.ceil(100 * 0.75) - 1` → `74`
-- The 75th-smallest value (`sorted[74]`) is returned.
-
-`percentile = 0` is special-cased to return the smallest element, since the formula above would otherwise produce `-1`.
 
 ## Examples
 

--- a/docs/zh_hans/reference/math/percentile.md
+++ b/docs/zh_hans/reference/math/percentile.md
@@ -1,0 +1,52 @@
+# percentile
+
+计算数字数组中给定百分位数对应的值。
+
+```typescript
+const value = percentile(arr, p);
+```
+
+## 签名
+
+```typescript
+function percentile(arr: readonly number[], percentile: number): number;
+```
+
+### 参数
+
+- `arr` (`readonly number[]`): 要计算百分位数的数字数组。
+- `percentile` (`number`): 要计算的百分位数,取值范围为 `[0, 100]`。
+
+### 返回值
+
+(`number`): 返回给定百分位数对应的值。如果数组为空,则返回 `NaN`。
+
+### 异常
+
+如果 `percentile` 为 `NaN`、小于 `0` 或大于 `100`,则抛出 `Error`。
+
+## 示例
+
+```typescript
+import { percentile } from 'es-toolkit/math';
+
+// 返回数组的中位数(第 50 百分位)
+percentile([1, 2, 3, 4, 5], 50);
+// 返回 3
+
+// 计算第 75 百分位
+percentile([1, 2, 3, 4, 5], 75);
+// 返回 4
+
+// 未排序的数组会自动排序
+percentile([50, 10, 30, 20, 40], 50);
+// 返回 30
+
+// 在第 0 百分位返回最小值
+percentile([5, 1, 4, 2, 3], 0);
+// 返回 1
+
+// 空数组返回 NaN
+percentile([], 50);
+// 返回 NaN
+```

--- a/docs/zh_hans/reference/math/percentile.md
+++ b/docs/zh_hans/reference/math/percentile.md
@@ -2,6 +2,8 @@
 
 计算数字数组中给定百分位数对应的值。
 
+`percentile` 函数将数组按升序排序,并返回最接近排名位置的元素 ([Nearest rank method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method))。
+
 ```typescript
 const value = percentile(arr, p);
 ```
@@ -24,24 +26,6 @@ function percentile(arr: readonly number[], percentile: number): number;
 ### 异常
 
 如果 `percentile` 为 `NaN`、小于 `0` 或大于 `100`,则抛出 `Error`。
-
-## 工作原理
-
-将数组按升序排序后,返回以下位置的元素:
-
-```typescript
-const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
-return sorted[index];
-```
-
-这是 **最近排名**(nearest-rank)方法。将数组长度乘以 `percentile / 100` 可以得到从 1 开始的排名(rank);使用 `Math.ceil` 向上取整,选出能覆盖所请求比例及以上数据的最小排名;再减去 `1`,将其转换为从 0 开始的数组索引。
-
-例如,对于长度为 100 的已排序数组,当 `percentile = 75` 时:
-
-- `Math.ceil(100 * 0.75) - 1` → `74`
-- 返回第 75 小的值(`sorted[74]`)。
-
-当 `percentile = 0` 时,按上述公式会得到 `-1`,因此作为特殊情况处理,直接返回最小值。
 
 ## 示例
 

--- a/docs/zh_hans/reference/math/percentile.md
+++ b/docs/zh_hans/reference/math/percentile.md
@@ -25,6 +25,24 @@ function percentile(arr: readonly number[], percentile: number): number;
 
 如果 `percentile` 为 `NaN`、小于 `0` 或大于 `100`,则抛出 `Error`。
 
+## 工作原理
+
+将数组按升序排序后,返回以下位置的元素:
+
+```typescript
+const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
+return sorted[index];
+```
+
+这是 **最近排名**(nearest-rank)方法。将数组长度乘以 `percentile / 100` 可以得到从 1 开始的排名(rank);使用 `Math.ceil` 向上取整,选出能覆盖所请求比例及以上数据的最小排名;再减去 `1`,将其转换为从 0 开始的数组索引。
+
+例如,对于长度为 100 的已排序数组,当 `percentile = 75` 时:
+
+- `Math.ceil(100 * 0.75) - 1` → `74`
+- 返回第 75 小的值(`sorted[74]`)。
+
+当 `percentile = 0` 时,按上述公式会得到 `-1`,因此作为特殊情况处理,直接返回最小值。
+
 ## 示例
 
 ```typescript

--- a/docs/zh_hans/reference/math/percentile.md
+++ b/docs/zh_hans/reference/math/percentile.md
@@ -8,47 +8,40 @@
 const value = percentile(arr, p);
 ```
 
-## 签名
+## 用法
 
-```typescript
-function percentile(arr: readonly number[], percentile: number): number;
-```
+### `percentile(arr, percentile)`
 
-### 参数
-
-- `arr` (`readonly number[]`): 要计算百分位数的数字数组。
-- `percentile` (`number`): 要计算的百分位数,取值范围为 `[0, 100]`。
-
-### 返回值
-
-(`number`): 返回给定百分位数对应的值。如果数组为空,则返回 `NaN`。
-
-### 异常
-
-如果 `percentile` 为 `NaN`、小于 `0` 或大于 `100`,则抛出 `Error`。
-
-## 示例
+当您想从数字数组中找到特定百分位数对应的值时,请使用 `percentile`。例如,第 50 百分位是中位数,第 75 百分位是 75% 的数据小于或等于该值的位置。
 
 ```typescript
 import { percentile } from 'es-toolkit/math';
 
-// 返回数组的中位数(第 50 百分位)
-percentile([1, 2, 3, 4, 5], 50);
-// 返回 3
+// 求数组的中位数(第 50 百分位)
+const median = percentile([1, 2, 3, 4, 5], 50); // median 为 3
 
-// 计算第 75 百分位
-percentile([1, 2, 3, 4, 5], 75);
-// 返回 4
+// 求第 75 百分位
+const p75 = percentile([1, 2, 3, 4, 5], 75); // p75 为 4
 
 // 未排序的数组会自动排序
-percentile([50, 10, 30, 20, 40], 50);
-// 返回 30
+const result = percentile([50, 10, 30, 20, 40], 50); // result 为 30
 
-// 在第 0 百分位返回最小值
-percentile([5, 1, 4, 2, 3], 0);
-// 返回 1
+// 第 0 百分位返回最小值
+const min = percentile([5, 1, 4, 2, 3], 0); // min 为 1
 
 // 空数组返回 NaN
-percentile([], 50);
-// 返回 NaN
+const empty = percentile([], 50); // empty 为 NaN
 ```
+
+#### 参数
+
+- `arr` (`readonly number[]`): 要计算百分位数的数字数组。
+- `percentile` (`number`): 要计算的百分位数,取值范围为 `[0, 100]`。
+
+#### 返回值
+
+(`number`): 返回给定百分位数对应的值。如果数组为空,则返回 `NaN`。
+
+#### 错误
+
+如果 `percentile` 为 `NaN`、小于 `0` 或大于 `100`,则抛出错误。

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -4,6 +4,7 @@ export { mean } from './mean.ts';
 export { meanBy } from './meanBy.ts';
 export { median } from './median.ts';
 export { medianBy } from './medianBy.ts';
+export { percentile } from './percentile.ts';
 export { random } from './random.ts';
 export { randomInt } from './randomInt.ts';
 export { range } from './range.ts';

--- a/src/math/percentile.spec.ts
+++ b/src/math/percentile.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { percentile } from './percentile';
+
+describe('percentile', () => {
+  it('returns the smallest value at the 0th percentile', () => {
+    expect(percentile([5, 1, 4, 2, 3], 0)).toBe(1);
+  });
+
+  it('returns the largest value at the 100th percentile', () => {
+    expect(percentile([5, 1, 4, 2, 3], 100)).toBe(5);
+  });
+
+  it('returns the middle value at the 50th percentile of an odd-length array', () => {
+    expect(percentile([1, 2, 3, 4, 5], 50)).toBe(3);
+  });
+
+  it('returns the correct value at the 25th, 50th, and 75th percentiles', () => {
+    const list = Array.from({ length: 100 }, (_, i) => i + 1);
+    expect(percentile(list, 25)).toBe(25);
+    expect(percentile(list, 50)).toBe(50);
+    expect(percentile(list, 75)).toBe(75);
+  });
+
+  it('sorts unsorted input before computing the percentile', () => {
+    const list = [50, 10, 30, 20, 40];
+    expect(percentile(list, 50)).toBe(30);
+  });
+
+  it('handles negative numbers', () => {
+    expect(percentile([-1, -2, -3, -4, -5], 50)).toBe(-3);
+    expect(percentile([7, 6, -1, -2, -3, -4, -5], 50)).toBe(-2);
+  });
+
+  it('treats NaN values as the smallest values when sorting', () => {
+    expect(percentile([NaN, NaN, 1, 100], 75)).toBe(1);
+    expect(percentile([1, 100, NaN, NaN], 75)).toBe(1);
+  });
+
+  it('does not mutate the input array', () => {
+    const list = [5, 1, 4, 2, 3];
+    percentile(list, 50);
+    expect(list).toEqual([5, 1, 4, 2, 3]);
+  });
+
+  it('returns NaN for an empty array', () => {
+    expect(percentile([], 50)).toBeNaN();
+  });
+
+  it('throws when percentile is NaN', () => {
+    expect(() => percentile([1, 2, 3], Number.NaN)).toThrow();
+  });
+
+  it('throws when percentile is less than 0', () => {
+    expect(() => percentile([1, 2, 3], -1)).toThrow();
+  });
+
+  it('throws when percentile is greater than 100', () => {
+    expect(() => percentile([1, 2, 3], 101)).toThrow();
+  });
+});

--- a/src/math/percentile.ts
+++ b/src/math/percentile.ts
@@ -1,12 +1,10 @@
 /**
  * Calculates the value at the given percentile of an array of numbers.
  *
- * The array is sorted in ascending order, and the value at the position
- * `Math.ceil(arr.length * (percentile / 100)) - 1` is returned. When the
- * percentile is `0`, the smallest value is returned. `NaN` values are
- * treated as the smallest possible values during sorting.
+ * Sorts the array in ascending order and returns the element at the nearest rank.
+ * See {@link https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method | Nearest rank method}.
  *
- * If the array is empty, this function returns `NaN`.
+ * `NaN` values are sorted as the smallest values. Returns `NaN` if the array is empty.
  *
  * @param {readonly number[]} arr - An array of numbers to calculate the percentile.
  * @param {number} percentile - The percentile to compute, in the range `[0, 100]`.
@@ -48,15 +46,11 @@ export function percentile(arr: readonly number[], percentile: number): number {
     return x - y;
   });
 
-  // `percentile === 0` would map to index `-1` with the formula below, so
-  // return the smallest element directly.
+  // Nearest rank method: https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method
   if (percentile === 0) {
     return sorted[0];
   }
 
-  // Nearest-rank method: `length * (percentile / 100)` is the 1-indexed rank,
-  // `Math.ceil` rounds up to the smallest rank that covers the requested
-  // fraction, and `- 1` converts that rank to a 0-indexed array position.
   const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
   return sorted[index];
 }

--- a/src/math/percentile.ts
+++ b/src/math/percentile.ts
@@ -1,0 +1,57 @@
+/**
+ * Calculates the value at the given percentile of an array of numbers.
+ *
+ * The array is sorted in ascending order, and the value at the position
+ * `Math.ceil(arr.length * (percentile / 100)) - 1` is returned. When the
+ * percentile is `0`, the smallest value is returned. `NaN` values are
+ * treated as the smallest possible values during sorting.
+ *
+ * If the array is empty, this function returns `NaN`.
+ *
+ * @param {readonly number[]} arr - An array of numbers to calculate the percentile.
+ * @param {number} percentile - The percentile to compute, in the range `[0, 100]`.
+ * @returns {number} The value at the given percentile.
+ * @throws {Error} Throws an error if `percentile` is not a number, less than `0`, or greater than `100`.
+ *
+ * @example
+ * percentile([1, 2, 3, 4, 5], 50);
+ * // Returns 3
+ *
+ * @example
+ * percentile([1, 2, 3, 4, 5], 75);
+ * // Returns 4
+ *
+ * @example
+ * percentile([5, 1, 4, 2, 3], 0);
+ * // Returns 1
+ */
+export function percentile(arr: readonly number[], percentile: number): number {
+  if (Number.isNaN(Number(percentile))) {
+    throw new Error(`Expected percentile to be a number but got "${percentile}".`);
+  }
+
+  if (percentile < 0) {
+    throw new Error(`Expected percentile to be >= 0 but got "${percentile}".`);
+  }
+
+  if (percentile > 100) {
+    throw new Error(`Expected percentile to be <= 100 but got "${percentile}".`);
+  }
+
+  if (arr.length === 0) {
+    return NaN;
+  }
+
+  const sorted = arr.slice().sort((a, b) => {
+    const x = Number.isNaN(a) ? Number.NEGATIVE_INFINITY : a;
+    const y = Number.isNaN(b) ? Number.NEGATIVE_INFINITY : b;
+    return x - y;
+  });
+
+  if (percentile === 0) {
+    return sorted[0];
+  }
+
+  const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
+  return sorted[index];
+}

--- a/src/math/percentile.ts
+++ b/src/math/percentile.ts
@@ -48,10 +48,15 @@ export function percentile(arr: readonly number[], percentile: number): number {
     return x - y;
   });
 
+  // `percentile === 0` would map to index `-1` with the formula below, so
+  // return the smallest element directly.
   if (percentile === 0) {
     return sorted[0];
   }
 
+  // Nearest-rank method: `length * (percentile / 100)` is the 1-indexed rank,
+  // `Math.ceil` rounds up to the smallest rank that covers the requested
+  // fraction, and `- 1` converts that rank to a 0-indexed array position.
   const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
   return sorted[index];
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/toss/es-toolkit/issues/1686

- Adds a new `percentile(arr, p)` math utility that returns the value at the given percentile of a numeric array.
- Uses the nearest-rank method (`Math.ceil(n * p / 100) - 1`).
- `NaN` inputs are sorted as the smallest values; throws when `p` is `NaN`, `< 0`, or `> 100`; returns `NaN` for an empty array (consistent with `median`).
- Re-exported from `src/math/index.ts` and documented in en/ko/ja/zh_hans.

## Test plan

- [x] `yarn vitest run src/math/percentile` — 12 tests passing
- [x] `yarn lint` — no new errors
- [x] `yarn tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)