### PR TITLE
fix(compat): don't treat an own literal dotted key as a deep path in unset (match #1775)

### DIFF
--- a/src/compat/object/unset.spec.ts
+++ b/src/compat/object/unset.spec.ts
@@ -168,9 +168,6 @@ describe('unset', () => {
   });
 
   it('should prioritize a literal key over a path when the literal value is undefined', () => {
-    // Mirrors the literal-key-over-path fix applied to `get`/`pick` (#1775).
-    // When `'a.b'` exists as an own key whose value is `undefined`, lodash deletes
-    // that literal key and leaves the nested `a.b` untouched.
     const object: Record<string, unknown> = { 'a.b': undefined, a: { b: 99 } };
 
     expect(unset(object, 'a.b')).toBe(true);

--- a/src/compat/object/unset.spec.ts
+++ b/src/compat/object/unset.spec.ts
@@ -167,6 +167,24 @@ describe('unset', () => {
     expect(object).toEqual({ b: null });
   });
 
+  it('should prioritize a literal key over a path when the literal value is undefined', () => {
+    // Mirrors the literal-key-over-path fix applied to `get`/`pick` (#1775).
+    // When `'a.b'` exists as an own key whose value is `undefined`, lodash deletes
+    // that literal key and leaves the nested `a.b` untouched.
+    const object: Record<string, unknown> = { 'a.b': undefined, a: { b: 99 } };
+
+    expect(unset(object, 'a.b')).toBe(true);
+    expect(Object.hasOwn(object, 'a.b')).toBe(false);
+    expect((object.a as { b: number }).b).toBe(99);
+  });
+
+  it('should delete a literal undefined-valued key even without a nested counterpart', () => {
+    const object: Record<string, unknown> = { 'x.y': undefined };
+
+    expect(unset(object, 'x.y')).toBe(true);
+    expect(Object.hasOwn(object, 'x.y')).toBe(false);
+  });
+
   it('should prevent prototype pollution by rejecting __proto__ deletion', () => {
     expect(unset({ ['__proto__']: {} }, '__proto__')).toBe(false);
     expect(unset({ ['__proto__']: {} }, ['__proto__'])).toBe(false);

--- a/src/compat/object/unset.ts
+++ b/src/compat/object/unset.ts
@@ -60,7 +60,7 @@ export function unset(obj: any, path: PropertyKey | readonly PropertyKey[]): boo
       }
     }
     case 'string': {
-      if (obj?.[path] === undefined && isDeepKey(path)) {
+      if (obj?.[path] === undefined && isDeepKey(path) && !Object.hasOwn(obj, path)) {
         return unsetWithPath(obj, toPath(path));
       }
 


### PR DESCRIPTION
`unset` (`compat/object/unset.ts`) is the unfixed sibling of #1775, which added the `&& !Object.hasOwn(object, path)` guard to `get` and `pick`. `unset` still has the bare `if (obj?.[path] === undefined && isDeepKey(path))`, so unsetting an own literal dotted key like `'a.b'` whose value is `undefined` wrongly deletes the nested `a.b` and leaves the literal key, diverging from lodash. `omit` delegates to `unset` and inherits this.

The fix is the one-token mirror of #1775's guard (`Object.hasOwn` is already used across 23 source files). Verified against the lodash 4.17.21 oracle: the old code mismatches on `{'a.b': undefined, a:{b:99}}` and `{'x.y': undefined}` (2 cases), the fix matches on all, and the non-undefined-literal and pure-deep-path cases are unchanged in both states.