### PR TITLE
test(deburr): cover all combining diacritical mark ranges and boundaries

### DIFF
--- a/src/compat/string/deburr.spec.ts
+++ b/src/compat/string/deburr.spec.ts
@@ -29,6 +29,36 @@ describe('deburr', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should remove combining marks from every supported range', () => {
+    // Combining Diacritical Marks (U+0300-U+036F).
+    expect(deburr('e\u0300i')).toBe('ei');
+    expect(deburr('e\u036fi')).toBe('ei');
+    // Combining Diacritical Marks for Symbols (U+20D0-U+20FF).
+    expect(deburr('e\u20d0i')).toBe('ei');
+    expect(deburr('e\u20ddi')).toBe('ei');
+    expect(deburr('e\u20e1i')).toBe('ei');
+    expect(deburr('e\u20ffi')).toBe('ei');
+    // Combining Half Marks (U+FE20-U+FE2F).
+    expect(deburr('e\ufe20i')).toBe('ei');
+    expect(deburr('e\ufe24i')).toBe('ei');
+    expect(deburr('e\ufe26i')).toBe('ei');
+    expect(deburr('e\ufe2fi')).toBe('ei');
+  });
+
+  it('should preserve characters just outside the combining mark ranges', () => {
+    expect(deburr('e\u02ffi')).toBe('e\u02ffi');
+    expect(deburr('e\u0370i')).toBe('e\u0370i');
+    expect(deburr('e\u20cfi')).toBe('e\u20cfi');
+    expect(deburr('e\u2100i')).toBe('e\u2100i');
+    expect(deburr('e\ufe1fi')).toBe('e\ufe1fi');
+    expect(deburr('e\ufe30i')).toBe('e\ufe30i');
+  });
+
+  it('should remove consecutive marks spanning different ranges', () => {
+    expect(deburr('a\u0301\u0327\u20d1')).toBe('a');
+    expect(deburr('\u00c6\u20dd')).toBe('Ae');
+  });
+
   it('should return an empty string for empty values', () => {
     // eslint-disable-next-line no-sparse-arrays
     const values = [, null, undefined, ''];

--- a/src/string/deburr.spec.ts
+++ b/src/string/deburr.spec.ts
@@ -30,4 +30,34 @@ describe('deburr', () => {
 
     expect(actual).toEqual(expected);
   });
+
+  it('should remove combining marks from every supported range', () => {
+    // Combining Diacritical Marks (U+0300-U+036F).
+    expect(deburr('e\u0300i')).toBe('ei');
+    expect(deburr('e\u036fi')).toBe('ei');
+    // Combining Diacritical Marks for Symbols (U+20D0-U+20FF).
+    expect(deburr('e\u20d0i')).toBe('ei');
+    expect(deburr('e\u20ddi')).toBe('ei');
+    expect(deburr('e\u20e1i')).toBe('ei');
+    expect(deburr('e\u20ffi')).toBe('ei');
+    // Combining Half Marks (U+FE20-U+FE2F).
+    expect(deburr('e\ufe20i')).toBe('ei');
+    expect(deburr('e\ufe24i')).toBe('ei');
+    expect(deburr('e\ufe26i')).toBe('ei');
+    expect(deburr('e\ufe2fi')).toBe('ei');
+  });
+
+  it('should preserve characters just outside the combining mark ranges', () => {
+    expect(deburr('e\u02ffi')).toBe('e\u02ffi');
+    expect(deburr('e\u0370i')).toBe('e\u0370i');
+    expect(deburr('e\u20cfi')).toBe('e\u20cfi');
+    expect(deburr('e\u2100i')).toBe('e\u2100i');
+    expect(deburr('e\ufe1fi')).toBe('e\ufe1fi');
+    expect(deburr('e\ufe30i')).toBe('e\ufe30i');
+  });
+
+  it('should remove consecutive marks spanning different ranges', () => {
+    expect(deburr('a\u0301\u0327\u20d1')).toBe('a');
+    expect(deburr('\u00c6\u20dd')).toBe('Ae');
+  });
 });


### PR DESCRIPTION
## Overview

Follow-up to #1807, which widened `deburr` to strip the full combining-mark ranges (`U+20D0–U+20FF` and the complete `U+FE20–U+FE2F` block) to match lodash. This PR adds thorough, fixture-independent tests for that behavior in both `es-toolkit` and `es-toolkit/compat`.

## Why

The existing `should deburr combining diacritical marks` test iterates over the `comboMarks` fixture. Since that fixture and the implementation were widened together, the test would still pass even if both were later narrowed in lockstep — so it doesn't independently guard the range change. These tests use hardcoded code points instead.

## What's added

In both `src/string/deburr.spec.ts` and `src/compat/string/deburr.spec.ts`:

- **`should remove combining marks from every supported range`** — explicit code points from each of the three ranges, including the endpoints of the newly covered ones (`U+20D0`/`U+20FF`, `U+FE20`/`U+FE2F`).
- **`should preserve characters just outside the combining mark ranges`** — boundary characters one code point below/above each range (`U+02FF`, `U+0370`, `U+20CF`, `U+2100`, `U+FE1F`, `U+FE30`) must be left intact. This is where off-by-one regressions would surface. Verified these have no canonical (NFD) decomposition, so they survive `normalize('NFD')`.
- **`should remove consecutive marks spanning different ranges`** — multiple marks from different ranges in sequence are all stripped, and stripping composes with the `deburrMap` letter replacement (e.g. `Æ` + a symbol mark → `Ae`).

All code points are written as `\u` escapes to keep the source unambiguous.

## Test

```
yarn vitest run src/string/deburr src/compat/string/deburr
# 15 passed
```
