### PR TITLE
docs(compat/filter, compat/find): mark predicate as optional in all locales

### DIFF
--- a/docs/compat/reference/array/filter.md
+++ b/docs/compat/reference/array/filter.md
@@ -16,7 +16,7 @@ const result = filter(collection, predicate);
 
 ## Usage
 
-### `filter(collection, predicate)`
+### `filter(collection, predicate?)`
 
 Use `filter` when you want to filter out only elements that satisfy a specific condition from an array or object. The condition can be specified in various formats such as a function, partial object, property-value pair, property name, etc.
 
@@ -71,7 +71,7 @@ filter(undefined, x => x > 0);
 #### Parameters
 
 - `collection` (`ArrayLike<T> | Record<string, unknown> | null | undefined`): The array or object to filter.
-- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`): The filtering condition. Can use a function, partial object, property-value pair, or property name.
+- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, optional): The filtering condition. Can use a function, partial object, property-value pair, or property name.
 
 #### Returns
 

--- a/docs/compat/reference/array/find.md
+++ b/docs/compat/reference/array/find.md
@@ -16,7 +16,7 @@ const result = find(collection, predicate, fromIndex);
 
 ## Usage
 
-### `find(collection, predicate, fromIndex?)`
+### `find(collection, predicate?, fromIndex?)`
 
 Use `find` when you want to find the first element that satisfies a specific condition in an array or object. The condition can be specified in various formats such as a function, partial object, property-value pair, property name, etc.
 
@@ -81,7 +81,7 @@ find(undefined, x => x > 0);
 #### Parameters
 
 - `collection` (`ArrayLike<T> | Record<string, unknown> | null | undefined`): The array or object to search.
-- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`): The search condition. Can use a function, partial object, property-value pair, or property name.
+- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, optional): The search condition. Can use a function, partial object, property-value pair, or property name.
 - `fromIndex` (`number`, optional): The index to start searching from. Defaults to `0`.
 
 #### Returns

--- a/docs/ja/compat/reference/array/filter.md
+++ b/docs/ja/compat/reference/array/filter.md
@@ -16,7 +16,7 @@ const result = filter(collection, predicate);
 
 ## 使用法
 
-### `filter(collection, predicate)`
+### `filter(collection, predicate?)`
 
 配列またはオブジェクトから特定の条件を満たす要素だけをフィルタリングしたい場合に `filter` を使用します。条件は関数、部分オブジェクト、プロパティ-値ペア、プロパティ名など、様々な形式で指定できます。
 
@@ -71,7 +71,7 @@ filter(undefined, x => x > 0);
 #### パラメータ
 
 - `collection` (`ArrayLike<T> | Record<string, unknown> | null | undefined`): フィルタリングする配列またはオブジェクトです。
-- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`): フィルタリング条件です。関数、部分オブジェクト、プロパティ-値ペア、プロパティ名を使用できます。
+- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, オプション): フィルタリング条件です。関数、部分オブジェクト、プロパティ-値ペア、プロパティ名を使用できます。
 
 #### 戻り値
 

--- a/docs/ja/compat/reference/array/find.md
+++ b/docs/ja/compat/reference/array/find.md
@@ -16,7 +16,7 @@ const result = find(collection, predicate, fromIndex);
 
 ## 使用法
 
-### `find(collection, predicate, fromIndex?)`
+### `find(collection, predicate?, fromIndex?)`
 
 配列またはオブジェクトから特定の条件を満たす最初の要素を探したい場合に `find` を使用します。条件は関数、部分オブジェクト、プロパティ-値ペア、プロパティ名など、様々な形式で指定できます。
 
@@ -81,7 +81,7 @@ find(undefined, x => x > 0);
 #### パラメータ
 
 - `collection` (`ArrayLike<T> | Record<string, unknown> | null | undefined`): 検索する配列またはオブジェクトです。
-- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`): 検索条件です。関数、部分オブジェクト、プロパティ-値ペア、プロパティ名を使用できます。
+- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, オプション): 検索条件です。関数、部分オブジェクト、プロパティ-値ペア、プロパティ名を使用できます。
 - `fromIndex` (`number`, オプション): 検索を開始するインデックスです。デフォルトは `0` です。
 
 #### 戻り値

--- a/docs/ko/compat/reference/array/filter.md
+++ b/docs/ko/compat/reference/array/filter.md
@@ -16,7 +16,7 @@ const result = filter(collection, predicate);
 
 ## 사용법
 
