### PR TITLE
fix(compat/difference): treat sparse array holes as undefined for compability

### DIFF
--- a/src/compat/array/difference.spec.ts
+++ b/src/compat/array/difference.spec.ts
@@ -89,6 +89,14 @@ describe('difference', () => {
     expect(difference([1, 2, 3], array)).toEqual([3]);
   });
 
+  it(`should treat sparse array holes as \`undefined\``, () => {
+    // eslint-disable-next-line
+    const array = [1, , 3];
+
+    expect(difference(array, [3])).toEqual([1, undefined]);
+    expect(difference([5, undefined], array)).toEqual([5]);
+  });
+
   it('should return an empty array when the first array is not array-like object', () => {
     expect(difference('23', ['2', '3'])).toEqual([]);
   });

--- a/src/compat/array/difference.ts
+++ b/src/compat/array/difference.ts
@@ -1,5 +1,4 @@
 import { difference as differenceToolkit } from '../../array/difference.ts';
-import { toArray } from '../_internal/toArray.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 
 /**
@@ -32,7 +31,7 @@ export function difference<T>(arr: ArrayLike<T> | undefined | null, ...values: A
     return [];
   }
 
-  const arr1 = toArray(arr);
+  const arr1 = Array.from(arr);
   const arr2 = [];
 
   for (let i = 0; i < values.length; i++) {


### PR DESCRIPTION
## Summary

There is a difference in return values between `compat/difference` and lodash when dealing with sparse arrays.
For compatibility, the two return values need to be made consistent.

## Reproduce

```ts
import { difference as loDiff } from 'lodash';
import { difference as esCompatDiff } from './src/compat/array/difference';

const arr = [1, , 3];

console.log(loDiff(arr, [3])); // [1, undefined]
console.log(esCompatDiff(arr, [3])); [1]
```