### PR TITLE
fix(compat/size): count array-like objects by their length

### DIFF
--- a/src/compat/array/size.spec.ts
+++ b/src/compat/array/size.spec.ts
@@ -66,6 +66,16 @@ describe('size', () => {
     expect(size(str)).toBe(10);
   });
 
+  it('should return the `length` of array-like objects', () => {
+    expect(size({ length: 3 })).toBe(3);
+    expect(size({ 0: 'a', 1: 'b', length: 2 })).toBe(2);
+    expect(size({ length: 0 })).toBe(0);
+  });
+
+  it('should prefer `length` over the number of own enumerable keys for array-like objects', () => {
+    expect(size({ length: 3, a: 1 })).toBe(3);
+  });
+
   it('should not treat objects with negative lengths as array-like', () => {
     expect(size({ length: -1 })).toBe(1);
   });

--- a/src/compat/array/size.ts
+++ b/src/compat/array/size.ts
@@ -1,4 +1,5 @@
 import { isNil } from '../../predicate/isNil.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
  * Returns the length of an array, string, or object.
@@ -35,12 +36,20 @@ import { isNil } from '../../predicate/isNil.ts';
  * const emptyObj = {};
  * const emptyObjSize = size(emptyObj);
  * // emptyObjSize will be 0
+ *
+ * const arrayLike = { length: 3 };
+ * const arrayLikeSize = size(arrayLike);
+ * // arrayLikeSize will be 3
  */
 export function size(collection: object | string | null | undefined): number;
 
 export function size(target: any): number {
   if (isNil(target)) {
     return 0;
+  }
+
+  if (isArrayLike(target)) {
+    return target.length;
   }
 
   if (target instanceof Map || target instanceof Set) {


### PR DESCRIPTION
## Summary

`compat/size` returns the number of own enumerable keys for array-like objects, so it diverges from lodash for values that have a valid `length` but aren't real arrays:

```js
import { size } from 'es-toolkit/compat';
import _ from 'lodash';

size({ length: 3 });             // 1   (expected 3)
_.size({ length: 3 });           // 3

size({ 0: 'a', 1: 'b', length: 2 }); // 3   (expected 2)
_.size({ 0: 'a', 1: 'b', length: 2 }); // 2
```

lodash's `size` checks `isArrayLike(collection)` first and returns `collection.length` for array-like values, only falling back to the own-key count for plain objects. es-toolkit skipped that check and went straight to `Object.keys(target).length`.

## Fix

Route array-like values through `isArrayLike` and return their `length`, matching lodash. Objects whose `length` is not a valid array length (negative, fractional, non-number, or above `MAX_SAFE_INTEGER`) are still not treated as array-like and fall back to the own-key count, exactly as before — the existing `size` tests covering those cases keep passing.

Arrays, strings, and `arguments` objects are unaffected (they were already array-like and produced the same result). Maps and Sets are not array-like, so they still return `.size`.

## Tests

Added cases asserting array-like objects are counted by `length`. The new tests fail on `main` and pass with the fix. The full `src/compat` suite (3093 tests), `tsc --noEmit`, and lint all pass.