### PR TITLE
fix(toMerged): deep clone target so untouched nested values aren't shared

### DIFF
--- a/src/object/toMerged.spec.ts
+++ b/src/object/toMerged.spec.ts
@@ -129,6 +129,42 @@ describe('toMerged', () => {
     `);
   });
 
+  it('should not mutate the target through nested values that the source does not touch', () => {
+    const target = { nested: { flag: true } };
+    const result = toMerged(target, {});
+
+    expect(result.nested).not.toBe(target.nested);
+
+    result.nested.flag = false;
+
+    expect(target.nested.flag).toBe(true);
+    expect(target).toEqual({ nested: { flag: true } });
+  });
+
+  it('should deeply clone untouched nested subtrees even when a sibling key is merged', () => {
+    const target = { nested: { flag: true, untouched: { deep: 1 } } };
+    const result = toMerged(target, { nested: { flag: false } });
+
+    expect(result).toEqual({ nested: { flag: false, untouched: { deep: 1 } } });
+    expect(result.nested.untouched).not.toBe(target.nested.untouched);
+
+    result.nested.untouched.deep = 999;
+
+    expect(target.nested.untouched.deep).toBe(1);
+  });
+
+  it('should deeply clone untouched array elements from the target', () => {
+    const target = { list: [{ a: 1 }, { b: 2 }] };
+    const result = toMerged(target, {});
+
+    expect(result.list).not.toBe(target.list);
+    expect(result.list[0]).not.toBe(target.list[0]);
+
+    result.list[0].a = 999;
+
+    expect(target.list[0].a).toBe(1);
+  });
+
   it('should merge arrays deeply', () => {
     const target = { a: [1, 2] };
     const source = { a: [3, 4] };

--- a/src/object/toMerged.ts
+++ b/src/object/toMerged.ts
@@ -1,4 +1,5 @@
 import { clone } from './clone.ts';
+import { cloneDeep } from './cloneDeep.ts';
 import { mergeWith } from './mergeWith.ts';
 import { isPlainObject } from '../predicate/isPlainObject.ts';
 
@@ -48,7 +49,7 @@ export function toMerged<T extends Record<PropertyKey, any>, S extends Record<Pr
   target: T,
   source: S
 ): T & S {
-  return mergeWith(clone(target), source, function mergeRecursively(targetValue, sourceValue) {
+  return mergeWith(cloneDeep(target), source, function mergeRecursively(targetValue, sourceValue) {
     if (Array.isArray(sourceValue)) {
       if (Array.isArray(targetValue)) {
         return mergeWith(clone(targetValue), sourceValue, mergeRecursively);


### PR DESCRIPTION
## Summary

`toMerged(target, source)` mutated the original `target` through nested values that the `source` did not touch — a regression introduced in 1.41.0 (#1495).

```js
const target = { nested: { flag: true } };
const result = toMerged(target, {});
result.nested.flag = false;
target.nested.flag; // 1.40.0: true → 1.41.0+: false (target mutated)
```

## Root cause

#1495 replaced `merge(cloneDeep(target), source)` with `mergeWith(clone(target), …)` to stop shared references inside the inputs from cross-contaminating each other. But `clone()` is shallow, and `mergeWith` only walks the `source` keys — so nested values present only in `target` were never deep-cloned and stayed shared with the original object.

## Fix

Deep clone the target up front (`clone` → `cloneDeep`), while keeping the per-path `clone()` inside the customizer that prevents the #1495 shared-reference cross-contamination. This restores the 1.40.0 deep-copy guarantee and makes the implementation match its own JSDoc ("a deep clone of the target object", "does not mutate the target object").

## Tests

Added regression tests in `toMerged.spec.ts`:

- target is not mutated through a nested value the source doesn't touch (the reported case)
- an untouched nested subtree is deep-cloned even when a sibling key is merged
- untouched array elements from the target are deep-cloned

Verified the new tests fail on the old code and pass after the fix; the existing #1495 shared-objects test still passes.

Fixes #1776
