### PR TITLE
chore[release]: prepare v1.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # es-toolkit Changelog
 
+## Version v1.49.0
+
+Released on June 26th, 2026.
+
+- Added the `es-toolkit/fp` entrypoint with data-last, pipeable utilities,
+  documentation, benchmarks, and bundle-size checks. ([#1781])
+- Added a broad set of array utilities to `es-toolkit/fp`, covering slicing,
+  grouping, set operations, ordering, zipping, and collection helpers. ([#1801])
+- Fixed `trimStart` to validate multi-character trim strings correctly before
+  it stops trimming. ([#1615])
+- Fixed `compat/pick` to prefer a literal key over a dot-notation path when the
+  picked value is `undefined`. ([#1775])
+- Fixed `compat/random` to better match Lodash behavior for coerced bounds and
+  floating-point options. ([#1767])
+- Fixed `compat/chunk` to handle `NaN` and `Infinity` size values consistently
+  with Lodash. ([#1797])
+- Improved documentation and JSDoc accuracy across array, function, and compat
+  references. ([#1785], [#1786], [#1788], [#1790], [#1791], [#1792], [#1793],
+  [#1795], [#1800])
+
+We sincerely thank @Antoliny0919, @D-Sketon, @eunwoo-levi, and @raon0211 for
+their contributions. We appreciate your great efforts!
+
 ## Version v1.48.1
 
 Released on June 21st, 2026.

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@es-toolkit/es-toolkit",
-  "version": "1.48.1",
+  "version": "1.49.0",
   "exports": {
     ".": "./src/index.ts",
     "./compat": "./src/compat/index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-toolkit",
-  "version": "1.48.1",
+  "version": "1.49.0",
   "description": "A state-of-the-art, high-performance JavaScript utility library with a small bundle size and strong type annotations.",
   "homepage": "https://es-toolkit.dev",
   "bugs": "https://github.com/toss/es-toolkit/issues",


### PR DESCRIPTION
## Summary

No related issues.

Prepare the v1.49.0 release metadata from the latest main branch.

## Changes

- Bump package.json and jsr.json from 1.48.1 to 1.49.0.
- Add the v1.49.0 CHANGELOG entry for the fp entrypoint, fp array utilities, compat fixes, and documentation updates since v1.48.1.

## Test results

- `node -e` version check: package.json and jsr.json are both 1.49.0.
- `yarn prettier --check CHANGELOG.md package.json jsr.json`: passed.
- `mise x node@24.13.0 -- yarn pack --dry-run`: passed.
- `mise x node@24.13.0 -- yarn typecheck`: passed.
- `mise x node@24.13.0 -- yarn lint`: passed with existing warnings (0 errors, 2130 warnings).
