### PR TITLE
fix(compat): match lodash when splitting ordinal numbers in case functions

### DIFF
--- a/src/compat/string/camelCase.spec.ts
+++ b/src/compat/string/camelCase.spec.ts
@@ -74,6 +74,12 @@ describe('camelCase', () => {
     expect(camelCase({ toString: () => 'foo bar' })).toBe('fooBar');
   });
 
+  it('should keep ordinal numbers as single words, identical to lodash', () => {
+    expect(camelCase('foo1stPlace')).toBe('foo1stPlace');
+    expect(camelCase('top10th')).toBe('top10th');
+    expect(camelCase('1st place 2nd 3rd 4th')).toBe('1stPlace2nd3rd4th');
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(camelCase).toEqualTypeOf<typeof camelCaseLodash>();
   });

--- a/src/compat/string/camelCase.ts
+++ b/src/compat/string/camelCase.ts
@@ -1,5 +1,6 @@
 import { deburr } from './deburr.ts';
-import { camelCase as camelCaseToolkit } from '../../string/camelCase.ts';
+import { words } from './words.ts';
+import { capitalize } from '../../string/capitalize.ts';
 import { normalizeForCase } from '../_internal/normalizeForCase.ts';
 
 /**
@@ -19,5 +20,13 @@ import { normalizeForCase } from '../_internal/normalizeForCase.ts';
  */
 
 export function camelCase(str?: string): string {
-  return camelCaseToolkit(normalizeForCase(deburr(str)));
+  const splitWords = words(normalizeForCase(deburr(str)));
+
+  if (splitWords.length === 0) {
+    return '';
+  }
+
+  const [first, ...rest] = splitWords;
+
+  return `${first.toLowerCase()}${rest.map(word => capitalize(word)).join('')}`;
 }

--- a/src/compat/string/kebabCase.spec.ts
+++ b/src/compat/string/kebabCase.spec.ts
@@ -56,6 +56,12 @@ describe('kebabCase', () => {
     expect(kebabCase({ toString: () => string })).toBe('foo-bar');
   });
 
+  it('should keep ordinal numbers as single words, identical to lodash', () => {
+    expect(kebabCase('foo1stPlace')).toBe('foo-1st-place');
+    expect(kebabCase('top10th')).toBe('top-10th');
+    expect(kebabCase('1st place 2nd 3rd 4th')).toBe('1st-place-2nd-3rd-4th');
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(kebabCase).toEqualTypeOf<typeof kebabCaseLodash>();
   });

--- a/src/compat/string/kebabCase.ts
+++ b/src/compat/string/kebabCase.ts
@@ -1,5 +1,5 @@
 import { deburr } from './deburr.ts';
-import { kebabCase as kebabCaseToolkit } from '../../string/kebabCase.ts';
+import { words } from './words.ts';
 import { normalizeForCase } from '../_internal/normalizeForCase.ts';
 
 /**
@@ -17,5 +17,7 @@ import { normalizeForCase } from '../_internal/normalizeForCase.ts';
  * const convertedStr4 = kebabCase('HTTPRequest') // returns 'http-request'
  */
 export function kebabCase(str?: string): string {
-  return kebabCaseToolkit(normalizeForCase(deburr(str)));
+  return words(normalizeForCase(deburr(str)))
+    .map(word => word.toLowerCase())
+    .join('-');
 }

--- a/src/compat/string/lowerCase.ts
+++ b/src/compat/string/lowerCase.ts
@@ -1,5 +1,5 @@
 import { deburr } from './deburr.ts';
-import { lowerCase as lowerCaseToolkit } from '../../string/lowerCase.ts';
+import { words } from './words.ts';
 import { normalizeForCase } from '../_internal/normalizeForCase.ts';
 
 /**
@@ -17,5 +17,7 @@ import { normalizeForCase } from '../_internal/normalizeForCase.ts';
  * const convertedStr4 = lowerCase('HTTPRequest') // returns 'http request'
  */
 export function lowerCase(str?: string): string {
-  return lowerCaseToolkit(normalizeForCase(deburr(str)));
+  return words(normalizeForCase(deburr(str)))
+    .map(word => word.toLowerCase())
+    .join(' ');
 }

--- a/src/compat/string/snakeCase.spec.ts
+++ b/src/compat/string/snakeCase.spec.ts
@@ -56,6 +56,12 @@ describe('snakeCase', () => {
     expect(snakeCase({ toString: () => string })).toBe('foo_bar');
   });
 
+  it('should keep ordinal numbers as single words, identical to lodash', () => {
+    expect(snakeCase('foo1stPlace')).toBe('foo_1st_place');
+    expect(snakeCase('top10th')).toBe('top_10th');
+    expect(snakeCase('1st place 2nd 3rd 4th')).toBe('1st_place_2nd_3rd_4th');
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(snakeCase).toEqualTypeOf<typeof snakeCaseLodash>();
   });

--- a/src/compat/string/snakeCase.ts
+++ b/src/compat/string/snakeCase.ts
@@ -1,5 +1,5 @@
 import { deburr } from './deburr.ts';
