### PR TITLE
chore(vscode): pin Prettier as default formatter for TS/JS files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,9 @@
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
-  }
+  },
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[javascriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" }
 }


### PR DESCRIPTION
## Problem

VS Code resolves `editor.defaultFormatter` with **language-specific** settings taking precedence over general ones — even when the language-specific one lives in a contributor's personal `settings.json` and the general one is in the workspace.

This repo's `.vscode/settings.json` only sets a general formatter:

```jsonc
"editor.defaultFormatter": "esbenp.prettier-vscode"
```

So if a contributor has a personal language override such as:

```jsonc
"[typescript]": { "editor.defaultFormatter": "denoland.vscode-deno" }
```

…it silently wins for `.ts` files. Format-on-save then runs the wrong formatter (or none at all), Prettier's import-sorting / re-export-sorting plugins never apply, and saved files drift from `yarn format` / CI.

## Fix

Pin the formatter per language at the **workspace** level. Workspace language-specific settings beat user language-specific settings, so Prettier is guaranteed regardless of personal overrides:

```jsonc
"[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
"[typescriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
"[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
"[javascriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" }
```

No runtime or package impact — `.vscode/` is dev-only and is not published to npm.