### PR TITLE
fix(compat/inRange): don't throw on a lone negative bound

### DIFF
--- a/src/compat/math/inRange.spec.ts
+++ b/src/compat/math/inRange.spec.ts
@@ -41,6 +41,14 @@ describe('inRange', () => {
     expect(inRange(-3, -2, -6)).toBe(true);
   });
 
+  it('should treat a lone negative `end` as the range `[end, 0)`', () => {
+    expect(inRange(-1, -2)).toBe(true);
+    expect(inRange(-2, -4)).toBe(true);
+    expect(inRange(0, -1)).toBe(false);
+    expect(inRange(-6, -5)).toBe(false);
+    expect(inRange(-1, -1)).toBe(true);
+  });
+
   it('should work with a floating point `n` value', () => {
     expect(inRange(0.5, 5)).toBe(true);
     expect(inRange(1.2, 1, 5)).toBe(true);

--- a/src/compat/math/inRange.ts
+++ b/src/compat/math/inRange.ts
@@ -1,47 +1,34 @@
-import { inRange as inRangeToolkit } from '../../math/inRange.ts';
+import { toFinite } from '../util/toFinite.ts';
+import { toNumber } from '../util/toNumber.ts';
 
 /**
  * Checks if the value is within a specified range.
+ *
+ * If only `minimum` is provided, it is treated as the exclusive upper bound and the range starts at `0`.
+ * When the resolved bounds are out of order they are swapped, so the lower one is always inclusive
+ * and the higher one exclusive.
  *
  * @param value The value to check.
  * @param minimum The lower bound of the range (inclusive).
  * @param maximum The upper bound of the range (exclusive).
  * @returns `true` if the value is within the specified range, otherwise `false`.
- * @throws {Error} Throws an error if the `minimum` is greater or equal than the `maximum`.
  *
  * @example
  * const result1 = inRange(3, 5); // result1 will be true.
  * const result2 = inRange(1, 2, 5); // result2 will be false.
- * const result3 = inRange(1, 5, 2); // If the minimum is greater or equal than the maximum, an error is thrown.
+ * const result3 = inRange(-2, -4); // result3 will be true, the range is [-4, 0).
  */
 export function inRange(value: number, minimum: number, maximum?: number): boolean {
-  if (!minimum) {
+  minimum = toFinite(minimum);
+
+  if (maximum === undefined) {
+    maximum = minimum;
     minimum = 0;
+  } else {
+    maximum = toFinite(maximum);
   }
 
-  if (maximum != null && !maximum) {
-    maximum = 0;
-  }
+  value = toNumber(value);
 
-  if (minimum != null && typeof minimum !== 'number') {
-    minimum = Number(minimum);
-  }
-
-  if (maximum == null && minimum === 0) {
-    return false;
-  }
-
-  if (maximum != null && typeof maximum !== 'number') {
-    maximum = Number(maximum);
-  }
-
-  if (maximum != null && minimum > maximum) {
-    [minimum, maximum] = [maximum, minimum];
-  }
-
-  if (minimum === maximum) {
-    return false;
-  }
-
-  return inRangeToolkit(value, minimum, maximum!);
+  return value >= Math.min(minimum, maximum) && value < Math.max(minimum, maximum);
 }


### PR DESCRIPTION
`inRange(-1, -2)` from `es-toolkit/compat` throws "The maximum value must be greater than the minimum value" instead of returning a boolean. With a single bound lodash reads the call as the range `[-2, 0)` and returns `true`, but the compat version skips its swap step for that case and hands the bounds straight to the toolkit `inRange`, which throws when min ≥ max.

This resolves the bounds the same way lodash does (coerce with `toFinite`, treat a lone argument as the upper bound starting from 0, then compare with min/max), so negative single-bound ranges work and it no longer throws. Added a test for the lone-negative case.