### PR TITLE
docs[fp]: localize flavor description

### DIFF
--- a/docs/.vitepress/libs/flavors.mts
+++ b/docs/.vitepress/libs/flavors.mts
@@ -126,6 +126,11 @@ export const flavors = [
     value: 'fp',
     label: 'es-toolkit/fp',
     description: 'Functional pipelines',
+    descriptions: {
+      ko: '함수형 파이프라인',
+      ja: '関数型パイプライン',
+      zh_hans: '函数式管道',
+    },
     prefix: 'fp',
     guideItems: [
       { labelKey: 'introduction', slug: 'intro' },


### PR DESCRIPTION
## Summary

Add localized descriptions for the `es-toolkit/fp` flavor in the docs flavor dropdown.

## Changes

- Added Korean, Japanese, and Simplified Chinese descriptions for `es-toolkit/fp`.

## Test results

- `yarn typecheck && yarn lint` passed with existing warnings.
- `yarn workspace docs docs:build` passed.