### PR TITLE
fix(compat/flattenDepth): move flattening logic from flatten to flattenDepth

### DIFF
--- a/docs/compat/reference/array/flatten.md
+++ b/docs/compat/reference/array/flatten.md
@@ -11,14 +11,14 @@ Use the faster and more modern [flatten](../../../reference/array/flatten.md) fr
 Flattens an array by one level.
 
 ```typescript
-const result = flatten(array, depth);
+const result = flatten(array);
 ```
 
 ## Usage
 
-### `flatten(value, depth)`
+### `flatten(array)`
 
-Flattens a nested array by the specified depth. By default, it flattens only one level, and also supports Arguments objects and objects with Symbol.isConcatSpreadable.
+Flattens a nested array by one level.
 
 ```typescript
 import { flatten } from 'es-toolkit/compat';
@@ -27,19 +27,20 @@ import { flatten } from 'es-toolkit/compat';
 flatten([1, [2, [3, [4]], 5]]);
 // Result: [1, 2, [3, [4]], 5]
 
-// Specify depth
-flatten([1, [2, [3, [4]], 5]], 2);
-// Result: [1, 2, 3, [4], 5]
-
 // Support for Arguments objects
 function example() {
   return flatten(arguments);
 }
 example(1, [2, 3], [[4]]);
 // Result: [1, 2, 3, [4]]
+
+// Support for objects with Symbol.isConcatSpreadable
+const spreadable = { 0: 'a', 1: 'b', length: 2, [Symbol.isConcatSpreadable]: true };
+flatten([1, spreadable, 3]);
+// Result: [1, 'a', 'b', 3]
 ```
 
-Empty arrays, null, or undefined return empty arrays.
+`null` or `undefined` are treated as empty arrays.
 
 ```typescript
 import { flatten } from 'es-toolkit/compat';
@@ -49,20 +50,9 @@ flatten(undefined); // []
 flatten([]); // []
 ```
 
-Objects with Symbol.isConcatSpreadable are also flattened like arrays.
-
-```typescript
-import { flatten } from 'es-toolkit/compat';
-
-const spreadable = { 0: 'a', 1: 'b', length: 2, [Symbol.isConcatSpreadable]: true };
-flatten([1, spreadable, 3]);
-// Result: [1, 'a', 'b', 3]
-```
-
 #### Parameters
 
-- `value` (`ArrayLike<T> | null | undefined`): The array to flatten.
-- `depth` (`number`, optional): The maximum depth to flatten. Default is `1`.
+- `array` (`ArrayLike<T> | null | undefined`): The array to flatten.
 
 #### Returns
 

--- a/docs/compat/reference/array/flattenDeep.md
+++ b/docs/compat/reference/array/flattenDeep.md
@@ -36,7 +36,7 @@ flattenDeep(['a', ['b', ['c', [['d']]]]]);
 // Result: ['a', 'b', 'c', 'd']
 ```
 
-Empty arrays, null, or undefined return empty arrays.
+`null` or `undefined` are treated as empty arrays.
 
 ```typescript
 import { flattenDeep } from 'es-toolkit/compat';

--- a/docs/compat/reference/array/flattenDepth.md
+++ b/docs/compat/reference/array/flattenDepth.md
@@ -16,7 +16,7 @@ const flattened = flattenDepth(array, depth);
 
 ## Usage
 
-### `flattenDepth(array, depth)`
+### `flattenDepth(array, depth?)`
 
 Use `flattenDepth` when you want to flatten a nested array to a desired depth. When you specify a depth, it flattens the nested array only to that depth.
 
@@ -47,7 +47,7 @@ flattenDepth(undefined, 2); // []
 
 #### Parameters
 
-- `array` (`ArrayLike<T> | null | undefined`): The array to flatten.
+- `array` (`ListOfRecursiveArraysOrValues<T> | null | undefined`): The array to flatten.
 - `depth` (`number`, optional): The maximum depth to flatten. Default is `1`.
 
 #### Returns

--- a/docs/ja/compat/reference/array/flatten.md
+++ b/docs/ja/compat/reference/array/flatten.md
@@ -11,14 +11,14 @@
 配列を1段階平坦化します。
 
 ```typescript
-const result = flatten(array, depth);
+const result = flatten(array);
 ```
 
 ## 使用法
 
-### `flatten(value, depth)`
+### `flatten(array)`
 
