### PR TITLE
fix(unzipWith): return an empty array instead of throwing on empty input

### DIFF
--- a/src/array/unzipWith.spec.ts
+++ b/src/array/unzipWith.spec.ts
@@ -16,4 +16,10 @@ describe('unzipWith', () => {
 
     expect(result).toEqual([4321, NaN]);
   });
+
+  it('should return an empty array when given an empty array', () => {
+    const result = unzipWith([], (...items: number[]) => items.reduce((sum, value) => sum + value, 0));
+
+    expect(result).toEqual([]);
+  });
 });

--- a/src/array/unzipWith.ts
+++ b/src/array/unzipWith.ts
@@ -13,7 +13,17 @@
  * // result will be [9, 12]
  */
 export function unzipWith<T, R>(target: readonly T[][], iteratee: (...args: T[]) => R): R[] {
-  const maxLength = Math.max(...target.map(innerArray => innerArray.length));
+  // Compute the longest inner array with a loop seeded at 0 instead of
+  // `Math.max(...target.map(...))`, which returns `-Infinity` for an empty
+  // `target` and makes `new Array(maxLength)` throw a RangeError.
+  let maxLength = 0;
+
+  for (let i = 0; i < target.length; i++) {
+    if (target[i].length > maxLength) {
+      maxLength = target[i].length;
+    }
+  }
+
   const result: R[] = new Array(maxLength);
 
   for (let i = 0; i < maxLength; i++) {

--- a/src/array/unzipWith.ts
+++ b/src/array/unzipWith.ts
@@ -13,17 +13,7 @@
  * // result will be [9, 12]
  */
 export function unzipWith<T, R>(target: readonly T[][], iteratee: (...args: T[]) => R): R[] {
-  // Compute the longest inner array with a loop seeded at 0 instead of
-  // `Math.max(...target.map(...))`, which returns `-Infinity` for an empty
-  // `target` and makes `new Array(maxLength)` throw a RangeError.
-  let maxLength = 0;
-
-  for (let i = 0; i < target.length; i++) {
-    if (target[i].length > maxLength) {
-      maxLength = target[i].length;
-    }
-  }
-
+  const maxLength = Math.max(0, ...target.map(innerArray => innerArray.length));
   const result: R[] = new Array(maxLength);
 
   for (let i = 0; i < maxLength; i++) {


### PR DESCRIPTION
## Summary

`unzipWith([], fn)` throws `RangeError: Invalid array length` instead of returning `[]`.

`unzip([])` already returns `[]`, and so does `es-toolkit/compat`'s `unzipWith([])` (and lodash's), so the throw is an edge-case inconsistency in the main `unzipWith`.

## Changes

- `unzipWith` derived the longest inner array with `Math.max(...target.map(...))`, which is `-Infinity` for an empty `target`, so `new Array(maxLength)` threw. I switched to a loop seeded at `0` — the same approach `unzip` already uses (and explains in a comment) — so an empty input now yields `[]`.
- Added a test for `unzipWith([])`.

## Test results

`yarn vitest run src/array/unzipWith.spec.ts` → 3 passed (the new empty-array case plus the two existing ones).
