### PR TITLE
fix(compat): round/ceil/floor should return Infinity for infinite values with precision

### DIFF
--- a/src/compat/_internal/decimalAdjust.ts
+++ b/src/compat/_internal/decimalAdjust.ts
@@ -8,7 +8,7 @@ export function decimalAdjust(
     number = '-0';
   }
   precision = Math.min(Number.parseInt(precision as string, 10), 292);
-  if (precision) {
+  if (precision && Number.isFinite(Number(number))) {
     const [magnitude, exponent = 0] = number.toString().split('e');
     let adjustedValue: string | number = Math[type](Number(`${magnitude}e${Number(exponent) + precision}`));
     if (Object.is(adjustedValue, -0)) {

--- a/src/compat/math/ceil.spec.ts
+++ b/src/compat/math/ceil.spec.ts
@@ -69,6 +69,14 @@ describe('ceil', () => {
     expect(actual).toEqual(expected);
   });
 
+  it(`\`ceil\` should return \`Infinity\` for infinite values regardless of \`precision\``, () => {
+    expect(ceil(Infinity)).toBe(Infinity);
+    expect(ceil(Infinity, 2)).toBe(Infinity);
+    expect(ceil(-Infinity, 2)).toBe(-Infinity);
+    expect(ceil(Infinity, -2)).toBe(Infinity);
+    expect(ceil(-Infinity, -2)).toBe(-Infinity);
+  });
+
   it(`\`ceil\` should handle edge cases`, () => {
     expect(ceil(1.797, 295)).toBe(1.797);
     expect(ceil(1.797, -295)).toBe(1e295);

--- a/src/compat/math/floor.spec.ts
+++ b/src/compat/math/floor.spec.ts
@@ -69,6 +69,14 @@ describe('floor', () => {
     expect(actual).toEqual(expected);
   });
 
+  it(`\`floor\` should return \`Infinity\` for infinite values regardless of \`precision\``, () => {
+    expect(floor(Infinity)).toBe(Infinity);
+    expect(floor(Infinity, 2)).toBe(Infinity);
+    expect(floor(-Infinity, 2)).toBe(-Infinity);
+    expect(floor(Infinity, -2)).toBe(Infinity);
+    expect(floor(-Infinity, -2)).toBe(-Infinity);
+  });
+
   it(`\`floor\` should handle edge cases`, () => {
     expect(floor(1.797, 295)).toBe(1.797);
     expect(floor(1.797, -295)).toBe(0);

--- a/src/compat/math/round.spec.ts
+++ b/src/compat/math/round.spec.ts
@@ -75,6 +75,14 @@ describe('round', () => {
     expect(actual).toEqual(expected);
   });
 
+  it(`\`round\` should return \`Infinity\` for infinite values regardless of \`precision\``, () => {
+    expect(round(Infinity)).toBe(Infinity);
+    expect(round(Infinity, 2)).toBe(Infinity);
+    expect(round(-Infinity, 2)).toBe(-Infinity);
+    expect(round(Infinity, -2)).toBe(Infinity);
+    expect(round(-Infinity, -2)).toBe(-Infinity);
+  });
+
   it(`\`round\` should handle edge cases`, () => {
     expect(round(1.797, 295)).toBe(1.797);
     expect(round(1.797, -295)).toBe(0);


### PR DESCRIPTION
## Summary

`es-toolkit/compat` aims for 100% behavioral parity with lodash, but `round`, `ceil`, and `floor` diverge when called on `Infinity` / `-Infinity` together with a non-zero `precision`: they return `NaN` instead of the infinite value.

```ts
import { round, ceil, floor } from 'es-toolkit/compat';

round(Infinity, 2);   // => NaN  (lodash: Infinity)
ceil(-Infinity, 2);   // => NaN  (lodash: -Infinity)
floor(Infinity, -2);  // => NaN  (lodash: Infinity)

// precision 0 / omitted already worked correctly:
round(Infinity);      // => Infinity ✓
```

## Root cause

All three functions delegate to the internal `decimalAdjust` helper. When `precision` is non-zero it shifts the value using exponential string notation:

```ts
const [magnitude, exponent = 0] = number.toString().split('e');
let adjustedValue = Math[type](Number(`${magnitude}e${Number(exponent) + precision}`));
```

For `Infinity`, `number.toString()` is `"Infinity"`, so the constructed string becomes `"Infinitye2"`, which is not a valid number — `Number("Infinitye2")` is `NaN`. The `precision === 0` path was unaffected because it skips this branch and calls `Math[type](number)` directly.

lodash guards this exact case in `createRound` by additionally checking that the number is finite before doing the exponential shift ([lodash.js#L5481](https://github.com/lodash/lodash/blob/4.17.21/lodash.js#L5481)):

```js
if (precision && nativeIsFinite(number)) { ... }
```

## Fix

Mirror lodash by only applying the exponential-shift logic when the value is finite; otherwise fall through to `Math[type](number)`, which returns the infinity unchanged.

```diff
-  if (precision) {
+  if (precision && Number.isFinite(Number(number))) {
```

The `-0` handling is preserved (`number` may be the string `'-0'` at this point; `Number('-0')` is `-0`, which is finite), and `NaN` input still yields `NaN` via the fall-through, matching lodash.

## Verification

- Added `should return Infinity for infinite values regardless of precision` tests to `round`, `ceil`, and `floor` spec files. They fail on `main` (`NaN`) and pass with this fix.
- Verified the new behavior matches lodash 4.17.21 across positive, negative, zero, and out-of-range precisions for both `Infinity` and `-Infinity`.
- Full `es-toolkit/compat` test suite passes (3091 tests); a fuzz comparison of the string/number compat functions against lodash now reports zero discrepancies.
- prettier and eslint clean on the changed files.

`decimalAdjust` is used only by `round`/`ceil`/`floor`, so the change is fully scoped to these three functions.