-ネストされた配列を指定された深さだけ平坦化します。デフォルトでは1段階のみ平坦化し、ArgumentsオブジェクトやSymbol.isConcatSpreadableを持つオブジェクトもサポートします。
+ネストされた配列を1段階平坦化します。
 
 ```typescript
 import { flatten } from 'es-toolkit/compat';
@@ -27,19 +27,20 @@ import { flatten } from 'es-toolkit/compat';
 flatten([1, [2, [3, [4]], 5]]);
 // 結果: [1, 2, [3, [4]], 5]
 
-// 深さを指定
-flatten([1, [2, [3, [4]], 5]], 2);
-// 結果: [1, 2, 3, [4], 5]
-
 // Argumentsオブジェクトのサポート
 function example() {
   return flatten(arguments);
 }
 example(1, [2, 3], [[4]]);
 // 結果: [1, 2, 3, [4]]
+
+// Symbol.isConcatSpreadableを持つオブジェクトのサポート
+const spreadable = { 0: 'a', 1: 'b', length: 2, [Symbol.isConcatSpreadable]: true };
+flatten([1, spreadable, 3]);
+// 結果: [1, 'a', 'b', 3]
 ```
 
-空の配列やnull、undefinedは空の配列を返します。
+`null`や`undefined`は空の配列として処理されます。
 
 ```typescript
 import { flatten } from 'es-toolkit/compat';
@@ -49,20 +50,9 @@ flatten(undefined); // []
 flatten([]); // []
 ```
 
-Symbol.isConcatSpreadableを持つオブジェクトも配列のように平坦化されます。
-
-```typescript
-import { flatten } from 'es-toolkit/compat';
-
-const spreadable = { 0: 'a', 1: 'b', length: 2, [Symbol.isConcatSpreadable]: true };
-flatten([1, spreadable, 3]);
-// 結果: [1, 'a', 'b', 3]
-```
-
 #### パラメータ
 
-- `value` (`ArrayLike<T> | null | undefined`): 平坦化する配列です。
-- `depth` (`number`, オプション): 平坦化する最大深さです。デフォルトは`1`です。
+- `array` (`ArrayLike<T> | null | undefined`): 平坦化する配列です。
 
 #### 戻り値
 

--- a/docs/ja/compat/reference/array/flattenDeep.md
+++ b/docs/ja/compat/reference/array/flattenDeep.md
@@ -36,7 +36,7 @@ flattenDeep(['a', ['b', ['c', [['d']]]]]);
 // 結果: ['a', 'b', 'c', 'd']
 ```
 
-空の配列やnull、undefinedは空の配列を返します。
+`null`や`undefined`は空の配列として処理されます。
 
 ```typescript
 import { flattenDeep } from 'es-toolkit/compat';

--- a/docs/ja/compat/reference/array/flattenDepth.md
+++ b/docs/ja/compat/reference/array/flattenDepth.md
@@ -16,7 +16,7 @@ const flattened = flattenDepth(array, depth);
 
 ## 使用法
 
-### `flattenDepth(array, depth)`
+### `flattenDepth(array, depth?)`
 
 ネストされた配列を望む深さまで平坦化したい場合は`flattenDepth`を使用してください。深さを指定すると、その深さまでのみネストされた配列を平坦化します。
 
@@ -47,7 +47,7 @@ flattenDepth(undefined, 2); // []
 
 #### パラメータ
 
-- `array` (`ArrayLike<T> | null | undefined`): 平坦化する配列です。
+- `array` (`ListOfRecursiveArraysOrValues<T> | null | undefined`): 平坦化する配列です。
 - `depth` (`number`, オプション): 平坦化する最大深さです。デフォルトは`1`です。
 
 #### 戻り値

--- a/docs/ko/compat/reference/array/flatten.md
+++ b/docs/ko/compat/reference/array/flatten.md
@@ -11,14 +11,14 @@
 배열을 한 단계 평탄화해요.
 
 ```typescript
-const result = flatten(array, depth);
+const result = flatten(array);
 ```
 
 ## 사용법
 
-### `flatten(value, depth)`
+### `flatten(array)`
 
