### PR TITLE
fix(compat/lastIndexOf): coerce fromIndex like lodash

### DIFF
--- a/src/compat/array/lastIndexOf.spec.ts
+++ b/src/compat/array/lastIndexOf.spec.ts
@@ -48,6 +48,14 @@ describe('lastIndexOf', () => {
 
   it(`should coerce \`fromIndex\` to an integer`, () => {
     expect(lastIndexOf(array, 2, 4.2)).toBe(4);
+    expect(lastIndexOf(array, 1, '-1' as any)).toBe(3);
+  });
+
+  it(`should treat explicit falsey \`fromIndex\` values as \`0\``, () => {
+    expect(lastIndexOf(array, 1, null as any)).toBe(0);
+    expect(lastIndexOf(array, 2, null as any)).toBe(-1);
+    expect(lastIndexOf(array, 1, false as any)).toBe(0);
+    expect(lastIndexOf(array, 1, true)).toBe(0);
   });
 
   it(`should return -1 for empty array or nullish values`, () => {

--- a/src/compat/array/lastIndexOf.spec.ts
+++ b/src/compat/array/lastIndexOf.spec.ts
@@ -51,7 +51,7 @@ describe('lastIndexOf', () => {
     expect(lastIndexOf(array, 1, '-1' as any)).toBe(3);
   });
 
-  it(`should treat explicit falsey \`fromIndex\` values as \`0\``, () => {
+  it(`should coerce null and boolean \`fromIndex\` values to integers`, () => {
     expect(lastIndexOf(array, 1, null as any)).toBe(0);
     expect(lastIndexOf(array, 2, null as any)).toBe(-1);
     expect(lastIndexOf(array, 1, false as any)).toBe(0);

--- a/src/compat/array/lastIndexOf.ts
+++ b/src/compat/array/lastIndexOf.ts
@@ -1,4 +1,5 @@
 import { isArrayLike } from '../predicate/isArrayLike.ts';
+import { toInteger } from '../util/toInteger.ts';
 
 /**
  * Gets the index at which the last occurrence of value is found in array.
@@ -36,8 +37,8 @@ export function lastIndexOf<T>(
 
   const length = array.length;
 
-  let index = (fromIndex as number) ?? length - 1;
-  if (fromIndex != null) {
+  let index = fromIndex === undefined ? length - 1 : toInteger(fromIndex);
+  if (fromIndex !== undefined) {
     index = index < 0 ? Math.max(length + index, 0) : Math.min(index, length - 1);
   }
 


### PR DESCRIPTION
## Summary

Fixes `compat/lastIndexOf` so explicit `fromIndex` values are coerced the same way as lodash.

Previously, `null` was treated like an omitted `fromIndex`, causing the search to start from the end of the array. String values such as `'-1'` were also not coerced before index normalization.

## Changes

- Use the existing `toInteger` helper for explicit `fromIndex` values.
- Keep omitted `fromIndex` behavior unchanged by defaulting to `array.length - 1`.
- Add regression tests for `null`, boolean, string, and decimal `fromIndex` values.

## Verification

- `corepack yarn vitest run src/compat/array/indexOf.spec.ts src/compat/array/lastIndexOf.spec.ts`
- `corepack yarn typecheck`
- `corepack yarn prettier --check src/compat/array/lastIndexOf.ts src/compat/array/lastIndexOf.spec.ts`