### PR TITLE
fix(compat/parseInt): coerce input to string before parsing

### DIFF
--- a/src/compat/math/parseInt.spec.ts
+++ b/src/compat/math/parseInt.spec.ts
@@ -58,6 +58,23 @@ describe('parseInt', () => {
     expect(parseInt('0x20', object)).toBe(32);
   });
 
+  it('should coerce `string` to a string before parsing', () => {
+    // `null`/`undefined` coerce to `''`, not to `'null'`/`'undefined'`.
+    // @ts-expect-error - unusual usage
+    expect(parseInt(null)).toBeNaN();
+    // @ts-expect-error - unusual usage
+    expect(parseInt(null, 25)).toBeNaN();
+    // @ts-expect-error - unusual usage
+    expect(parseInt(undefined)).toBeNaN();
+    // @ts-expect-error - unusual usage
+    expect(parseInt(undefined, 16)).toBeNaN();
+  });
+
+  it('should not throw for symbol input and return `NaN`', () => {
+    // @ts-expect-error - unusual usage
+    expect(parseInt(Symbol('s'))).toBeNaN();
+  });
+
   it('should work as an iteratee for methods like `map`', () => {
     const strings = ['6', '08', '10'].map(Object);
     let actual = strings.map(parseInt);

--- a/src/compat/math/parseInt.ts
+++ b/src/compat/math/parseInt.ts
@@ -1,3 +1,5 @@
+import { toString } from '../util/toString.ts';
+
 /**
  * Converts `string` to an integer of the specified radix. If `radix` is undefined or 0, a `radix` of 10 is used unless `string` is a hexadecimal, in which case a `radix` of 16 is used.
  *
@@ -39,5 +41,5 @@ export function parseInt(string: string, radix = 0, guard?: unknown): number {
     radix = 0;
   }
 
-  return Number.parseInt(string, radix);
+  return Number.parseInt(toString(string), radix);
 }


### PR DESCRIPTION
While migrating some code from lodash I noticed `compat/parseInt` diverges from lodash on non-string inputs.

```js
import { parseInt } from 'es-toolkit/compat';

parseInt(null);          // lodash: NaN   es-toolkit: 23  (parses "null" as base 25 via map iteratee, "null" otherwise)
parseInt(null, 25);      // lodash: NaN   es-toolkit: 23
parseInt(Symbol('x'));   // lodash: NaN   es-toolkit: throws TypeError
```

lodash's `parseInt` runs the input through its own `toString` before handing it to the native `parseInt`, so `null`/`undefined` become `''` and symbols stringify instead of crashing. es-toolkit was passing the raw value straight to `Number.parseInt`, which relies on native coercion (`null` → `"null"`, symbols throw).

The fix routes the input through the existing `compat/util/toString`, matching lodash. Added tests for the `null`/`undefined` and symbol cases (they fail on `main`, pass with the change). Full `compat` suite, `tsc`, and lint are green.
