### PR TITLE
fix(uniqWith): match lodash comparator argument order in compat

### DIFF
--- a/src/compat/array/uniqWith.spec.ts
+++ b/src/compat/array/uniqWith.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import * as lodashStable from 'es-toolkit/compat';
 import type { uniqWith as uniqWithLodash } from 'lodash';
 import { uniqWith } from './uniqWith';
@@ -170,6 +170,35 @@ describe('uniqWith', () => {
 
   it('should return an empty array when input is not array-like', () => {
     expect(uniqWith(null, (a, b) => a === b)).toEqual([]);
+  });
+
+  it('should invoke the comparator with `(candidate, kept)` order, matching lodash', () => {
+    const comparator = vi.fn(() => false);
+
+    uniqWith(['A', 'B'], comparator);
+
+    // When processing the second element ('B'), lodash invokes the comparator
+    // as `(candidate, kept)` === `('B', 'A')`.
+    expect(comparator).toHaveBeenCalledWith('B', 'A');
+  });
+
+  it('should drop later elements that are subsets according to an asymmetric comparator', () => {
+    const sets: Record<string, string[]> = {
+      Big: ['x', 'y', 'z'],
+      Small: ['x'],
+    };
+
+    const isSubset = (a: string, b: string) => {
+      const diff = sets[a].filter(t => !sets[b].includes(t));
+
+      if (diff.length) {
+        return false;
+      }
+
+      return sets[a].length < sets[b].length;
+    };
+
+    expect(uniqWith(['Big', 'Small'], isSubset)).toEqual(['Big']);
   });
 
   it('should match the type of lodash', () => {

--- a/src/compat/array/uniqWith.ts
+++ b/src/compat/array/uniqWith.ts
@@ -32,5 +32,12 @@ export function uniqWith<T>(arr: ArrayLike<T> | null | undefined, comparator?: C
     return [];
   }
 
-  return typeof comparator === 'function' ? uniqWithToolkit(Array.from(arr), comparator) : uniqToolkit(Array.from(arr));
+  if (typeof comparator !== 'function') {
+    return uniqToolkit(Array.from(arr));
+  }
+
+  // `es-toolkit`'s `uniqWith` invokes the comparator as `(kept, candidate)`, but
+  // lodash documents and invokes it as `(candidate, kept)`. Swap the arguments so
+  // that asymmetric comparators behave the same as in lodash.
+  return uniqWithToolkit(Array.from(arr), (kept, candidate) => comparator(candidate, kept));
 }


### PR DESCRIPTION
## Summary
`es-toolkit/compat`'s `uniqWith` invoked the comparator with reversed argument order compared to lodash. lodash calls the comparator as `(candidate, kept)` (documented `(arrVal, othVal)`), but compat passed the comparator straight to the non-compat implementation, which calls it as `(kept, candidate)`. Any asymmetric comparator silently produced different results after migrating from lodash.

## Changes
- Wrap the comparator in compat `uniqWith` so the toolkit's `(kept, candidate)` call is forwarded as `comparator(candidate, kept)`, matching lodash.
- Add a test asserting the comparator is invoked with `(candidate, kept)` order, plus a behavioral test for an asymmetric (subset) comparator.

The non-compat `uniqWith` keeps its own documented `(item1, item2)` semantics and is unchanged.

## Test plan
- `yarn vitest run src/compat/array/uniqWith.spec.ts` — 19 passed (new tests fail before the fix)
- `yarn vitest run src/compat/array/` — 1000 passed
- non-compat `uniqWith` unaffected; typecheck + lint clean

Closes #1728