### PR TITLE
docs[playground]: add link to playground editor title

### DIFF
--- a/docs/.vitepress/components/Playground.vue
+++ b/docs/.vitepress/components/Playground.vue
@@ -30,9 +30,10 @@
     </div>
     <div class="playground-editor">
       <div class="playground-editor-header">
-        <span class="playground-editor-title">{{
-          selectedCategoryLabel === '' ? t.selectFunction : `${selectedCategoryLabel}/${selectedFunction}`
-        }}</span>
+        <a v-if="selectedFunction && docUrl" :href="docUrl" class="playground-editor-title playground-editor-title-link"
+          >{{ selectedCategoryLabel }}/{{ selectedFunction }}</a
+        >
+        <span v-else class="playground-editor-title">{{ t.selectFunction }}</span>
         <div class="playground-header-actions">
           <button
             v-if="currentDoc"
@@ -229,6 +230,13 @@ const selectedCategory = ref('');
 const selectedCategoryLabel = ref('');
 const openCategories = ref(new Set(['array']));
 const sandpackKey = ref(0);
+
+const docUrl = computed(() => {
+  if (!selectedFunction.value || !selectedCategory.value) return null;
+  const locale = lang.value;
+  const prefix = locale && locale !== 'en' && locale !== 'root' ? `/${locale}` : '';
+  return `${prefix}/reference/${selectedCategory.value}/${selectedFunction.value}`;
+});
 
 const currentDoc = computed(() => {
   if (!selectedFunction.value) {
@@ -454,6 +462,16 @@ function resetCode() {
   font-weight: 600;
   color: var(--vp-c-text-1);
   font-family: var(--vp-font-family-mono);
+}
+
+.playground-editor-title-link {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  transition: color 0.15s;
+}
+
+.playground-editor-title-link:hover {
+  color: var(--vp-c-brand-1);
 }
 
 .playground-header-actions {


### PR DESCRIPTION
## Summary

Added a link to the playground editor title that navigates to the function's detail page. Users may want to explore a function in more detail after testing it in the playground, so linking to the detail page is expected to provide a better UX experience.

## Changes

### Before

<img width="887" height="774" alt="스크린샷 2026-05-24 오후 1 06 55" src="https://github.com/user-attachments/assets/79fd0d3a-fe75-44d4-88ac-24548ea33c1a" />


### After

<img width="1200" height="625" alt="es-toolkit-link-example" src="https://github.com/user-attachments/assets/6de036b7-3502-4197-84a7-7a2a141a6104" />


