### PR TITLE
docs[playground]: prevent code reset when toggle documentation panel

### DIFF
--- a/docs/.vitepress/components/Playground.vue
+++ b/docs/.vitepress/components/Playground.vue
@@ -84,12 +84,7 @@
               'es-toolkit': 'latest',
             },
           }"
-          :files="{
-            '/index.ts': {
-              code: currentCode,
-              active: true,
-            },
-          }"
+          :files="sandpackFiles"
         />
       </div>
     </div>
@@ -304,6 +299,13 @@ console.log('groupBy:', grouped);
 `;
 
 const currentCode = ref(defaultCode);
+
+const sandpackFiles = computed(() => ({
+  '/index.ts': {
+    code: currentCode.value,
+    active: true,
+  },
+}));
 
 function selectFunction(category, fn) {
   const selectKey = `${category.name}/${fn}`;


### PR DESCRIPTION
## Summary

Fixed an issue where modified code in the playground was lost when clicking the toggle documentation button.

## Change

### Before

<img width="1200" height="625" alt="화면 기록 2026-05-24 오후 8 05 32" src="https://github.com/user-attachments/assets/adc2de67-31d1-4436-8755-0d03cc7f8011" />


### After

<img width="1200" height="625" alt="화면 기록 2026-05-24 오후 8 05 51" src="https://github.com/user-attachments/assets/e4fc88e1-038f-41cb-9c5c-017fc17c88ec" />
