### PR TITLE
docs(search): add ja tanslation to search

### DIFF
--- a/docs/.vitepress/shared.mts
+++ b/docs/.vitepress/shared.mts
@@ -2,6 +2,7 @@ import { createRequire } from 'module';
 import path from 'path';
 import { defineConfig } from 'vitepress';
 import llmstxt from 'vitepress-plugin-llms';
+import { search as jaSearch } from './ja.mts';
 import { search as koSearch } from './ko.mts';
 import { search as zh_hansSearch } from './zh_hans.mts';
 
@@ -119,6 +120,7 @@ export const shared = defineConfig({
         locales: {
           ...koSearch,
           ...zh_hansSearch,
+          ...jaSearch,
         },
       },
     },


### PR DESCRIPTION
## Summary

It appears that Japanese translations for the search feature were missing.
The translation values already existed but were not being applied 🥲

## Change

### Before

<img width="894" height="147" alt="스크린샷 2026-06-02 오후 8 00 55" src="https://github.com/user-attachments/assets/0f440f6a-f5c6-4d0a-bbf2-ed3d87f9e5a1" />

### After

<img width="762" height="159" alt="스크린샷 2026-06-02 오후 8 01 28" src="https://github.com/user-attachments/assets/c6715573-21e9-4478-8765-5edded80c801" />
