### PR TITLE
docs(compat): align method chaining guidance across locales

### DIFF
--- a/docs/compat/intro.md
+++ b/docs/compat/intro.md
@@ -49,7 +49,7 @@ However, the following are out of scope for `es-toolkit/compat`:
 - Functions that have specialized implementations for specific types of arrays, like [sortedUniq](https://lodash.com/docs/4.17.15#sortedUniq).
 - Handling cases where internal object prototypes, like `Array.prototype`, have been modified.
 - Managing cases with JavaScript realms.
-- Method chaining support through "Seq" methods.
+- Method chaining: method chaining like `_(arr).map(...).filter(...)`.
 
 ## Implementation Status
 

--- a/docs/zh_hans/compat/intro.md
+++ b/docs/zh_hans/compat/intro.md
@@ -49,7 +49,7 @@ chunk([1, 2, 3, 4], 0);
 - 针对特定类型数组具有专门实现的函数，如 [sortedUniq](https://lodash.com/docs/4.17.15#sortedUniq)。
 - 处理修改了内置对象（如 `Array.prototype`）原型的情况。
 - 处理 JavaScript Realm 的情况。
-- 通过 "Seq" 方法支持的方法链。
+- 方法链：像 `_(arr).map(...).filter(...)` 这样的方法链。
 
 ## 实现状态
 


### PR DESCRIPTION
## Summary

Follow-up to #1725.
Align the English and Simplified Chinese compat docs with the Korean method chaining guidance.

## Changes

- Update the English compat intro to describe method chaining with the `_(arr).map(...).filter(...)` example.
- Update the Simplified Chinese compat intro with the same example-based wording.

## Test results

Not run. Documentation-only change.