### PR TITLE
docs(flavor-switcher): localize descriptions and widen the dropdown

### DIFF
--- a/docs/.vitepress/components/FlavorDropdown.vue
+++ b/docs/.vitepress/components/FlavorDropdown.vue
@@ -145,9 +145,15 @@ onBeforeUnmount(() => {
 
 .flavor-dropdown__panel {
   position: absolute;
-  inset-inline: 0;
+  inset-inline-start: 0;
   top: calc(100% + 6px);
   z-index: 50;
+  /* Grow past the trigger to fit the longest flavor label without truncation.
+     The sidebar clips horizontal overflow at its padding box, so the panel can
+     extend by at most the sidebar's padding-right (32px); cap just under that. */
+  width: max-content;
+  min-width: 100%;
+  max-width: calc(100% + 30px);
   display: flex;
   flex-direction: column;
   gap: 4px;

--- a/docs/.vitepress/components/FlavorOptionRow.vue
+++ b/docs/.vitepress/components/FlavorOptionRow.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
+import { useData } from 'vitepress';
+import { computed } from 'vue';
 import type { FlavorSpec } from '../libs/flavors.mts';
 
-defineProps<{ flavor: FlavorSpec }>();
+const props = defineProps<{ flavor: FlavorSpec }>();
+
+const { lang } = useData();
+const description = computed(() => props.flavor.descriptions?.[lang.value] ?? props.flavor.description);
 </script>
 
 <template>
@@ -24,7 +29,7 @@ defineProps<{ flavor: FlavorSpec }>();
       <span class="flavor-row__title">{{ flavor.label }}</span>
       <span v-if="flavor.badge" class="flavor-row__badge">{{ flavor.badge }}</span>
     </span>
-    <span class="flavor-row__desc">{{ flavor.description }}</span>
+    <span class="flavor-row__desc">{{ description }}</span>
   </span>
 </template>
 
@@ -86,7 +91,7 @@ defineProps<{ flavor: FlavorSpec }>();
 }
 
 .flavor-row__desc {
-  font-size: 13px;
+  font-size: 11.5px;
   line-height: 1.3;
   color: var(--vp-c-text-2);
   white-space: nowrap;

--- a/docs/.vitepress/libs/flavors.mts
+++ b/docs/.vitepress/libs/flavors.mts
@@ -27,6 +27,11 @@ export interface FlavorSpec {
   value: string;
   label: string;
   description: string;
+  /**
+   * Localized descriptions keyed by locale `lang` (e.g. `ko`, `ja`, `zh_hans`).
+   * Falls back to `description` (English) when a locale has no entry.
+   */
+  descriptions?: Readonly<Record<string, string>>;
   prefix: string;
   guideItems: readonly GuideItem[];
   categories: readonly string[];
@@ -55,7 +60,12 @@ export const flavors = [
   {
     value: 'esToolkit',
     label: 'es-toolkit',
-    description: 'Strict Utilities',
+    description: 'Modern Utilities',
+    descriptions: {
+      ko: '현대적인 유틸리티',
+      ja: 'モダンなユーティリティ',
+      zh_hans: '现代工具集',
+    },
     prefix: '',
     guideItems: [
       { labelKey: 'introduction', slug: 'intro' },
@@ -84,6 +94,11 @@ export const flavors = [
     value: 'server',
     label: 'es-toolkit/server',
     description: 'Server utilities',
+    descriptions: {
+      ko: '서버 유틸리티',
+      ja: 'サーバーユーティリティ',
+      zh_hans: '服务器工具集',
+    },
     prefix: 'server',
     guideItems: [{ labelKey: 'introduction', slug: 'intro' }],
     categories: [],
@@ -95,6 +110,11 @@ export const flavors = [
     value: 'compat',
     label: 'es-toolkit/compat',
     description: 'Lodash compatibility',
+    descriptions: {
+      ko: 'Lodash 호환성',
+      ja: 'Lodash 互換性',
+      zh_hans: 'Lodash 兼容性',
+    },
     prefix: 'compat',
     guideItems: [{ labelKey: 'introduction', slug: 'intro' }],
     categories: ['array', 'function', 'math', 'object', 'predicate', 'string', 'util'],


### PR DESCRIPTION
## Summary

Improves the documentation site's flavor switcher (the **es-toolkit / es-toolkit/server / es-toolkit/compat** selector at the top of the sidebar).

- **Wider dropdown** — the open panel now grows to fit the longest label (e.g. `es-toolkit/server` with its `NEW` badge) instead of truncating it. It expands only into the sidebar's `padding-right` gutter, so it is never clipped by the sidebar's `overflow-x: hidden`, regardless of scrollbar width.
- **Localized descriptions** — each flavor's tagline is now translated for `ko` / `ja` / `zh_hans`, falling back to English. Package-name labels and the `NEW` badge are intentionally left as-is.
- **Tagline wording** — the es-toolkit tagline changed from *Strict Utilities* to *Modern Utilities*.
- **Description size** — the tagline font is slightly smaller (`13px` → `11.5px`) so the closed trigger fits every locale, including longer CJK strings, without widening the sidebar column.

## Tagline reference

|        | es-toolkit          | es-toolkit/server      | es-toolkit/compat    |
| ------ | ------------------- | ---------------------- | -------------------- |
| en     | Modern Utilities    | Server utilities       | Lodash compatibility |
| ko     | 현대적인 유틸리티   | 서버 유틸리티          | Lodash 호환성        |
| ja     | モダンなユーティリティ | サーバーユーティリティ | Lodash 互換性        |
| zh     | 现代工具集          | 服务器工具集           | Lodash 兼容性        |

## How it works

Localized strings live in `flavors.mts` (the only flavor module that is safe to import into the client bundle — the per-locale config files pull in `node:path` via the sidebar builder). `FlavorOptionRow` resolves the description from the active locale via `useData().lang`, so both the trigger and the option rows are localized.

## Verification

Checked in the browser across all four locales (en / ko / ja / zh_hans), in both light and dark mode, for both the closed trigger and the open panel: no label truncation and no clipping.
