### PR TITLE
fix(compat): count string size by code points for multi-byte characters

### DIFF
--- a/src/compat/array/size.spec.ts
+++ b/src/compat/array/size.spec.ts
@@ -66,6 +66,11 @@ describe('size', () => {
     expect(size(str)).toBe(10);
   });
 
+  it('should count multi-byte characters in a string as single code points', () => {
+    expect(size('😀😁😂')).toBe(3);
+    expect(size('a😀b')).toBe(3);
+  });
+
   it('should return the `length` of array-like objects', () => {
     expect(size({ length: 3 })).toBe(3);
     expect(size({ 0: 'a', 1: 'b', length: 2 })).toBe(2);

--- a/src/compat/array/size.ts
+++ b/src/compat/array/size.ts
@@ -1,6 +1,9 @@
 import { isNil } from '../../predicate/isNil.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
+// eslint-disable-next-line no-misleading-character-class
+const regexMultiByte = /[\u200d\ud800-\udfff\u0300-\u036f\ufe20-\ufe2f\u20d0-\u20ff\ufe0e\ufe0f]/;
+
 /**
  * Returns the length of an array, string, or object.
  *
@@ -46,6 +49,10 @@ export function size(collection: object | string | null | undefined): number;
 export function size(target: any): number {
   if (isNil(target)) {
     return 0;
+  }
+
+  if (typeof target === 'string') {
+    return regexMultiByte.test(target) ? Array.from(target).length : target.length;
   }
 
   if (isArrayLike(target)) {


### PR DESCRIPTION
`size` returns `String#length` for strings — the number of UTF-16 code units — so a string with astral characters is over-counted:

```js
size('😀😁😂') // 6  (expected 3)
size('a😀b')   // 4  (expected 3)
```

Count strings by Unicode code points, matching lodash and the existing `truncate` handling. Strings without multi-byte characters keep using `length` to avoid the extra allocation.
