### PR TITLE
fix(compat/chunk): handle NaN and Infinity size values for compability

### DIFF
--- a/src/compat/array/chunk.spec.ts
+++ b/src/compat/array/chunk.spec.ts
@@ -59,6 +59,14 @@ describe('chunk', () => {
     expect(chunk(args, 2)).toEqual([[1, 2], [3]]);
   });
 
+  it('should return an empty array when the size is NaN', () => {
+    expect(chunk([1, 2, 3], NaN)).toEqual([]);
+  });
+
+  it('should return an full elements array when the size is Infinity', () => {
+    expect(chunk([1, 2, 3], Infinity)).toEqual([[1, 2, 3]]);
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(chunk).toEqualTypeOf<typeof chunkLodash>();
   });

--- a/src/compat/array/chunk.ts
+++ b/src/compat/array/chunk.ts
@@ -26,10 +26,15 @@ import { isArrayLike } from '../predicate/isArrayLike.ts';
  */
 export function chunk<T>(arr: ArrayLike<T> | null | undefined, size = 1): T[][] {
   size = Math.max(Math.floor(size), 0);
-
-  if (size === 0 || !isArrayLike(arr)) {
+  if (size === 0 || !isArrayLike(arr) || Number.isNaN(size)) {
     return [];
   }
 
-  return chunkToolkit(toArray(arr), size);
+  const array = toArray(arr);
+
+  if (!isFinite(size)) {
+    return [array];
+  }
+
+  return chunkToolkit(array, size);
 }


### PR DESCRIPTION
## Summary

When `NaN` or `Infinity` is passed as the size value, an error is thrown.
In Lodash, passing `NaN` returns an empty array, while passing Infinity returns the [original array] unchanged.
The issue occurs because these values are passed directly to es-toolkit  chunk implementation without handling those edge cases first.

## Reproduce

### NaN

```ts
import { chunk as loChunk } from 'lodash';
import { chunk as esChunk } from './src/compat/array/chunk';

const array = [0, 1, 2, 3, 4, 5];

console.log(loChunk(array, NaN)); // []

try {
  console.log(esChunk(array, NaN));
} catch (e) {
  console.log(e.message); // Size must be an integer greater than zero.
}
```

### Infinity

```ts
import { chunk as loChunk } from 'lodash';
import { chunk as esChunk } from './src/compat/array/chunk';

const array = [0, 1, 2, 3, 4, 5];

console.log(loChunk(array, Infinity)); // [[0,1,2,3,4,5]]

try {
  console.log(esChunk(array, Infinity));
} catch (e) {
  console.log(e.message); // Size must be an integer greater than zero.
}
```