### PR TITLE
fix(compat/toLength): coerce non-numeric values to 0

### DIFF
--- a/src/compat/util/toLength.spec.ts
+++ b/src/compat/util/toLength.spec.ts
@@ -23,6 +23,14 @@ describe('toLength', () => {
     expect(1 / toLength(-0)).toBe(Infinity);
   });
 
+  it('should coerce non-numeric values to `0`', () => {
+    expect(toLength('a')).toBe(0);
+    expect(toLength('12px')).toBe(0);
+    expect(toLength(NaN)).toBe(0);
+    expect(toLength({})).toBe(0);
+    expect(toLength(undefined)).toBe(0);
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(toLength).toEqualTypeOf<typeof toLengthLodash>();
   });

--- a/src/compat/util/toLength.ts
+++ b/src/compat/util/toLength.ts
@@ -1,10 +1,11 @@
+import { toInteger } from './toInteger.ts';
 import { MAX_ARRAY_LENGTH } from '../_internal/MAX_ARRAY_LENGTH.ts';
 import { clamp } from '../math/clamp.ts';
 
 /**
  * Converts the value to a valid index. A valid index is an integer that is greater than or equal to `0` and less than or equal to `2^32 - 1`.
  *
- * It converts the given value to a number and floors it to an integer. If the value is less than `0`, it returns `0`. If the value exceeds `2^32 - 1`, it returns `2^32 - 1`.
+ * It converts the given value to an integer. If the value is less than `0`, it returns `0`. If the value exceeds `2^32 - 1`, it returns `2^32 - 1`. Values that cannot be converted to a number (such as `NaN` or non-numeric strings) return `0`.
  *
  * @param {unknown} value - The value to convert to a valid index.
  * @returns {number} The converted value.
@@ -15,13 +16,12 @@ import { clamp } from '../math/clamp.ts';
  * toLength(1.9)  // => 1
  * toLength('42') // => 42
  * toLength(null) // => 0
+ * toLength('a')  // => 0
  */
 export function toLength(value: any): number {
   if (value == null) {
     return 0;
   }
 
-  const length = Math.floor(Number(value));
-
-  return clamp(length, 0, MAX_ARRAY_LENGTH);
+  return clamp(toInteger(value), 0, MAX_ARRAY_LENGTH);
 }


### PR DESCRIPTION
## Summary

`compat/toLength` returns `NaN` for values that coerce to `NaN`, where lodash returns `0`:

```js
import { toLength } from 'es-toolkit/compat';

toLength('a');    // NaN  (lodash: 0)
toLength('12px'); // NaN  (lodash: 0)
toLength(NaN);    // NaN  (lodash: 0)
toLength({});     // NaN  (lodash: 0)
```

lodash's `toLength` always produces a valid length in `[0, 2^32 - 1]` and never returns `NaN`. The cause here is `Math.floor(Number(value))`: for a non-numeric input that's `NaN`, and `clamp` passes `NaN` straight through.

I noticed `toInteger`, `toFinite`, and `toSafeInteger` already agree with lodash on these inputs, and the sibling `toSafeInteger` is implemented as `clamp(toInteger(value), ...)`. `toInteger` maps `NaN` to `0`, so routing `toLength` through it fixes the inconsistency and lines the two functions up. This also matches lodash, whose `toLength` is `baseClamp(toInteger(value), 0, MAX_ARRAY_LENGTH)`.

## Test

Extended `toLength.spec.ts` with the non-numeric cases (`'a'`, `'12px'`, `NaN`, `{}`, `undefined`); they failed before and pass now. The full `compat` suite stays green.
