### PR TITLE
refactor(compat/dropRightWhile): align implementation predicate param type with docs

### DIFF
--- a/src/compat/array/dropRightWhile.ts
+++ b/src/compat/array/dropRightWhile.ts
@@ -59,14 +59,7 @@ export function dropRightWhile<T>(array: ArrayLike<T> | null | undefined, predic
  * const result = dropRightWhile(array, (item, index, arr) => index >= 1);
  * // Returns: [3]
  */
-export function dropRightWhile<T>(
-  array: ArrayLike<T> | null | undefined,
-  predicate:
-    | ((item: T, index: number, array: readonly T[]) => unknown)
-    | Partial<T>
-    | [keyof T, unknown]
-    | PropertyKey = identity
-): T[] {
+export function dropRightWhile<T>(array: ArrayLike<T> | null | undefined, predicate: ListIteratee<T> = identity): T[] {
   if (!isArrayLike(array)) {
     return [];
   }
@@ -74,10 +67,7 @@ export function dropRightWhile<T>(
   return dropRightWhileImpl(toArray(array), predicate);
 }
 
-function dropRightWhileImpl<T>(
-  arr: readonly T[],
-  predicate: ((item: T, index: number, arr: readonly T[]) => unknown) | Partial<T> | [keyof T, unknown] | PropertyKey
-): T[] {
+function dropRightWhileImpl<T>(arr: readonly T[], predicate: ListIteratee<T>): T[] {
   switch (typeof predicate) {
     case 'function': {
       return dropRightWhileToolkit(arr, (item, index, arr) => Boolean(predicate(item, index, arr)));


### PR DESCRIPTION
## Summary

I think we can also change the implementation signature of dropRightWhile to use ListIteratee, just like dropWhile. Interestingly, it looks like the documentation has already been updated to reflect this 😅

https://es-toolkit.dev/ko/compat/reference/array/dropRightWhile.html#%E1%84%91%E1%85%A1%E1%84%85%E1%85%A1%E1%84%86%E1%85%B5%E1%84%90%E1%85%A5

<img width="613" height="123" alt="스크린샷 2026-07-06 오후 5 47 17" src="https://github.com/user-attachments/assets/b3624bef-984a-4b9c-84ec-6a468250555b" />