-중첩 배열을 지정된 깊이만큼 평탄화해요. 기본적으로 한 단계만 평탄화하며, Arguments 객체나 Symbol.isConcatSpreadable을 가진 객체도 지원해요.
+중첩 배열을 한 단계 평탄화해요.
 
 ```typescript
 import { flatten } from 'es-toolkit/compat';
@@ -27,19 +27,20 @@ import { flatten } from 'es-toolkit/compat';
 flatten([1, [2, [3, [4]], 5]]);
 // 결과: [1, 2, [3, [4]], 5]
 
-// 깊이 지정
-flatten([1, [2, [3, [4]], 5]], 2);
-// 결과: [1, 2, 3, [4], 5]
-
 // Arguments 객체 지원
 function example() {
   return flatten(arguments);
 }
 example(1, [2, 3], [[4]]);
 // 결과: [1, 2, 3, [4]]
+
+// Symbol.isConcatSpreadable을 가진 객체 지원
+const spreadable = { 0: 'a', 1: 'b', length: 2, [Symbol.isConcatSpreadable]: true };
+flatten([1, spreadable, 3]);
+// 결과: [1, 'a', 'b', 3]
 ```
 
-빈 배열이나 null, undefined는 빈 배열을 반환해요.
+`null`이나 `undefined`는 빈 배열로 처리해요.
 
 ```typescript
 import { flatten } from 'es-toolkit/compat';
@@ -49,20 +50,9 @@ flatten(undefined); // []
 flatten([]); // []
 ```
 
-Symbol.isConcatSpreadable을 가진 객체도 배열처럼 평탄화돼요.
-
-```typescript
-import { flatten } from 'es-toolkit/compat';
-
-const spreadable = { 0: 'a', 1: 'b', length: 2, [Symbol.isConcatSpreadable]: true };
-flatten([1, spreadable, 3]);
-// 결과: [1, 'a', 'b', 3]
-```
-
 #### 파라미터
 
-- `value` (`ArrayLike<T> | null | undefined`): 평탄화할 배열이에요.
-- `depth` (`number`, 선택): 평탄화할 최대 깊이예요. 기본값은 `1`이에요.
+- `array` (`ArrayLike<T> | null | undefined`): 평탄화할 배열이에요.
 
 #### 반환 값
 

--- a/docs/ko/compat/reference/array/flattenDeep.md
+++ b/docs/ko/compat/reference/array/flattenDeep.md
@@ -36,7 +36,7 @@ flattenDeep(['a', ['b', ['c', [['d']]]]]);
 // 결과: ['a', 'b', 'c', 'd']
 ```
 
-빈 배열이나 null, undefined는 빈 배열을 반환해요.
+`null`이나 `undefined`는 빈 배열로 처리해요.
 
 ```typescript
 import { flattenDeep } from 'es-toolkit/compat';

--- a/docs/ko/compat/reference/array/flattenDepth.md
+++ b/docs/ko/compat/reference/array/flattenDepth.md
@@ -16,7 +16,7 @@ const flattened = flattenDepth(array, depth);
 
 ## 사용법
 
-### `flattenDepth(array, depth)`
+### `flattenDepth(array, depth?)`
 
 중첩된 배열을 원하는 깊이까지 평탄화하고 싶을 때 `flattenDepth`를 사용하세요. 깊이를 지정하면 그 깊이까지만 중첩된 배열을 평탄화해요.
 
@@ -47,7 +47,7 @@ flattenDepth(undefined, 2); // []
 
 #### 파라미터
 
-- `array` (`ArrayLike<T> | null | undefined`): 평탄화할 배열이에요.
+- `array` (`ListOfRecursiveArraysOrValues<T> | null | undefined`): 평탄화할 배열이에요.
 - `depth` (`number`, 선택): 평탄화할 최대 깊이예요. 기본값은 `1`이에요.
 
 #### 반환 값

--- a/docs/zh_hans/compat/reference/array/flatten.md
+++ b/docs/zh_hans/compat/reference/array/flatten.md
@@ -11,14 +11,14 @@
 将数组展平一层。
 
 ```typescript
-const result = flatten(array, depth);
+const result = flatten(array);
 ```
 
 ## 用法
 
-### `flatten(value, depth)`
+### `flatten(array)`
 
