### PR TITLE
refactor(fp): simplify chunkFunctions in pipe

### DIFF
--- a/src/fp/pipe.ts
+++ b/src/fp/pipe.ts
@@ -444,40 +444,23 @@ interface OperatorFunctionGroup extends Array<OperatorFunction> {
 }
 
 function chunkFunctions(functions: readonly OperatorFunction[]): OperatorFunctionGroup[] {
-  if (functions.length === 0) {
-    return [];
-  }
+  const result: OperatorFunctionGroup[] = [];
+  let currentGroup: OperatorFunctionGroup | undefined;
 
-  let currentGroup: OperatorFunctionGroup = [functions[0]];
-  const result: OperatorFunctionGroup[] = [currentGroup];
-  let previousIsLazy: boolean = currentGroup[0].lazy != null;
-
-  if (previousIsLazy) {
-    currentGroup.lazy = true;
-  }
-  if (currentGroup[0].shortCircuit) {
-    currentGroup.shortCircuit = true;
-  }
-
-  for (let index = 1; index < functions.length; index++) {
+  for (let index = 0; index < functions.length; index++) {
     const func = functions[index];
     const isLazy = func.lazy != null;
 
-    if (isLazy !== previousIsLazy) {
-      currentGroup = [func];
+    if (currentGroup === undefined || currentGroup.lazy !== isLazy) {
+      currentGroup = [];
+      currentGroup.lazy = isLazy;
       result.push(currentGroup);
-    } else {
-      currentGroup.push(func);
     }
 
-    if (isLazy) {
-      currentGroup.lazy = true;
-    }
+    currentGroup.push(func);
     if (func.shortCircuit) {
       currentGroup.shortCircuit = true;
     }
-
-    previousIsLazy = isLazy;
   }
 
   return result;


### PR DESCRIPTION
## Overview

A small readability refactor of `chunkFunctions` in `src/fp/pipe.ts`. No behavior change.

`chunkFunctions` splits the operator list into maximal runs of consecutive same-kind (lazy / non-lazy) functions. The previous implementation seeded the result with `functions[0]` and started the loop at index `1`, which required:

- an empty-input guard,
- a special case for the first function (duplicated flag setup), and
- a separate `previousIsLazy` variable.

## What changed

- Handle the first function inside the loop via `currentGroup === undefined`, so every function goes through the same branch.
- Compare against the current group's own `lazy` flag instead of tracking `previousIsLazy` separately.
- The empty-input guard falls out for free (the loop simply doesn't run).

The core rule is now expressed in one place — **start a new group whenever laziness flips** (`currentGroup === undefined || currentGroup.lazy !== isLazy`).

## Notes

- Eager groups now carry `lazy: false` instead of `undefined`. Both are falsy under the `group.lazy && ...` check in `pipe`, so the grouping decision is unchanged. `OperatorFunctionGroup.lazy` is already typed `boolean | undefined`.
- Internal helper only; no public API change, so no changeset.

## Test

`yarn vitest run src/fp` — 75 files / 150 tests pass. `tsc --noEmit` and `eslint` clean.