### PR TITLE
fix(exports): provide ESM resolution for ./compat/* subpaths

### DIFF
--- a/.scripts/postbuild.sh
+++ b/.scripts/postbuild.sh
@@ -12,7 +12,9 @@ create_compat_export() {
     local category=$1
     local name=$2
     echo "module.exports = require('../dist/compat/$category/$name.js').$name;" > compat/$name.js
+    echo "export { $name as default } from '../dist/compat/$category/$name.mjs';" > compat/$name.mjs
     echo "export { $name as default } from '../dist/compat/$category/$name.js';" > compat/$name.d.ts
+    echo "export { $name as default } from '../dist/compat/$category/$name.mjs';" > compat/$name.d.mts
 }
 
 # Function to create compat reexports (for functions from main src)
@@ -20,7 +22,9 @@ create_compat_reexport() {
     local category=$1
     local name=$2
     echo "module.exports = require('../dist/$category/$name.js').$name;" > compat/$name.js
+    echo "export { $name as default } from '../dist/$category/$name.mjs';" > compat/$name.mjs
     echo "export { $name as default } from '../dist/$category/$name.js';" > compat/$name.d.ts
+    echo "export { $name as default } from '../dist/$category/$name.mjs';" > compat/$name.d.mts
 }
 
 # Function to create compat alias
@@ -29,7 +33,9 @@ create_compat_alias() {
     local original=$2
     local alias=$3
     echo "module.exports = require('../dist/compat/$category/$original.js').$original;" > compat/$alias.js
+    echo "export { $original as default } from '../dist/compat/$category/$original.mjs';" > compat/$alias.mjs
     echo "export { $original as default } from '../dist/compat/$category/$original.js';" > compat/$alias.d.ts
+    echo "export { $original as default } from '../dist/compat/$category/$original.mjs';" > compat/$alias.d.mts
 }
 
 # Create root exports

--- a/package.json
+++ b/package.json
@@ -137,7 +137,11 @@
         }
       },
       "./compat/*": {
-        "default": {
+        "import": {
+          "types": "./compat/*.d.mts",
+          "default": "./compat/*.mjs"
+        },
+        "require": {
           "types": "./compat/*.d.ts",
           "default": "./compat/*.js"
         }


### PR DESCRIPTION
The `./compat/*` wildcard export only declared a CJS `default` condition, so `import get from "es-toolkit/compat/get"` always resolved to a CommonJS stub even in fully-ESM graphs. Every other subpath already splits `import`/`require`; compat alone shipped CJS to ESM importers, costing interop wrappers and worse tree-shaking.

This was uncovered by a rolldown (vite 8) chunk-rendering bug where the dist `require_*` helper naming crashed production builds (rolldown#9653) — but that bug is now fixed upstream, so it is not the motivation here. The motivation is the independent, measurable cost of shipping CJS to ESM consumers, which stands regardless of any bundler.

Generate `.mjs` (ESM) stubs and `.d.mts` types alongside the existing `.js`/`.d.ts` in postbuild, and split `./compat/*` into `import` / `require` conditions like every other subpath. ESM importers now resolve to pure-ESM `.mjs` (zero `require(` in the chain); `require` still gets CJS. attw `node16 (from ESM)` goes from "Incorrect default export" to "OK (ESM)".

Package size impact (measured via `npm pack`; dist/ is byte-identical between old and new — the ESM implementations already ship either way, this only adds tiny one-line re-export stubs):

```
    metric            OLD (CJS)   NEW (+ESM)   delta
    tarball (gzip)    645.5 KB    670.0 KB     +24.5 KB (+3.8%)
    unpacked          3.33 MB     3.37 MB      +0.04 MB (+1.2%)
    file count        3018        3612         +594 (297 fns x 2)
```

Smaller consumer bundles. Bundled small ESM apps that deep-import compat functions with esbuild (bundle + tree-shake + minify) against the old and new packages and compared output bytes:
```
    import set                       OLD (CJS)   NEW (ESM)   reduction
    get + maxBy                      11,602 B    8,122 B     -30.0%
    recharts 3's 11 deep-imports     21,526 B    15,193 B    -29.4%
```

Timeline:
  2025-06-07  #1199 (f6e1ce35) added this exact change (.mjs/.d.mts
              stubs + import/require split) to support ESM consumers.
  2025-06-15  e6f67626 reverted it ("Provide compat/* in CommonJS
              format by default") — direct push to main, no PR, no
              rationale in the message.
  2025-10-18  #1479 reported `exports is not defined` and proposed
              this identical fix. Closed; maintainer rationale was
              package size + "importing CJS from ESM is fine."
  2026-06-05  #1756 filed. The triggering rolldown bug is fixed
              upstream, but it surfaced that compat/* ships CJS to ESM
              importers — independently worth fixing (size, resolution,
              tree-shaking) per the measurements above.

Closes https://github.com/toss/es-toolkit/issues/1756