### PR TITLE
docs(compat/dropWhile): rename parameter from arr to array

### DIFF
--- a/src/compat/array/dropWhile.ts
+++ b/src/compat/array/dropWhile.ts
@@ -13,7 +13,7 @@ import { matchesProperty } from '../predicate/matchesProperty.ts';
  * The predicate is invoked with three arguments: (value, index, array).
  *
  * @template T - The type of elements in the array
- * @param arr - The array to query
+ * @param array - The array to query
  * @param [predicate=identity] - The function invoked per iteration
  * @returns Returns the slice of array
  *
@@ -30,12 +30,12 @@ import { matchesProperty } from '../predicate/matchesProperty.ts';
  * dropWhile([{ a: 1, b: 2 }, { a: 1, b: 3 }], 'a')
  * // => []
  */
-export function dropWhile<T>(arr: ArrayLike<T> | null | undefined, predicate: ListIteratee<T> = identity): T[] {
-  if (!isArrayLike(arr)) {
+export function dropWhile<T>(array: ArrayLike<T> | null | undefined, predicate: ListIteratee<T> = identity): T[] {
+  if (!isArrayLike(array)) {
     return [];
   }
 
-  return dropWhileImpl(toArray(arr), predicate);
+  return dropWhileImpl(toArray(array), predicate);
 }
 
 function dropWhileImpl<T>(arr: readonly T[], predicate: ListIteratee<T>): T[] {


### PR DESCRIPTION
<img width="609" height="185" alt="스크린샷 2026-06-23 오후 4 48 01" src="https://github.com/user-attachments/assets/80f4601f-4f71-49a8-b956-4acb2310140f" />

The documentation refers to it as array, but the actual parameter name is arr.
It would be better to keep the documentation consistent with the implementation.
