### PR TITLE
fix: add alt text to VitePress logo

### DIFF
--- a/docs/.vitepress/shared.mts
+++ b/docs/.vitepress/shared.mts
@@ -104,6 +104,7 @@ export const shared = defineConfig({
     logo: {
       dark: '/logo_white.png',
       light: '/logo_black.png',
+      alt: 'es-toolkit',
     },
 
     siteTitle: false,


### PR DESCRIPTION
## Summary
Issues: #1721 

Add `alt` text to the VitePress logo configuration to improve accessibility for screen reader users.

## Changes

* Added `alt` property to `themeConfig.logo`
* Improved accessibility compliance for logo images

```ts
themeConfig: {
  logo: {
    dark: '/logo_white.png',
    light: '/logo_black.png',
    alt: 'es-toolkit',
  },
}
```
