### PR TITLE
docs(compat/flatMap): add default iteratee value across all languages

### DIFF
--- a/docs/compat/reference/array/flatMap.md
+++ b/docs/compat/reference/array/flatMap.md
@@ -70,7 +70,7 @@ flatMap(users, { active: false });
 #### Parameters
 
 - `collection` (`object | null | undefined`): The collection to iterate over. Can be an array, object, or string.
-- `iteratee` (`ListIterator | ObjectIterator | string | object`, optional): The iteratee to apply to each element. Can be a function, property name, or partial object. Default is `identity`
+- `iteratee` (`ListIterator | ObjectIterator | string | object`, optional): The iteratee to apply to each element. Can be a function, property name, or partial object. Defaults to `identity`.
 
 #### Returns
 

--- a/docs/compat/reference/array/flatMap.md
+++ b/docs/compat/reference/array/flatMap.md
@@ -70,7 +70,7 @@ flatMap(users, { active: false });
 #### Parameters
 
 - `collection` (`object | null | undefined`): The collection to iterate over. Can be an array, object, or string.
-- `iteratee` (`ListIterator | ObjectIterator | string | object`, optional): The iteratee to apply to each element. Can be a function, property name, or partial object.
+- `iteratee` (`ListIterator | ObjectIterator | string | object`, optional): The iteratee to apply to each element. Can be a function, property name, or partial object. Default is `identity`
 
 #### Returns
 

--- a/docs/ja/compat/reference/array/flatMap.md
+++ b/docs/ja/compat/reference/array/flatMap.md
@@ -70,7 +70,7 @@ flatMap(users, { active: false });
 #### パラメータ
 
 - `collection` (`object | null | undefined`): 反復処理するコレクションです。配列、オブジェクト、文字列が可能です。
-- `iteratee` (`ListIterator | ObjectIterator | string | object`, オプション): 各要素に適用するイテレータです。関数、プロパティ名、または部分オブジェクトが可能です。
+- `iteratee` (`ListIterator | ObjectIterator | string | object`, オプション): 各要素に適用するイテレータです。関数、プロパティ名、または部分オブジェクトが可能です。デフォルトは `identity` です。
 
 #### 戻り値
 

--- a/docs/ko/compat/reference/array/flatMap.md
+++ b/docs/ko/compat/reference/array/flatMap.md
@@ -70,7 +70,7 @@ flatMap(users, { active: false });
 #### 파라미터
 
 - `collection` (`object | null | undefined`): 순회할 컬렉션이에요. 배열, 객체, 문자열이 될 수 있어요.
-- `iteratee` (`ListIterator | ObjectIterator | string | object`, 선택): 각 요소에 적용할 반복자예요. 함수, 속성 이름, 또는 부분 객체가 될 수 있어요.
+- `iteratee` (`ListIterator | ObjectIterator | string | object`, 선택): 각 요소에 적용할 반복자예요. 함수, 속성 이름, 또는 부분 객체가 될 수 있어요. 기본값은 `identity`예요.
 
 #### 반환 값
 

--- a/docs/zh_hans/compat/reference/array/flatMap.md
+++ b/docs/zh_hans/compat/reference/array/flatMap.md
@@ -70,7 +70,7 @@ flatMap(users, { active: false });
 #### 参数
 
 - `collection` (`object | null | undefined`): 要迭代的集合。可以是数组、对象或字符串。
-- `iteratee` (`ListIterator | ObjectIterator | string | object`, 可选): 应用于每个元素的迭代器。可以是函数、属性名或部分对象。
+- `iteratee` (`ListIterator | ObjectIterator | string | object`, 可选): 应用于每个元素的迭代器。可以是函数、属性名或部分对象。默认值为 `identity`。
 
 #### 返回值
 

--- a/src/compat/array/flatMap.ts
+++ b/src/compat/array/flatMap.ts
@@ -1,5 +1,6 @@
 import { flattenDepth } from './flattenDepth.ts';
 import { map } from './map.ts';
+import { identity } from '../../function/identity.ts';
 import { isNil } from '../../predicate/isNil.ts';
 import { ListIterator } from '../_internal/ListIterator.ts';
 import { Many } from '../_internal/Many.ts';
@@ -106,14 +107,14 @@ export function flatMap(collection: object | null | undefined, iteratee: object)
  *
  * @template R
  * @param collection - The collection to iterate over.
- * @param [iteratee] - The function invoked per iteration.
+ * @param [iteratee=identity] - The function invoked per iteration.
  * @returns Returns the new flattened array.
  *
  * @example
  * flatMap([1, 2], n => [n, n * 2]);
  * // => [1, 2, 2, 4]
  */
-export function flatMap<R = any>(collection: object | null | undefined, iteratee?: any): R[] {
+export function flatMap<R = any>(collection: object | null | undefined, iteratee: any = identity): R[] {
   if (isNil(collection)) {
     return [];
   }


### PR DESCRIPTION
## Summary

The behavior looks correct, but it seems like the default value for iteratee is missing 😅

<img width="1189" height="643" alt="스크린샷 2026-07-07 오후 6 57 34" src="https://github.com/user-attachments/assets/c8e98890-8053-4e19-8667-1166500ec803" />
