### PR TITLE
refactor(compat): extract regexMultiByte into shared _internal constant

### DIFF
--- a/src/compat/_internal/createPadding.ts
+++ b/src/compat/_internal/createPadding.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-misleading-character-class
-const regexMultiByte = /[\u200d\ud800-\udfff\u0300-\u036f\ufe20-\ufe2f\u20d0-\u20ff\ufe0e\ufe0f]/;
+import { regexMultiByte } from './regexMultiByte.ts';
 
 export function stringSize(str: string): number {
   return regexMultiByte.test(str) ? Array.from(str).length : str.length;

--- a/src/compat/_internal/regexMultiByte.ts
+++ b/src/compat/_internal/regexMultiByte.ts
@@ -1,0 +1,12 @@
+/**
+ * Used to compose unicode character classes.
+ * @link https://github.com/lodash/lodash/blob/4.17.21-es/_hasUnicode.js
+ *
+ * Used to detect strings with zero-width joiners or code points from the astral planes.
+ * @link http://eev.ee/blog/2015/09/12/dark-corners-of-unicode/
+ */
+
+export const regexMultiByte = new RegExp(
+  // eslint-disable-next-line no-misleading-character-class
+  '[\\u200d\\ud800-\\udfff\\u0300-\\u036f\\ufe20-\\ufe2f\\u20d0-\\u20ff\\ufe0e\\ufe0f]'
+);

--- a/src/compat/array/size.ts
+++ b/src/compat/array/size.ts
@@ -1,8 +1,6 @@
 import { isNil } from '../../predicate/isNil.ts';
+import { regexMultiByte } from '../_internal/regexMultiByte.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
-
-// eslint-disable-next-line no-misleading-character-class
-const regexMultiByte = /[\u200d\ud800-\udfff\u0300-\u036f\ufe20-\ufe2f\u20d0-\u20ff\ufe0e\ufe0f]/;
 
 /**
  * Returns the length of an array, string, or object.

--- a/src/compat/string/truncate.ts
+++ b/src/compat/string/truncate.ts
@@ -1,3 +1,4 @@
+import { regexMultiByte } from '../_internal/regexMultiByte.ts';
 import { isObject } from '../predicate/isObject.ts';
 
 type TruncateOptions = {
@@ -5,16 +6,6 @@ type TruncateOptions = {
   separator?: string | RegExp;
   omission?: string;
 };
-
-/**
- * Used to compose unicode character classes.
- * @link https://github.com/lodash/lodash/blob/4.17.21-es/_hasUnicode.js
- *
- * Used to detect strings with zero-width joiners or code points from the astral planes.
- * @link http://eev.ee/blog/2015/09/12/dark-corners-of-unicode/
- */
-// eslint-disable-next-line no-misleading-character-class
-const regexMultiByte = /[\u200d\ud800-\udfff\u0300-\u036f\ufe20-\ufe2f\u20d0-\u20ff\ufe0e\ufe0f]/;
 
 /**
  * This regex might more completely detect unicode, but it is slower and this project


### PR DESCRIPTION
## Changes

The same `regexMultiByte` regex (used to detect strings containing multi-byte characters, such as surrogate pairs, combining marks, zero-width joiners, and variation selectors) was duplicated in three places. This PR extracts it into a shared `src/compat/_internal/regexMultiByte.ts` constant:

- `src/compat/string/truncate.ts`
- `src/compat/array/size.ts`
- `src/compat/_internal/createPadding.ts`

## Test

- `yarn vitest run` passes for `truncate`, `size`, `pad`, `padStart`, `padEnd` specs
- `yarn lint` and `yarn tsc --noEmit` pass
