### PR TITLE
fix(compat/toPath): keep empty segments for consecutive and trailing dots

### DIFF
--- a/src/compat/array/invokeMap.spec.ts
+++ b/src/compat/array/invokeMap.spec.ts
@@ -162,7 +162,7 @@ describe('invokeMap', () => {
     };
 
     const aEmptyDotC = invokeMap([objectWithEmptyPart], 'a..c');
-    expect(aEmptyDotC[0]).toBeUndefined();
+    expect(aEmptyDotC[0]).toBe(objectWithEmptyPart.a['']);
   });
 
   it('should match the type of lodash', () => {

--- a/src/compat/object/get.spec.ts
+++ b/src/compat/object/get.spec.ts
@@ -164,4 +164,8 @@ describe('get', () => {
     const object = { '-0': undefined };
     expect(get(object, Object(-0), 'defaultValue')).toBe('defaultValue');
   });
+
+  it('should read empty-string keys produced by consecutive dots', () => {
+    expect(get({ a: { '': { b: 1 } } }, 'a..b')).toBe(1);
+  });
 });

--- a/src/compat/util/toPath.spec.ts
+++ b/src/compat/util/toPath.spec.ts
@@ -48,6 +48,18 @@ describe('toPath function', () => {
     expect(result).toEqual(['a', '', 'b']);
   });
 
+  it('keeps empty segments for consecutive dots', () => {
+    expect(toPath('a..b')).toEqual(['a', '', 'b']);
+    expect(toPath('a...b')).toEqual(['a', '', '', 'b']);
+    expect(toPath('..a')).toEqual(['', '', 'a']);
+    expect(toPath('a.b..c.d')).toEqual(['a', 'b', '', 'c', 'd']);
+  });
+
+  it('keeps a trailing empty segment for a trailing dot', () => {
+    expect(toPath('a.')).toEqual(['a', '']);
+    expect(toPath('a.b.')).toEqual(['a', 'b', '']);
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(toPath).toEqualTypeOf<typeof toPathLodash>();
   });

--- a/src/compat/util/toPath.ts
+++ b/src/compat/util/toPath.ts
@@ -40,10 +40,10 @@ export function toPath(deepKey: any): string[] {
   let quoteChar = '';
   let bracket = false;
 
-  // Leading dot
+  // Leading dot. Record the empty segment that precedes it, but leave the dot for the
+  // main loop so it is still treated as a separator (e.g. '..a' -> ['', '', 'a']).
   if (deepKey.charCodeAt(0) === 46) {
     result.push('');
-    index++;
   }
 
   while (index < length) {
@@ -84,6 +84,13 @@ export function toPath(deepKey: any): string[] {
         if (key) {
           result.push(key);
           key = '';
+        }
+        // A dot that is directly followed by another dot or the end of the string
+        // separates an empty segment, matching lodash (e.g. 'a..b' -> ['a', '', 'b'],
+        // 'a.' -> ['a', '']).
+        const next = deepKey[index + 1];
+        if (next === undefined || next === '.') {
+          result.push('');
         }
       } else {
         key += char;


### PR DESCRIPTION
## Summary

`compat/toPath` drops empty segments that lodash keeps, so consecutive or
trailing dots resolve differently. `toPath('a..b')` returns `['a', 'b']`
instead of lodash's `['a', '', 'b']`, and `toPath('a.')` returns `['a']`
instead of `['a', '']`.

Since `get`/`set`/`has`/`unset`/`invokeMap` parse string paths through
`toPath`, this makes an empty-string key in the middle of a path
unreachable when migrating from lodash:

```ts
get({ a: { '': { b: 1 } } }, 'a..b'); // lodash: 1, es-toolkit: undefined
```

## Changes

- Emit an empty segment when a dot is directly followed by another dot or
  by the end of the string (matching lodash's `stringToPath`).
- Let the leading dot fall through to the main loop so it is still treated
  as a separator (`'..a'` -> `['', '', 'a']`).
- Updated `invokeMap`'s "string path" test, which asserted the old
  divergent result for `'a..c'`; lodash invokes through the empty-string
  key, so it now expects that.

## Test results

`yarn vitest run src/compat` — 300 files, 3099 passed, 2 skipped.
