### PR TITLE
docs(compat/findLastIndex): mark predicate and fromIndex as optional in heading

### DIFF
--- a/docs/compat/reference/array/findLastIndex.md
+++ b/docs/compat/reference/array/findLastIndex.md
@@ -16,7 +16,7 @@ const lastIndex = findLastIndex(array, predicate, fromIndex);
 
 ## Usage
 
-### `findLastIndex(array, predicate, fromIndex)`
+### `findLastIndex(array, predicate?, fromIndex?)`
 
 Use `findLastIndex` when you want to find the index of the first element that matches a given condition starting from the end of the array. Returns `-1` if no element satisfies the condition.
 

--- a/docs/ja/compat/reference/array/findLastIndex.md
+++ b/docs/ja/compat/reference/array/findLastIndex.md
@@ -16,7 +16,7 @@ const lastIndex = findLastIndex(array, predicate, fromIndex);
 
 ## 使用法
 
-### `findLastIndex(array, predicate, fromIndex)`
+### `findLastIndex(array, predicate?, fromIndex?)`
 
 配列の末尾から開始して、与えられた条件に一致する最初の要素のインデックスを見つけたい場合は`findLastIndex`を使用してください。条件を満たす要素がない場合は`-1`を返します。
 

--- a/docs/ko/compat/reference/array/findLastIndex.md
+++ b/docs/ko/compat/reference/array/findLastIndex.md
@@ -16,7 +16,7 @@ const lastIndex = findLastIndex(array, predicate, fromIndex);
 
 ## 사용법
 
-### `findLastIndex(array, predicate, fromIndex)`
+### `findLastIndex(array, predicate?, fromIndex?)`
 
 배열의 끝에서부터 시작해서 주어진 조건과 일치하는 첫 번째 요소의 인덱스를 찾고 싶을 때 `findLastIndex`를 사용하세요. 조건을 만족하는 요소가 없으면 `-1`을 반환해요.
 

--- a/docs/zh_hans/compat/reference/array/findLastIndex.md
+++ b/docs/zh_hans/compat/reference/array/findLastIndex.md
@@ -16,7 +16,7 @@ const lastIndex = findLastIndex(array, predicate, fromIndex);
 
 ## 用法
 
-### `findLastIndex(array, predicate, fromIndex)`
+### `findLastIndex(array, predicate?, fromIndex?)`
 
 当您想要从数组末尾开始查找满足给定条件的第一个元素的索引时,使用 `findLastIndex`。如果没有元素满足条件,则返回 `-1`。
 


### PR DESCRIPTION
## Summary

It looks like the optional indicator is missing from the heading 🥲