### PR TITLE
fix(reduce, reduceRight): respect nullish accumulators

### DIFF
--- a/docs/.vitepress/components/FlavorDropdown.vue
+++ b/docs/.vitepress/components/FlavorDropdown.vue
@@ -19,12 +19,16 @@ function toggle() {
 
 function select(option: FlavorSpec) {
   open.value = false;
-  if (option.value === currentFlavor.value.value) return;
+  if (option.value === currentFlavor.value.value) {
+    return;
+  }
   router.go(flavorIntroPath({ flavor: option, localePrefix: localePrefix.value }));
 }
 
 function onDocumentPointerDown(event: PointerEvent) {
-  if (!open.value || !root.value) return;
+  if (!open.value || !root.value) {
+    return;
+  }
   if (!root.value.contains(event.target as Node)) {
     open.value = false;
   }

--- a/docs/.vitepress/components/Playground.vue
+++ b/docs/.vitepress/components/Playground.vue
@@ -227,7 +227,9 @@ const openCategories = ref(new Set(['array']));
 const sandpackKey = ref(0);
 
 const docUrl = computed(() => {
-  if (!selectedFunction.value || !selectedCategory.value) return null;
+  if (!selectedFunction.value || !selectedCategory.value) {
+    return null;
+  }
   const locale = lang.value;
   const prefix = locale && locale !== 'en' && locale !== 'root' ? `/${locale}` : '';
   return `${prefix}/reference/${selectedCategory.value}/${selectedFunction.value}`;

--- a/src/compat/array/reduce.spec.ts
+++ b/src/compat/array/reduce.spec.ts
@@ -54,6 +54,39 @@ describe('reduce', () => {
     expect(actual).toBe(undefined);
   });
 
+  it('should respect nullish initial `accumulator` values', () => {
+    const array = [1, 2, 3];
+    const object = { a: 1, b: 2 };
+
+    for (const accumulator of [null, undefined]) {
+      let args: unknown[] | undefined;
+
+      reduce(
+        array,
+        function () {
+          // eslint-disable-next-line
+          args || (args = Array.prototype.slice.call(arguments));
+        },
+        accumulator
+      );
+
+      expect(args).toEqual([accumulator, 1, 0, array]);
+
+      args = undefined;
+
+      reduce(
+        object,
+        function () {
+          // eslint-disable-next-line
+          args || (args = Array.prototype.slice.call(arguments));
+        },
+        accumulator
+      );
+
+      expect(args).toEqual([accumulator, 1, 'a', object]);
+    }
+  });
+
   it(`should return \`undefined\` for empty collections when no \`accumulator\` is given (test in IE > 9 and modern browsers)`, () => {
     const array: any[] = [];
     const object = { 0: 1, length: 0 };

--- a/src/compat/array/reduce.ts
+++ b/src/compat/array/reduce.ts
@@ -131,6 +131,8 @@ export function reduce(
   iteratee: (accumulator: any, value: any, index: any, collection: any) => any = identity,
   accumulator?: any
 ): any {
+  const hasAccumulator = arguments.length >= 3;
+
   if (!collection) {
     return accumulator;
   }
@@ -141,14 +143,14 @@ export function reduce(
   if (isArrayLike(collection)) {
     keys = range(0, collection.length);
 
-    if (accumulator == null && collection.length > 0) {
+    if (!hasAccumulator && collection.length > 0) {
       accumulator = (collection as ArrayLike<any>)[0];
       startIndex += 1;
     }
   } else {
     keys = Object.keys(collection);
 
-    if (accumulator == null) {
+    if (!hasAccumulator && keys.length > 0) {
       accumulator = (collection as any)[keys[0]];
       startIndex += 1;
     }

--- a/src/compat/array/reduceRight.spec.ts
+++ b/src/compat/array/reduceRight.spec.ts
@@ -116,6 +116,39 @@ describe('reduceRight', () => {
     expect(actual).toBe(undefined);
   });
 
+  it('should respect nullish initial `accumulator` values', () => {
+    const array = [1, 2, 3];
+    const object = { a: 1, b: 2 };
+
+    for (const accumulator of [null, undefined]) {
+      let args: unknown[] | undefined;
+
+      reduceRight(
+        array,
+        function () {
+          // eslint-disable-next-line
+          args || (args = Array.prototype.slice.call(arguments));
+        },
+        accumulator
+      );
+
+      expect(args).toEqual([accumulator, 3, 2, array]);
+
+      args = undefined;
+
+      reduceRight(
+        object,
+        function () {
+          // eslint-disable-next-line
+          args || (args = Array.prototype.slice.call(arguments));
+        },
+        accumulator
+      );
+
+      expect(args).toEqual([accumulator, 2, 'b', object]);
+    }
+  });
+
   it(`should return \`undefined\` for empty collections when no \`accumulator\` is given (test in IE > 9 and modern browsers)`, () => {
     const array: any[] = [];
     const object = { 0: 1, length: 0 };

--- a/src/compat/array/reduceRight.ts
+++ b/src/compat/array/reduceRight.ts
@@ -172,6 +172,8 @@ export function reduceRight(
   iteratee: (accumulator: any, value: any, index: any, collection: any) => any = identity,
   accumulator?: any
 ): any {
+  const hasAccumulator = arguments.length >= 3;
+
   if (!collection) {
     return accumulator;
   }
@@ -182,7 +184,7 @@ export function reduceRight(
   if (isArrayLike(collection)) {
     keys = range(0, collection.length).reverse();
 
-    if (accumulator == null && collection.length > 0) {
+    if (!hasAccumulator && collection.length > 0) {
       accumulator = (collection as ArrayLike<any>)[collection.length - 1];
       startIndex = 1;
     } else {
@@ -191,7 +193,7 @@ export function reduceRight(
   } else {
     keys = Object.keys(collection).reverse();
 
-    if (accumulator == null) {
+    if (!hasAccumulator && keys.length > 0) {
       accumulator = (collection as any)[keys[0]];
       startIndex = 1;
     } else {


### PR DESCRIPTION
## Summary

Fixes #1741.

`es-toolkit/compat` now matches lodash when `reduce` or `reduceRight` receives an explicit `null` or `undefined` accumulator.

## Changes

- Detect whether an accumulator was provided using argument count, matching lodash's `arguments.length < 3` behavior.
- Add compat tests for explicit `null` and `undefined` accumulators across arrays and objects.
- Fix existing docs `curly` lint errors so the full lint command completes.

## Test results

- `mise exec node@24.13.0 -- yarn typecheck`
- `mise exec node@24.13.0 -- yarn lint`
- `mise exec node@24.13.0 -- yarn vitest run src/compat/array/reduce.spec.ts src/compat/array/reduceRight.spec.ts`
- `mise exec node@24.13.0 -- yarn vitest run`
