### PR TITLE
fix(globalThis): remove Function eval fallback for edge runtime compatibility

### DIFF
--- a/src/_internal/globalThis.ts
+++ b/src/_internal/globalThis.ts
@@ -1,14 +1,4 @@
-declare let global: typeof globalThis;
-
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const globalThis_: typeof globalThis =
-  (typeof globalThis === 'object' && globalThis) ||
-  (typeof window === 'object' && window) ||
-  (typeof self === 'object' && self) ||
-  (typeof global === 'object' && global) ||
-  (function (this: unknown) {
-    return this;
-  })() ||
-  Function('return this')();
+const globalThis_: typeof globalThis = globalThis;
 
 export { globalThis_ as globalThis };


### PR DESCRIPTION
## Summary

Importing any function whose graph reaches `isBuffer` or `DOMException` fails to build under Next.js Edge Runtime / Cloudflare Workers since `1.46.0`:

```
Error: Dynamic Code Evaluation (e.g. 'eval', 'new Function', 'WebAssembly.compile') not allowed in Edge Runtime
```

The culprit is the final fallback in `_internal/globalThis.ts`:

```ts
Function('return this')()
```

Edge runtimes scan for `Function(...)` syntactically and reject the module at build time, regardless of whether the branch is reachable. Since `globalThis` is standard from Node 12 and all modern edge runtimes, the entire fallback chain is dead code.

This removes it and assigns `globalThis` directly:

```ts
const globalThis_: typeof globalThis = globalThis;
```

Fixes #1760

## Test

Existing tests for `isBuffer`, `cloneDeep`, `isEqual`, `AbortError`, `TimeoutError`, and the full `compat` suite all pass.