### PR TITLE
fix(invokeMap): normalize string path via toPath for `this` binding

### DIFF
--- a/src/compat/array/invokeMap.ts
+++ b/src/compat/array/invokeMap.ts
@@ -1,6 +1,7 @@
 import { isFunction, isNil } from '../../predicate/index.ts';
 import { get } from '../object/get.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
+import { toPath } from '../util/toPath.ts';
 
 /**
  * Invokes the method at path of each element in collection.
@@ -71,15 +72,9 @@ export function invokeMap<T, R>(
 
     let thisContext = value;
 
-    if (Array.isArray(path)) {
-      const pathExceptLast = path.slice(0, -1);
-      if (pathExceptLast.length > 0) {
-        thisContext = get(value, pathExceptLast);
-      }
-    } else if (typeof path === 'string' && path.includes('.')) {
-      const parts = path.split('.');
-      const pathExceptLast = parts.slice(0, -1).join('.');
-      thisContext = get(value, pathExceptLast);
+    const keys = Array.isArray(path) ? path : toPath(path);
+    if (keys.length > 1) {
+      thisContext = get(value, keys.slice(0, -1));
     }
 
     result.push(method == null ? undefined : method.apply(thisContext, args));


### PR DESCRIPTION
## Summary

`#1621` made `isDeepKey` stricter so that `isDeepKey('a.')` now returns `false`. As a side effect, `get(obj, 'a.')` stops descending and returns `undefined`, which broke `invokeMap`'s `this`-binding logic and caused CI to fail on `src/compat/array/invokeMap.spec.ts`.

```
AssertionError: expected undefined to be { c: [Function c] }
 ❯ src/compat/array/invokeMap.spec.ts:165:27
```

The root cause is that `invokeMap` computed the parent path by `split('.')` and re-`join('.')`, so for a path like `'a..c'` the parent was reconstructed as the string `'a.'` and fed back into `get` — which no longer resolves it.

## Fix

Normalize the path to an array of keys once (via `toPath` for strings, as-is for arrays) and slice off the last key to get the `this` context. This mirrors how lodash resolves the parent object and is robust to empty path segments.

- empty string path, single key, nested `a.b.c`, and empty-segment `a..c` all behave identically to lodash.

## Test

- `invokeMap` tests pass (11/11)
- Full suite: 4677 passed, no regressions
- `tsc --noEmit` and lint clean
