### PR TITLE
test(compat/drop, compat/dropRight): add falsey n value test cases

### DIFF
--- a/src/compat/array/drop.spec.ts
+++ b/src/compat/array/drop.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { drop as dropLodash } from 'lodash';
 import { drop } from './drop';
 import { args } from '../_internal/args';
+import { falsey } from '../_internal/falsey';
 
 /**
  * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/drop.spec.js#L1
@@ -11,6 +12,12 @@ describe('drop', () => {
 
   it('should drop the first two elements', () => {
     expect(drop(array, 2)).toEqual([3]);
+  });
+
+  it('should treat falsey `n` values, except `undefined`, as `0`', () => {
+    const expected = falsey.map(value => (value === undefined ? [2, 3] : array));
+    const actual = falsey.map(value => drop(array, value as any));
+    expect(actual).toEqual(expected);
   });
 
   it('should return all elements when `n` < `1`', () => {

--- a/src/compat/array/dropRight.spec.ts
+++ b/src/compat/array/dropRight.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { dropRight as dropRightLodash } from 'lodash';
 import { dropRight } from './dropRight';
 import { args } from '../_internal/args';
+import { falsey } from '../_internal/falsey';
 
 /**
  * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/dropRight.spec.js#L1
@@ -11,6 +12,13 @@ describe('dropRight', () => {
 
   it('should drop the last two elements', () => {
     expect(dropRight(array, 2)).toEqual([1]);
+  });
+
+  it('should treat falsey `n` values, except `undefined`, as `0`', () => {
+    const expected = falsey.map(value => (value === undefined ? [1, 2] : array));
+    const actual = falsey.map(value => dropRight(array, value as any));
+
+    expect(actual).toEqual(expected);
   });
 
   it('should return all elements when `n` < `1`', () => {


### PR DESCRIPTION
It seems that one of the Lodash test cases was missing.
The existing tests covered 0 and `undefined`, but not the other cases.
(dropRight only covers the 0 case.)