-按指定深度展平嵌套数组。默认情况下只展平一层,并且还支持 Arguments 对象和具有 Symbol.isConcatSpreadable 的对象。
+将嵌套数组展平一层。
 
 ```typescript
 import { flatten } from 'es-toolkit/compat';
@@ -27,19 +27,20 @@ import { flatten } from 'es-toolkit/compat';
 flatten([1, [2, [3, [4]], 5]]);
 // 结果: [1, 2, [3, [4]], 5]
 
-// 指定深度
-flatten([1, [2, [3, [4]], 5]], 2);
-// 结果: [1, 2, 3, [4], 5]
-
 // 支持 Arguments 对象
 function example() {
   return flatten(arguments);
 }
 example(1, [2, 3], [[4]]);
 // 结果: [1, 2, 3, [4]]
+
+// 支持具有 Symbol.isConcatSpreadable 的对象
+const spreadable = { 0: 'a', 1: 'b', length: 2, [Symbol.isConcatSpreadable]: true };
+flatten([1, spreadable, 3]);
+// 结果: [1, 'a', 'b', 3]
 ```
 
-空数组、null 或 undefined 返回空数组。
+`null` 或 `undefined` 被视为空数组。
 
 ```typescript
 import { flatten } from 'es-toolkit/compat';
@@ -49,20 +50,9 @@ flatten(undefined); // []
 flatten([]); // []
 ```
 
-具有 Symbol.isConcatSpreadable 的对象也像数组一样被展平。
-
-```typescript
-import { flatten } from 'es-toolkit/compat';
-
-const spreadable = { 0: 'a', 1: 'b', length: 2, [Symbol.isConcatSpreadable]: true };
-flatten([1, spreadable, 3]);
-// 结果: [1, 'a', 'b', 3]
-```
-
 #### 参数
 
-- `value` (`ArrayLike<T> | null | undefined`): 要展平的数组。
-- `depth` (`number`, 可选): 要展平的最大深度。默认为 `1`。
+- `array` (`ArrayLike<T> | null | undefined`): 要展平的数组。
 
 #### 返回值
 

--- a/docs/zh_hans/compat/reference/array/flattenDeep.md
+++ b/docs/zh_hans/compat/reference/array/flattenDeep.md
@@ -36,7 +36,7 @@ flattenDeep(['a', ['b', ['c', [['d']]]]]);
 // 结果: ['a', 'b', 'c', 'd']
 ```
 
-空数组、null 或 undefined 返回空数组。
+`null` 或 `undefined` 被视为空数组。
 
 ```typescript
 import { flattenDeep } from 'es-toolkit/compat';

--- a/docs/zh_hans/compat/reference/array/flattenDepth.md
+++ b/docs/zh_hans/compat/reference/array/flattenDepth.md
@@ -16,7 +16,7 @@ const flattened = flattenDepth(array, depth);
 
 ## 用法
 
-### `flattenDepth(array, depth)`
+### `flattenDepth(array, depth?)`
 
 当您想将嵌套数组展平到所需深度时使用 `flattenDepth`。指定深度后,它只会将嵌套数组展平到该深度。
 
@@ -47,7 +47,7 @@ flattenDepth(undefined, 2); // []
 
 #### 参数
 
-- `array` (`ArrayLike<T> | null | undefined`): 要展平的数组。
+- `array` (`ListOfRecursiveArraysOrValues<T> | null | undefined`): 要展平的数组。
 - `depth` (`number`, 可选): 要展平的最大深度。默认为 `1`。
 
 #### 返回值

--- a/src/compat/array/flatMapDepth.ts
+++ b/src/compat/array/flatMapDepth.ts
@@ -1,4 +1,4 @@
-import { flatten } from './flatten.ts';
+import { flattenDepth } from './flattenDepth.ts';
 import { map } from './map.ts';
 import { identity } from '../../function/identity.ts';
 import { ListIterator } from '../_internal/ListIterator.ts';
@@ -140,5 +140,5 @@ export function flatMapDepth<T, R>(
   const iterateeFn = createIteratee(iteratee);
   const mapped = map(collection, iterateeFn);
 
-  return (flatten as any)(mapped, depth);
+  return flattenDepth(mapped, depth);
 }

--- a/src/compat/array/flatten.ts
+++ b/src/compat/array/flatten.ts
@@ -1,48 +1,17 @@
-import { isArrayLike } from '../predicate/isArrayLike.ts';
+import { flattenDepth } from './flattenDepth.ts';
+import { ListOfRecursiveArraysOrValues } from '../_internal/ListOfRecursiveArraysOrValues.ts';
 
 /**
  * Flattens array up to depth times.
  *
  * @template T
- * @param value - The array to flatten.
- * @param depth - The maximum recursion depth.
+ * @param array - The array to flatten.
  * @returns Returns the new flattened array.
  *
  * @example
- * flatten([1, [2, [3, [4]], 5]], 2);
- * // => [1, 2, 3, [4], 5]
+ * flatten([1, [2, [3, [4]], 5]]);
+ * // => [1, 2, [3, [4]], 5]
  */
