### PR TITLE
fix(compat/filter, compat/find): mark optional params with bracket notation in JSDoc

### DIFF
--- a/src/compat/array/filter.ts
+++ b/src/compat/array/filter.ts
@@ -11,7 +11,7 @@ import { iteratee } from '../util/iteratee.ts';
  * Filters characters in a string based on the predicate function.
  *
  * @param collection - The string to filter
- * @param predicate - The function to test each character
+ * @param [predicate] - The function to test each character
  * @returns An array of characters that pass the predicate test
  *
  * @example
@@ -40,7 +40,7 @@ export function filter<T, U extends T>(
  * Filters elements in an array-like object based on the predicate.
  *
  * @param collection - The array-like object to filter
- * @param predicate - The function or shorthand to test each element
+ * @param [predicate] - The function or shorthand to test each element
  * @returns An array of elements that pass the predicate test
  *
  * @example
@@ -72,7 +72,7 @@ export function filter<T extends object, U extends T[keyof T]>(
  * Filters values in an object based on the predicate.
  *
  * @param collection - The object to filter
- * @param predicate - The function or shorthand to test each value
+ * @param [predicate] - The function or shorthand to test each value
  * @returns An array of values that pass the predicate test
  *
  * @example

--- a/src/compat/array/find.ts
+++ b/src/compat/array/find.ts
@@ -10,7 +10,7 @@ import { iteratee } from '../util/iteratee.ts';
  *
  * @param collection - The array-like object to search
  * @param predicate - The type guard function to test each element
- * @param fromIndex - The index to start searching from
+ * @param [fromIndex] - The index to start searching from
  * @returns The first element that matches the type guard, or undefined if none found
  *
  * @example
@@ -27,8 +27,8 @@ export function find<T, U extends T>(
  * Finds the first element in an array-like object that matches a predicate.
  *
  * @param collection - The array-like object to search
- * @param predicate - The function or shorthand to test each element
- * @param fromIndex - The index to start searching from
+ * @param [predicate] - The function or shorthand to test each element
+ * @param [fromIndex] - The index to start searching from
  * @returns The first matching element, or undefined if none found
  *
  * @example
@@ -49,7 +49,7 @@ export function find<T>(
  *
  * @param collection - The object to search
  * @param predicate - The type guard function to test each value
- * @param fromIndex - The index to start searching from
+ * @param [fromIndex] - The index to start searching from
  * @returns The first value that matches the type guard, or undefined if none found
  *
  * @example
@@ -66,8 +66,8 @@ export function find<T extends object, U extends T[keyof T]>(
  * Finds the first value in an object that matches a predicate.
  *
  * @param collection - The object to search
- * @param predicate - The function or shorthand to test each value
- * @param fromIndex - The index to start searching from
+ * @param [predicate] - The function or shorthand to test each value
+ * @param [fromIndex] - The index to start searching from
  * @returns The first matching value, or undefined if none found
  *
  * @example
@@ -88,7 +88,7 @@ export function find<T extends object>(
  *
  * @template T
  * @param source - The source array or object to search through.
- * @param doesMatch - The criteria to match. It can be a function, a partial object, a key-value pair, or a property name.
+ * @param [doesMatch=identity] - The criteria to match. It can be a function, a partial object, a key-value pair, or a property name.
  * @param [fromIndex=0] - The index to start the search from, defaults to 0.
  * @returns The first property value that has the specified property, or `undefined` if no match is found.
  *


### PR DESCRIPTION
## Summary

optional param JSDoc:
some -> [some]