### PR TITLE
fix[toArray]: convert Sets to arrays to match lodash

### DIFF
--- a/src/compat/util/toArray.spec.ts
+++ b/src/compat/util/toArray.spec.ts
@@ -26,6 +26,13 @@ describe('toArray', () => {
     }
   });
 
+  it('should convert sets to arrays', () => {
+    if (Set) {
+      const set = new Set([1, 2, 3]);
+      expect(toArray(set)).toEqual([1, 2, 3]);
+    }
+  });
+
   it('should convert strings to arrays', () => {
     expect(toArray('')).toEqual([]);
     expect(toArray('ab')).toEqual(['a', 'b']);

--- a/src/compat/util/toArray.ts
+++ b/src/compat/util/toArray.ts
@@ -1,5 +1,6 @@
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { isMap } from '../predicate/isMap.ts';
+import { isSet } from '../predicate/isSet.ts';
 
 /**
  * Converts a record or null/undefined to an array of its values.
@@ -54,7 +55,7 @@ export function toArray(value?: unknown): any[] {
     return [];
   }
 
-  if (isArrayLike(value) || isMap(value)) {
+  if (isArrayLike(value) || isMap(value) || isSet(value)) {
     return Array.from(value);
   }
 


### PR DESCRIPTION
`toArray` returns an empty array for a `Set`, which diverges from lodash. `toArray(new Set([1, 2, 3]))` gives `[]` in `es-toolkit/compat` but `[1, 2, 3]` in lodash.

The cause is in the type dispatch: the function handles array-likes and `Map` via `Array.from`, then falls through to `Object.values` for everything else. A `Set` isn't array-like and isn't a `Map`, so it hits `Object.values`, which only returns own enumerable properties — and a `Set` keeps its elements internally, so the result is always `[]` regardless of contents.

The fix adds `isSet` to the same branch that already handles `Map`. `Array.from` already knows how to drain any iterable, so a `Set` flows through the identical path and produces its members, matching lodash's `setToArray`. Added a `Set` case to the spec alongside the existing `Map` test.
