### PR TITLE
docs: fix grammar in clone JSDoc examples

### DIFF
--- a/src/compat/object/clone.ts
+++ b/src/compat/object/clone.ts
@@ -35,7 +35,7 @@ import { isTypedArray } from '../predicate/isTypedArray.ts';
  * @returns {T} - A shallow clone of the given object.
  *
  * @example
- * // Clone a primitive objs
+ * // Clone a primitive object
  * const num = 29;
  * const clonedNum = clone(num);
  * console.log(clonedNum); // 29

--- a/src/compat/object/cloneDeep.ts
+++ b/src/compat/object/cloneDeep.ts
@@ -8,7 +8,7 @@ import { cloneDeepWith } from './cloneDeepWith.ts';
  * @returns {T} - A deep clone of the given object.
  *
  * @example
- * // Clone a primitive values
+ * // Clone a primitive value
  * const num = 29;
  * const clonedNum = clone(num);
  * console.log(clonedNum); // 29

--- a/src/compat/object/cloneWith.ts
+++ b/src/compat/object/cloneWith.ts
@@ -73,7 +73,7 @@ export function cloneWith<T>(value: T): T;
  * @returns {T} - A shallow clone of the given object.
  *
  * @example
- * // Clone a primitive values
+ * // Clone a primitive value
  * const num = 29;
  * const clonedNum = cloneWith(num);
  * console.log(clonedNum); // 29

--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -9,7 +9,7 @@ import { isTypedArray } from '../predicate/isTypedArray.ts';
  * @returns {T} - A shallow clone of the given object.
  *
  * @example
- * // Clone a primitive values
+ * // Clone a primitive value
  * const num = 29;
  * const clonedNum = clone(num);
  * console.log(clonedNum); // 29

--- a/src/object/cloneDeep.ts
+++ b/src/object/cloneDeep.ts
@@ -8,7 +8,7 @@ import { cloneDeepWithImpl } from './cloneDeepWith.ts';
  * @returns {T} - A deep clone of the given object.
  *
  * @example
- * // Clone a primitive values
+ * // Clone a primitive value
  * const num = 29;
  * const clonedNum = cloneDeep(num);
  * console.log(clonedNum); // 29


### PR DESCRIPTION
Several `clone`-family `@example` comments read **"Clone a primitive values"** (and one **"Clone a primitive objs"**) — the article *a* with a plural noun.

Each example clones a single value (`const num = 29; clone(num);`), so the singular is correct. This changes them to **"Clone a primitive value"** / **"Clone a primitive object"**, which also matches the existing `cloneDeepWith` docs that already say "Clone a primitive value".

Affected files:
- `src/object/clone.ts`
- `src/object/cloneDeep.ts`
- `src/compat/object/clone.ts`
- `src/compat/object/cloneDeep.ts`
- `src/compat/object/cloneWith.ts`

Comment-only change; no code or behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)