### PR TITLE
refactor(compat/dropRightWhile): use toArray instead of Array.from

### DIFF
--- a/src/compat/array/dropRightWhile.ts
+++ b/src/compat/array/dropRightWhile.ts
@@ -1,6 +1,7 @@
 import { dropRightWhile as dropRightWhileToolkit } from '../../array/dropRightWhile.ts';
 import { identity } from '../../function/identity.ts';
 import { ListIteratee } from '../_internal/ListIteratee.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { property } from '../object/property.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { matches } from '../predicate/matches.ts';
@@ -70,7 +71,7 @@ export function dropRightWhile<T>(
     return [];
   }
 
-  return dropRightWhileImpl(Array.from(arr), predicate);
+  return dropRightWhileImpl(toArray(arr), predicate);
 }
 
 function dropRightWhileImpl<T>(


### PR DESCRIPTION
`dropRight` uses `toArray`, while `dropRightWhile` uses `Array.from`.
Since `toArray` internally uses `Array.from`, there is no behavioral difference, but I think it would be better to keep these two implementations consistent.
Using `toArray` also seems preferable because it preserves the behavior for existing arrays.