### PR TITLE
ci: run vitest on changed files for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -86,6 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - if: github.event_name == 'pull_request'
+        run: git fetch origin ${{ github.event.pull_request.base.sha }} --depth=1
       - run: corepack enable
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -93,7 +97,12 @@ jobs:
           cache: 'yarn'
       - run: yarn install
       - name: vitest
-        run: yarn vitest --reporter=junit --outputFile=./junit.xml
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            yarn vitest --changed ${{ github.event.pull_request.base.sha }} --reporter=junit --outputFile=./junit.xml
+          else
+            yarn vitest --reporter=junit --outputFile=./junit.xml
+          fi
       - name: Upload Test Results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()


### PR DESCRIPTION
## Summary

- PR에서는 `vitest --changed <base.sha>`로 변경된 파일에 영향받는 테스트만 실행
- main push 시에는 전체 vitest 그대로 실행 (`push: branches: [main]` 트리거 추가)
- vitest는 import 그래프를 따라가서 변경 파일을 사용하는 테스트도 함께 돌려요

## Test plan

- [ ] PR 빌드에서 test job이 변경된 파일과 그에 의존하는 테스트만 실행하는지 확인
- [ ] main push 빌드에서 test job이 전체 테스트를 실행하는지 확인