### PR TITLE
fix(compat/random): coerce the upper bound (not the lower) when max is a non-number

### DIFF
--- a/src/compat/math/random.spec.ts
+++ b/src/compat/math/random.spec.ts
@@ -69,6 +69,16 @@ describe('random', () => {
     expect(actual).toEqual([0, 1, Number.MAX_SAFE_INTEGER]);
   });
 
+  it('should coerce a string upper bound and respect both bounds', () => {
+    for (let i = 0; i < 100; i++) {
+      // eslint-disable-next-line
+      // @ts-ignore
+      const actual = random('5', '10');
+      expect(actual).toBeGreaterThanOrEqual(5);
+      expect(actual).toBeLessThanOrEqual(10);
+    }
+  });
+
   it('should support floats', () => {
     const min = 1.5;
     const max = 1.6;

--- a/src/compat/math/random.ts
+++ b/src/compat/math/random.ts
@@ -106,7 +106,7 @@ export function random(...args: any[]): number {
   }
 
   if (typeof maximum !== 'number') {
-    minimum = Number(maximum);
+    maximum = Number(maximum);
   }
 
   if (!minimum) {


### PR DESCRIPTION
### Bug

In `src/compat/math/random.ts`, the block that coerces a non-number **upper** bound assigns the result to `minimum` instead of `maximum`:

```ts
if (typeof minimum !== 'number') {
  minimum = Number(minimum);
}

if (typeof maximum !== 'number') {
  minimum = Number(maximum);   // ❌ should be: maximum = Number(maximum)
}
```

So when `maximum` is a numeric string, its value is written into `minimum` and `maximum` is left as the original string.

### Impact

```ts
random('5', '10'); // always returns 10
```

Trace: `minimum` becomes `Number('5') = 5`, then `minimum` is overwritten with `Number('10') = 10` while `maximum` stays `'10'`. `minimum > maximum` is `10 > '10'` → `false` (no swap), `clamp` makes both `10`, and `minimum === maximum` returns `10`. So any call with a non-number upper bound collapses to that upper bound.

lodash coerces **both** bounds via `toFinite` and returns a value in `[lower, upper]`.

### Fix

Assign the coerced value to `maximum`. Added a regression test with distinct string bounds (`random('5', '10')`) — the existing `random('1', '1')` case can't catch this because `min === max` returns early regardless of the bug.