### PR TITLE
fix(compat/findLastIndex): treat NaN fromIndex as 0

### DIFF
--- a/src/compat/array/findLastIndex.spec.ts
+++ b/src/compat/array/findLastIndex.spec.ts
@@ -107,6 +107,13 @@ describe('findLastIndex', () => {
     expect(findLastIndex(array, x => x === 2, 4.2)).toBe(4);
   });
 
+  it(`\`findLastIndex\` with \`NaN\` \`fromIndex\` should start from 0`, () => {
+    // Lodash coerces `NaN` via `toInteger`, so `fromIndex` becomes `0` and the
+    // search still covers the first element. The existing falsey test uses a
+    // predicate that never matches index 0, so it does not catch this.
+    expect(findLastIndex(array, x => x === 1, NaN)).toBe(0);
+  });
+
   it('should return `-1` when provided `null` or `undefined`', () => {
     expect(findLastIndex(null, 'a')).toBe(-1);
     expect(findLastIndex(undefined, 'a')).toBe(-1);

--- a/src/compat/array/findLastIndex.ts
+++ b/src/compat/array/findLastIndex.ts
@@ -61,6 +61,9 @@ export function findLastIndex<T>(
   if (!arr) {
     return -1;
   }
+  if (Number.isNaN(fromIndex)) {
+    fromIndex = 0;
+  }
   if (fromIndex < 0) {
     fromIndex = Math.max(arr.length + fromIndex, 0);
   } else {


### PR DESCRIPTION
## Summary

In `es-toolkit/compat`, `findLastIndex` does not normalize a `NaN` `fromIndex`, so it diverges from lodash. `findIndex` received this guard in #1828; this applies the same fix to its mirror.

## The bug

With `fromIndex = NaN`, the `fromIndex < 0` check is false, so the `else` branch runs `Math.min(NaN, arr.length - 1)`, which stays `NaN`. The slice then becomes `arr.slice(0, NaN + 1)` -> `arr.slice(0, NaN)` -> `[]`, so the search runs over an empty array and returns `-1` even when the element at index 0 matches.

Lodash coerces `NaN` to `0` via `toInteger`, so index 0 is still searched:

```js
_.findLastIndex([1, 2, 3], x => x === 1, NaN); // => 0
```

Before this change:

```js
findLastIndex([1, 2, 3], x => x === 1, NaN); // => -1  (should be 0)
```

## Why the existing test did not catch it

The `should treat falsey fromIndex values correctly` test passes `NaN`, but with a predicate (`x => x === 3`) that never matches index 0, so both the old and new code return `-1` there. The added test uses a predicate that matches index 0 to pin the behavior.

## Fix

Same guard `findIndex` got in #1828:

```js
if (Number.isNaN(fromIndex)) {
  fromIndex = 0;
}
```

`yarn vitest run src/compat/array` stays green (1011 tests).