-### `filter(collection, predicate)`
+### `filter(collection, predicate?)`
 
 배열이나 객체에서 특정 조건을 만족하는 요소들만 걸러내고 싶을 때 `filter`를 사용하세요. 조건은 함수, 부분 객체, 프로퍼티-값 쌍, 프로퍼티 이름 등 다양한 형태로 지정할 수 있어요.
 
@@ -71,7 +71,7 @@ filter(undefined, x => x > 0);
 #### 파라미터
 
 - `collection` (`ArrayLike<T> | Record<string, unknown> | null | undefined`): 필터링할 배열이나 객체예요.
-- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`): 필터링 조건이에요. 함수, 부분 객체, 프로퍼티-값 쌍, 프로퍼티 이름을 사용할 수 있어요.
+- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, 선택): 필터링 조건이에요. 함수, 부분 객체, 프로퍼티-값 쌍, 프로퍼티 이름을 사용할 수 있어요.
 
 #### 반환 값
 

--- a/docs/ko/compat/reference/array/find.md
+++ b/docs/ko/compat/reference/array/find.md
@@ -16,7 +16,7 @@ const result = find(collection, predicate, fromIndex);
 
 ## 사용법
 
-### `find(collection, predicate, fromIndex?)`
+### `find(collection, predicate?, fromIndex?)`
 
 배열이나 객체에서 특정 조건을 만족하는 첫 번째 요소를 찾고 싶을 때 `find`를 사용하세요. 조건은 함수, 부분 객체, 프로퍼티-값 쌍, 프로퍼티 이름 등 다양한 형태로 지정할 수 있어요.
 
@@ -81,7 +81,7 @@ find(undefined, x => x > 0);
 #### 파라미터
 
 - `collection` (`ArrayLike<T> | Record<string, unknown> | null | undefined`): 검색할 배열이나 객체예요.
-- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`): 검색 조건이에요. 함수, 부분 객체, 프로퍼티-값 쌍, 프로퍼티 이름을 사용할 수 있어요.
+- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, 선택): 검색 조건이에요. 함수, 부분 객체, 프로퍼티-값 쌍, 프로퍼티 이름을 사용할 수 있어요.
 - `fromIndex` (`number`, 선택): 검색을 시작할 인덱스예요. 기본값은 `0`이에요.
 
 #### 반환 값

--- a/docs/zh_hans/compat/reference/array/filter.md
+++ b/docs/zh_hans/compat/reference/array/filter.md
@@ -16,7 +16,7 @@ const result = filter(collection, predicate);
 
 ## 用法
 
-### `filter(collection, predicate)`
+### `filter(collection, predicate?)`
 
 当您想从数组或对象中筛选出满足特定条件的元素时,使用 `filter`。条件可以以各种格式指定,如函数、部分对象、属性-值对、属性名称等。
 
@@ -71,7 +71,7 @@ filter(undefined, x => x > 0);
 #### 参数
 
 - `collection` (`ArrayLike<T> | Record<string, unknown> | null | undefined`): 要过滤的数组或对象。
-- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`): 过滤条件。可以使用函数、部分对象、属性-值对或属性名称。
+- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, 可选): 过滤条件。可以使用函数、部分对象、属性-值对或属性名称。
 
 #### 返回值
 

--- a/docs/zh_hans/compat/reference/array/find.md
+++ b/docs/zh_hans/compat/reference/array/find.md
@@ -16,7 +16,7 @@ const result = find(collection, predicate, fromIndex);
 
 ## 用法
 
-### `find(collection, predicate, fromIndex?)`
+### `find(collection, predicate?, fromIndex?)`
 
 当您想在数组或对象中查找满足特定条件的第一个元素时,使用 `find`。条件可以以各种格式指定,如函数、部分对象、属性-值对、属性名称等。
 
@@ -81,7 +81,7 @@ find(undefined, x => x > 0);
 #### 参数
 
 - `collection` (`ArrayLike<T> | Record<string, unknown> | null | undefined`): 要搜索的数组或对象。
-- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`): 搜索条件。可以使用函数、部分对象、属性-值对或属性名称。
+- `predicate` (`((item: T, index: number, collection: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, 可选): 搜索条件。可以使用函数、部分对象、属性-值对或属性名称。
 - `fromIndex` (`number`, 可选): 开始搜索的索引。默认为 `0`。
 
 #### 返回值


### PR DESCRIPTION
## Summary

predicate is an optional parameter, but the documentation doesn't indicate that it's optional.