### PR TITLE
fix(compat/nth): support string inputs

### DIFF
--- a/src/compat/array/nth.spec.ts
+++ b/src/compat/array/nth.spec.ts
@@ -51,6 +51,12 @@ describe('nth', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should support strings', () => {
+    expect(nth('abc', 0)).toBe('a');
+    expect(nth('abc', 1)).toBe('b');
+    expect(nth('abc', -1)).toBe('c');
+  });
+
   it('should return `undefined` for non-indexes', () => {
     const array = [1, 2];
     const values = [Infinity, array.length];

--- a/src/compat/array/nth.ts
+++ b/src/compat/array/nth.ts
@@ -1,4 +1,4 @@
-import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
 /**
@@ -13,7 +13,7 @@ import { toInteger } from '../util/toInteger.ts';
  * nth([1, 2, 3], -1); // => 3
  */
 export function nth<T>(array: ArrayLike<T> | null | undefined, n = 0): T | undefined {
-  if (!isArrayLikeObject(array) || array.length === 0) {
+  if (!isArrayLike(array) || array.length === 0) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Fixes `compat/nth` so it supports primitive string inputs like lodash.

Previously, `nth` used `isArrayLikeObject`, which excludes primitive strings. Lodash treats strings as array-like, so `_.nth('abc', 1)` returns `'b'`.

## Changes

- Use `isArrayLike` instead of `isArrayLikeObject` in `compat/nth`.
- Add regression tests for positive and negative string indexes.

## Verification

- `corepack yarn vitest run src/compat/array/nth.spec.ts`
- `corepack yarn typecheck`
- `corepack yarn prettier --check src/compat/array/nth.ts src/compat/array/nth.spec.ts`