### PR TITLE
fix(compat/drop): rename parameter n to itemsCount in docs and implementation

### DIFF
--- a/docs/compat/reference/array/drop.md
+++ b/docs/compat/reference/array/drop.md
@@ -11,12 +11,12 @@ Instead, use the faster and more modern [`drop`](../../../reference/array/drop.m
 Removes a specified number of elements from the beginning of an array.
 
 ```typescript
-const result = drop(array, n);
+const result = drop(array, itemsCount);
 ```
 
 ## Usage
 
-### `drop(array, n?)`
+### `drop(array, itemsCount?)`
 
 Use `drop` when you want to remove several elements from the beginning of an array and get the rest. By default, it removes the first element.
 
@@ -90,7 +90,7 @@ drop(arrayLike, 1);
 #### Parameters
 
 - `array` (`ArrayLike<T> | null | undefined`): The array from which elements will be removed.
-- `n` (`number`, optional): The number of elements to remove. Default is `1`.
+- `itemsCount` (`number`, optional): The number of elements to remove. Default is `1`.
 
 #### Returns
 

--- a/docs/ja/compat/reference/array/drop.md
+++ b/docs/ja/compat/reference/array/drop.md
@@ -11,12 +11,12 @@
 配列の先頭から指定された個数の要素を削除します。
 
 ```typescript
-const result = drop(array, n);
+const result = drop(array, itemsCount);
 ```
 
 ## 使用法
 
-### `drop(array, n?)`
+### `drop(array, itemsCount?)`
 
 配列の先頭からいくつかの要素を削除し、残りを取得したい場合に `drop` を使用します。デフォルトでは、最初の要素を1つ削除します。
 
@@ -90,7 +90,7 @@ drop(arrayLike, 1);
 #### パラメータ
 
 - `array` (`ArrayLike<T> | null | undefined`): 要素を削除する配列です。
-- `n` (`number`, オプション): 削除する要素の個数です。デフォルトは `1` です。
+- `itemsCount` (`number`, オプション): 削除する要素の個数です。デフォルトは `1` です。
 
 #### 戻り値
 

--- a/docs/ko/compat/reference/array/drop.md
+++ b/docs/ko/compat/reference/array/drop.md
@@ -11,12 +11,12 @@
 배열의 앞에서부터 지정된 개수만큼 요소들을 제거해요.
 
 ```typescript
-const result = drop(array, n);
+const result = drop(array, itemsCount);
 ```
 
 ## 사용법
 
-### `drop(array, n?)`
+### `drop(array, itemsCount?)`
 
 배열의 처음 부분에서 몇 개의 요소를 제거하고 나머지를 얻고 싶을 때 `drop`을 사용하세요. 기본적으로 첫 번째 요소 하나를 제거해요.
 
@@ -90,7 +90,7 @@ drop(arrayLike, 1);
 #### 파라미터
 
 - `array` (`ArrayLike<T> | null | undefined`): 요소를 제거할 배열이에요.
-- `n` (`number`, 선택): 제거할 요소의 개수예요. 기본값은 `1`이에요.
+- `itemsCount` (`number`, 선택): 제거할 요소의 개수예요. 기본값은 `1`이에요.
 
 #### 반환 값
 

--- a/docs/zh_hans/compat/reference/array/drop.md
+++ b/docs/zh_hans/compat/reference/array/drop.md
@@ -11,12 +11,12 @@
 从数组的开头删除指定数量的元素。
 
 ```typescript
-const result = drop(array, n);
+const result = drop(array, itemsCount);
 ```
 
 ## 用法
 
-### `drop(array, n?)`
+### `drop(array, itemsCount?)`
 
 当您想从数组的开头删除几个元素并获取其余元素时,使用 `drop`。默认情况下,它会删除第一个元素。
 
@@ -90,7 +90,7 @@ drop(arrayLike, 1);
 #### 参数
 
 - `array` (`ArrayLike<T> | null | undefined`): 要删除元素的数组。
-- `n` (`number`, 可选): 要删除的元素数量。默认为 `1`。
+- `itemsCount` (`number`, 可选): 要删除的元素数量。默认为 `1`。
 
 #### 返回值
 

--- a/src/compat/array/drop.ts
+++ b/src/compat/array/drop.ts
@@ -10,9 +10,8 @@ import { toInteger } from '../util/toInteger.ts';
  * of elements removed from the start.
  *
  * @template T - The type of elements in the array.
- * @param collection - The array from which to drop elements.
+ * @param array - The array from which to drop elements.
  * @param itemsCount - The number of elements to drop from the beginning of the array.
- * @param [guard] - Enables use as an iteratee for methods like `_.map`.
  * @returns A new array with the specified number of elements removed from the start.
  *
  * @example
@@ -20,13 +19,13 @@ import { toInteger } from '../util/toInteger.ts';
  * const result = drop(array, 2);
  * result will be [3, 4, 5] since the first two elements are dropped.
  */
-export function drop<T>(array: ArrayLike<T> | null | undefined, n?: number): T[];
+export function drop<T>(array: ArrayLike<T> | null | undefined, itemsCount?: number): T[];
 
-export function drop<T>(collection: ArrayLike<T> | null | undefined, itemsCount = 1, guard?: unknown): T[] {
-  if (!isArrayLike(collection)) {
+export function drop<T>(array: ArrayLike<T> | null | undefined, itemsCount = 1, guard?: unknown): T[] {
+  if (!isArrayLike(array)) {
     return [];
   }
   itemsCount = guard ? 1 : toInteger(itemsCount);
 
-  return dropToolkit(toArray(collection), itemsCount);
+  return dropToolkit(toArray(array), itemsCount);
 }


### PR DESCRIPTION
## Summary

I've renamed it to `itemsCount` for consistency with `dropRight`.
I also changed the parameter name from collection to array. Since this function accepts an `ArrayLike`, array feels more semantically appropriate than collection.