### PR TITLE
docs[playground]: separate playground page layout

### DIFF
--- a/docs/.vitepress/components/Playground.vue
+++ b/docs/.vitepress/components/Playground.vue
@@ -267,7 +267,7 @@ const defaultCode = `import { chunk, groupBy, uniq } from 'es-toolkit';
 
 // ============================================
 // es-toolkit Playground
-// Try any function from the sidebar!
+// Try any function from the function list!
 // ============================================
 
 // chunk(arr, size)
@@ -334,9 +334,9 @@ function resetCode() {
 .playground {
   display: flex;
   gap: 16px;
-  margin-top: 24px;
-  height: min(calc(100dvh - 200px), 800px);
-  min-height: 500px;
+  margin-top: var(--playground-margin-top, 24px);
+  height: var(--playground-height, min(calc(100dvh - 200px), 800px));
+  min-height: var(--playground-min-height, 500px);
 }
 
 .playground-sidebar {

--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -11,3 +11,50 @@
 :root[lang='ko'] {
   word-break: keep-all;
 }
+
+.playground-page-shell {
+  box-sizing: border-box;
+  max-width: calc(var(--vp-layout-max-width) - 64px);
+  min-height: calc(100dvh - var(--vp-nav-height));
+  margin: 0 auto;
+  padding: 48px 24px 40px;
+  --playground-margin-top: 0;
+  --playground-height: min(calc(100dvh - var(--vp-nav-height) - 176px), 840px);
+  --playground-min-height: 560px;
+}
+
+.playground-page-header {
+  margin-bottom: 24px;
+}
+
+.playground-page-header h1 {
+  margin: 0;
+  color: var(--vp-c-text-1);
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.playground-page-header p {
+  max-width: 760px;
+  margin: 8px 0 0;
+  color: var(--vp-c-text-2);
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+@media (max-width: 768px) {
+  .playground-page-shell {
+    padding: 24px 16px 32px;
+    --playground-height: auto;
+    --playground-min-height: 720px;
+  }
+
+  .playground-page-header h1 {
+    font-size: 28px;
+  }
+
+  .playground-page-header p {
+    font-size: 15px;
+  }
+}

--- a/docs/ja/playground.md
+++ b/docs/ja/playground.md
@@ -1,6 +1,9 @@
 ---
+layout: page
 description: es-toolkitの関数を試せるインタラクティブプレイグラウンド
+sidebar: false
 aside: false
+outline: false
 pageClass: playground-page
 ---
 
@@ -10,8 +13,11 @@ import { defineAsyncComponent } from 'vue';
 const Playground = defineAsyncComponent(() => import('../.vitepress/components/Playground.vue'));
 </script>
 
-# プレイグラウンド
+<div class="playground-page-shell">
+  <header class="playground-page-header">
+    <h1>プレイグラウンド</h1>
+    <p>このインタラクティブプレイグラウンドで es-toolkit の関数を探索・実験できます。関数リストから関数を選択してライブサンプルを確認するか、独自のコードを書いてみてください。</p>
+  </header>
 
-このインタラクティブプレイグラウンドで es-toolkit の関数を探索・実験できます。サイドバーから関数を選択してライブサンプルを確認するか、独自のコードを書いてみてください。
-
-<Playground />
+  <Playground />
+</div>

--- a/docs/ko/playground.md
+++ b/docs/ko/playground.md
@@ -1,6 +1,9 @@
 ---
+layout: page
 description: es-toolkit 함수를 탐색할 수 있는 인터랙티브 플레이그라운드
+sidebar: false
 aside: false
+outline: false
 pageClass: playground-page
 ---
 
@@ -10,8 +13,11 @@ import { defineAsyncComponent } from 'vue';
 const Playground = defineAsyncComponent(() => import('../.vitepress/components/Playground.vue'));
 </script>
 
-# 플레이그라운드
+<div class="playground-page-shell">
+  <header class="playground-page-header">
+    <h1>플레이그라운드</h1>
+    <p>인터랙티브 플레이그라운드에서 es-toolkit 함수를 탐색하고 실험해 보세요. 함수 목록에서 함수를 선택하면 라이브 예제를 볼 수 있고, 직접 코드를 작성할 수도 있어요.</p>
+  </header>
 
-인터랙티브 플레이그라운드에서 es-toolkit 함수를 탐색하고 실험해 보세요. 사이드바에서 함수를 선택하면 라이브 예제를 볼 수 있고, 직접 코드를 작성할 수도 있어요.
-
-<Playground />
+  <Playground />
+</div>

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -1,6 +1,9 @@
 ---
+layout: page
 description: Interactive playground to explore es-toolkit functions
+sidebar: false
 aside: false
+outline: false
 pageClass: playground-page
 ---
 
@@ -10,8 +13,11 @@ import { defineAsyncComponent } from 'vue';
 const Playground = defineAsyncComponent(() => import('./.vitepress/components/Playground.vue'));
 </script>
 
-# Playground
+<div class="playground-page-shell">
+  <header class="playground-page-header">
+    <h1>Playground</h1>
+    <p>Explore and experiment with es-toolkit functions in this interactive playground. Select a function from the function list to see a live example, or write your own code.</p>
+  </header>
 
-Explore and experiment with es-toolkit functions in this interactive playground. Select a function from the sidebar to see a live example, or write your own code.
-
-<Playground />
+  <Playground />
+</div>

--- a/docs/zh_hans/playground.md
+++ b/docs/zh_hans/playground.md
@@ -1,6 +1,9 @@
 ---
+layout: page
 description: 探索 es-toolkit 函数的交互式演练场
+sidebar: false
 aside: false
+outline: false
 pageClass: playground-page
 ---
 
@@ -10,8 +13,11 @@ import { defineAsyncComponent } from 'vue';
 const Playground = defineAsyncComponent(() => import('../.vitepress/components/Playground.vue'));
 </script>
 
-# 演练场
+<div class="playground-page-shell">
+  <header class="playground-page-header">
+    <h1>演练场</h1>
+    <p>在这个交互式演练场中探索和试验 es-toolkit 函数。从函数列表选择一个函数查看实时示例，或者编写你自己的代码。</p>
+  </header>
 
-在这个交互式演练场中探索和试验 es-toolkit 函数。从侧边栏选择一个函数查看实时示例，或者编写你自己的代码。
-
-<Playground />
+  <Playground />
+</div>


### PR DESCRIPTION
## Summary

Separates the VitePress playground page from the standard docs layout so it renders without the docs sidebar.

## Changes

- Use the page layout and disable sidebar/outline for playground pages in all locales.
- Add a playground-specific shell to control max width, spacing, and responsive sizing.
- Make the playground component height/margin configurable through CSS custom properties.
- Update playground copy to refer to the function list instead of the docs sidebar.

## Test results

- `yarn prettier --check docs/.vitepress/theme/index.css`
- `git diff --check`
- Browser visual check on `http://127.0.0.1:5173/playground.html`
- Not run: `yarn workspace docs docs:build` (skipped per request)
