### PR TITLE
docs(compat/dropWhile, compat/dropRightWhile): mark predicate as optional in headers

### DIFF
--- a/docs/compat/reference/array/dropRightWhile.md
+++ b/docs/compat/reference/array/dropRightWhile.md
@@ -16,7 +16,7 @@ const result = dropRightWhile(array, predicate);
 
 ## Usage
 
-### `dropRightWhile(array, predicate)`
+### `dropRightWhile(array, predicate?)`
 
 Use `dropRightWhile` when you want to consecutively remove elements from the end of an array that satisfy a specific condition. Removal stops when the predicate function returns `false`.
 

--- a/docs/compat/reference/array/dropWhile.md
+++ b/docs/compat/reference/array/dropWhile.md
@@ -16,7 +16,7 @@ const result = dropWhile(array, predicate);
 
 ## Usage
 
-### `dropWhile(array, predicate)`
+### `dropWhile(array, predicate?)`
 
 Use `dropWhile` when you want to consecutively remove elements from the beginning of an array that satisfy a specific condition. Removal stops when the predicate function returns `false`.
 

--- a/docs/ja/compat/reference/array/dropRightWhile.md
+++ b/docs/ja/compat/reference/array/dropRightWhile.md
@@ -16,7 +16,7 @@ const result = dropRightWhile(array, predicate);
 
 ## 使用法
 
-### `dropRightWhile(array, predicate)`
+### `dropRightWhile(array, predicate?)`
 
 配列の末尾から特定の条件を満たす要素を連続して削除したい場合に `dropRightWhile` を使用します。条件関数が `false` を返すと削除を中断します。
 

--- a/docs/ja/compat/reference/array/dropWhile.md
+++ b/docs/ja/compat/reference/array/dropWhile.md
@@ -16,7 +16,7 @@ const result = dropWhile(array, predicate);
 
 ## 使用法
 
-### `dropWhile(array, predicate)`
+### `dropWhile(array, predicate?)`
 
 配列の先頭から特定の条件を満たす要素を連続して削除したい場合に `dropWhile` を使用します。条件関数が `false` を返すと削除を中断します。
 

--- a/docs/ko/compat/reference/array/dropRightWhile.md
+++ b/docs/ko/compat/reference/array/dropRightWhile.md
@@ -16,7 +16,7 @@ const result = dropRightWhile(array, predicate);
 
 ## 사용법
 
-### `dropRightWhile(array, predicate)`
+### `dropRightWhile(array, predicate?)`
 
 배열의 끝에서부터 특정 조건을 만족하는 요소들을 연속으로 제거하고 싶을 때 `dropRightWhile`을 사용하세요. 조건 함수가 `false`를 반환하면 제거를 중단해요.
 

--- a/docs/ko/compat/reference/array/dropWhile.md
+++ b/docs/ko/compat/reference/array/dropWhile.md
@@ -16,7 +16,7 @@ const result = dropWhile(array, predicate);
 
 ## 사용법
 
-### `dropWhile(array, predicate)`
+### `dropWhile(array, predicate?)`
 
 배열의 시작에서부터 특정 조건을 만족하는 요소들을 연속으로 제거하고 싶을 때 `dropWhile`을 사용하세요. 조건 함수가 `false`를 반환하면 제거를 중단해요.
 

--- a/docs/zh_hans/compat/reference/array/dropRightWhile.md
+++ b/docs/zh_hans/compat/reference/array/dropRightWhile.md
@@ -16,7 +16,7 @@ const result = dropRightWhile(array, predicate);
 
 ## 用法
 
-### `dropRightWhile(array, predicate)`
+### `dropRightWhile(array, predicate?)`
 
 当您想从数组的末尾连续删除满足特定条件的元素时,使用 `dropRightWhile`。当条件函数返回 `false` 时停止删除。
 

--- a/docs/zh_hans/compat/reference/array/dropWhile.md
+++ b/docs/zh_hans/compat/reference/array/dropWhile.md
@@ -16,7 +16,7 @@ const result = dropWhile(array, predicate);
 
 ## 用法
 
-### `dropWhile(array, predicate)`
+### `dropWhile(array, predicate?)`
 
 当您想从数组的开头连续删除满足特定条件的元素时,使用 `dropWhile`。当条件函数返回 `false` 时停止删除。
 


### PR DESCRIPTION
## Summary

I think the optional marker is missing from the documentation(dropWhile, dropRightWhile) heading!