### PR TITLE
fix(invert/invertBy): skip unsafe properties __proto__ in invert and invertBy

### DIFF
--- a/src/compat/object/invertBy.ts
+++ b/src/compat/object/invertBy.ts
@@ -1,3 +1,4 @@
+import { isUnsafeProperty } from '../../_internal/isUnsafeProperty.ts';
 import { identity } from '../../function/identity.ts';
 import { isNil } from '../../predicate/isNil.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
@@ -87,6 +88,10 @@ export function invertBy<T extends object>(
 
     const value = (object as any)[key];
     const valueStr = getString(value);
+
+    if (isUnsafeProperty(valueStr)) {
+      continue;
+    }
 
     if (Array.isArray(result[valueStr])) {
       result[valueStr].push(key);

--- a/src/object/invert.ts
+++ b/src/object/invert.ts
@@ -1,3 +1,5 @@
+import { isUnsafeProperty } from '../_internal/isUnsafeProperty';
+
 /**
  * Inverts the keys and values of an object. The keys of the input object become the values of the output object and vice versa.
  *
@@ -24,6 +26,9 @@ export function invert<K extends PropertyKey, V extends PropertyKey>(obj: Record
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     const value = obj[key];
+    if (isUnsafeProperty(value)) {
+      continue;
+    }
     result[value] = key;
   }
 


### PR DESCRIPTION
## Problem

When proto or other special properties are passed as values to `invert` and `invertBy`, unexpected behavior may occur.

```js
const result = invert({ a: '__proto__', b: 'foo' });
```

**expected**

`{"__proto__": "a", "foo": "b"}`

**Actual**

`{"foo": "b"}`

Unlike expected, the key "proto" does not exist.
This behavior is an attempt to assign a value to a special property, but since it is not an actual object, it will not be modified.

```js
> const x = {'a': 1};
undefined
> x
{ a: 1 }
> x['b'] = 2;
2
> x
{ a: 1, b: 2 }
> x['__proto__'] = 3
3
> x
{ a: 1, b: 2 }
> x.__proto__
[Object: null prototype] {}
```

## Solution

Since only string, number, and symbol(`PropertyKey`) types can be used as values, there is no risk of prototype chain pollution.
However, it would be worth explicitly notifying users that keys such as `__proto__` are ignored.