### PR TITLE
fix(compat/pick): prioritize literal key over dot notation path when value is undefined

### DIFF
--- a/src/compat/object/get.spec.ts
+++ b/src/compat/object/get.spec.ts
@@ -28,6 +28,12 @@ describe('get', () => {
     expect(get(obj, 'a[].b')).toBe(undefined);
   });
 
+  it('should prioritize literal key over path when value is undefined', () => {
+    const object = { 'a.b': undefined, a: { b: 99 } };
+    expect(get(object, 'a.b')).toBe(undefined);
+    expect(get(object, 'a.b', 'default')).toBe('default');
+  });
+
   /**
    * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/get-and-result.spec.js#L1
    */

--- a/src/compat/object/get.ts
+++ b/src/compat/object/get.ts
@@ -466,7 +466,7 @@ export function get(object: any, path: PropertyKey | readonly PropertyKey[], def
       const result = object[path];
 
       if (result === undefined) {
-        if (isDeepKey(path)) {
+        if (isDeepKey(path) && !Object.hasOwn(object, path)) {
           return get(object, toPath(path), defaultValue);
         } else {
           return defaultValue;

--- a/src/compat/object/pick.spec.ts
+++ b/src/compat/object/pick.spec.ts
@@ -102,6 +102,11 @@ describe('compat/pick', () => {
     });
   });
 
+  it('should pick a key with undefined value over a path', () => {
+    const object = { 'a.b': undefined, a: { b: 2 } };
+    expect(pick(object, 'a.b')).toEqual({ 'a.b': undefined });
+  });
+
   it('should coerce `paths` to strings', () => {
     expect(pick({ 0: 'a', 1: 'b' }, 0)).toEqual({ 0: 'a' });
   });

--- a/src/compat/object/pick.ts
+++ b/src/compat/object/pick.ts
@@ -105,7 +105,7 @@ export function pick<T extends object, U extends keyof T>(
       }
 
       if (typeof key === 'string' && Object.hasOwn(object, key)) {
-        result[key] = value;
+        result[key] = object[key];
       } else {
         set(result, key, value);
       }


### PR DESCRIPTION
## Summary

In pick, when using dot notation, a literal key matching the dot-notation path takes priority, as documented.

<img width="525" height="152" alt="스크린샷 2026-06-13 오후 9 43 10" src="https://github.com/user-attachments/assets/0ac7f15d-0807-4329-baf0-7eb88ac2b0d6" />

However, there is a bug where the literal key is ignored when its value is `undefined`.

## Reproduce

```ts
import { pick as loPick } from 'lodash';
import { pick as esCompatPick } from './src/compat/object/pick';

const pickObj = { 'a.b': undefined, a: { b: 99 } };

console.log(loPick(pickObj, 'a.b')); // { 'a.b': undefined }
console.log(esCompatPick(pickObj, 'a.b')); // { 'a.b': 99 }
```