### PR TITLE
fix(compat/findIndex): rename doesMatch parameter to predicate for consistency

### DIFF
--- a/docs/compat/reference/array/findIndex.md
+++ b/docs/compat/reference/array/findIndex.md
@@ -11,12 +11,12 @@ Use the faster and more modern `Array.prototype.findIndex` instead.
 Finds the index of the first element in an array that matches a condition.
 
 ```typescript
-const index = findIndex(arr, doesMatch, fromIndex);
+const index = findIndex(arr, predicate, fromIndex);
 ```
 
 ## Usage
 
-### `findIndex(arr, doesMatch, fromIndex)`
+### `findIndex(arr, predicate, fromIndex)`
 
 Use `findIndex` when you want to find the position of the first element in an array that matches a specific condition. You can specify the condition in various ways. If no element matches the condition, it returns `-1`.
 
@@ -92,7 +92,7 @@ findIndex(undefined, 'active'); // -1
 #### Parameters
 
 - `arr` (`ArrayLike<T> | null | undefined`): The array to search.
-- `doesMatch` (`((item: T, index: number, arr: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, optional): The matching condition. Can be a function, partial object, key-value pair, or property name.
+- `predicate` (`((item: T, index: number, arr: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, optional): The matching condition. Can be a function, partial object, key-value pair, or property name.
 - `fromIndex` (`number`, optional): The index to start the search from. Default is `0`.
 
 #### Returns

--- a/docs/ja/compat/reference/array/findIndex.md
+++ b/docs/ja/compat/reference/array/findIndex.md
@@ -11,12 +11,12 @@
 配列内で条件に一致する最初の要素のインデックスを検索します。
 
 ```typescript
-const index = findIndex(arr, doesMatch, fromIndex);
+const index = findIndex(arr, predicate, fromIndex);
 ```
 
 ## 使用法
 
-### `findIndex(arr, doesMatch, fromIndex)`
+### `findIndex(arr, predicate, fromIndex)`
 
 配列内で特定の条件に一致する最初の要素の位置を見つけたい場合は `findIndex` を使用してください。さまざまな方法で条件を指定できます。条件に一致する要素がない場合は `-1` を返します。
 
@@ -92,7 +92,7 @@ findIndex(undefined, 'active'); // -1
 #### パラメータ
 
 - `arr` (`ArrayLike<T> | null | undefined`): 検索する配列です。
-- `doesMatch` (`((item: T, index: number, arr: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, オプション): 一致条件です。関数、部分オブジェクト、キーと値のペア、またはプロパティ名を指定できます。
+- `predicate` (`((item: T, index: number, arr: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, オプション): 一致条件です。関数、部分オブジェクト、キーと値のペア、またはプロパティ名を指定できます。
 - `fromIndex` (`number`, オプション): 検索を開始するインデックスです。デフォルトは `0` です。
 
 #### 戻り値

--- a/docs/ko/compat/reference/array/findIndex.md
+++ b/docs/ko/compat/reference/array/findIndex.md
@@ -11,12 +11,12 @@
 배열에서 조건에 맞는 첫 번째 요소의 인덱스를 찾아요.
 
 ```typescript
-const index = findIndex(arr, doesMatch, fromIndex);
+const index = findIndex(arr, predicate, fromIndex);
 ```
 
 ## 사용법
 
-### `findIndex(arr, doesMatch, fromIndex)`
+### `findIndex(arr, predicate, fromIndex)`
 
 배열에서 특정 조건에 맞는 첫 번째 요소의 위치를 찾고 싶을 때 `findIndex`를 사용하세요. 다양한 방식으로 조건을 지정할 수 있어요. 조건에 맞는 요소가 없으면 `-1`을 반환해요.
 
@@ -92,7 +92,7 @@ findIndex(undefined, 'active'); // -1
 #### 파라미터
 
 - `arr` (`ArrayLike<T> | null | undefined`): 검색할 배열이에요.
-- `doesMatch` (`((item: T, index: number, arr: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, 선택): 일치 조건이에요. 함수, 부분 객체, 키-값 쌍, 또는 속성 이름이 될 수 있어요.
+- `predicate` (`((item: T, index: number, arr: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, 선택): 일치 조건이에요. 함수, 부분 객체, 키-값 쌍, 또는 속성 이름이 될 수 있어요.
 - `fromIndex` (`number`, 선택): 검색을 시작할 인덱스예요. 기본값은 `0`이에요.
 
 #### 반환 값

--- a/docs/zh_hans/compat/reference/array/findIndex.md
+++ b/docs/zh_hans/compat/reference/array/findIndex.md
@@ -11,12 +11,12 @@
 查找数组中满足条件的第一个元素的索引。
 
 ```typescript
-const index = findIndex(arr, doesMatch, fromIndex);
+const index = findIndex(arr, predicate, fromIndex);
 ```
 
 ## 用法
 
-### `findIndex(arr, doesMatch, fromIndex)`
+### `findIndex(arr, predicate, fromIndex)`
 
 当您想要查找数组中满足特定条件的第一个元素的位置时,使用 `findIndex`。您可以通过多种方式指定条件。如果没有元素满足条件,则返回 `-1`。
 
@@ -92,7 +92,7 @@ findIndex(undefined, 'active'); // -1
 #### 参数
 
 - `arr` (`ArrayLike<T> | null | undefined`): 要搜索的数组。
-- `doesMatch` (`((item: T, index: number, arr: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, 可选): 匹配条件。可以是函数、部分对象、键值对或属性名。
+- `predicate` (`((item: T, index: number, arr: any) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey`, 可选): 匹配条件。可以是函数、部分对象、键值对或属性名。
 - `fromIndex` (`number`, 可选): 开始搜索的索引。默认为 `0`。
 
 #### 返回值

--- a/src/compat/array/findIndex.ts
+++ b/src/compat/array/findIndex.ts
@@ -9,7 +9,7 @@ import { matchesProperty } from '../predicate/matchesProperty.ts';
  *
  * @template T
  * @param arr - The array to search through.
- * @param doesMatch - The criteria to match against the items in the array. This can be a function, a partial object, a key-value pair, or a property name.
+ * @param [predicate=identity] - The criteria to match against the items in the array. This can be a function, a partial object, a key-value pair, or a property name.
  * @param propertyToCheck - The property name to check for in the items of the array.
  * @param [fromIndex=0] - The index to start the search from, defaults to 0.
  * @returns The index of the first item that has the specified property, or `-1` if no match is found.
@@ -22,7 +22,7 @@ import { matchesProperty } from '../predicate/matchesProperty.ts';
  */
 export function findIndex<T>(
   arr: ArrayLike<T> | null | undefined,
-  doesMatch: ListIterateeCustom<T, boolean> = identity,
+  predicate: ListIterateeCustom<T, boolean> = identity,
   fromIndex = 0
 ): number {
   if (!arr) {
@@ -33,26 +33,26 @@ export function findIndex<T>(
   }
   const subArray = Array.from(arr).slice(fromIndex);
   let index = -1;
-  switch (typeof doesMatch) {
+  switch (typeof predicate) {
     case 'function': {
-      index = subArray.findIndex(doesMatch);
+      index = subArray.findIndex(predicate);
       break;
     }
     case 'object': {
-      if (Array.isArray(doesMatch) && doesMatch.length === 2) {
-        const key = doesMatch[0];
-        const value = doesMatch[1];
+      if (Array.isArray(predicate) && predicate.length === 2) {
+        const key = predicate[0];
+        const value = predicate[1];
 
         index = subArray.findIndex(matchesProperty(key, value));
       } else {
-        index = subArray.findIndex(matches(doesMatch));
+        index = subArray.findIndex(matches(predicate));
       }
       break;
     }
     case 'number':
     case 'symbol':
     case 'string': {
-      index = subArray.findIndex(property(doesMatch));
+      index = subArray.findIndex(property(predicate));
     }
   }
   return index === -1 ? -1 : index + fromIndex;


### PR DESCRIPTION
## Summary

I think predicate would be a more appropriate name than doesMatch. It would also make the parameter name consistent with find, findLast, and findLastIndex, which would improve consistency across the API.