-export function flatten<T>(value: ArrayLike<T | readonly T[]> | null | undefined): T[];
-
-export function flatten<T>(value: ArrayLike<T | readonly T[]> | null | undefined, depth = 1): T[] {
-  const result: T[] = [];
-  const flooredDepth = Math.floor(depth);
-
-  if (!isArrayLike(value)) {
-    return result as T[];
-  }
-
-  const recursive = (arr: readonly T[], currentDepth: number) => {
-    for (let i = 0; i < arr.length; i++) {
-      const item = arr[i];
-      if (
-        currentDepth < flooredDepth &&
-        (Array.isArray(item) ||
-          Boolean(item?.[Symbol.isConcatSpreadable as keyof object]) ||
-          (item !== null && typeof item === 'object' && Object.prototype.toString.call(item) === '[object Arguments]'))
-      ) {
-        if (Array.isArray(item)) {
-          recursive(item, currentDepth + 1);
-        } else {
-          recursive(Array.from(item as T[]), currentDepth + 1);
-        }
-      } else {
-        result.push(item);
-      }
-    }
-  };
-
-  recursive(Array.from(value) as any, 0);
-
-  return result;
+export function flatten<T>(array: ArrayLike<T | readonly T[]> | null | undefined): T[] {
+  return flattenDepth(array as ListOfRecursiveArraysOrValues<T> | null | undefined, 1);
 }

--- a/src/compat/array/flattenDeep.ts
+++ b/src/compat/array/flattenDeep.ts
@@ -13,7 +13,7 @@ import { ListOfRecursiveArraysOrValues } from '../_internal/ListOfRecursiveArray
  * // => [1, 2, 3, 4, 5]
  */
 export function flattenDeep<T>(
-  value: ListOfRecursiveArraysOrValues<T> | null | undefined
+  array: ListOfRecursiveArraysOrValues<T> | null | undefined
 ): Array<T extends string ? T : T extends ArrayLike<any> ? never : T> {
-  return flattenDepth(value, Infinity) as any;
+  return flattenDepth(array, Infinity) as any;
 }

--- a/src/compat/array/flattenDepth.ts
+++ b/src/compat/array/flattenDepth.ts
@@ -1,5 +1,7 @@
-import { flatten } from './flatten.ts';
 import { ListOfRecursiveArraysOrValues } from '../_internal/ListOfRecursiveArraysOrValues.ts';
+import { isArguments } from '../predicate/isArguments.ts';
+import { isArray } from '../predicate/isArray.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
  * Recursively flattens array up to depth times.
@@ -19,5 +21,28 @@ import { ListOfRecursiveArraysOrValues } from '../_internal/ListOfRecursiveArray
  * // => [1, 2, 3, [4], 5]
  */
 export function flattenDepth<T>(array: ListOfRecursiveArraysOrValues<T> | null | undefined, depth = 1): T[] {
-  return (flatten as any)(array, depth) as T[];
+  if (!isArrayLike(array)) {
+    return [];
+  }
+  const result: T[] = [];
+  const flooredDepth = Math.floor(depth);
+
+  const recursive = (arr: readonly T[], currentDepth: number) => {
+    for (let i = 0; i < arr.length; i++) {
+      const item = arr[i];
+      if (isFlattenable(item) && currentDepth < flooredDepth) {
+        recursive(item as T[], currentDepth + 1);
+      } else {
+        result.push(item);
+      }
+    }
+  };
+
+  recursive(Array.from(array) as T[], 0);
+
+  return result;
+}
+
+function isFlattenable(value: unknown): boolean {
+  return isArray(value) || isArguments(value) || Boolean(value && (value as any)[Symbol.isConcatSpreadable]);
 }


### PR DESCRIPTION
## Summary

Previously, `flatten` behaved the same as `flattenDepth`.
Remove the depth parameter from `flatten` and delegate its behavior to `flattenDepth`.

## Change

### flatten

- Remove the `depth` parameter.
- Remove the internal implementation and delegate all behavior to `flattenDepth`.

### flattenDeep

- Rename the parameter to array.( for consistency)

### flattenDepth

It previously acted as a wrapper around `flatten` 😂
- Move the actual flattening logic from `flatten` into `flattenDepth`.