### PR TITLE
fix(pull): Remove unused generic type parameters from template

### DIFF
--- a/src/array/pull.ts
+++ b/src/array/pull.ts
@@ -4,7 +4,7 @@
  * This function changes `arr` in place.
  * If you want to remove values without modifying the original array, use `difference`.
  *
- * @template T, U
+ * @template T
  * @param {T[]} arr - The array to modify.
  * @param {unknown[]} valuesToRemove - The values to remove from the array.
  * @returns {T[]} The modified array with the specified values removed.

--- a/src/compat/array/pull.ts
+++ b/src/compat/array/pull.ts
@@ -44,7 +44,7 @@ export function pull<L extends ArrayLike<any>>(array: L extends readonly any[] ?
  * This function changes `arr` in place.
  * If you want to remove values without modifying the original array, use `difference`.
  *
- * @template T, U
+ * @template T
  * @param {T[]} arr - The array to modify.
  * @param {...unknown[]} valuesToRemove - The values to remove from the array.
  * @returns {T[]} The modified array with the specified values removed.


### PR DESCRIPTION
## Summay

It looks like only `T` is used as a generic type parameter in pull. Not sure why `U` was introduced, but it should be removed!