### PR TITLE
docs: exclude CLAUDE.md from VitePress build

### DIFF
--- a/docs/.vitepress/shared.mts
+++ b/docs/.vitepress/shared.mts
@@ -13,6 +13,8 @@ export const shared = defineConfig({
   lastUpdated: true,
   metaChunk: true,
 
+  srcExclude: ['**/CLAUDE.md'],
+
   /* prettier-ignore */
   head: [
     [


### PR DESCRIPTION
## Summary

- The VitePress build was failing with a dead link error: `./../.github/CONTRIBUTING` referenced from `docs/CLAUDE.md`. The target lives outside the docs source root, so VitePress can't resolve it.
- `docs/CLAUDE.md` is AI agent instructions (added in #1711), not a user-facing doc page. Excluding it via `srcExclude` keeps it out of the published site and resolves the build failure.

## Test plan

- [x] `yarn docs:build` succeeds