### PR TITLE
fix(compat/dropRightWhile): align parameter names with overload signatures

### DIFF
--- a/src/compat/array/dropRightWhile.ts
+++ b/src/compat/array/dropRightWhile.ts
@@ -47,7 +47,7 @@ export function dropRightWhile<T>(array: ArrayLike<T> | null | undefined, predic
  * predicate function returns false. It then returns a new array with the remaining elements.
  *
  * @template T - The type of elements in the array.
- * @param arr - The array from which to drop elements.
+ * @param array - The array from which to drop elements.
  * @param predicate - A predicate function that determines
  * whether to continue dropping elements. The function is called with each element, index, and array, and dropping
  * continues as long as it returns true.
@@ -59,18 +59,18 @@ export function dropRightWhile<T>(array: ArrayLike<T> | null | undefined, predic
  * // Returns: [3]
  */
 export function dropRightWhile<T>(
-  arr: ArrayLike<T> | null | undefined,
+  array: ArrayLike<T> | null | undefined,
   predicate:
-    | ((item: T, index: number, arr: readonly T[]) => unknown)
+    | ((item: T, index: number, array: readonly T[]) => unknown)
     | Partial<T>
     | [keyof T, unknown]
     | PropertyKey = identity
 ): T[] {
-  if (!isArrayLike(arr)) {
+  if (!isArrayLike(array)) {
     return [];
   }
 
-  return dropRightWhileImpl(Array.from(arr), predicate);
+  return dropRightWhileImpl(Array.from(array), predicate);
 }
 
 function dropRightWhileImpl<T>(


### PR DESCRIPTION
Made the parameter names in the overload signatures consistent 👍
`arr` → `array`