### PR TITLE
fix(compat/random): compatibility issues with random function

### DIFF
--- a/src/compat/math/random.spec.ts
+++ b/src/compat/math/random.spec.ts
@@ -90,13 +90,13 @@ describe('random', () => {
 
   it('should support providing a `floating`', () => {
     let actual = random(true);
-    expect(actual % 1 && actual >= 0 && actual <= 1);
+    expect(actual % 1 && actual >= 0 && actual <= 1).toBeTruthy();
 
     actual = random(2, true);
     expect(actual % 1 && actual >= 0 && actual <= 2);
 
     actual = random(2, 4, true);
-    expect(actual % 1 && actual >= 2 && actual <= 4);
+    expect(actual % 1 && actual >= 2 && actual <= 4).toBeTruthy();
   });
 
   it('should work as an iteratee for methods like `_.map`', () => {

--- a/src/compat/math/random.spec.ts
+++ b/src/compat/math/random.spec.ts
@@ -111,7 +111,7 @@ describe('random', () => {
     expect(actual % 1 && actual >= 0 && actual <= 1).toBeTruthy();
 
     actual = random(2, true);
-    expect(actual % 1 && actual >= 0 && actual <= 2);
+    expect(actual % 1 && actual >= 0 && actual <= 2).toBeTruthy();
 
     actual = random(2, 4, true);
     expect(actual % 1 && actual >= 2 && actual <= 4).toBeTruthy();

--- a/src/compat/math/random.spec.ts
+++ b/src/compat/math/random.spec.ts
@@ -79,13 +79,31 @@ describe('random', () => {
     }
   });
 
+  it('should support a float `min` or `max`', () => {
+    const floatMinSamples = array.map(() => random(1.5, 2));
+    expect(floatMinSamples.some(v => v % 1 !== 0)).toBeTruthy();
+    expect(floatMinSamples.every(v => v >= 1.5 && v <= 2)).toBeTruthy();
+
+    const floatMaxSamples = array.map(() => random(1, 2.5));
+    expect(floatMaxSamples.some(v => v % 1 !== 0)).toBeTruthy();
+    expect(floatMaxSamples.every(v => v >= 1 && v <= 2.5)).toBeTruthy();
+  });
+
+  it('should support a float `max`', () => {
+    const max = 2.5;
+    const samples = array.map(() => random(max));
+
+    expect(samples.some(v => v % 1 !== 0)).toBeTruthy();
+    expect(samples.every(v => v >= 0 && v <= max)).toBeTruthy();
+  });
+
   it('should support floats', () => {
     const min = 1.5;
     const max = 1.6;
     const actual = random(min, max);
 
-    expect(actual % 1);
-    expect(actual >= min && actual <= max);
+    expect(actual % 1).toBeTruthy();
+    expect(actual >= min && actual <= max).toBeTruthy();
   });
 
   it('should support providing a `floating`', () => {

--- a/src/compat/math/random.ts
+++ b/src/compat/math/random.ts
@@ -129,7 +129,7 @@ export function random(...args: any[]): number {
   }
 
   if (floating) {
-    return randomToolkit(minimum, maximum + 1);
+    return randomToolkit(minimum, maximum);
   } else {
     return randomIntToolkit(minimum, maximum + 1);
   }

--- a/src/compat/math/random.ts
+++ b/src/compat/math/random.ts
@@ -82,6 +82,7 @@ export function random(...args: any[]): number {
       if (typeof args[1] === 'boolean') {
         maximum = args[0];
         floating = args[1];
+        break;
       } else {
         minimum = args[0];
         maximum = args[1];

--- a/src/compat/math/random.ts
+++ b/src/compat/math/random.ts
@@ -121,6 +121,10 @@ export function random(...args: any[]): number {
     [minimum, maximum] = [maximum, minimum];
   }
 
+  if (!floating && (!Number.isInteger(minimum) || !Number.isInteger(maximum))) {
+    floating = true;
+  }
+
   minimum = clamp(minimum, -Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
   maximum = clamp(maximum, -Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
 


### PR DESCRIPTION
## Incorrect Range(`floating=true`) -> [b15a478](https://github.com/toss/es-toolkit/pull/1767/commits/b15a478fd98cf4049b0418378d2872bf2fab86e6)

### Summary

Currently, when floating is true, values are returned in a range 1 higher than max.
e.g. `when min=1, max=2 with floating enabled`, values like 2.xx can be returned.

### Reproduce
```ts
import { random as loRandom } from 'lodash';
import { random as esRandom } from './src/compat/math/random';

const call = 500;

function checkOver(value) {
  if (value > 2) {
    return true;
  }
}

let loOver2 = 0;
let esOver2 = 0;

for (let i = 0; i < call; i++) {
  const value = loRandom(1, 2, true);
  if (checkOver(value)) {
    loOver2 += 1;
  }
}

for (let i = 0; i < call; i++) {
  const value = esRandom(1, 2, true);
  if (checkOver(value)) {
    esOver2 += 1;
  }
}

console.log(loOver2); // 0
console.log(esOver2); // 246
```

## Return integer when float value in parameter -> [fdf699b](https://github.com/toss/es-toolkit/pull/1767/commits/fdf699bf3cd64bc854eb0962fec0cddccb507940)

### Summary

- random(1.5, 2.5)
- random(1.5)
- random(1.5, 2)

In all of the above cases, integers are returned.
However, Lodash returns a float if at least one float value is included in the arguments.

### REproduce

```ts
import { random as loRandom } from 'lodash';
import { random as esCompatRandom } from './src/compat/math/random';

const call = 500;

let loIsInteger = 0;
let esCompatIsInteger = 0;

for (let i = 0; i < call; i++) {
  const value = loRandom(1.5, 2.5);
  if (Number.isInteger(value)) {
    loIsInteger += 1;
  }
}

for (let i = 0; i < call; i++) {
  const value = esCompatRandom(1.5, 2.5);
  if (Number.isInteger(value)) {
    esCompatIsInteger += 1;
  }
}

console.log(loIsInteger); // 0
console.log(esCompatIsInteger); // 500
```

## Return integer when (max=1, floating=true) case -> [dafe6d4](https://github.com/toss/es-toolkit/pull/1767/commits/dafe6d40cedac1280b7de64f656b31accfb2b8d2)

### Summary

Returns an integer when called with (max=some..., floating=true)
Shouldn't it return a float since `floating=true` 😁

### Reproduce

```ts
import { random as loRandom } from 'lodash';
import { random as esCompatRandom } from './src/compat/math/random';

const call = 500;

let loIsInteger = 0;
let esCompatIsInteger = 0;

for (let i = 0; i < call; i++) {
  const value = loRandom(2, true);
  if (Number.isInteger(value)) {
    loIsInteger += 1;
  }
}

for (let i = 0; i < call; i++) {
  const value = esCompatRandom(2, true);
  if (Number.isInteger(value)) {
    esCompatIsInteger += 1;
  }
}

console.log(loIsInteger); // 0
console.log(esCompatIsInteger); // 500
```
