### PR TITLE
fix(compat/findIndex): treat NaN fromIndex as 0

### DIFF
--- a/src/compat/array/findIndex.spec.ts
+++ b/src/compat/array/findIndex.spec.ts
@@ -60,6 +60,11 @@ describe('findIndex', () => {
     expect(findIndex(objects, { b: 2 }, 4)).toBe(-1);
   });
 
+  it('findIndex with NaN fromIndex should start from 0', () => {
+    const arr = [1, 2, 3];
+    expect(findIndex(arr, x => x === 1, NaN)).toBe(0);
+  });
+
   it('should return `-1` when provided `null` or `undefined`', () => {
     expect(findIndex(null, 'a')).toBe(-1);
     expect(findIndex(undefined, 'a')).toBe(-1);

--- a/src/compat/array/findIndex.ts
+++ b/src/compat/array/findIndex.ts
@@ -28,6 +28,9 @@ export function findIndex<T>(
   if (!arr) {
     return -1;
   }
+  if (Number.isNaN(fromIndex)) {
+    fromIndex = 0;
+  }
   if (fromIndex < 0) {
     fromIndex = Math.max(arr.length + fromIndex, 0);
   }


### PR DESCRIPTION
## Summary

There's a compatibility issue with Lodash when fromIndex is NaN. Lodash treats NaN as 0 and starts searching from the beginning.

## Reproduce

```ts
import { findIndex as loFindIndex } from 'lodash';
import { findIndex as esFindIndex } from '../../src/compat/array/findIndex';

const arr = [1, 2, 3];
const predicate = (x: number) => x === 1;

console.log(loFindIndex(arr, predicate, NaN)); // 0
console.log(esFindIndex(arr, predicate, NaN)); // NaN
```