### PR TITLE
docs: improve consistency of Korean translation for unsupported features

### DIFF
--- a/docs/ko/compatibility.md
+++ b/docs/ko/compatibility.md
@@ -44,7 +44,7 @@ chunk([1, 2, 3, 4], 0);
 
 - 암시적 타입 변환: 빈 문자열을 0 또는 false로 변환하는 것과 같은 동작
 - 어떤 경우에 특화된 구현: [sortedUniq](https://lodash.com/docs/4.17.15#sortedUniq)와 같이 정렬된 배열만 받는 함수
-- JavaScript 내장 객체의 프로토타입이 바뀐 경우에 대응하는 코드
+- `Array.prototype`과 같은 JavaScript 내장 객체의 프로토타입이 수정된 경우에 대한 처리
 - JavaScript Realm에 대응하는 코드
 - 메서드 체이닝: `_(arr).map(...).filter(...)`와 같은 메서드 체이닝
 


### PR DESCRIPTION
The Korean message lacks consistency with the English, Japanese, and Chinese versions.The Korean message lacks consistency with the English, Japanese, and Chinese versions.

**Korean**
JavaScript 내장 객체의 프로토타입이 바뀐 경우에 대응하는 코드

**English**
Handling cases where internal object prototypes, like `Array.prototype`, have been modified.

**Japenese**
`Array.prototype`のようなJavaScriptの組み込みオブジェクトのプロトタイプが変更された場合に対応するコード

**Chinese**
处理内部对象原型（例如 `Array.prototype`）被修改的情况。

The messages used in the English, Japanese, and Chinese versions feel more user friendly in terms of examples.(`Array.prototype`)