### PR TITLE
test[camelCase, capitalize]: refine string case tests

### DIFF
--- a/src/compat/string/camelCase.spec.ts
+++ b/src/compat/string/camelCase.spec.ts
@@ -46,6 +46,12 @@ describe('camelCase', () => {
     expect(camelCase('Москва')).toBe('москва');
   });
 
+  it('should handle double-converting strings', () => {
+    const actual = strings.map(str => camelCase(camelCase(str)));
+    const expected = strings.map(() => 'fooBar');
+    expect(actual).toEqual(expected);
+  });
+
   it('should remove contraction apostrophes', () => {
     const apostrophes = ["'", '\u2019'];
     const postfixes = ['d', 'll', 'm', 're', 's', 't', 've'];

--- a/src/compat/string/camelCase.spec.ts
+++ b/src/compat/string/camelCase.spec.ts
@@ -46,12 +46,6 @@ describe('camelCase', () => {
     expect(camelCase('Москва')).toBe('москва');
   });
 
-  it('should handle double-converting strings', () => {
-    const actual = strings.map(str => camelCase(camelCase(str)));
-    const expected = strings.map(() => 'fooBar');
-    expect(actual).toEqual(expected);
-  });
-
   it('should remove contraction apostrophes', () => {
     const apostrophes = ["'", '\u2019'];
     const postfixes = ['d', 'll', 'm', 're', 's', 't', 've'];

--- a/src/compat/string/capitalize.spec.ts
+++ b/src/compat/string/capitalize.spec.ts
@@ -3,19 +3,16 @@ import type { capitalize as capitalizeLodash } from 'lodash';
 import { capitalize } from './capitalize';
 
 describe('capitalize', () => {
-  it('should capitalize the first character', () => {
+  it('should capitalize the first character of a string', () => {
     expect(capitalize('fred')).toBe('Fred');
     expect(capitalize('Fred')).toBe('Fred');
+    expect(capitalize(' fred')).toBe(' fred');
+    expect(capitalize(' fred  ')).toBe(' fred  ');
   });
 
   it('should lowercase the remaining characters', () => {
     expect(capitalize('FRED')).toBe('Fred');
     expect(capitalize('FOO BAR')).toBe('Foo bar');
-  });
-
-  it('should not trim leading whitespace', () => {
-    expect(capitalize(' fred')).toBe(' fred');
-    expect(capitalize('  fred')).toBe('  fred');
   });
 
   it('should return an empty string for an empty string', () => {

--- a/src/compat/string/capitalize.spec.ts
+++ b/src/compat/string/capitalize.spec.ts
@@ -3,10 +3,23 @@ import type { capitalize as capitalizeLodash } from 'lodash';
 import { capitalize } from './capitalize';
 
 describe('capitalize', () => {
-  it('should capitalize the first character of a string', () => {
+  it('should capitalize the first character', () => {
     expect(capitalize('fred')).toBe('Fred');
     expect(capitalize('Fred')).toBe('Fred');
+  });
+
+  it('should lowercase the remaining characters', () => {
+    expect(capitalize('FRED')).toBe('Fred');
+    expect(capitalize('FOO BAR')).toBe('Foo bar');
+  });
+
+  it('should not trim leading whitespace', () => {
     expect(capitalize(' fred')).toBe(' fred');
+    expect(capitalize('  fred')).toBe('  fred');
+  });
+
+  it('should return an empty string for an empty string', () => {
+    expect(capitalize('')).toBe('');
   });
 
   it('should match the type of lodash', () => {


### PR DESCRIPTION
## Summary

Refines compat string case tests by removing a redundant camelCase double-conversion case and adding clearer capitalize coverage.

## Changes

- Removed the redundant camelCase(camelCase(...)) test.
- Added capitalize cases for:
  - lowercasing remaining uppercase characters
  - preserving leading whitespace
  - preserving an empty string

## Test

- `yarn vitest run src/compat/string/camelCase.spec.ts`
- `yarn vitest run src/compat/string/capitalize.spec.ts`