-import { snakeCase as snakeCaseToolkit } from '../../string/snakeCase.ts';
+import { words } from './words.ts';
 import { normalizeForCase } from '../_internal/normalizeForCase.ts';
 
 /**
@@ -17,5 +17,7 @@ import { normalizeForCase } from '../_internal/normalizeForCase.ts';
  * const convertedStr4 = snakeCase('HTTPRequest') // returns 'http_request'
  */
 export function snakeCase(str?: string): string {
-  return snakeCaseToolkit(normalizeForCase(deburr(str)));
+  return words(normalizeForCase(deburr(str)))
+    .map(word => word.toLowerCase())
+    .join('_');
 }

--- a/src/compat/string/startCase.spec.ts
+++ b/src/compat/string/startCase.spec.ts
@@ -62,6 +62,12 @@ describe('startCase', () => {
     expect(startCase('__FOO_BAR__')).toBe('FOO BAR');
   });
 
+  it('should keep ordinal numbers as single words, identical to lodash', () => {
+    expect(startCase('foo1stPlace')).toBe('Foo 1st Place');
+    expect(startCase('top10th')).toBe('Top 10th');
+    expect(startCase('1st place 2nd 3rd 4th')).toBe('1st Place 2nd 3rd 4th');
+  });
+
   it('should match the type of lodash', () => {
     expectTypeOf(startCase).toEqualTypeOf<typeof startCaseLodash>();
   });

--- a/src/compat/string/startCase.ts
+++ b/src/compat/string/startCase.ts
@@ -1,5 +1,5 @@
 import { deburr } from './deburr.ts';
-import { words as getWords } from '../../string/words.ts';
+import { words as getWords } from './words.ts';
 import { normalizeForCase } from '../_internal/normalizeForCase.ts';
 
 /**

--- a/src/compat/string/upperCase.ts
+++ b/src/compat/string/upperCase.ts
@@ -1,5 +1,5 @@
 import { deburr } from './deburr.ts';
-import { upperCase as upperCaseToolkit } from '../../string/upperCase.ts';
+import { words } from './words.ts';
 import { normalizeForCase } from '../_internal/normalizeForCase.ts';
 
 /**
@@ -17,5 +17,7 @@ import { normalizeForCase } from '../_internal/normalizeForCase.ts';
  * const convertedStr4 = upperCase('HTTPRequest') // returns 'HTTP REQUEST'
  */
 export function upperCase(str?: string): string {
-  return upperCaseToolkit(normalizeForCase(deburr(str)));
+  return words(normalizeForCase(deburr(str)))
+    .map(word => word.toUpperCase())
+    .join(' ');
 }


### PR DESCRIPTION
The `es-toolkit/compat` case functions mis-split ordinal numbers, so they diverge from lodash on inputs like `foo1stPlace`, `top10th`, and `1st place 2nd 3rd 4th`.

## Repro (es-toolkit/compat actual vs lodash 4.17/4.18 expected)

| input | fn | es-toolkit/compat (before) | lodash (expected) |
| --- | --- | --- | --- |
| `foo1stPlace` | `snakeCase` | `foo_1_st_place` | `foo_1st_place` |
| `foo1stPlace` | `camelCase` | `foo1StPlace` | `foo1stPlace` |
| `foo1stPlace` | `kebabCase` | `foo-1-st-place` | `foo-1st-place` |
| `foo1stPlace` | `startCase` | `Foo 1 St Place` | `Foo 1st Place` |
| `top10th` | `snakeCase` | `top_10_th` | `top_10th` |
| `top10th` | `kebabCase` | `top-10-th` | `top-10th` |
| `1st place 2nd 3rd 4th` | `snakeCase` | `1_st_place_2_nd_3_rd_4_th` | `1st_place_2nd_3rd_4th` |
| `1st place 2nd 3rd 4th` | `camelCase` | `1StPlace2Nd3Rd4Th` | `1stPlace2nd3rd4th` |

`upperCase` and `lowerCase` are affected the same way.

## Root cause

The compat case functions delegated word splitting to the strict `es-toolkit` splitter (`src/string/words.ts`, `CASE_SPLIT_PATTERN`), which has no ordinal handling. The compat `words()` splitter already recognizes ordinals as single words (added in #1163), but the compat case functions never used it, so #1163 never reached them.

## Fix

Route the six compat case functions through the ordinal-aware compat `words()` splitter instead of the strict one. The word-joining logic for each function is preserved.

Strict `es-toolkit` (`src/string/words.ts` and the strict case functions) is unchanged. Strict output intentionally still splits ordinals (`snakeCase('foo1stPlace')` stays `foo_1_st_place`), matching its documented divergence from lodash. Only `src/compat/string/` files are touched.

## Authority

`es-toolkit/compat` matches lodash exactly (per the compat contract in the repo contributor guide). Expected values above were taken from lodash 4.18.1 at runtime, and the fixed compat output matches lodash on both the ordinal cases and the existing non-ordinal cases (acronyms, `IDs`, `Product XMLs`, `enable 6h format`, accented input, and so on).

## Tests and suite status

Added an ordinal case to `camelCase.spec.ts`, `snakeCase.spec.ts`, `kebabCase.spec.ts`, and `startCase.spec.ts`. Verified red before the fix (all four fail on the current splitter) and green after. `vitest run src/string src/compat src/object` passes 3511 tests, 0 failures.
