### PR TITLE
refactor(compat/_internal): simplify ListIterateeCustom using ListIterator and IterateeShorthand

### DIFF
--- a/src/compat/_internal/ListIterateeCustom.ts
+++ b/src/compat/_internal/ListIterateeCustom.ts
@@ -1,5 +1,4 @@
-import { PartialShallow } from './PartialShallow.ts';
+import { IterateeShorthand } from './IterateeShorthand';
+import { ListIterator } from './ListIterator.ts';
 
-export type ListIterateeCustom<T, R> =
-  | ((value: T, index: number, collection: ArrayLike<T>) => R)
-  | (PropertyKey | [PropertyKey, any] | PartialShallow<T>);
+export type ListIterateeCustom<T, R> = ListIterator<T, R> | IterateeShorthand<T>;


### PR DESCRIPTION
## Summary

Instead of using the raw type, we could leverage the existing internal utilities here, just like`ObjectIterateeCustom`.

https://github.com/toss/es-toolkit/blob/1da529ffa25cdbc19260caf96f48b2e0a5919c03/src/compat/_internal/ObjectIterateeCustom.ts#L4-L6