### PR TITLE
refactor(benchmarks): remove import reassignment workaround by disabling vite module runner

### DIFF
--- a/.scripts/generate-benchmark.mjs
+++ b/.scripts/generate-benchmark.mjs
@@ -60,16 +60,19 @@ async function main() {
   };
 
   for (const funcName of funcNames) {
-    const benchFile = `benchmarks/performance/${funcName}.bench.ts`;
+    const benchFile = `${funcName}.bench.ts`;
     const tempJsonPath = path.join(TEMP_DIR, `${funcName}.json`);
 
     console.log(`Running benchmark: ${funcName}`);
 
     try {
-      await execAsync(`yarn vitest bench ${benchFile} --run --reporter=default --outputJson=${tempJsonPath}`, {
-        cwd: ROOT,
-        maxBuffer: 1024 * 1024 * 10,
-      });
+      await execAsync(
+        `yarn workspace benchmarks bench ${benchFile} --run --reporter=default --outputJson=${tempJsonPath}`,
+        {
+          cwd: ROOT,
+          maxBuffer: 1024 * 1024 * 10,
+        }
+      );
 
       const rawData = await fs.readFile(tempJsonPath, 'utf8');
       const benchData = JSON.parse(rawData);

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -2,6 +2,7 @@
   "name": "benchmarks",
   "private": true,
   "scripts": {
+    "bench": "vitest bench --root performance",
     "check-bundle-size": "vitest run --update bundle-size"
   },
   "dependencies": {
@@ -10,7 +11,7 @@
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
     "remeda": "^2.39.0",
-    "vitest": "4.0.17"
+    "vitest": "4.1.10"
   },
   "devDependencies": {
     "@types/lodash": "4.17.20",

--- a/benchmarks/performance/add.bench.ts
+++ b/benchmarks/performance/add.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { add as addToolkitCompat_ } from 'es-toolkit/compat';
-import { add as addLodash_ } from 'lodash';
+import { add as addToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const addToolkitCompat = addToolkitCompat_;
-const addLodash = addLodash_;
+const { add: addLodash } = lodash;
 
 describe('add function benchmark', () => {
   bench('es-toolkit/compat/add', () => {

--- a/benchmarks/performance/after.bench.ts
+++ b/benchmarks/performance/after.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { after as afterToolkit_ } from 'es-toolkit';
-import { after as afterCompatToolkit_ } from 'es-toolkit/compat';
-import { after as afterLodash_ } from 'lodash';
+import { after as afterToolkit } from 'es-toolkit';
+import { after as afterCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const afterToolkit = afterToolkit_;
-const afterCompatToolkit = afterCompatToolkit_;
-const afterLodash = afterLodash_;
+const { after: afterLodash } = lodash;
 
 describe('after', () => {
   bench('es-toolkit/after', () => {

--- a/benchmarks/performance/ary.bench.ts
+++ b/benchmarks/performance/ary.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { ary as aryToolkit_ } from 'es-toolkit';
-import { ary as aryCompactToolkit_ } from 'es-toolkit/compat';
-import { ary as aryLodash_ } from 'lodash';
+import { ary as aryToolkit } from 'es-toolkit';
+import { ary as aryCompactToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const aryToolkit = aryToolkit_;
-const aryCompactToolkit = aryCompactToolkit_;
-const aryLodash = aryLodash_;
+const { ary: aryLodash } = lodash;
 
 describe('ary', () => {
   bench('es-toolkit/ary', () => {

--- a/benchmarks/performance/assign.bench.ts
+++ b/benchmarks/performance/assign.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { assign as assignCompatToolkit_ } from 'es-toolkit/compat';
-import { assign as assignLodash_ } from 'lodash';
+import { assign as assignToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const assignToolkit = assignCompatToolkit_;
-const assignLodash = assignLodash_;
+const { assign: assignLodash } = lodash;
 
 describe('assign', () => {
   bench('es-toolkit/assign', () => {

--- a/benchmarks/performance/assignIn.bench.ts
+++ b/benchmarks/performance/assignIn.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { assignIn as assignInCompatToolkit_ } from 'es-toolkit/compat';
-import { assignIn as assignInLodash_ } from 'lodash';
+import { assignIn as assignInToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const assignInToolkit = assignInCompatToolkit_;
-const assignInLodash = assignInLodash_;
+const { assignIn: assignInLodash } = lodash;
 
 describe('assignIn', () => {
   bench('es-toolkit/assignIn', () => {

--- a/benchmarks/performance/assignInWith.bench.ts
+++ b/benchmarks/performance/assignInWith.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { assignInWith as assignInWithCompatToolkit_ } from 'es-toolkit/compat';
-import { assignInWith as assignInWithLodash_ } from 'lodash';
+import { assignInWith as assignInWithToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const assignInWithToolkit = assignInWithCompatToolkit_;
-const assignInWithLodash = assignInWithLodash_;
+const { assignInWith: assignInWithLodash } = lodash;
 
 describe('assignInWith', () => {
   bench('es-toolkit/assignInWith', () => {

--- a/benchmarks/performance/assignWith.bench.ts
+++ b/benchmarks/performance/assignWith.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { assignWith as assignWithCompatToolkit_ } from 'es-toolkit/compat';
-import { assignWith as assignWithLodash_ } from 'lodash';
+import { assignWith as assignWithToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const assignWithToolkit = assignWithCompatToolkit_;
-const assignWithLodash = assignWithLodash_;
+const { assignWith: assignWithLodash } = lodash;
 
 describe('assignWith', () => {
   bench('es-toolkit/assignWith', () => {

--- a/benchmarks/performance/at.bench.ts
+++ b/benchmarks/performance/at.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { at as atToolkit_ } from 'es-toolkit';
-import { at as atToolkitCompat_ } from 'es-toolkit/compat';
-import { at as atLodash_ } from 'lodash';
+import { at as atToolkit } from 'es-toolkit';
+import { at as atToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const atToolkit = atToolkit_;
-const atToolkitCompat = atToolkitCompat_;
-const atLodash = atLodash_;
+const { at: atLodash } = lodash;
 
 describe('at', () => {
   const data = ['a', 'b', 'c', 'd', 'e'];

--- a/benchmarks/performance/attempt.bench.ts
+++ b/benchmarks/performance/attempt.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { attempt as attemptToolkit_ } from 'es-toolkit/compat';
-import { attempt as attemptLodash_ } from 'lodash';
+import { attempt as attemptToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const attemptToolkit = attemptToolkit_;
-const attemptLodash = attemptLodash_;
+const { attempt: attemptLodash } = lodash;
 
 describe('attempt', () => {
   bench('es-toolkit/attempt', () => {

--- a/benchmarks/performance/before.bench.ts
+++ b/benchmarks/performance/before.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { before as beforeToolkit_ } from 'es-toolkit';
-import { before as beforeToolkitCompat_ } from 'es-toolkit/compat';
-import { before as beforeLodash_ } from 'lodash';
+import { before as beforeToolkit } from 'es-toolkit';
+import { before as beforeToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const beforeToolkit = beforeToolkit_;
-const beforeToolkitCompat = beforeToolkitCompat_;
-const beforeLodash = beforeLodash_;
+const { before: beforeLodash } = lodash;
 
 describe('before', () => {
   bench(

--- a/benchmarks/performance/bind.bench.ts
+++ b/benchmarks/performance/bind.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { bind as bindToolkit_ } from 'es-toolkit/compat';
-import { bind as bindLodash_ } from 'lodash';
+import { bind as bindToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const bindToolkit = bindToolkit_;
-const bindLodash = bindLodash_;
+const { bind: bindLodash } = lodash;
 
 function fn(this: any) {
   const result = [this];

--- a/benchmarks/performance/bindAll.bench.ts
+++ b/benchmarks/performance/bindAll.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { bindAll as bindAllToolkit_ } from 'es-toolkit/compat';
-import { bindAll as bindAllLodash_ } from 'lodash';
+import { bindAll as bindAllToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const bindAllToolkit = bindAllToolkit_;
-const bindAllLodash = bindAllLodash_;
+const { bindAll: bindAllLodash } = lodash;
 
 const object = {
   greet() {

--- a/benchmarks/performance/bindKey.bench.ts
+++ b/benchmarks/performance/bindKey.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { bindKey as bindKeyToolkit_ } from 'es-toolkit/compat';
-import { bindKey as bindKeyLodash_ } from 'lodash';
+import { bindKey as bindKeyToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const bindKeyToolkit = bindKeyToolkit_;
-const bindKeyLodash = bindKeyLodash_;
+const { bindKey: bindKeyLodash } = lodash;
 
 const object = {
   user: 'fred',

--- a/benchmarks/performance/camelCase.bench.ts
+++ b/benchmarks/performance/camelCase.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { camelCase as camelCaseToolkit_ } from 'es-toolkit';
-import { camelCase as camelCaseToolkitCompat_ } from 'es-toolkit/compat';
-import { camelCase as camelCaseLodash_ } from 'lodash';
+import { camelCase as camelCaseToolkit } from 'es-toolkit';
+import { camelCase as camelCaseToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const camelCaseToolkit = camelCaseToolkit_;
-const camelCaseToolkitCompat = camelCaseToolkitCompat_;
-const camelCaseLodash = camelCaseLodash_;
+const { camelCase: camelCaseLodash } = lodash;
 
 describe('camelCase', () => {
   bench('es-toolkit/camelCase', () => {

--- a/benchmarks/performance/capitalize.bench.ts
+++ b/benchmarks/performance/capitalize.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { capitalize as capitalizeToolkit_ } from 'es-toolkit';
-import { capitalize as capitalizeToolkitCompat_ } from 'es-toolkit/compat';
-import { capitalize as capitalizeLodash_ } from 'lodash';
+import { capitalize as capitalizeToolkit } from 'es-toolkit';
+import { capitalize as capitalizeToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const capitalizeToolkit = capitalizeToolkit_;
-const capitalizeToolkitCompat = capitalizeToolkitCompat_;
-const capitalizeLodash = capitalizeLodash_;
+const { capitalize: capitalizeLodash } = lodash;
 
 describe('capitalize', () => {
   bench('es-toolkit/capitalize', () => {

--- a/benchmarks/performance/castArray.bench.ts
+++ b/benchmarks/performance/castArray.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { castArray as castArrayToolkit_ } from 'es-toolkit/compat';
-import { castArray as castArrayLodash_ } from 'lodash';
+import { castArray as castArrayToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const castArrayToolkit = castArrayToolkit_;
-const castArrayLodash = castArrayLodash_;
+const { castArray: castArrayLodash } = lodash;
 
 describe('castArray', () => {
   bench('es-toolkit/castArray', () => {

--- a/benchmarks/performance/ceil.bench.ts
+++ b/benchmarks/performance/ceil.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { ceil as ceilToolkit_ } from 'es-toolkit/compat';
-import { ceil as ceilLodash_ } from 'lodash';
+import { ceil as ceilToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const ceilToolkit = ceilToolkit_;
-const ceilLodash = ceilLodash_;
+const { ceil: ceilLodash } = lodash;
 
 describe('ceil', () => {
   bench('es-toolkit/ceil', () => {

--- a/benchmarks/performance/chunk.bench.ts
+++ b/benchmarks/performance/chunk.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { chunk as chunkToolkit_ } from 'es-toolkit';
-import { chunk as chunkCompatToolkit_ } from 'es-toolkit/compat';
-import { chunk as chunkLodash_ } from 'lodash';
+import { chunk as chunkToolkit } from 'es-toolkit';
+import { chunk as chunkCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const chunkToolkit = chunkToolkit_;
-const chunkCompatToolkit = chunkCompatToolkit_;
-const chunkLodash = chunkLodash_;
+const { chunk: chunkLodash } = lodash;
 
 describe('chunk', () => {
   bench('lodash/chunk', () => {

--- a/benchmarks/performance/clamp.bench.ts
+++ b/benchmarks/performance/clamp.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { clamp as clampToolkit_ } from 'es-toolkit';
-import { clamp as clampCompatToolkit_ } from 'es-toolkit/compat';
-import { clamp as clampLodash_ } from 'lodash';
+import { clamp as clampToolkit } from 'es-toolkit';
+import { clamp as clampCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const clampToolkit = clampToolkit_;
-const clampCompatToolkit = clampCompatToolkit_;
-const clampLodash = clampLodash_;
+const { clamp: clampLodash } = lodash;
 
 describe('clamp', () => {
   bench('es-toolkit/clamp', () => {

--- a/benchmarks/performance/clone.bench.ts
+++ b/benchmarks/performance/clone.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { clone as cloneToolkit_ } from 'es-toolkit';
-import { clone as cloneToolkitCompat_ } from 'es-toolkit/compat';
-import { clone as cloneLodash_ } from 'lodash';
+import { clone as cloneToolkit } from 'es-toolkit';
+import { clone as cloneToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const cloneToolkit = cloneToolkit_;
-const cloneToolkitCompat = cloneToolkitCompat_;
-const cloneLodash = cloneLodash_;
+const { clone: cloneLodash } = lodash;
 
 const obj = {
   number: 29,

--- a/benchmarks/performance/cloneDeep.bench.ts
+++ b/benchmarks/performance/cloneDeep.bench.ts
@@ -1,16 +1,14 @@
 import { bench, describe } from 'vitest';
-import { cloneDeep as cloneDeepToolkit_ } from 'es-toolkit';
-import { cloneDeep as cloneDeepCompatToolkit_ } from 'es-toolkit/compat';
-import { cloneDeep as cloneDeepLodash_ } from 'lodash';
-import rfdc_ from 'rfdc';
+import { cloneDeep as cloneDeepToolkit } from 'es-toolkit';
+import { cloneDeep as cloneDeepCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
+import createRfdc from 'rfdc';
 
-const cloneDeepToolkit = cloneDeepToolkit_;
-const cloneDeepCompatToolkit = cloneDeepCompatToolkit_;
-const cloneDeepLodash = cloneDeepLodash_;
-const rfdcWithCircle = rfdc_({
+const { cloneDeep: cloneDeepLodash } = lodash;
+const rfdcWithCircle = createRfdc({
   circles: true,
 });
-const rfdc = rfdc_();
+const rfdc = createRfdc();
 
 const obj = {
   number: 29,

--- a/benchmarks/performance/cloneWith.bench.ts
+++ b/benchmarks/performance/cloneWith.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { cloneWith as cloneWithToolkitCompat_ } from 'es-toolkit/compat';
-import { cloneWith as cloneWithLodash_ } from 'lodash';
+import { cloneWith as cloneWithToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const cloneWithLodash = cloneWithLodash_;
-const cloneWithToolkitCompat = cloneWithToolkitCompat_;
+const { cloneWith: cloneWithLodash } = lodash;
 
 const obj = {
   number: 29,

--- a/benchmarks/performance/compact.bench.ts
+++ b/benchmarks/performance/compact.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { compact as compactToolkit_ } from 'es-toolkit';
-import { compact as compactToolkitCompat_ } from 'es-toolkit/compat';
-import { compact as compactLodash_ } from 'lodash';
+import { compact as compactToolkit } from 'es-toolkit';
+import { compact as compactToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const compactToolkit = compactToolkit_;
-const compactToolkitCompat = compactToolkitCompat_;
-const compactLodash = compactLodash_;
+const { compact: compactLodash } = lodash;
 
 describe('compact', () => {
   bench('es-toolkit', () => {

--- a/benchmarks/performance/concat.bench.ts
+++ b/benchmarks/performance/concat.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { concat as concatToolkit_ } from 'es-toolkit/compat';
-import { concat as concatLodash_ } from 'lodash';
+import { concat as concatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const concatToolkit = concatToolkit_;
-const concatLodash = concatLodash_;
+const { concat: concatLodash } = lodash;
 
 describe('concat', () => {
   bench('es-toolkit/concat', () => {

--- a/benchmarks/performance/cond.bench.ts
+++ b/benchmarks/performance/cond.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { cond as condToolkitCompat_ } from 'es-toolkit/compat';
-import { cond as condLodash_ } from 'lodash';
+import { cond as condToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const condToolkitCompat = condToolkitCompat_;
-const condLodash = condLodash_;
+const { cond: condLodash } = lodash;
 
 describe('cond', () => {
   const isA = (obj: { a: number }) => obj && obj.a === 1;

--- a/benchmarks/performance/conforms.bench.ts
+++ b/benchmarks/performance/conforms.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { conforms as conformsToolkit_ } from 'es-toolkit/compat';
-import { conforms as conformsLodash_ } from 'lodash';
+import { conforms as conformsToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const conformsToolkit = conformsToolkit_;
-const conformsLodash = conformsLodash_;
+const { conforms: conformsLodash } = lodash;
 
 describe('conforms', () => {
   bench('es-toolkit/conforms', () => {

--- a/benchmarks/performance/conformsTo.bench.ts
+++ b/benchmarks/performance/conformsTo.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { conformsTo as conformsToToolkit_ } from 'es-toolkit/compat';
-import { conformsTo as conformsToLodash_ } from 'lodash';
+import { conformsTo as conformsToToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const conformsToToolkit = conformsToToolkit_;
-const conformsToLodash = conformsToLodash_;
+const { conformsTo: conformsToLodash } = lodash;
 
 describe('conformsTo', () => {
   bench('es-toolkit/conformsTo', () => {

--- a/benchmarks/performance/constant.bench.ts
+++ b/benchmarks/performance/constant.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { constant as constantToolkitCompat_ } from 'es-toolkit/compat';
-import { constant as constantToLodash_ } from 'lodash';
+import { constant as constantToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const constantToolkitCompat = constantToolkitCompat_;
-const constantToLodash = constantToLodash_;
+const { constant: constantToLodash } = lodash;
 
 describe('constant', () => {
   bench(

--- a/benchmarks/performance/countBy.bench.ts
+++ b/benchmarks/performance/countBy.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { countBy as countByToolkit_ } from 'es-toolkit';
-import { countBy as countByLodash_ } from 'lodash';
+import { countBy as countByToolkit } from 'es-toolkit';
+import lodash from 'lodash';
 
-const countByToolkit = countByToolkit_;
-const countByLodash = countByLodash_;
+const { countBy: countByLodash } = lodash;
 
 describe('countBy', () => {
   bench('es-toolkit/countBy', () => {

--- a/benchmarks/performance/create.bench.ts
+++ b/benchmarks/performance/create.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { create as createToolkitCompat_ } from 'es-toolkit/compat';
-import { create as createToLodash_ } from 'lodash';
+import { create as createToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const createToolkitCompat = createToolkitCompat_;
-const createToLodash = createToLodash_;
+const { create: createToLodash } = lodash;
 
 describe('create', () => {
   bench('es-toolkit/compat/create', () => {

--- a/benchmarks/performance/curry.bench.ts
+++ b/benchmarks/performance/curry.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { curry as curryToolkit_ } from 'es-toolkit';
-import { curry as curryCompat_ } from 'es-toolkit/compat';
-import { curry as curryLodash_ } from 'lodash';
+import { curry as curryToolkit } from 'es-toolkit';
+import { curry as curryCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const curryToolkit = curryToolkit_;
-const curryCompat = curryCompat_;
-const curryLodash = curryLodash_;
+const { curry: curryLodash } = lodash;
 
 describe('curry', () => {
   const fn = (a: number, b: string, c: boolean) => ({ a, b, c });

--- a/benchmarks/performance/curryRight.bench.ts
+++ b/benchmarks/performance/curryRight.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { curryRight as curryRightToolkit_ } from 'es-toolkit';
-import { curryRight as curryRightToolkitCompat_ } from 'es-toolkit/compat';
-import { curryRight as curryRightLodash_ } from 'lodash';
+import { curryRight as curryRightToolkit } from 'es-toolkit';
+import { curryRight as curryRightToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const curryRightToolkit = curryRightToolkit_;
-const curryRightToolkitCompat = curryRightToolkitCompat_;
-const curryRightLodash = curryRightLodash_;
+const { curryRight: curryRightLodash } = lodash;
 
 describe('curryRight', () => {
   const fn = (a: number, b: string, c: boolean) => ({ a, b, c });

--- a/benchmarks/performance/debounce.bench.ts
+++ b/benchmarks/performance/debounce.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { debounce as debounceToolkit_ } from 'es-toolkit';
-import { debounce as debounceCompatToolkit_ } from 'es-toolkit/compat';
-import { debounce as debounceLodash_ } from 'lodash';
+import { debounce as debounceToolkit } from 'es-toolkit';
+import { debounce as debounceCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const debounceToolkit = debounceToolkit_;
-const debounceCompatToolkit = debounceCompatToolkit_;
-const debounceLodash = debounceLodash_;
+const { debounce: debounceLodash } = lodash;
 
 describe('debounce', () => {
   bench('es-toolkit/debounce', () => {

--- a/benchmarks/performance/deburr.bench.ts
+++ b/benchmarks/performance/deburr.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { deburr as deburrToolkit_ } from 'es-toolkit';
-import { deburr as deburrCompatToolkit_ } from 'es-toolkit/compat';
-import { deburr as deburrLodash_ } from 'lodash';
+import { deburr as deburrToolkit } from 'es-toolkit';
+import { deburr as deburrCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const deburrToolkit = deburrToolkit_;
-const deburrCompatToolkit = deburrCompatToolkit_;
-const deburrLodash = deburrLodash_;
+const { deburr: deburrLodash } = lodash;
 
 const longWord = 'déjà vu'.repeat(1000);
 describe('deburr', () => {

--- a/benchmarks/performance/defaultTo.bench.ts
+++ b/benchmarks/performance/defaultTo.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { defaultTo as defaultToToolkitCompat_ } from 'es-toolkit/compat';
-import { defaultTo as defaultToLodash_ } from 'lodash';
+import { defaultTo as defaultToToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const defaultToToolkitCompat = defaultToToolkitCompat_;
-const defaultToLodash = defaultToLodash_;
+const { defaultTo: defaultToLodash } = lodash;
 
 describe('defaultTo', () => {
   bench('es-toolkit/compat/defaultTo', () => {

--- a/benchmarks/performance/defaults.bench.ts
+++ b/benchmarks/performance/defaults.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { defaults as defaultsToolkitCompat_ } from 'es-toolkit/compat';
-import { defaults as defaultsLodash_ } from 'lodash';
+import { defaults as defaultsToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const defaultsToolkitCompat = defaultsToolkitCompat_;
-const defaultsLodash = defaultsLodash_;
+const { defaults: defaultsLodash } = lodash;
 
 describe('defaults', () => {
   bench('es-toolkit/compat/defaults', () => {

--- a/benchmarks/performance/defaultsDeep.bench.ts
+++ b/benchmarks/performance/defaultsDeep.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { defaultsDeep as defaultsDeepToolkitCompat_ } from 'es-toolkit/compat';
-import { defaultsDeep as defaultsDeepLodash_ } from 'lodash';
+import { defaultsDeep as defaultsDeepToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const defaultsDeepToolkitCompat = defaultsDeepToolkitCompat_;
-const defaultsDeepLodash = defaultsDeepLodash_;
+const { defaultsDeep: defaultsDeepLodash } = lodash;
 
 describe('defaultsDeep', () => {
   bench('es-toolkit/compat/defaultsDeep ', () => {

--- a/benchmarks/performance/defer.bench.ts
+++ b/benchmarks/performance/defer.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { defer as deferToolkit_ } from 'es-toolkit/compat';
-import { defer as deferLodash_ } from 'lodash';
+import { defer as deferToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const deferToolkit = deferToolkit_;
-const deferLodash = deferLodash_;
+const { defer: deferLodash } = lodash;
 
 describe('defer', () => {
   bench('es-toolkit/defer', () => {

--- a/benchmarks/performance/delay.bench.ts
+++ b/benchmarks/performance/delay.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { delay as delayToolkitCompat_ } from 'es-toolkit/compat';
-import { delay as delayLodash_ } from 'lodash';
+import { delay as delayToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const delayToolkitCompat = delayToolkitCompat_;
-const delayLodash = delayLodash_;
+const { delay: delayLodash } = lodash;
 
 describe('delay', () => {
   bench('es-toolkit/compat/delay', () => {

--- a/benchmarks/performance/difference.bench.ts
+++ b/benchmarks/performance/difference.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { difference as differenceToolkit_ } from 'es-toolkit';
-import { difference as differenceCompatToolkit_ } from 'es-toolkit/compat';
-import { difference as differenceLodash_ } from 'lodash';
+import { difference as differenceToolkit } from 'es-toolkit';
+import { difference as differenceCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const differenceToolkit = differenceToolkit_;
-const differenceCompatToolkit = differenceCompatToolkit_;
-const differenceLodash = differenceLodash_;
+const { difference: differenceLodash } = lodash;
 
 describe('difference', () => {
   bench('es-toolkit/difference', () => {

--- a/benchmarks/performance/differenceBy.bench.ts
+++ b/benchmarks/performance/differenceBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { differenceBy as differenceByToolkit_ } from 'es-toolkit';
-import { differenceBy as differenceByToolkitCompat_ } from 'es-toolkit/compat';
-import { differenceBy as differenceByLodash_ } from 'lodash';
+import { differenceBy as differenceByToolkit } from 'es-toolkit';
+import { differenceBy as differenceByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const differenceByToolkit = differenceByToolkit_;
-const differenceByToolkitCompat = differenceByToolkitCompat_;
-const differenceByLodash = differenceByLodash_;
+const { differenceBy: differenceByLodash } = lodash;
 
 describe('differenceBy', () => {
   bench('es-toolkit/differenceBy', () => {

--- a/benchmarks/performance/differenceWith.bench.ts
+++ b/benchmarks/performance/differenceWith.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { differenceWith as differenceWithToolkit_ } from 'es-toolkit';
-import { differenceWith as differenceWithCompatToolkit_ } from 'es-toolkit/compat';
-import { differenceWith as differenceWithLodash_ } from 'lodash';
+import { differenceWith as differenceWithToolkit } from 'es-toolkit';
+import { differenceWith as differenceWithCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const differenceWithToolkit = differenceWithToolkit_;
-const differenceWithCompatToolkit = differenceWithCompatToolkit_;
-const differenceWithLodash = differenceWithLodash_;
+const { differenceWith: differenceWithLodash } = lodash;
 
 describe('differenceWith', () => {
   bench('es-toolkit/differenceWith', () => {

--- a/benchmarks/performance/divide.bench.ts
+++ b/benchmarks/performance/divide.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { divide as divideToolkitCompat_ } from 'es-toolkit/compat';
-import { divide as divideLodash_ } from 'lodash';
+import { divide as divideToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const divideToolkitCompat = divideToolkitCompat_;
-const divideLodash = divideLodash_;
+const { divide: divideLodash } = lodash;
 
 describe('divide function benchmark', () => {
   bench('es-toolkit/compat/divide', () => {

--- a/benchmarks/performance/drop.bench.ts
+++ b/benchmarks/performance/drop.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { drop as dropToolkit_ } from 'es-toolkit';
-import { drop as dropCompatToolkit_ } from 'es-toolkit/compat';
-import { drop as dropLodash_ } from 'lodash';
+import { drop as dropToolkit } from 'es-toolkit';
+import { drop as dropCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const dropToolkit = dropToolkit_;
-const dropCompatToolkit = dropCompatToolkit_;
-const dropLodash = dropLodash_;
+const { drop: dropLodash } = lodash;
 
 describe('drop', () => {
   bench('es-toolkit/drop', () => {

--- a/benchmarks/performance/dropRight.bench.ts
+++ b/benchmarks/performance/dropRight.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { dropRight as dropRightToolkit_ } from 'es-toolkit';
-import { dropRight as dropRightToolkitCompat_ } from 'es-toolkit/compat';
-import { dropRight as dropRightLodash_ } from 'lodash';
+import { dropRight as dropRightToolkit } from 'es-toolkit';
+import { dropRight as dropRightToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const dropRightToolkit = dropRightToolkit_;
-const dropRightToolkitCompat = dropRightToolkitCompat_;
-const dropRightLodash = dropRightLodash_;
+const { dropRight: dropRightLodash } = lodash;
 
 describe('dropRight', () => {
   bench('es-toolkit/dropRight', () => {

--- a/benchmarks/performance/dropRightWhile.bench.ts
+++ b/benchmarks/performance/dropRightWhile.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { dropRightWhile as dropRightWhileToolkit_ } from 'es-toolkit';
-import { dropRightWhile as dropRightWhileToolkitCompat_ } from 'es-toolkit/compat';
-import { dropRightWhile as dropRightWhileLodash_ } from 'lodash';
+import { dropRightWhile as dropRightWhileToolkit } from 'es-toolkit';
+import { dropRightWhile as dropRightWhileToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const dropRightWhileToolkit = dropRightWhileToolkit_;
-const dropRightWhileToolkitCompat = dropRightWhileToolkitCompat_;
-const dropRightWhileLodash = dropRightWhileLodash_;
+const { dropRightWhile: dropRightWhileLodash } = lodash;
 
 describe('dropRightWhile', () => {
   bench('es-toolkit/dropRightWhile', () => {

--- a/benchmarks/performance/dropWhile.bench.ts
+++ b/benchmarks/performance/dropWhile.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { dropWhile as dropWhileToolkit_ } from 'es-toolkit';
-import { dropWhile as dropWhileToolkitCompat_ } from 'es-toolkit/compat';
-import { dropWhile as dropWhileLodash_ } from 'lodash';
+import { dropWhile as dropWhileToolkit } from 'es-toolkit';
+import { dropWhile as dropWhileToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const dropWhileToolkit = dropWhileToolkit_;
-const dropWhileToolkitCompat = dropWhileToolkitCompat_;
-const dropWhileLodash = dropWhileLodash_;
+const { dropWhile: dropWhileLodash } = lodash;
 
 describe('dropWhile', () => {
   bench('es-toolkit/dropWhile', () => {

--- a/benchmarks/performance/endsWith.bench.ts
+++ b/benchmarks/performance/endsWith.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { endsWith as endsWithToolkit_ } from 'es-toolkit/compat';
-import { endsWith as endsWithLodash_ } from 'lodash';
+import { endsWith as endsWithToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const endsWithToolkit = endsWithToolkit_;
-const endsWithLodash = endsWithLodash_;
+const { endsWith: endsWithLodash } = lodash;
 
 describe('endsWith', () => {
   bench('es-toolkit/endsWith', () => {

--- a/benchmarks/performance/eq.bench.ts
+++ b/benchmarks/performance/eq.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { eq as eqToolkitCompat_ } from 'es-toolkit/compat';
-import { eq as eqLodash_ } from 'lodash';
+import { eq as eqToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const eqToolkitCompat = eqToolkitCompat_;
-const eqLodash = eqLodash_;
+const { eq: eqLodash } = lodash;
 
 describe('eq', () => {
   bench('es-toolkit/compat/eq', () => {

--- a/benchmarks/performance/escape.bench.ts
+++ b/benchmarks/performance/escape.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { escape as escapeToolkit_ } from 'es-toolkit';
-import { escape as escapeToolkitCompat_ } from 'es-toolkit/compat';
-import { escape as escapeLodash_ } from 'lodash';
+import { escape as escapeToolkit } from 'es-toolkit';
+import { escape as escapeToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const escapeToolkit = escapeToolkit_;
-const escapeToolkitCompat = escapeToolkitCompat_;
-const escapeLodash = escapeLodash_;
+const { escape: escapeLodash } = lodash;
 
 describe('escape', () => {
   bench('es-toolkit/escape', () => {

--- a/benchmarks/performance/escapeRegExp.bench.ts
+++ b/benchmarks/performance/escapeRegExp.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { escapeRegExp as escapeRegExpToolkit_ } from 'es-toolkit';
-import { escapeRegExp as escapeRegExpCompatToolkit_ } from 'es-toolkit/compat';
-import { escapeRegExp as escapeRegExpLodash_ } from 'lodash';
+import { escapeRegExp as escapeRegExpToolkit } from 'es-toolkit';
+import { escapeRegExp as escapeRegExpCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const escapeRegExpToolkit = escapeRegExpToolkit_;
-const escapeRegExpCompatToolkit = escapeRegExpCompatToolkit_;
-const escapeRegExpLodash = escapeRegExpLodash_;
+const { escapeRegExp: escapeRegExpLodash } = lodash;
 
 describe('escape', () => {
   const longString = '^$.*+?()[]{}|\\'.repeat(100);

--- a/benchmarks/performance/every.bench.ts
+++ b/benchmarks/performance/every.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { every as everyEsToolkit_ } from 'es-toolkit/compat';
-import { every as everyLodash_ } from 'lodash';
+import { every as everyEsToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const everyEsToolkit = everyEsToolkit_;
-const everyLodash = everyLodash_;
+const { every: everyLodash } = lodash;
 
 const generateArray = (length: number, max: number) => Array.from({ length }, () => Math.floor(Math.random() * max));
 const array = generateArray(1_000_000, 1000);

--- a/benchmarks/performance/fill.bench.ts
+++ b/benchmarks/performance/fill.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { fill as fillToolkit_ } from 'es-toolkit';
-import { fill as fillCompatToolkit_ } from 'es-toolkit/compat';
-import { fill as fillLodash_ } from 'lodash';
+import { fill as fillToolkit } from 'es-toolkit';
+import { fill as fillCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const fillToolkit = fillToolkit_;
-const fillCompatToolkit = fillCompatToolkit_;
-const fillLodash = fillLodash_;
+const { fill: fillLodash } = lodash;
 
 describe('fill function performance comparison', () => {
   bench('es-toolkit/fill', () => {

--- a/benchmarks/performance/filter.bench.ts
+++ b/benchmarks/performance/filter.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { filter as filterToolkit_ } from 'es-toolkit/compat';
-import { filter as filterLodash_ } from 'lodash';
+import { filter as filterToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const filterToolkit = filterToolkit_;
-const filterLodash = filterLodash_;
+const { filter: filterLodash } = lodash;
 
 const arr = [
   { a: 0, b: true },

--- a/benchmarks/performance/find.bench.ts
+++ b/benchmarks/performance/find.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { find as findToolkit_ } from 'es-toolkit/compat';
-import { find as findLodash_ } from 'lodash';
+import { find as findToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const findToolkit = findToolkit_;
-const findLodash = findLodash_;
+const { find: findLodash } = lodash;
 
 const items = [
   { id: 1, name: 'Alice' },

--- a/benchmarks/performance/findIndex.bench.ts
+++ b/benchmarks/performance/findIndex.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { findIndex as findIndexToolkit_ } from 'es-toolkit/compat';
-import { findIndex as findIndexLodash_ } from 'lodash';
+import { findIndex as findIndexToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const findIndexToolkit = findIndexToolkit_;
-const findIndexLodash = findIndexLodash_;
+const { findIndex: findIndexLodash } = lodash;
 
 const items = [
   { id: 1, name: 'Alice' },

--- a/benchmarks/performance/findKey.bench.ts
+++ b/benchmarks/performance/findKey.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { findKey as findKeyToolkit_ } from 'es-toolkit';
-import { findKey as findKeyCompatToolkit_ } from 'es-toolkit/compat';
-import { findKey as findKeyLodash_ } from 'lodash';
+import { findKey as findKeyToolkit } from 'es-toolkit';
+import { findKey as findKeyCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const findKeyToolkit = findKeyToolkit_;
-const findKeyCompatToolkit = findKeyCompatToolkit_;
-const findKeyLodash = findKeyLodash_;
+const { findKey: findKeyLodash } = lodash;
 
 describe('findKey', () => {
   const users = {

--- a/benchmarks/performance/findLast.bench.ts
+++ b/benchmarks/performance/findLast.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { findLast as findLastToolkitCompat_ } from 'es-toolkit/compat';
-import { findLast as findLastLodash_ } from 'lodash';
+import { findLast as findLastToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const findLastToolkitCompat = findLastToolkitCompat_;
-const findLastLodash = findLastLodash_;
+const { findLast: findLastLodash } = lodash;
 
 const items = [
   { id: 1, name: 'Alice' },

--- a/benchmarks/performance/findLastIndex.bench.ts
+++ b/benchmarks/performance/findLastIndex.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { findLastIndex as findLastIndexToolkit_ } from 'es-toolkit/compat';
-import { findLastIndex as findLastIndexLodash_ } from 'lodash';
+import { findLastIndex as findLastIndexToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const findLastIndexToolkit = findLastIndexToolkit_;
-const findLastIndexLodash = findLastIndexLodash_;
+const { findLastIndex: findLastIndexLodash } = lodash;
 
 const items = [
   { id: 1, name: 'Alice' },

--- a/benchmarks/performance/findLastKey.bench.ts
+++ b/benchmarks/performance/findLastKey.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { findLastKey as findLastKeyCompatToolkit_ } from 'es-toolkit/compat';
-import { findLastKey as findLastKeyLodash_ } from 'lodash';
+import { findLastKey as findLastKeyCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const findLastKeyCompatToolkit = findLastKeyCompatToolkit_;
-const findLastKeyLodash = findLastKeyLodash_;
+const { findLastKey: findLastKeyLodash } = lodash;
 
 describe('findLastKey', () => {
   const users = {

--- a/benchmarks/performance/flatMap.bench.ts
+++ b/benchmarks/performance/flatMap.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { flatMap as flatMapToolkit_ } from 'es-toolkit';
-import { flatMap as flatMapToolkitCompat_ } from 'es-toolkit/compat';
-import { flatMapDepth as flatMapDepthLodash_ } from 'lodash';
+import { flatMap as flatMapToolkit } from 'es-toolkit';
+import { flatMap as flatMapToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const flatMapToolkit = flatMapToolkit_;
-const flatMapToolkitCompat = flatMapToolkitCompat_;
-const flatMapDepthLodash = flatMapDepthLodash_;
+const { flatMapDepth: flatMapDepthLodash } = lodash;
 
 function createNestedArray(arr: any[], depth: number) {
   let result = arr;

--- a/benchmarks/performance/flatMapDeep.bench.ts
+++ b/benchmarks/performance/flatMapDeep.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { flatMapDeep as flatMapDeepToolkit_ } from 'es-toolkit';
-import { flatMapDeep as flatMapDeepToolkitCompat_ } from 'es-toolkit/compat';
-import { flatMapDeep as flatMapDeepLodash_ } from 'lodash';
+import { flatMapDeep as flatMapDeepToolkit } from 'es-toolkit';
+import { flatMapDeep as flatMapDeepToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const flatMapDeepToolkit = flatMapDeepToolkit_;
-const flatMapDeepToolkitCompat = flatMapDeepToolkitCompat_;
-const flatMapDeepLodash = flatMapDeepLodash_;
+const { flatMapDeep: flatMapDeepLodash } = lodash;
 
 function createNestedArray(arr: any[], depth: number) {
   let result = arr;

--- a/benchmarks/performance/flatMapDepth.bench.ts
+++ b/benchmarks/performance/flatMapDepth.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { flatMapDepth as flatMapDepthToolkitCompat_ } from 'es-toolkit/compat';
-import { flatMapDepth as flatMapDepthLodash_ } from 'lodash';
+import { flatMapDepth as flatMapDepthToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const flatMapDepthToolkitCompat = flatMapDepthToolkitCompat_;
-const flatMapDepthLodash = flatMapDepthLodash_;
+const { flatMapDepth: flatMapDepthLodash } = lodash;
 
 function createNestedArray(arr: any[], depth: number) {
   let result = arr;

--- a/benchmarks/performance/flatten.bench.ts
+++ b/benchmarks/performance/flatten.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { flatten as flattenToolkit_ } from 'es-toolkit';
-import { flatten as flattenCompatToolkit_ } from 'es-toolkit/compat';
-import { flattenDepth as flattenDepthLodash_ } from 'lodash';
+import { flatten as flattenToolkit } from 'es-toolkit';
+import { flatten as flattenCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const flattenToolkit = flattenToolkit_;
-const flattenCompatToolkit = flattenCompatToolkit_;
-const flattenDepthLodash = flattenDepthLodash_;
+const { flattenDepth: flattenDepthLodash } = lodash;
 
 const createNestedArray = (values: any[]): any[] => {
   if (values.length === 0) {

--- a/benchmarks/performance/flattenDeep.bench.ts
+++ b/benchmarks/performance/flattenDeep.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { flattenDeep as flattenDeepToolkit_ } from 'es-toolkit';
-import { flattenDeep as flattenDeepToolkitCompat_ } from 'es-toolkit/compat';
-import { flattenDeep as flattenDeepLodash_ } from 'lodash';
+import { flattenDeep as flattenDeepToolkit } from 'es-toolkit';
+import { flattenDeep as flattenDeepToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const flattenDeepToolkit = flattenDeepToolkit_;
-const flattenDeepToolkitCompat = flattenDeepToolkitCompat_;
-const flattenDeepLodash = flattenDeepLodash_;
+const { flattenDeep: flattenDeepLodash } = lodash;
 
 const createNestedArray = (values: number[]): any[] => {
   if (values.length === 0) {

--- a/benchmarks/performance/flattenDepth.bench.ts
+++ b/benchmarks/performance/flattenDepth.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { flattenDepth as flattenDepthToolkit_ } from 'es-toolkit/compat';
-import { flattenDepth as flattenDepthLodash_ } from 'lodash';
+import { flattenDepth as flattenDepthToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const flattenDepthToolkit = flattenDepthToolkit_;
-const flattenDepthLodash = flattenDepthLodash_;
+const { flattenDepth: flattenDepthLodash } = lodash;
 
 describe('flattenDepth', () => {
   const arr = [1, [2, 3], [4, [5, 6]]];

--- a/benchmarks/performance/flip.bench.ts
+++ b/benchmarks/performance/flip.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { flip as flipToolkit_ } from 'es-toolkit/compat';
-import { flip as flipLodash_ } from 'lodash';
+import { flip as flipToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const flipToolkit = flipToolkit_;
-const flipLodash = flipLodash_;
+const { flip: flipLodash } = lodash;
 
 describe('flip', () => {
   function fn(a: any, b: any, c: any, d: any) {

--- a/benchmarks/performance/floor.bench.ts
+++ b/benchmarks/performance/floor.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { floor as floorToolkit_ } from 'es-toolkit/compat';
-import { floor as floorLodash_ } from 'lodash';
+import { floor as floorToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const floorToolkit = floorToolkit_;
-const floorLodash = floorLodash_;
+const { floor: floorLodash } = lodash;
 
 describe('floor', () => {
   bench('es-toolkit/floor', () => {

--- a/benchmarks/performance/flow.bench.ts
+++ b/benchmarks/performance/flow.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { flow as flowToolkit_ } from 'es-toolkit';
-import { flow as flowToolkitCompat_ } from 'es-toolkit/compat';
-import { flow as flowLodash_ } from 'lodash';
+import { flow as flowToolkit } from 'es-toolkit';
+import { flow as flowCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const flowToolkit = flowToolkit_;
-const flowCompat = flowToolkitCompat_;
-const flowLodash = flowLodash_;
+const { flow: flowLodash } = lodash;
 
 describe('flow', () => {
   const add = (x: number, y: number) => x + y;

--- a/benchmarks/performance/flowRight.bench.ts
+++ b/benchmarks/performance/flowRight.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { flowRight as flowRightToolkit_ } from 'es-toolkit';
-import { flowRight as flowRightToolkitCompat_ } from 'es-toolkit/compat';
-import { flowRight as flowRightLodash_ } from 'lodash';
+import { flowRight as flowRightToolkit } from 'es-toolkit';
+import { flowRight as flowRightCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const flowRightToolkit = flowRightToolkit_;
-const flowRightCompat = flowRightToolkitCompat_;
-const flowRightLodash = flowRightLodash_;
+const { flowRight: flowRightLodash } = lodash;
 
 describe('flowRight', () => {
   const add = (x: number, y: number) => x + y;

--- a/benchmarks/performance/forEach.bench.ts
+++ b/benchmarks/performance/forEach.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { forEach as forEachToolkit_ } from 'es-toolkit/compat';
-import { forEach as forEachLodash_ } from 'lodash';
+import { forEach as forEachToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const forEachToolkit = forEachToolkit_;
-const forEachLodash = forEachLodash_;
+const { forEach: forEachLodash } = lodash;
 
 describe('forEach', () => {
   bench('es-toolkit/compat/forEach', () => {

--- a/benchmarks/performance/forEachRight.bench.ts
+++ b/benchmarks/performance/forEachRight.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { forEachRight as forEachRightToolkit_ } from 'es-toolkit';
-import { forEachRight as forEachRightToolkitCompat_ } from 'es-toolkit/compat';
-import { forEachRight as forEachRightLodash_ } from 'lodash';
+import { forEachRight as forEachRightToolkit } from 'es-toolkit';
+import { forEachRight as forEachRightToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const forEachRightToolkit = forEachRightToolkit_;
-const forEachRightToolkitCompat = forEachRightToolkitCompat_;
-const forEachRightLodash = forEachRightLodash_;
+const { forEachRight: forEachRightLodash } = lodash;
 
 describe('forEachRight', () => {
   bench('es-toolkit/forEachRight', () => {

--- a/benchmarks/performance/forIn.bench.ts
+++ b/benchmarks/performance/forIn.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { forIn as forInToolkitCompat_, times } from 'es-toolkit/compat';
-import { forIn as forInLodash_ } from 'lodash';
+import { forIn as forInToolkitCompat, times } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const forInToolkitCompat = forInToolkitCompat_;
-const forInLodash = forInLodash_;
+const { forIn: forInLodash } = lodash;
 
 describe('forIn', () => {
   const bigObject = Object.fromEntries(times(1000, i => [i, i]));

--- a/benchmarks/performance/forInRight.bench.ts
+++ b/benchmarks/performance/forInRight.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { forInRight as forInToolkitCompat_, times } from 'es-toolkit/compat';
-import { forInRight as forInLodash_ } from 'lodash';
+import { forInRight as forInToolkitCompat, times } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const forInToolkitCompat = forInToolkitCompat_;
-const forInLodash = forInLodash_;
+const { forInRight: forInLodash } = lodash;
 
 describe('forInRight', () => {
   const bigObject = Object.fromEntries(times(1000, i => [i, i]));

--- a/benchmarks/performance/forOwn.bench.ts
+++ b/benchmarks/performance/forOwn.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { forOwn as forOwnToolkitCompat_ } from 'es-toolkit/compat';
-import { forOwn as forOwnLodash_ } from 'lodash';
+import { forOwn as forOwnToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const forOwnToolkitCompat = forOwnToolkitCompat_;
-const forOwnLodash = forOwnLodash_;
+const { forOwn: forOwnLodash } = lodash;
 
 describe('forOwn', () => {
   const obj = { a: 1, b: 2, c: 3 };

--- a/benchmarks/performance/forOwnRight.bench.ts
+++ b/benchmarks/performance/forOwnRight.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { forOwnRight as forOwnRightToolkitCompat_ } from 'es-toolkit/compat';
-import { forOwnRight as forOwnRightLodash_ } from 'lodash';
+import { forOwnRight as forOwnRightToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const forOwnRightToolkitCompat = forOwnRightToolkitCompat_;
-const forOwnRightLodash = forOwnRightLodash_;
+const { forOwnRight: forOwnRightLodash } = lodash;
 
 describe('forOwnRight', () => {
   const obj = { a: 1, b: 2, c: 3 };

--- a/benchmarks/performance/fromPairs.bench.ts
+++ b/benchmarks/performance/fromPairs.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { fromPairs as fromPairsToolkit_ } from 'es-toolkit/compat';
-import { fromPairs as fromPairsLodash_ } from 'lodash';
+import { fromPairs as fromPairsToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const fromPairsToolkit = fromPairsToolkit_;
-const fromPairsLodash = fromPairsLodash_;
+const { fromPairs: fromPairsLodash } = lodash;
 
 describe('fromPairs', () => {
   const data = [

--- a/benchmarks/performance/functions.bench.ts
+++ b/benchmarks/performance/functions.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { functions as functionsToolkit_ } from 'es-toolkit/compat';
-import { functions as functionsLodash_ } from 'lodash';
+import { functions as functionsToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const functionsToolkit = functionsToolkit_;
-const functionsLodash = functionsLodash_;
+const { functions: functionsLodash } = lodash;
 
 describe('functions', () => {
   const testObject = {

--- a/benchmarks/performance/functionsIn.bench.ts
+++ b/benchmarks/performance/functionsIn.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { functionsIn as functionsInToolkitCompat_ } from 'es-toolkit/compat';
-import { functionsIn as functionsInLodash_ } from 'lodash';
+import { functionsIn as functionsInToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const functionsInToolkitCompat = functionsInToolkitCompat_;
-const functionsInLodash = functionsInLodash_;
+const { functionsIn: functionsInLodash } = lodash;
 
 describe('functionsIn', () => {
   class Foo {

--- a/benchmarks/performance/get.bench.ts
+++ b/benchmarks/performance/get.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { get as getToolkit_ } from 'es-toolkit/compat';
-import { get as getLodash_ } from 'lodash';
+import { get as getToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const getToolkit = getToolkit_;
-const getLodash = getLodash_;
+const { get: getLodash } = lodash;
 
 describe('get with simple string', () => {
   bench('es-toolkit/get', () => {

--- a/benchmarks/performance/groupBy.bench.ts
+++ b/benchmarks/performance/groupBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { groupBy as groupByToolkit_ } from 'es-toolkit';
-import { groupBy as groupByToolkitCompat_ } from 'es-toolkit/compat';
-import { groupBy as groupByLodash_ } from 'lodash';
+import { groupBy as groupByToolkit } from 'es-toolkit';
+import { groupBy as groupByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const groupByToolkit = groupByToolkit_;
-const groupByToolkitCompat = groupByToolkitCompat_;
-const groupByLodash = groupByLodash_;
+const { groupBy: groupByLodash } = lodash;
 
 describe('groupBy', () => {
   bench('es-toolkit/groupBy', () => {

--- a/benchmarks/performance/gt.bench.ts
+++ b/benchmarks/performance/gt.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { gt as gtToolkitCompat_ } from 'es-toolkit/compat';
-import { gt as gtLodash_ } from 'lodash';
+import { gt as gtToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const gtToolkitCompat = gtToolkitCompat_;
-const gtLodash = gtLodash_;
+const { gt: gtLodash } = lodash;
 
 describe('gt', () => {
   bench('es-toolkit/compat/gt', () => {

--- a/benchmarks/performance/gte.bench.ts
+++ b/benchmarks/performance/gte.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { gte as gteToolkitCompat_ } from 'es-toolkit/compat';
-import { gte as gteLodash_ } from 'lodash';
+import { gte as gteToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const gteToolkitCompat = gteToolkitCompat_;
-const gteLodash = gteLodash_;
+const { gte: gteLodash } = lodash;
 
 describe('gte', () => {
   bench('es-toolkit/compat/gte', () => {

--- a/benchmarks/performance/has.bench.ts
+++ b/benchmarks/performance/has.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { has as hasToolkit_ } from 'es-toolkit/compat';
-import { has as hasLodash_ } from 'lodash';
+import { has as hasToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const hasToolkit = hasToolkit_;
-const hasLodash = hasLodash_;
+const { has: hasLodash } = lodash;
 
 describe('has with string', () => {
   bench('es-toolkit/has', () => {

--- a/benchmarks/performance/hasIn.bench.ts
+++ b/benchmarks/performance/hasIn.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { hasIn as hasInToolkit_ } from 'es-toolkit/compat';
-import { hasIn as hasInLodash_ } from 'lodash';
+import { hasIn as hasInToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const hasInToolkit = hasInToolkit_;
-const hasInLodash = hasInLodash_;
+const { hasIn: hasInLodash } = lodash;
 
 describe('hasIn', () => {
   // 기본 객체 경로 테스트 (문자열)

--- a/benchmarks/performance/head.bench.ts
+++ b/benchmarks/performance/head.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { head as headToolkit_ } from 'es-toolkit';
-import { head as headCompatToolkit_ } from 'es-toolkit/compat';
-import { head as headLodash_ } from 'lodash';
+import { head as headToolkit } from 'es-toolkit';
+import { head as headCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const headToolkit = headToolkit_;
-const headCompatToolkit = headCompatToolkit_;
-const headLodash = headLodash_;
+const { head: headLodash } = lodash;
 
 describe('head', () => {
   bench('es-toolkit/head', () => {

--- a/benchmarks/performance/identity.bench.ts
+++ b/benchmarks/performance/identity.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { identity as identityToolkit_ } from 'es-toolkit';
-import { identity as identityLodash_ } from 'lodash';
+import { identity as identityToolkit } from 'es-toolkit';
+import lodash from 'lodash';
 
-const identityToolkit = identityToolkit_;
-const identityLodash = identityLodash_;
+const { identity: identityLodash } = lodash;
 
 describe('identity', () => {
   bench('es-toolkit/identity', () => {

--- a/benchmarks/performance/inRange.bench.ts
+++ b/benchmarks/performance/inRange.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { inRange as inRangeToolkit_ } from 'es-toolkit';
-import { inRange as inRangeCompatToolkit_ } from 'es-toolkit/compat';
-import { inRange as inRangeLodash_ } from 'lodash';
+import { inRange as inRangeToolkit } from 'es-toolkit';
+import { inRange as inRangeCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const inRangeToolkit = inRangeToolkit_;
-const inRangeCompatToolkit = inRangeCompatToolkit_;
-const inRangeLodash = inRangeLodash_;
+const { inRange: inRangeLodash } = lodash;
 
 describe('inRange', () => {
   bench('es-toolkit/inRange', () => {

--- a/benchmarks/performance/includes.bench.ts
+++ b/benchmarks/performance/includes.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { includes as includesToolkitCompat_ } from 'es-toolkit/compat';
-import { includes as includesLodash_ } from 'lodash';
+import { includes as includesToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const includesToolkitCompat = includesToolkitCompat_;
-const includesLodash = includesLodash_;
+const { includes: includesLodash } = lodash;
 
 describe('includes (object)', () => {
   const object = {

--- a/benchmarks/performance/indexOf.bench.ts
+++ b/benchmarks/performance/indexOf.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { indexOf as indexOfToolkitCompat_ } from 'es-toolkit/compat';
-import { indexOf as indexOfLodash_ } from 'lodash';
+import { indexOf as indexOfToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const indexOfToolkitCompat = indexOfToolkitCompat_;
-const indexOfLodash = indexOfLodash_;
+const { indexOf: indexOfLodash } = lodash;
 
 describe('indexOf', () => {
   const array = [1, 2, 3, 4, NaN, '1', '2', '3', '4', 'NaN'];

--- a/benchmarks/performance/initial.bench.ts
+++ b/benchmarks/performance/initial.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { initial as initialToolkit_ } from 'es-toolkit';
-import { initial as initialToolkitCompat_ } from 'es-toolkit/compat';
-import { initial as initialLodash_ } from 'lodash';
+import { initial as initialToolkit } from 'es-toolkit';
+import { initial as initialToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const initialLodash = initialLodash_;
-const initialToolkitCompat = initialToolkitCompat_;
-const initialToolkit = initialToolkit_;
+const { initial: initialLodash } = lodash;
 
 // Helper function to generate a large array
 function generateLargeArray(size: number) {

--- a/benchmarks/performance/intersection.bench.ts
+++ b/benchmarks/performance/intersection.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { intersection as intersectionToolkit_ } from 'es-toolkit';
-import { intersection as intersectionCompatToolkit_ } from 'es-toolkit/compat';
-import { intersection as intersectionLodash_ } from 'lodash';
+import { intersection as intersectionToolkit } from 'es-toolkit';
+import { intersection as intersectionCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const intersectionToolkit = intersectionToolkit_;
-const intersectionCompatToolkit = intersectionCompatToolkit_;
-const intersectionLodash = intersectionLodash_;
+const { intersection: intersectionLodash } = lodash;
 
 describe('intersection, small arrays', () => {
   const array1 = [1, 2, 3];

--- a/benchmarks/performance/intersectionBy.bench.ts
+++ b/benchmarks/performance/intersectionBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { intersectionBy as intersectionByToolkit_ } from 'es-toolkit';
-import { intersectionBy as intersectionByCompatToolkit_ } from 'es-toolkit/compat';
-import { intersectionBy as intersectionByLodash_ } from 'lodash';
+import { intersectionBy as intersectionByToolkit } from 'es-toolkit';
+import { intersectionBy as intersectionByCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const intersectionByToolkit = intersectionByToolkit_;
-const intersectionByCompatToolkit = intersectionByCompatToolkit_;
-const intersectionByLodash = intersectionByLodash_;
+const { intersectionBy: intersectionByLodash } = lodash;
 
 describe('intersectionBy', () => {
   bench('es-toolkit/intersectionBy', () => {

--- a/benchmarks/performance/intersectionWith.bench.ts
+++ b/benchmarks/performance/intersectionWith.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { intersectionWith as intersectionWithToolkit_ } from 'es-toolkit';
-import { intersectionWith as intersectionWithCompat_ } from 'es-toolkit/compat';
-import { intersectionWith as intersectionWithLodash_ } from 'lodash';
+import { intersectionWith as intersectionWithToolkit } from 'es-toolkit';
+import { intersectionWith as intersectionWithCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const intersectionWithToolkit = intersectionWithToolkit_;
-const intersectionWithCompat = intersectionWithCompat_;
-const intersectionWithLodash = intersectionWithLodash_;
+const { intersectionWith: intersectionWithLodash } = lodash;
 
 describe('intersectionWith', () => {
   bench('es-toolkit/intersectionWith', () => {

--- a/benchmarks/performance/invert.bench.ts
+++ b/benchmarks/performance/invert.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { invert as invertByToolkit_ } from 'es-toolkit';
-import { invert as invertByToolkitCompat_ } from 'es-toolkit/compat';
-import { invert as invertByLodash_ } from 'lodash';
+import { invert as invertByToolkit } from 'es-toolkit';
+import { invert as invertByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const invertByLodash = invertByLodash_;
-const invertByToolkitCompat = invertByToolkitCompat_;
-const invertByToolkit = invertByToolkit_;
+const { invert: invertByLodash } = lodash;
 
 const object: { [key: string]: string } = {};
 for (let i = 0; i < 10000; i++) {

--- a/benchmarks/performance/invertBy.bench.ts
+++ b/benchmarks/performance/invertBy.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { invertBy as invertByWithCompatToolkit_ } from 'es-toolkit/compat';
-import { invertBy as invertByWithLodash_ } from 'lodash';
+import { invertBy as invertByWithCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const invertByWithCompatToolkit = invertByWithCompatToolkit_;
-const invertByWithLodash = invertByWithLodash_;
+const { invertBy: invertByWithLodash } = lodash;
 
 const object = { a: 1, b: 2, c: 1, d: 4 };
 

--- a/benchmarks/performance/invokeMap.bench.ts
+++ b/benchmarks/performance/invokeMap.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { invokeMap as invokeMapToolkitCompat_ } from 'es-toolkit/compat';
-import { invokeMap as invokeMapLodash_ } from 'lodash';
+import { invokeMap as invokeMapToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const invokeMapToolkitCompat = invokeMapToolkitCompat_;
-const invokeMapLodash = invokeMapLodash_;
+const { invokeMap: invokeMapLodash } = lodash;
 
 describe('invokeMap', () => {
   const stringArray = ['a', 'b', 'c'];

--- a/benchmarks/performance/isArguments.bench.ts
+++ b/benchmarks/performance/isArguments.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isArguments as isArgumentsToolkit_ } from 'es-toolkit/compat';
-import { isArguments as isArgumentsLodash_ } from 'lodash';
+import { isArguments as isArgumentsToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isArgumentsToolkit = isArgumentsToolkit_;
-const isArgumentsLodash = isArgumentsLodash_;
+const { isArguments: isArgumentsLodash } = lodash;
 
 describe('isArguments', () => {
   bench('es-toolkit/isArguments', () => {

--- a/benchmarks/performance/isArray.bench.ts
+++ b/benchmarks/performance/isArray.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isArray as isArrayToolkit_ } from 'es-toolkit/compat';
-import { isArray as isArrayLodash_ } from 'lodash';
+import { isArray as isArrayToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isArrayToolkit = isArrayToolkit_;
-const isArrayLodash = isArrayLodash_;
+const { isArray: isArrayLodash } = lodash;
 
 describe('isArray', () => {
   bench('es-toolkit/isArray', () => {

--- a/benchmarks/performance/isArrayBuffer.bench.ts
+++ b/benchmarks/performance/isArrayBuffer.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isArrayBuffer as isArrayBufferToolkit_ } from 'es-toolkit';
-import { isArrayBuffer as isArrayBufferToolkitCompat_ } from 'es-toolkit/compat';
-import { isArrayBuffer as isArrayBufferLodash_ } from 'lodash';
+import { isArrayBuffer as isArrayBufferToolkit } from 'es-toolkit';
+import { isArrayBuffer as isArrayBufferToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isArrayBufferToolkit = isArrayBufferToolkit_;
-const isArrayBufferToolkitCompat = isArrayBufferToolkitCompat_;
-const isArrayBufferLodash = isArrayBufferLodash_;
+const { isArrayBuffer: isArrayBufferLodash } = lodash;
 
 describe('isArrayBuffer', () => {
   bench('es-toolkit/isArrayBuffer', () => {

--- a/benchmarks/performance/isArrayLike.bench.ts
+++ b/benchmarks/performance/isArrayLike.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isArrayLike as isArrayLikeToolkit_ } from 'es-toolkit/compat';
-import { isArrayLike as isArrayLikeLodash_ } from 'lodash';
+import { isArrayLike as isArrayLikeToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isArrayLikeToolkit = isArrayLikeToolkit_;
-const isArrayLikeLodash = isArrayLikeLodash_;
+const { isArrayLike: isArrayLikeLodash } = lodash;
 
 describe('isArrayLike', () => {
   bench('es-toolkit/isArrayLike', () => {

--- a/benchmarks/performance/isArrayLikeObject.bench.ts
+++ b/benchmarks/performance/isArrayLikeObject.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isArrayLikeObject as isArrayLikeObjectToolkit_ } from 'es-toolkit/compat';
-import { isArrayLikeObject as isArrayLikeObjectLodash_ } from 'lodash';
+import { isArrayLikeObject as isArrayLikeObjectToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isArrayLikeObjectToolkit = isArrayLikeObjectToolkit_;
-const isArrayLikeObjectLodash = isArrayLikeObjectLodash_;
+const { isArrayLikeObject: isArrayLikeObjectLodash } = lodash;
 
 describe('isArrayLikeObject', () => {
   bench('es-toolkit/isArrayLikeObject', () => {

--- a/benchmarks/performance/isBoolean.bench.ts
+++ b/benchmarks/performance/isBoolean.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isBoolean as isBooleanToolkit_ } from 'es-toolkit';
-import { isBoolean as isBooleanToolkitCompat_ } from 'es-toolkit/compat';
-import { isBoolean as isBooleanLodash_ } from 'lodash';
+import { isBoolean as isBooleanToolkit } from 'es-toolkit';
+import { isBoolean as isBooleanToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isBooleanToolkit = isBooleanToolkit_;
-const isBooleanToolkitCompat = isBooleanToolkitCompat_;
-const isBooleanLodash = isBooleanLodash_;
+const { isBoolean: isBooleanLodash } = lodash;
 
 describe('isBoolean', () => {
   bench('es-toolkit/isBoolean', () => {

--- a/benchmarks/performance/isBuffer.bench.ts
+++ b/benchmarks/performance/isBuffer.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isBuffer as isBufferToolkit_ } from 'es-toolkit';
-import { isBuffer as isBufferToolkitCompat_ } from 'es-toolkit/compat';
-import { isBuffer as isBufferLodash_ } from 'lodash';
+import { isBuffer as isBufferToolkit } from 'es-toolkit';
+import { isBuffer as isBufferToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isBufferToolkit = isBufferToolkit_;
-const isBufferToolkitCompat = isBufferToolkitCompat_;
-const isBufferLodash = isBufferLodash_;
+const { isBuffer: isBufferLodash } = lodash;
 
 describe('isBuffer', () => {
   bench('es-toolkit/isBuffer', () => {

--- a/benchmarks/performance/isDate.bench.ts
+++ b/benchmarks/performance/isDate.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isDate as isDateToolkit_ } from 'es-toolkit';
-import { isDate as isDateToolkitCompat_ } from 'es-toolkit/compat';
-import { isDate as isDateLodash_ } from 'lodash';
+import { isDate as isDateToolkit } from 'es-toolkit';
+import { isDate as isDateToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isDateToolkit = isDateToolkit_;
-const isDateToolkitCompat = isDateToolkitCompat_;
-const isDateLodash = isDateLodash_;
+const { isDate: isDateLodash } = lodash;
 
 describe('isDate', () => {
   bench('es-toolkit/isDate', () => {

--- a/benchmarks/performance/isElement.bench.ts
+++ b/benchmarks/performance/isElement.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isElement as isElementCompatToolkit_ } from 'es-toolkit/compat';
-import { isElement as isElementLodash_ } from 'lodash';
+import { isElement as isElementToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isElementToolkit = isElementCompatToolkit_;
-const isElementLodash = isElementLodash_;
+const { isElement: isElementLodash } = lodash;
 
 class ElementLike {
   nodeType = 1;

--- a/benchmarks/performance/isEqual.bench.ts
+++ b/benchmarks/performance/isEqual.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isEqual as isEqualToolkit_ } from 'es-toolkit';
-import { isEqual as isEqualToolkitCompat_ } from 'es-toolkit/compat';
-import { isEqual as isEqualLodash_ } from 'lodash';
+import { isEqual as isEqualToolkit } from 'es-toolkit';
+import { isEqual as isEqualToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isEqualToolkit = isEqualToolkit_;
-const isEqualToolkitCompat = isEqualToolkitCompat_;
-const isEqualLodash = isEqualLodash_;
+const { isEqual: isEqualLodash } = lodash;
 
 describe('isEqual primitives', () => {
   bench('es-toolkit/isEqual', () => {

--- a/benchmarks/performance/isEqualWith.bench.ts
+++ b/benchmarks/performance/isEqualWith.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isEqualWith as isEqualWithToolkit_ } from 'es-toolkit';
-import { isEqualWith as isEqualWithToolkitCompat_ } from 'es-toolkit/compat';
-import { isEqualWith as isEqualWithLodash_ } from 'lodash';
+import { isEqualWith as isEqualWithToolkit } from 'es-toolkit';
+import { isEqualWith as isEqualWithToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isEqualWithToolkit = isEqualWithToolkit_;
-const isEqualWithToolkitCompat = isEqualWithToolkitCompat_;
-const isEqualWithLodash = isEqualWithLodash_;
+const { isEqualWith: isEqualWithLodash } = lodash;
 
 describe('isEqualWith primitives', () => {
   const customizer = (a: unknown, b: unknown) => {

--- a/benchmarks/performance/isError.bench.ts
+++ b/benchmarks/performance/isError.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isError as isErrorToolkit_ } from 'es-toolkit';
-import { isError as isErrorCompatToolkit_ } from 'es-toolkit/compat';
-import { isError as isErrorLodash_ } from 'lodash';
+import { isError as isErrorToolkit } from 'es-toolkit';
+import { isError as isErrorCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isErrorToolkit = isErrorToolkit_;
-const isErrorCompatToolkit = isErrorCompatToolkit_;
-const isErrorLodash = isErrorLodash_;
+const { isError: isErrorLodash } = lodash;
 
 describe('isError', () => {
   bench('es-toolkit/isError', () => {

--- a/benchmarks/performance/isFinite.bench.ts
+++ b/benchmarks/performance/isFinite.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isFinite as isFiniteToolkit_ } from 'es-toolkit/compat';
-import { isFinite as isFiniteLodash_ } from 'lodash';
+import { isFinite as isFiniteToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isFiniteToolkit = isFiniteToolkit_;
-const isFiniteLodash = isFiniteLodash_;
+const { isFinite: isFiniteLodash } = lodash;
 
 describe('isFinite', () => {
   bench('es-toolkit/isFinite', () => {

--- a/benchmarks/performance/isFunction.bench.ts
+++ b/benchmarks/performance/isFunction.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isFunction as isFunctionToolkit_ } from 'es-toolkit';
-import { isFunction as isFunctionToolkitCompat_ } from 'es-toolkit/compat';
-import { isFunction as isFunctionLodash_ } from 'lodash';
+import { isFunction as isFunctionToolkit } from 'es-toolkit';
+import { isFunction as isFunctionToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isFunctionToolkit = isFunctionToolkit_;
-const isFunctionToolkitCompat = isFunctionToolkitCompat_;
-const isFunctionLodash = isFunctionLodash_;
+const { isFunction: isFunctionLodash } = lodash;
 
 describe('isFunction', () => {
   bench('es-toolkit/isFunction', () => {

--- a/benchmarks/performance/isInteger.bench.ts
+++ b/benchmarks/performance/isInteger.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isInteger as isIntegerToolkit_ } from 'es-toolkit/compat';
-import { isInteger as isIntegerLodash_ } from 'lodash';
+import { isInteger as isIntegerToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isIntegerToolkit = isIntegerToolkit_;
-const isIntegerLodash = isIntegerLodash_;
+const { isInteger: isIntegerLodash } = lodash;
 
 describe('isInteger', () => {
   bench('es-toolkit/isInteger', () => {

--- a/benchmarks/performance/isJSONObject.bench.ts
+++ b/benchmarks/performance/isJSONObject.bench.ts
@@ -1,7 +1,5 @@
 import { bench, describe } from 'vitest';
-import { isJSONObject as isJSONObjectToolkit_ } from 'es-toolkit';
-
-const isJSONObjectToolkit = isJSONObjectToolkit_;
+import { isJSONObject as isJSONObjectToolkit } from 'es-toolkit';
 
 describe('isJSONObject', () => {
   bench('es-toolkit/isJSONObject', () => {

--- a/benchmarks/performance/isLength.bench.ts
+++ b/benchmarks/performance/isLength.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isLength as isLengthToolkit_ } from 'es-toolkit';
-import { isLength as isLengthToolkitCompat_ } from 'es-toolkit/compat';
-import { isLength as isLengthLodash_ } from 'lodash';
+import { isLength as isLengthToolkit } from 'es-toolkit';
+import { isLength as isLengthToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isLengthToolkit = isLengthToolkit_;
-const isLengthToolkitCompat = isLengthToolkitCompat_;
-const isLengthLodash = isLengthLodash_;
+const { isLength: isLengthLodash } = lodash;
 
 describe('isLength', () => {
   bench('es-toolkit/isLength', () => {

--- a/benchmarks/performance/isMap.bench.ts
+++ b/benchmarks/performance/isMap.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isMap as isMapToolkit_ } from 'es-toolkit';
-import { isMap as isMapToolkitCompat_ } from 'es-toolkit/compat';
-import { isMap as isMapLodash_ } from 'lodash';
+import { isMap as isMapToolkit } from 'es-toolkit';
+import { isMap as isMapToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isMapToolkit = isMapToolkit_;
-const isMapToolkitCompat = isMapToolkitCompat_;
-const isMapLodash = isMapLodash_;
+const { isMap: isMapLodash } = lodash;
 
 describe('isMap', () => {
   bench('es-toolkit/isMap', () => {

--- a/benchmarks/performance/isMatch.bench.ts
+++ b/benchmarks/performance/isMatch.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isMatch as isMatchToolkit_ } from 'es-toolkit/compat';
-import { isMatch as isMatchLodash_ } from 'lodash';
+import { isMatch as isMatchToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isMatchToolkit = isMatchToolkit_;
-const isMatchLodash = isMatchLodash_;
+const { isMatch: isMatchLodash } = lodash;
 
 describe('isMatch', () => {
   bench('es-toolkit/isMatch', () => {

--- a/benchmarks/performance/isMatchWith.bench.ts
+++ b/benchmarks/performance/isMatchWith.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isMatchWith as isMatchWithToolkitCompat_ } from 'es-toolkit/compat';
-import { isMatchWith as isMatchWithLodash_ } from 'lodash';
+import { isMatchWith as isMatchWithToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isMatchWithToolkitCompat = isMatchWithToolkitCompat_;
-const isMatchWithLodash = isMatchWithLodash_;
+const { isMatchWith: isMatchWithLodash } = lodash;
 
 const customizer = (objValue: unknown, srcValue: unknown) => {
   if (typeof objValue === 'string' && typeof srcValue === 'string') {

--- a/benchmarks/performance/isNaN.bench.ts
+++ b/benchmarks/performance/isNaN.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isNaN as isNaNToolkit_ } from 'es-toolkit/compat';
-import { isNaN as isNaNLodash_ } from 'lodash';
+import { isNaN as isNaNToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isNaNToolkit = isNaNToolkit_;
-const isNaNLodash = isNaNLodash_;
+const { isNaN: isNaNLodash } = lodash;
 
 describe('isNaN', () => {
   bench('es-toolkit/isNaN', () => {

--- a/benchmarks/performance/isNative.bench.ts
+++ b/benchmarks/performance/isNative.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isNative as isNativeToolkit_ } from 'es-toolkit/compat';
-import { isNative as isNativeLodash_ } from 'lodash';
+import { isNative as isNativeToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isNativeToolkit = isNativeToolkit_;
-const isNativeLodash = isNativeLodash_;
+const { isNative: isNativeLodash } = lodash;
 
 describe('isNative', () => {
   bench('es-toolkit/isNative', () => {

--- a/benchmarks/performance/isNil.bench.ts
+++ b/benchmarks/performance/isNil.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isNil as isNilToolkit_ } from 'es-toolkit';
-import { isNil as isNilCompatToolkit_ } from 'es-toolkit/compat';
-import { isNil as isNilLodash_ } from 'lodash';
+import { isNil as isNilToolkit } from 'es-toolkit';
+import { isNil as isNilCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isNilToolkit = isNilToolkit_;
-const isNilCompatToolkit = isNilCompatToolkit_;
-const isNilLodash = isNilLodash_;
+const { isNil: isNilLodash } = lodash;
 
 describe('isNil', () => {
   bench('es-toolkit/isNil', () => {

--- a/benchmarks/performance/isNull.bench.ts
+++ b/benchmarks/performance/isNull.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isNull as isNullToolkit_ } from 'es-toolkit';
-import { isNull as isNullToolkitCompat_ } from 'es-toolkit/compat';
-import { isNull as isNullLodash_ } from 'lodash';
+import { isNull as isNullToolkit } from 'es-toolkit';
+import { isNull as isNullToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isNullToolkit = isNullToolkit_;
-const isNullToolkitCompat = isNullToolkitCompat_;
-const isNullLodash = isNullLodash_;
+const { isNull: isNullLodash } = lodash;
 
 describe('isNull', () => {
   bench('es-toolkit/isNull', () => {

--- a/benchmarks/performance/isNumber.bench.ts
+++ b/benchmarks/performance/isNumber.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isNumber as isNumberToolkit_ } from 'es-toolkit/compat';
-import { isNumber as isNumberLodash_ } from 'lodash';
+import { isNumber as isNumberToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isNumberToolkit = isNumberToolkit_;
-const isNumberLodash = isNumberLodash_;
+const { isNumber: isNumberLodash } = lodash;
 
 describe('isNumber', () => {
   bench('es-toolkit/isNumber', () => {

--- a/benchmarks/performance/isObject.bench.ts
+++ b/benchmarks/performance/isObject.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isObject as isObjectToolkit_ } from 'es-toolkit/compat';
-import { isObject as isObjectLodash_ } from 'lodash';
+import { isObject as isObjectToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isObjectToolkit = isObjectToolkit_;
-const isObjectLodash = isObjectLodash_;
+const { isObject: isObjectLodash } = lodash;
 
 describe('isObject', () => {
   bench('es-toolkit/isObject', () => {

--- a/benchmarks/performance/isObjectLike.bench.ts
+++ b/benchmarks/performance/isObjectLike.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isObjectLike as isObjectLikeToolkit_ } from 'es-toolkit/compat';
-import { isObjectLike as isObjectLikeLodash_ } from 'lodash';
+import { isObjectLike as isObjectLikeToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isObjectLikeToolkit = isObjectLikeToolkit_;
-const isObjectLikeLodash = isObjectLikeLodash_;
+const { isObjectLike: isObjectLikeLodash } = lodash;
 
 describe('isObjectLike', () => {
   bench('es-toolkit/isObjectLike', () => {

--- a/benchmarks/performance/isPlainObject.bench.ts
+++ b/benchmarks/performance/isPlainObject.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isPlainObject as isPlainObjectToolkit_ } from 'es-toolkit';
-import { isPlainObject as isPlainObjectCompatToolkit_ } from 'es-toolkit/compat';
-import { isPlainObject as isPlainObjectLodash_ } from 'lodash';
+import { isPlainObject as isPlainObjectToolkit } from 'es-toolkit';
+import { isPlainObject as isPlainObjectCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isPlainObjectToolkit = isPlainObjectToolkit_;
-const isPlainObjectCompatToolkit = isPlainObjectCompatToolkit_;
-const isPlainObjectLodash = isPlainObjectLodash_;
+const { isPlainObject: isPlainObjectLodash } = lodash;
 
 const object = Object.create(null);
 const buffer = Buffer.from('hello, world');

--- a/benchmarks/performance/isRegExp.bench.ts
+++ b/benchmarks/performance/isRegExp.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isRegExp as isRegExpToolkit_ } from 'es-toolkit';
-import { isRegExp as isRegExpToolkitCompat_ } from 'es-toolkit/compat';
-import { isRegExp as isRegExpLodash_ } from 'lodash';
+import { isRegExp as isRegExpToolkit } from 'es-toolkit';
+import { isRegExp as isRegExpToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isRegExpToolkit = isRegExpToolkit_;
-const isRegExpToolkitCompat = isRegExpToolkitCompat_;
-const isRegExpLodash = isRegExpLodash_;
+const { isRegExp: isRegExpLodash } = lodash;
 
 describe('isRegExp', () => {
   bench('es-toolkit/isRegExp', () => {

--- a/benchmarks/performance/isSafeInteger.bench.ts
+++ b/benchmarks/performance/isSafeInteger.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isSafeInteger as isSafeIntegerToolkit_ } from 'es-toolkit/compat';
-import { isSafeInteger as isSafeIntegerLodash_ } from 'lodash';
+import { isSafeInteger as isSafeIntegerToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isSafeIntegerToolkit = isSafeIntegerToolkit_;
-const isSafeIntegerLodash = isSafeIntegerLodash_;
+const { isSafeInteger: isSafeIntegerLodash } = lodash;
 
 describe('after', () => {
   bench('es-toolkit/isSafeInteger', () => {

--- a/benchmarks/performance/isSet.bench.ts
+++ b/benchmarks/performance/isSet.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isSet as isSetToolkit_ } from 'es-toolkit';
-import { isSet as isSetToolkitCompat_ } from 'es-toolkit/compat';
-import { isSet as isSetLodash_ } from 'lodash';
+import { isSet as isSetToolkit } from 'es-toolkit';
+import { isSet as isSetToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isSetToolkit = isSetToolkit_;
-const isSetToolkitCompat = isSetToolkitCompat_;
-const isSetLodash = isSetLodash_;
+const { isSet: isSetLodash } = lodash;
 
 describe('isSet', () => {
   bench('es-toolkit/isSet', () => {

--- a/benchmarks/performance/isString.bench.ts
+++ b/benchmarks/performance/isString.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isString as isStringToolkit_ } from 'es-toolkit';
-import { isString as isStringToolkitCompat_ } from 'es-toolkit/compat';
-import { isString as isStringLodash_ } from 'lodash';
+import { isString as isStringToolkit } from 'es-toolkit';
+import { isString as isStringToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isStringToolkit = isStringToolkit_;
-const isStringToolkitCompat = isStringToolkitCompat_;
-const isStringLodash = isStringLodash_;
+const { isString: isStringLodash } = lodash;
 
 describe('isString', () => {
   bench('es-toolkit/isString', () => {

--- a/benchmarks/performance/isSubset.bench.ts
+++ b/benchmarks/performance/isSubset.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { isSubset as isSubsetToolkit_ } from 'es-toolkit';
-import { difference as differenceLodash_ } from 'lodash';
+import { isSubset as isSubsetToolkit } from 'es-toolkit';
+import lodash from 'lodash';
 
-const isSubsetToolkit = isSubsetToolkit_;
-const differenceLodash = differenceLodash_;
+const { difference: differenceLodash } = lodash;
 
 const isSubsetLodash = (array: any[], subset: any[]) => {
   return differenceLodash(array, subset).length === 0;

--- a/benchmarks/performance/isSymbol.bench.ts
+++ b/benchmarks/performance/isSymbol.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isSymbol as isSymbolToolkit_ } from 'es-toolkit';
-import { isSymbol as isSymbolToolkitCompat_ } from 'es-toolkit/compat';
-import { isSymbol as isSymbolLodash_ } from 'lodash';
+import { isSymbol as isSymbolToolkit } from 'es-toolkit';
+import { isSymbol as isSymbolToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isSymbolToolkit = isSymbolToolkit_;
-const isSymbolToolkitCompat = isSymbolToolkitCompat_;
-const isSymbolLodash = isSymbolLodash_;
+const { isSymbol: isSymbolLodash } = lodash;
 
 describe('isSymbol', () => {
   bench('es-toolkit/isSymbol', () => {

--- a/benchmarks/performance/isTypedArray.bench.ts
+++ b/benchmarks/performance/isTypedArray.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isTypedArray as isTypedArrayToolkit_ } from 'es-toolkit';
-import { isTypedArray as isTypedArrayCompatToolkit_ } from 'es-toolkit/compat';
-import { isTypedArray as isTypedArrayLodash_ } from 'lodash';
+import { isTypedArray as isTypedArrayToolkit } from 'es-toolkit';
+import { isTypedArray as isTypedArrayCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isTypedArrayToolkit = isTypedArrayToolkit_;
-const isTypedArrayCompatToolkit = isTypedArrayCompatToolkit_;
-const isTypedArrayLodash = isTypedArrayLodash_;
+const { isTypedArray: isTypedArrayLodash } = lodash;
 
 describe('isTypedArrayToolkit', () => {
   bench('es-toolkit/isTypedArray', () => {

--- a/benchmarks/performance/isUndefined.bench.ts
+++ b/benchmarks/performance/isUndefined.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isUndefined as isUndefinedToolkit_ } from 'es-toolkit';
-import { isUndefined as isUndefinedToolkitCompat_ } from 'es-toolkit/compat';
-import { isUndefined as isUndefinedLodash_ } from 'lodash';
+import { isUndefined as isUndefinedToolkit } from 'es-toolkit';
+import { isUndefined as isUndefinedToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isUndefinedToolkit = isUndefinedToolkit_;
-const isUndefinedToolkitCompat = isUndefinedToolkitCompat_;
-const isUndefinedLodash = isUndefinedLodash_;
+const { isUndefined: isUndefinedLodash } = lodash;
 
 describe('isUndefined', () => {
   bench('es-toolkit/isUndefined', () => {

--- a/benchmarks/performance/isWeakMap.bench.ts
+++ b/benchmarks/performance/isWeakMap.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isWeakMap as isWeakMapToolkit_ } from 'es-toolkit';
-import { isWeakMap as isWeakMapToolkitCompat_ } from 'es-toolkit/compat';
-import { isWeakMap as isWeakMapLodash_ } from 'lodash';
+import { isWeakMap as isWeakMapToolkit } from 'es-toolkit';
+import { isWeakMap as isWeakMapToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isWeakMapToolkit = isWeakMapToolkit_;
-const isWeakMapToolkitCompat = isWeakMapToolkitCompat_;
-const isWeakMapLodash = isWeakMapLodash_;
+const { isWeakMap: isWeakMapLodash } = lodash;
 
 describe('isWeakMap', () => {
   bench('es-toolkit/isWeakMap', () => {

--- a/benchmarks/performance/isWeakSet.bench.ts
+++ b/benchmarks/performance/isWeakSet.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { isWeakSet as isWeakSetToolkit_ } from 'es-toolkit';
-import { isWeakSet as isWeakSetToolkitCompat_ } from 'es-toolkit/compat';
-import { isWeakSet as isWeakSetLodash_ } from 'lodash';
+import { isWeakSet as isWeakSetToolkit } from 'es-toolkit';
+import { isWeakSet as isWeakSetToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const isWeakSetToolkit = isWeakSetToolkit_;
-const isWeakSetToolkitCompat = isWeakSetToolkitCompat_;
-const isWeakSetLodash = isWeakSetLodash_;
+const { isWeakSet: isWeakSetLodash } = lodash;
 
 describe('isWeakSet', () => {
   bench('es-toolkit/isWeakSet', () => {

--- a/benchmarks/performance/iteratee.bench.ts
+++ b/benchmarks/performance/iteratee.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { iteratee as iterateeToolkit_ } from 'es-toolkit/compat';
-import { iteratee as iterateeLodash_ } from 'lodash';
+import { iteratee as iterateeToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const iterateeToolkit = iterateeToolkit_;
-const iterateeLodash = iterateeLodash_;
+const { iteratee: iterateeLodash } = lodash;
 
 describe('iteratee', () => {
   bench('es-toolkit/compat/iteratee', () => {

--- a/benchmarks/performance/join.bench.ts
+++ b/benchmarks/performance/join.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { join as joinToolkit_ } from 'es-toolkit/compat';
-import { join as joinLodash_ } from 'lodash';
+import { join as joinToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const joinToolkit = joinToolkit_;
-const joinLodash = joinLodash_;
+const { join: joinLodash } = lodash;
 
 describe('join', () => {
   bench('es-toolkit', () => {

--- a/benchmarks/performance/kebabCase.bench.ts
+++ b/benchmarks/performance/kebabCase.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { kebabCase as kebabCaseToolkit_ } from 'es-toolkit';
-import { kebabCase as kebabCaseToolkitCompat_ } from 'es-toolkit/compat';
-import { kebabCase as kebabCaseLodash_ } from 'lodash';
+import { kebabCase as kebabCaseToolkit } from 'es-toolkit';
+import { kebabCase as kebabCaseToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const kebabCaseToolkit = kebabCaseToolkit_;
-const kebabCaseToolkitCompat = kebabCaseToolkitCompat_;
-const kebabCaseLodash = kebabCaseLodash_;
+const { kebabCase: kebabCaseLodash } = lodash;
 
 describe('kebabCase', () => {
   bench('es-toolkit/kebabCase', () => {

--- a/benchmarks/performance/keyBy.bench.ts
+++ b/benchmarks/performance/keyBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { keyBy as keyByToolkit_ } from 'es-toolkit';
-import { keyBy as keyByToolkitCompat_ } from 'es-toolkit/compat';
-import { keyBy as keyByLodash_ } from 'lodash';
+import { keyBy as keyByToolkit } from 'es-toolkit';
+import { keyBy as keyByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const keyByToolkit = keyByToolkit_;
-const keyByToolkitCompat = keyByToolkitCompat_;
-const keyByLodash = keyByLodash_;
+const { keyBy: keyByLodash } = lodash;
 
 describe('keyBy', () => {
   bench('es-toolkit/keyBy', () => {

--- a/benchmarks/performance/keys.bench.ts
+++ b/benchmarks/performance/keys.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { keys as keysToolkit_ } from 'es-toolkit/compat';
-import { keys as keysLodash_ } from 'lodash';
+import { keys as keysToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const keysToolkit = keysToolkit_;
-const keysLodash = keysLodash_;
+const { keys: keysLodash } = lodash;
 
 class Foo {
   a = 1;

--- a/benchmarks/performance/keysIn.bench.ts
+++ b/benchmarks/performance/keysIn.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { keysIn as keysInToolkit_ } from 'es-toolkit/compat';
-import { keysIn as keysInLodash_ } from 'lodash';
+import { keysIn as keysInToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const keysInToolkit = keysInToolkit_;
-const keysInLodash = keysInLodash_;
+const { keysIn: keysInLodash } = lodash;
 
 class Foo {
   a = 1;

--- a/benchmarks/performance/last.bench.ts
+++ b/benchmarks/performance/last.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { last as lastToolkit_ } from 'es-toolkit';
-import { last as lastToolkitCompat_ } from 'es-toolkit/compat';
-import { last as lastLodash_ } from 'lodash';
+import { last as lastToolkit } from 'es-toolkit';
+import { last as lastToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const lastToolkit = lastToolkit_;
-const lastToolkitCompat = lastToolkitCompat_;
-const lastLodash = lastLodash_;
+const { last: lastLodash } = lodash;
 
 describe('last', () => {
   bench('es-toolkit/last', () => {

--- a/benchmarks/performance/lastIndexOf.bench.ts
+++ b/benchmarks/performance/lastIndexOf.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { lastIndexOf as lastIndexOfToolkitCompat_ } from 'es-toolkit/compat';
-import { lastIndexOf as lastIndexOfLodash_ } from 'lodash';
+import { lastIndexOf as indexOfToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const indexOfToolkitCompat = lastIndexOfToolkitCompat_;
-const indexOfLodash = lastIndexOfLodash_;
+const { lastIndexOf: indexOfLodash } = lodash;
 
 describe('lastIndexOf', () => {
   const largeArray = Array(1_000_000)

--- a/benchmarks/performance/lowerCase.bench.ts
+++ b/benchmarks/performance/lowerCase.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { lowerCase as lowerCaseToolkit_ } from 'es-toolkit';
-import { lowerCase as lowerCaseToolkitCompat_ } from 'es-toolkit/compat';
-import { lowerCase as lowerCaseLodash_ } from 'lodash';
+import { lowerCase as lowerCaseToolkit } from 'es-toolkit';
+import { lowerCase as lowerCaseToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const lowerCaseToolkit = lowerCaseToolkit_;
-const lowerCaseToolkitCompat = lowerCaseToolkitCompat_;
-const lowerCaseLodash = lowerCaseLodash_;
+const { lowerCase: lowerCaseLodash } = lodash;
 
 describe('lowerCase - short string', () => {
   bench('es-toolkit/lowerCase', () => {

--- a/benchmarks/performance/lowerFirst.bench.ts
+++ b/benchmarks/performance/lowerFirst.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { lowerFirst as lowerFirstToolkit_ } from 'es-toolkit';
-import { lowerFirst as lowerFirstCompatToolkit_ } from 'es-toolkit/compat';
-import { lowerFirst as lowerFirstLodash_ } from 'lodash';
+import { lowerFirst as lowerFirstToolkit } from 'es-toolkit';
+import { lowerFirst as lowerFirstCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const lowerFirstToolkit = lowerFirstToolkit_;
-const lowerFirstCompatToolkit = lowerFirstCompatToolkit_;
-const lowerFirstLodash = lowerFirstLodash_;
+const { lowerFirst: lowerFirstLodash } = lodash;
 
 describe('lowerFirst', () => {
   describe('short string', () => {

--- a/benchmarks/performance/map.bench.ts
+++ b/benchmarks/performance/map.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { map as mapToolkit_ } from 'es-toolkit/compat';
-import { map as mapLodash_ } from 'lodash';
+import { map as mapToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const mapToolkit = mapToolkit_;
-const mapLodash = mapLodash_;
+const { map: mapLodash } = lodash;
 
 const generateArray = (length: number) => Array.from({ length }, (_, i) => i);
 const generateObject = (length: number) => Object.fromEntries(generateArray(length).map(i => [`key${i}`, i]));

--- a/benchmarks/performance/mapKeys.bench.ts
+++ b/benchmarks/performance/mapKeys.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { mapKeys as mapKeysToolkit_ } from 'es-toolkit';
-import { mapKeys as mapKeysCompatToolkit_ } from 'es-toolkit/compat';
-import { mapKeys as mapKeysLodash_ } from 'lodash';
+import { mapKeys as mapKeysToolkit } from 'es-toolkit';
+import { mapKeys as mapKeysCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const mapKeysToolkit = mapKeysToolkit_;
-const mapKeysCompatToolkit = mapKeysCompatToolkit_;
-const mapKeysLodash = mapKeysLodash_;
+const { mapKeys: mapKeysLodash } = lodash;
 
 describe('mapKeys', () => {
   bench('es-toolkit/mapKeys', () => {

--- a/benchmarks/performance/mapValues.bench.ts
+++ b/benchmarks/performance/mapValues.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { mapValues as mapValuesToolkit_ } from 'es-toolkit';
-import { mapValues as mapValuesCompatToolkit_ } from 'es-toolkit/compat';
-import { mapValues as mapValuesLodash_ } from 'lodash';
+import { mapValues as mapValuesToolkit } from 'es-toolkit';
+import { mapValues as mapValuesCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const mapValuesToolkit = mapValuesToolkit_;
-const mapValuesCompatToolkit = mapValuesCompatToolkit_;
-const mapValuesLodash = mapValuesLodash_;
+const { mapValues: mapValuesLodash } = lodash;
 
 describe('mapValues', () => {
   bench('es-toolkit/mapValues', () => {

--- a/benchmarks/performance/matches.bench.ts
+++ b/benchmarks/performance/matches.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { matches as matchesToolkit_ } from 'es-toolkit/compat';
-import { matches as matchesLodash_ } from 'lodash';
+import { matches as matchesToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const matchesToolkit = matchesToolkit_;
-const matchesLodash = matchesLodash_;
+const { matches: matchesLodash } = lodash;
 
 describe('matches', () => {
   bench('es-toolkit/matches', () => {

--- a/benchmarks/performance/matchesProperty.bench.ts
+++ b/benchmarks/performance/matchesProperty.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { matchesProperty as matchesPropertyToolkit_ } from 'es-toolkit/compat';
-import { matchesProperty as matchesPropertyLodash_ } from 'lodash';
+import { matchesProperty as matchesPropertyToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const matchesPropertyToolkit = matchesPropertyToolkit_;
-const matchesPropertyLodash = matchesPropertyLodash_;
+const { matchesProperty: matchesPropertyLodash } = lodash;
 
 describe('matchesProperty', () => {
   bench('es-toolkit/matchesProperty', () => {

--- a/benchmarks/performance/max.bench.ts
+++ b/benchmarks/performance/max.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { max as maxToolkit_ } from 'es-toolkit/compat';
-import { max as maxLodash_ } from 'lodash';
+import { max as maxToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const maxToolkit = maxToolkit_;
-const maxLodash = maxLodash_;
+const { max: maxLodash } = lodash;
 
 describe('max', () => {
   bench('es-toolkit/max', () => {

--- a/benchmarks/performance/maxBy.bench.ts
+++ b/benchmarks/performance/maxBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { maxBy as maxByToolkit_ } from 'es-toolkit';
-import { maxBy as maxByCompat_ } from 'es-toolkit/compat';
-import { maxBy as maxByLodash_ } from 'lodash';
+import { maxBy as maxByToolkit } from 'es-toolkit';
+import { maxBy as maxByCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const maxByToolkit = maxByToolkit_;
-const maxByCompat = maxByCompat_;
-const maxByLodash = maxByLodash_;
+const { maxBy: maxByLodash } = lodash;
 
 describe('maxBy', () => {
   bench('es-toolkit/maxBy', () => {

--- a/benchmarks/performance/mean.bench.ts
+++ b/benchmarks/performance/mean.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { mean as meanToolkit_ } from 'es-toolkit';
-import { mean as meanToolkitCompat_ } from 'es-toolkit/compat';
-import { mean as meanLodash_ } from 'lodash';
+import { mean as meanToolkit } from 'es-toolkit';
+import { mean as meanToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const meanToolkit = meanToolkit_;
-const meanToolkitCompat = meanToolkitCompat_;
-const meanLodash = meanLodash_;
+const { mean: meanLodash } = lodash;
 
 describe('mean', () => {
   bench('es-toolkit/mean', () => {

--- a/benchmarks/performance/meanBy.bench.ts
+++ b/benchmarks/performance/meanBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { meanBy as meanByToolkit_ } from 'es-toolkit';
-import { meanBy as meanByToolkitCompat_ } from 'es-toolkit/compat';
-import { meanBy as meanByLodash_ } from 'lodash';
+import { meanBy as meanByToolkit } from 'es-toolkit';
+import { meanBy as meanByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const meanByToolkit = meanByToolkit_;
-const meanByToolkitCompat = meanByToolkitCompat_;
-const meanByLodash = meanByLodash_;
+const { meanBy: meanByLodash } = lodash;
 
 describe('meanBy', () => {
   bench('es-toolkit/meanBy', () => {

--- a/benchmarks/performance/memoize.bench.ts
+++ b/benchmarks/performance/memoize.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { memoize as memoizeToolkit_ } from 'es-toolkit';
-import { memoize as memoizeToolkitCompat_ } from 'es-toolkit/compat';
-import { memoize as memoizeLodash_ } from 'lodash';
+import { memoize as memoizeToolkit } from 'es-toolkit';
+import { memoize as memoizeToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const memoizeToolkit = memoizeToolkit_;
-const memoizeToolkitCompat = memoizeToolkitCompat_;
-const memoizeLodash = memoizeLodash_;
+const { memoize: memoizeLodash } = lodash;
 
 describe('memoize', () => {
   const object = { a: 1, b: 2, c: 3 };

--- a/benchmarks/performance/merge.bench.ts
+++ b/benchmarks/performance/merge.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { merge as mergeToolkit_ } from 'es-toolkit';
-import { merge as mergeCompatToolkit_ } from 'es-toolkit/compat';
-import { merge as mergeLodash_ } from 'lodash';
+import { merge as mergeToolkit } from 'es-toolkit';
+import { merge as mergeCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const mergeToolkit = mergeToolkit_;
-const mergeCompatToolkit = mergeCompatToolkit_;
-const mergeLodash = mergeLodash_;
+const { merge: mergeLodash } = lodash;
 
 const object = {
   a: [{ b: 2 }, { d: 4 }],

--- a/benchmarks/performance/mergeWith.bench.ts
+++ b/benchmarks/performance/mergeWith.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { mergeWith as mergeWithToolkit_ } from 'es-toolkit';
-import { mergeWith as mergeWithCompatToolkit_ } from 'es-toolkit/compat';
-import { mergeWith as mergeWithLodash_ } from 'lodash';
+import { mergeWith as mergeWithToolkit } from 'es-toolkit';
+import { mergeWith as mergeWithCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const mergeWithToolkit = mergeWithToolkit_;
-const mergeWithCompatToolkit = mergeWithCompatToolkit_;
-const mergeWithLodash = mergeWithLodash_;
+const { mergeWith: mergeWithLodash } = lodash;
 
 const object = { a: 1, b: 2 };
 

--- a/benchmarks/performance/method.bench.ts
+++ b/benchmarks/performance/method.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { method as methodToolkit_ } from 'es-toolkit/compat';
-import { method as methodLodash_ } from 'lodash';
+import { method as methodToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const methodToolkit = methodToolkit_;
-const methodLodash = methodLodash_;
+const { method: methodLodash } = lodash;
 
 const object = {
   a: {

--- a/benchmarks/performance/methodOf.bench.ts
+++ b/benchmarks/performance/methodOf.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { methodOf as methodOfToolkit_ } from 'es-toolkit/compat';
-import { methodOf as methodOfLodash_ } from 'lodash';
+import { methodOf as methodOfToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const methodOfToolkit = methodOfToolkit_;
-const methodOfLodash = methodOfLodash_;
+const { methodOf: methodOfLodash } = lodash;
 
 const object = {
   a: {

--- a/benchmarks/performance/min.bench.ts
+++ b/benchmarks/performance/min.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { min as minToolkit_ } from 'es-toolkit/compat';
-import { min as minLodash_ } from 'lodash';
+import { min as minToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const minToolkit = minToolkit_;
-const minLodash = minLodash_;
+const { min: minLodash } = lodash;
 
 describe('min', () => {
   bench('es-toolkit/min', () => {

--- a/benchmarks/performance/minBy.bench.ts
+++ b/benchmarks/performance/minBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { minBy as minByToolkit_ } from 'es-toolkit';
-import { minBy as minByToolkitCompat_ } from 'es-toolkit/compat';
-import { minBy as minByLodash_ } from 'lodash';
+import { minBy as minByToolkit } from 'es-toolkit';
+import { minBy as minByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const minByToolkit = minByToolkit_;
-const minByToolkitCompat = minByToolkitCompat_;
-const minByLodash = minByLodash_;
+const { minBy: minByLodash } = lodash;
 
 describe('minBy', () => {
   bench('es-toolkit/minBy', () => {

--- a/benchmarks/performance/multiply.bench.ts
+++ b/benchmarks/performance/multiply.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { multiply as multiplyToolkitCompat_ } from 'es-toolkit/compat';
-import { multiply as multiplyLodash_ } from 'lodash';
+import { multiply as multiplyToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const multiplyToolkitCompat = multiplyToolkitCompat_;
-const multiplyLodash = multiplyLodash_;
+const { multiply: multiplyLodash } = lodash;
 
 describe('multiply function benchmark', () => {
   bench('es-toolkit/compat/multiply', () => {

--- a/benchmarks/performance/negate.bench.ts
+++ b/benchmarks/performance/negate.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { negate as negateToolkit_ } from 'es-toolkit';
-import { negate as negateCompatToolkit_ } from 'es-toolkit/compat';
-import { negate as negateLodash_ } from 'lodash';
+import { negate as negateToolkit } from 'es-toolkit';
+import { negate as negateCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const negateToolkit = negateToolkit_;
-const negateCompatToolkit = negateCompatToolkit_;
-const negateLodash = negateLodash_;
+const { negate: negateLodash } = lodash;
 
 describe('compact', () => {
   bench('es-toolkit', () => {

--- a/benchmarks/performance/node-ts-loader.mjs
+++ b/benchmarks/performance/node-ts-loader.mjs
@@ -1,0 +1,54 @@
+import { transformSync } from 'esbuild';
+import { readFileSync } from 'node:fs';
+import { registerHooks } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+// Lets benchmarks run on native ESM without the Vite module runner
+// (see vitest.config.mts):
+//
+// - `src/` uses extensionless relative imports (e.g. `./predicate/isNumber`),
+//   and lodash subpaths (e.g. `lodash/fp`) have no `exports` map, so failed
+//   imports are retried with explicit extensions.
+// - `.ts` files are transpiled with esbuild, which strips type-only imports
+//   that Node.js's own type stripping would leave behind, while keeping
+//   real ESM bindings.
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    try {
+      return nextResolve(specifier, context);
+    } catch (error) {
+      for (const suffix of ['.ts', '/index.ts', '.js']) {
+        try {
+          return nextResolve(specifier + suffix, context);
+        } catch {
+          // fall through to the original error
+        }
+      }
+      throw error;
+    }
+  },
+  load(url, context, nextLoad) {
+    if (url.startsWith('file://') && url.endsWith('.ts')) {
+      const filePath = fileURLToPath(url);
+      const { code } = transformSync(readFileSync(filePath, 'utf8'), {
+        loader: 'ts',
+        format: 'esm',
+        sourcemap: 'inline',
+        sourcefile: filePath,
+      });
+      return { format: 'module', source: code, shortCircuit: true };
+    }
+    try {
+      return nextLoad(url, context);
+    } catch (error) {
+      // The Yarn PnP ESM loader defers CommonJS modules (e.g. lodash) to the
+      // CJS loader by returning `source: undefined`, which Node.js rejects
+      // when a sync load hook is registered. Read the source explicitly
+      // instead; PnP's patched `fs` can read into zip archives.
+      if (error?.code === 'ERR_INVALID_RETURN_PROPERTY_VALUE' && url.startsWith('file://')) {
+        return { format: 'commonjs', source: readFileSync(fileURLToPath(url), 'utf8'), shortCircuit: true };
+      }
+      throw error;
+    }
+  },
+});

--- a/benchmarks/performance/noop.bench.ts
+++ b/benchmarks/performance/noop.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { noop as noopToolkit_ } from 'es-toolkit';
-import { noop as noopLodash_ } from 'lodash';
+import { noop as noopToolkit } from 'es-toolkit';
+import lodash from 'lodash';
 
-const noopToolkit = noopToolkit_;
-const noopLodash = noopLodash_;
+const { noop: noopLodash } = lodash;
 
 describe('noop', () => {
   bench('es-toolkit/noop', () => {

--- a/benchmarks/performance/nth.bench.ts
+++ b/benchmarks/performance/nth.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { nth as nthToolkitCompat_ } from 'es-toolkit/compat';
-import { nth as nthLodash_ } from 'lodash';
+import { nth as nthToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const nthToolkitCompat = nthToolkitCompat_;
-const nthLodash = nthLodash_;
+const { nth: nthLodash } = lodash;
 
 describe('nth', () => {
   const array = [1, 2, 3];

--- a/benchmarks/performance/nthArg.bench.ts
+++ b/benchmarks/performance/nthArg.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { nthArg as nthArgToolkitCompat_ } from 'es-toolkit/compat';
-import { nthArg as nthArgLodash_ } from 'lodash';
+import { nthArg as nthArgToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const nthArgToolkitCompat = nthArgToolkitCompat_;
-const nthArgLodash = nthArgLodash_;
+const { nthArg: nthArgLodash } = lodash;
 
 describe('nthArg', () => {
   const array = [1, 2, 3];

--- a/benchmarks/performance/omit.bench.ts
+++ b/benchmarks/performance/omit.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { omit as omitToolkit_ } from 'es-toolkit';
-import { omit as omitToolkitCompat_ } from 'es-toolkit/compat';
-import { omit as omitLodash_ } from 'lodash';
+import { omit as omitToolkit } from 'es-toolkit';
+import { omit as omitToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const omitToolkit = omitToolkit_;
-const omitToolkitCompat = omitToolkitCompat_;
-const omitLodash = omitLodash_;
+const { omit: omitLodash } = lodash;
 
 describe('omit: simple', () => {
   bench('es-toolkit/omit', () => {

--- a/benchmarks/performance/omitBy.bench.ts
+++ b/benchmarks/performance/omitBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { omitBy as omitByToolkit_ } from 'es-toolkit';
-import { omitBy as omitByToolkitCompat_ } from 'es-toolkit/compat';
-import { omitBy as omitByLodash_ } from 'lodash';
+import { omitBy as omitByToolkit } from 'es-toolkit';
+import { omitBy as omitByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const omitByToolkit = omitByToolkit_;
-const omitByToolkitCompat = omitByToolkitCompat_;
-const omitByLodash = omitByLodash_;
+const { omitBy: omitByLodash } = lodash;
 
 describe('omitBy', () => {
   const obj = { a: 1, b: 'omit', c: 3, d: 'test', e: 0 };

--- a/benchmarks/performance/once.bench.ts
+++ b/benchmarks/performance/once.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { once as onceToolkit_ } from 'es-toolkit';
-import { once as onceToolkitCompat_ } from 'es-toolkit/compat';
-import { once as onceLodash_ } from 'lodash';
+import { once as onceToolkit } from 'es-toolkit';
+import { once as onceToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const onceToolkit = onceToolkit_;
-const onceToolkitCompat = onceToolkitCompat_;
-const onceLodash = onceLodash_;
+const { once: onceLodash } = lodash;
 
 describe('once', () => {
   bench('es-toolkit/once', () => {

--- a/benchmarks/performance/orderBy.bench.ts
+++ b/benchmarks/performance/orderBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { orderBy as orderByToolkit_ } from 'es-toolkit';
-import { orderBy as orderByToolkitCompat_ } from 'es-toolkit/compat';
-import { orderBy as orderByLodash_ } from 'lodash';
+import { orderBy as orderByToolkit } from 'es-toolkit';
+import { orderBy as orderByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const orderByToolkit = orderByToolkit_;
-const orderByToolkitCompat = orderByToolkitCompat_;
-const orderByLodash = orderByLodash_;
+const { orderBy: orderByLodash } = lodash;
 
 const users = [
   { user: 'fred', age: 48, nested: { user: 'fred' } },

--- a/benchmarks/performance/over.bench.ts
+++ b/benchmarks/performance/over.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { over as overToolkitCompat_ } from 'es-toolkit/compat';
-import { over as overLodash_ } from 'lodash';
+import { over as overToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const overToolkitCompat = overToolkitCompat_;
-const overLodash = overLodash_;
+const { over: overLodash } = lodash;
 
 describe('over - math functions', () => {
   const mathFunctions = [Math.max, Math.min];

--- a/benchmarks/performance/overArgs.bench.ts
+++ b/benchmarks/performance/overArgs.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { overArgs as overArgsToolkitCompat_ } from 'es-toolkit/compat';
-import { overArgs as overArgsLodash_ } from 'lodash';
+import { overArgs as overArgsToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const overArgsToolkitCompat = overArgsToolkitCompat_;
-const overArgsLodash = overArgsLodash_;
+const { overArgs: overArgsLodash } = lodash;
 
 function doubled(n: number) {
   return n * 2;

--- a/benchmarks/performance/overEvery.bench.ts
+++ b/benchmarks/performance/overEvery.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { overEvery as overEveryToolkit_ } from 'es-toolkit/compat';
-import { overEvery as overEveryLodash_ } from 'lodash';
+import { overEvery as overEveryToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const overEveryToolkit = overEveryToolkit_;
-const overEveryLodash = overEveryLodash_;
+const { overEvery: overEveryLodash } = lodash;
 
 describe('overEvery', () => {
   bench('es-toolkit/overEvery', () => {

--- a/benchmarks/performance/overSome.bench.ts
+++ b/benchmarks/performance/overSome.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { overSome as overSomeToolkit_ } from 'es-toolkit/compat';
-import { overSome as overSomeLodash_ } from 'lodash';
+import { overSome as overSomeToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const overSomeToolkit = overSomeToolkit_;
-const overSomeLodash = overSomeLodash_;
+const { overSome: overSomeLodash } = lodash;
 
 describe('overSome', () => {
   bench('es-toolkit/overSome', () => {

--- a/benchmarks/performance/pad.bench.ts
+++ b/benchmarks/performance/pad.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { pad as padToolkit_ } from 'es-toolkit';
-import { pad as padToolkitCompat_ } from 'es-toolkit/compat';
-import { pad as padLodash_ } from 'lodash';
+import { pad as padToolkit } from 'es-toolkit';
+import { pad as padToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const padToolkit = padToolkit_;
-const padToolkitCompat = padToolkitCompat_;
-const padLodash = padLodash_;
+const { pad: padLodash } = lodash;
 
 describe('pad', () => {
   bench('es-toolkit/pad', () => {

--- a/benchmarks/performance/padEnd.bench.ts
+++ b/benchmarks/performance/padEnd.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { padEnd as padEndToolkit_ } from 'es-toolkit/compat';
-import { padEnd as padEndLodash_ } from 'lodash';
+import { padEnd as padEndToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const padEndToolkit = padEndToolkit_;
-const padEndLodash = padEndLodash_;
+const { padEnd: padEndLodash } = lodash;
 
 describe('padEnd', () => {
   bench('es-toolkit/padEnd', () => {

--- a/benchmarks/performance/padStart.bench.ts
+++ b/benchmarks/performance/padStart.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { padStart as padStartToolkit_ } from 'es-toolkit/compat';
-import { padStart as padStartLodash_ } from 'lodash';
+import { padStart as padStartToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const padStartToolkit = padStartToolkit_;
-const padStartLodash = padStartLodash_;
+const { padStart: padStartLodash } = lodash;
 
 describe('padStart', () => {
   bench('es-toolkit/padStart', () => {

--- a/benchmarks/performance/parseInt.bench.ts
+++ b/benchmarks/performance/parseInt.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { parseInt as parseIntToolkit_ } from 'es-toolkit/compat';
-import { parseInt as parseIntLodash_ } from 'lodash';
+import { parseInt as parseIntToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const parseIntToolkit = parseIntToolkit_;
-const parseIntLodash = parseIntLodash_;
+const { parseInt: parseIntLodash } = lodash;
 
 describe('parseInt', () => {
   bench('es-toolkit/parseInt', () => {

--- a/benchmarks/performance/partial.bench.ts
+++ b/benchmarks/performance/partial.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { partial as partialToolkit_ } from 'es-toolkit';
-import { partial as partialToolkitCompat_ } from 'es-toolkit/compat';
-import { partial as partialLodash_ } from 'lodash';
+import { partial as partialToolkit } from 'es-toolkit';
+import { partial as partialToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const partialToolkit = partialToolkit_;
-const partialToolkitCompat = partialToolkitCompat_;
-const partialLodash = partialLodash_;
+const { partial: partialLodash } = lodash;
 
 const fn = function () {
   // eslint-disable-next-line prefer-rest-params

--- a/benchmarks/performance/partialRight.bench.ts
+++ b/benchmarks/performance/partialRight.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { partialRight as partialRightToolkit_ } from 'es-toolkit';
-import { partialRight as partialRightToolkitCompat_ } from 'es-toolkit/compat';
-import { partialRight as partialRightLodash_ } from 'lodash';
+import { partialRight as partialRightToolkit } from 'es-toolkit';
+import { partialRight as partialRightToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const partialRightToolkit = partialRightToolkit_;
-const partialRightToolkitCompat = partialRightToolkitCompat_;
-const partialRightLodash = partialRightLodash_;
+const { partialRight: partialRightLodash } = lodash;
 
 const fn = function () {
   // eslint-disable-next-line prefer-rest-params

--- a/benchmarks/performance/partition.bench.ts
+++ b/benchmarks/performance/partition.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { partition as partitionToolkit_ } from 'es-toolkit';
-import { partition as partitionToolkitCompat_ } from 'es-toolkit/compat';
-import { partition as partitionLodash_ } from 'lodash';
+import { partition as partitionToolkit } from 'es-toolkit';
+import { partition as partitionToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const partitionToolkit = partitionToolkit_;
-const partitionToolkitCompat = partitionToolkitCompat_;
-const partitionLodash = partitionLodash_;
+const { partition: partitionLodash } = lodash;
 
 describe('partition', () => {
   bench('es-toolkit/partition', () => {

--- a/benchmarks/performance/pick.bench.ts
+++ b/benchmarks/performance/pick.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { pick as pickToolkit_ } from 'es-toolkit';
-import { pick as pickCompatToolkit_ } from 'es-toolkit/compat';
-import { pick as pickLodash_ } from 'lodash';
+import { pick as pickToolkit } from 'es-toolkit';
+import { pick as pickCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const pickToolkit = pickToolkit_;
-const pickCompatToolkit = pickCompatToolkit_;
-const pickLodash = pickLodash_;
+const { pick: pickLodash } = lodash;
 
 describe('pick', () => {
   bench('es-toolkit/pick', () => {

--- a/benchmarks/performance/pickBy.bench.ts
+++ b/benchmarks/performance/pickBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { pickBy as pickByToolkit_ } from 'es-toolkit';
-import { pickBy as pickByCompat_ } from 'es-toolkit/compat';
-import { pickBy as pickByLodash_ } from 'lodash';
+import { pickBy as pickByToolkit } from 'es-toolkit';
+import { pickBy as pickByCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const pickByToolkit = pickByToolkit_;
-const pickByCompat = pickByCompat_;
-const pickByLodash = pickByLodash_;
+const { pickBy: pickByLodash } = lodash;
 
 describe('pickBy', () => {
   bench('es-toolkit/pickBy', () => {

--- a/benchmarks/performance/property.bench.ts
+++ b/benchmarks/performance/property.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { property as propertyToolkit_ } from 'es-toolkit/compat';
-import { property as propertyLodash_ } from 'lodash';
+import { property as propertyToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const propertyToolkit = propertyToolkit_;
-const propertyLodash = propertyLodash_;
+const { property: propertyLodash } = lodash;
 
 describe('property', () => {
   bench('es-toolkit/property', () => {

--- a/benchmarks/performance/propertyOf.bench.ts
+++ b/benchmarks/performance/propertyOf.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { propertyOf as propertyOfToolkit_ } from 'es-toolkit/compat';
-import { propertyOf as propertyOfLodash_ } from 'lodash';
+import { propertyOf as propertyOfToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const propertyOfToolkit = propertyOfToolkit_;
-const propertyOfLodash = propertyOfLodash_;
+const { propertyOf: propertyOfLodash } = lodash;
 
 describe('propertyOf', () => {
   bench('es-toolkit/propertyOf', () => {

--- a/benchmarks/performance/pull.bench.ts
+++ b/benchmarks/performance/pull.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { pull as pullToolkit_ } from 'es-toolkit/compat';
-import { pull as pullLodash_ } from 'lodash';
+import { pull as pullToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const pullToolkit = pullToolkit_;
-const pullLodash = pullLodash_;
+const { pull: pullLodash } = lodash;
 
 describe('pull array size 100', () => {
   const array = [...Array(100)].map((_, i) => i);

--- a/benchmarks/performance/pullAllBy.bench.ts
+++ b/benchmarks/performance/pullAllBy.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { pullAllBy as pullAllByToolkitCompat_ } from 'es-toolkit/compat';
-import { pullAllBy as pullAllByLodash_ } from 'lodash';
+import { pullAllBy as pullAllByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const pullAllByToolkitCompat = pullAllByToolkitCompat_;
-const pullAllByLodash = pullAllByLodash_;
+const { pullAllBy: pullAllByLodash } = lodash;
 
 const array = [{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }, { x: 2 }, { x: 3 }];
 

--- a/benchmarks/performance/pullAllWith.bench.ts
+++ b/benchmarks/performance/pullAllWith.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { pullAllWith as pullAllWithToolkit_ } from 'es-toolkit/compat';
-import { pullAllWith as pullAllWithLodash_ } from 'lodash';
+import { pullAllWith as pullAllWithToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const pullAllWithToolkit = pullAllWithToolkit_;
-const pullAllWithLodash = pullAllWithLodash_;
+const { pullAllWith: pullAllWithLodash } = lodash;
 
 describe('pullAllWith', () => {
   const array = [{ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }, { x: 5 }];

--- a/benchmarks/performance/pullAt.bench.ts
+++ b/benchmarks/performance/pullAt.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { pullAt as pullAtToolkit_ } from 'es-toolkit';
-import { pullAt as pullAtToolkitCompat_ } from 'es-toolkit/compat';
-import { pullAt as pullAtLodash_ } from 'lodash';
+import { pullAt as pullAtToolkit } from 'es-toolkit';
+import { pullAt as pullAtToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const pullAtToolkit = pullAtToolkit_;
-const pullAtToolkitCompat = pullAtToolkitCompat_;
-const pullAtLodash = pullAtLodash_;
+const { pullAt: pullAtLodash } = lodash;
 
 describe('pullAt', () => {
   bench('es-toolkit/pullAt', () => {

--- a/benchmarks/performance/random.bench.ts
+++ b/benchmarks/performance/random.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { random as randomToolkit_ } from 'es-toolkit';
-import { random as randomCompatToolkit_ } from 'es-toolkit/compat';
-import { random as randomLodash_ } from 'lodash';
+import { random as randomToolkit } from 'es-toolkit';
+import { random as randomCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const randomToolkit = randomToolkit_;
-const randomCompatToolkit = randomCompatToolkit_;
-const randomLodash = randomLodash_;
+const { random: randomLodash } = lodash;
 
 describe('random', () => {
   bench('es-toolkit/random', () => {

--- a/benchmarks/performance/randomInt.bench.ts
+++ b/benchmarks/performance/randomInt.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { randomInt as randomIntToolkit_ } from 'es-toolkit';
-import { random as randomLodash_ } from 'lodash';
+import { randomInt as randomIntToolkit } from 'es-toolkit';
+import lodash from 'lodash';
 
-const randomIntToolkit = randomIntToolkit_;
-const randomLodash = randomLodash_;
+const { random: randomLodash } = lodash;
 
 describe('randomInt', () => {
   bench('es-toolkit/randomInt', () => {

--- a/benchmarks/performance/range.bench.ts
+++ b/benchmarks/performance/range.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { range as rangeToolkit_ } from 'es-toolkit';
-import { range as rangeCompatToolkit_ } from 'es-toolkit/compat';
-import { range as rangeLodash_ } from 'lodash';
+import { range as rangeToolkit } from 'es-toolkit';
+import { range as rangeCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const rangeToolkit = rangeToolkit_;
-const rangeCompatToolkit = rangeCompatToolkit_;
-const rangeLodash = rangeLodash_;
+const { range: rangeLodash } = lodash;
 
 describe('range', () => {
   bench('es-toolkit/range', () => {

--- a/benchmarks/performance/rangeRight.bench.ts
+++ b/benchmarks/performance/rangeRight.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { rangeRight as rangeRightToolkit_ } from 'es-toolkit';
-import { rangeRight as rangeRightCompatToolkiTt_ } from 'es-toolkit/compat';
-import { rangeRight as rangeRightLodash_ } from 'lodash';
+import { rangeRight as rangeRightToolkit } from 'es-toolkit';
+import { rangeRight as rangeRightCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const rangeRightToolkit = rangeRightToolkit_;
-const rangeRightCompatToolkit = rangeRightCompatToolkiTt_;
-const rangeRightLodash = rangeRightLodash_;
+const { rangeRight: rangeRightLodash } = lodash;
 
 describe('rangeRight', () => {
   bench('es-toolkit/rangeRight', () => {

--- a/benchmarks/performance/rearg.bench.ts
+++ b/benchmarks/performance/rearg.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { rearg as reargToolkit_ } from 'es-toolkit/compat';
-import { rearg as reargLodash_ } from 'lodash';
+import { rearg as reargToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const reargToolkit = reargToolkit_;
-const reargLodash = reargLodash_;
+const { rearg: reargLodash } = lodash;
 
 describe('rearg', () => {
   function fn() {

--- a/benchmarks/performance/reduce.bench.ts
+++ b/benchmarks/performance/reduce.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { reduce as reduceToolkitCompat_ } from 'es-toolkit/compat';
-import { reduce as reduceLodash_ } from 'lodash';
+import { reduce as reduceToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const reduceToolkitCompat = reduceToolkitCompat_;
-const reduceLodash = reduceLodash_;
+const { reduce: reduceLodash } = lodash;
 
 const array = [1, 2, 3, 4, 5];
 

--- a/benchmarks/performance/reduceRight.bench.ts
+++ b/benchmarks/performance/reduceRight.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { reduceRight as reduceRightToolkitCompat_ } from 'es-toolkit/compat';
-import { reduceRight as reduceRightLodash_ } from 'lodash';
+import { reduceRight as reduceRightToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const reduceRightToolkitCompat = reduceRightToolkitCompat_;
-const reduceRightLodash = reduceRightLodash_;
+const { reduceRight: reduceRightLodash } = lodash;
 
 const array = [1, 2, 3, 4, 5];
 

--- a/benchmarks/performance/reject.bench.ts
+++ b/benchmarks/performance/reject.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { reject as rejectToolkit_ } from 'es-toolkit/compat';
-import { reject as rejectLodash_ } from 'lodash';
+import { reject as rejectToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const rejectToolkit = rejectToolkit_;
-const rejectLodash = rejectLodash_;
+const { reject: rejectLodash } = lodash;
 
 const arr = [
   { a: 0, b: true },

--- a/benchmarks/performance/repeat.bench.ts
+++ b/benchmarks/performance/repeat.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { repeat as repeatToolkit_ } from 'es-toolkit/compat';
-import { repeat as repeatLodash_ } from 'lodash';
+import { repeat as repeatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const repeatToolkit = repeatToolkit_;
-const repeatLodash = repeatLodash_;
+const { repeat: repeatLodash } = lodash;
 
 describe('repeat', () => {
   bench('es-toolkit/repeat', () => {

--- a/benchmarks/performance/replace.bench.ts
+++ b/benchmarks/performance/replace.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { replace as replaceToolkitCompat_ } from 'es-toolkit/compat';
-import { replace as replaceLodash_ } from 'lodash';
+import { replace as replaceToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const replaceToolkitCompat = replaceToolkitCompat_;
-const replaceLodash = replaceLodash_;
+const { replace: replaceLodash } = lodash;
 
 describe('replace', () => {
   bench('es-toolkit/compat/replace', () => {

--- a/benchmarks/performance/rest.bench.ts
+++ b/benchmarks/performance/rest.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { rest as restToolkit_ } from 'es-toolkit';
-import { rest as restCompat_ } from 'es-toolkit/compat';
-import { rest as restLodash_ } from 'lodash';
+import { rest as restToolkit } from 'es-toolkit';
+import { rest as restCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const restToolkit = restToolkit_;
-const restCompat = restCompat_;
-const restLodash = restLodash_;
+const { rest: restLodash } = lodash;
 
 describe('rest', () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/benchmarks/performance/result.bench.ts
+++ b/benchmarks/performance/result.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { result as resultToolkit_ } from 'es-toolkit/compat';
-import { result as resultLodash_ } from 'lodash';
+import { result as resultToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const resultToolkit = resultToolkit_;
-const resultLodash = resultLodash_;
+const { result: resultLodash } = lodash;
 
 describe('result', () => {
   const object = {

--- a/benchmarks/performance/reverse.bench.ts
+++ b/benchmarks/performance/reverse.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { reverse as reverseCompat_ } from 'es-toolkit/compat';
-import { reverse as reverseLodash_ } from 'lodash';
+import { reverse as reverseCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const reverseCompat = reverseCompat_;
-const reverseLodash = reverseLodash_;
+const { reverse: reverseLodash } = lodash;
 
 const testArray = Array.from({ length: 1000 }, (_, i) => i);
 

--- a/benchmarks/performance/round.bench.ts
+++ b/benchmarks/performance/round.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { round as roundToolkit_ } from 'es-toolkit';
-import { round as roundCompat_ } from 'es-toolkit/compat';
-import { round as roundLodash_ } from 'lodash';
+import { round as roundToolkit } from 'es-toolkit';
+import { round as roundCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const roundToolkit = roundToolkit_;
-const roundCompat = roundCompat_;
-const roundLodash = roundLodash_;
+const { round: roundLodash } = lodash;
 
 describe('round', () => {
   bench('es-toolkit/round', () => {

--- a/benchmarks/performance/sample.bench.ts
+++ b/benchmarks/performance/sample.bench.ts
@@ -1,10 +1,9 @@
 import { bench, describe } from 'vitest';
-import { sample as sampleToolkit_ } from 'es-toolkit';
+import { sample as sampleToolkit } from 'es-toolkit';
 import { sample as sampleToolkitCompat } from 'es-toolkit/compat';
-import { sample as sampleLodash_ } from 'lodash';
+import lodash from 'lodash';
 
-const sampleToolkit = sampleToolkit_;
-const sampleLodash = sampleLodash_;
+const { sample: sampleLodash } = lodash;
 
 describe('sample', () => {
   bench('es-toolkit/sample', () => {

--- a/benchmarks/performance/sampleSize.bench.ts
+++ b/benchmarks/performance/sampleSize.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { sampleSize as sampleSizeToolkit_ } from 'es-toolkit';
-import { sampleSize as sampleSizeToolkitCompat_ } from 'es-toolkit/compat';
-import { sampleSize as sampleSizeLodash_ } from 'lodash';
+import { sampleSize as sampleSizeToolkit } from 'es-toolkit';
+import { sampleSize as sampleSizeToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const sampleSizeToolkit = sampleSizeToolkit_;
-const sampleSizeToolkitCompat = sampleSizeToolkitCompat_;
-const sampleSizeLodash = sampleSizeLodash_;
+const { sampleSize: sampleSizeLodash } = lodash;
 
 describe('sampleSize', () => {
   bench('es-toolkit/sampleSize', () => {

--- a/benchmarks/performance/set.bench.ts
+++ b/benchmarks/performance/set.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { set as setToolkitCompat_ } from 'es-toolkit/compat';
-import { set as lodashSet_ } from 'lodash';
+import { set as setToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const setToolkitCompat = setToolkitCompat_;
-const lodashSet = lodashSet_;
+const { set: lodashSet } = lodash;
 
 describe('set - dot', () => {
   bench('es-toolkit/set', () => {

--- a/benchmarks/performance/setWith.bench.ts
+++ b/benchmarks/performance/setWith.bench.ts
@@ -1,10 +1,9 @@
 import { bench, describe } from 'vitest';
-import { setWith as setWithToolkitCompat_ } from 'es-toolkit/compat';
+import { setWith as setWithToolkitCompat } from 'es-toolkit/compat';
 import { isObject } from 'es-toolkit/compat';
-import { setWith as setWithLodash_ } from 'lodash';
+import lodash from 'lodash';
 
-const setWithToolkitCompat = setWithToolkitCompat_;
-const setWithLodash = setWithLodash_;
+const { setWith: setWithLodash } = lodash;
 
 describe('setWith - simple path', () => {
   bench('es-toolkit/setWith', () => {

--- a/benchmarks/performance/shuffle.bench.ts
+++ b/benchmarks/performance/shuffle.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { shuffle as shuffleToolkit_ } from 'es-toolkit';
-import { shuffle as shuffleToolkitCompat_ } from 'es-toolkit/compat';
-import { shuffle as shuffleLodash_ } from 'lodash';
+import { shuffle as shuffleToolkit } from 'es-toolkit';
+import { shuffle as shuffleToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const shuffleToolkit = shuffleToolkit_;
-const shuffleToolkitCompat = shuffleToolkitCompat_;
-const shuffleLodash = shuffleLodash_;
+const { shuffle: shuffleLodash } = lodash;
 
 describe('shuffle', () => {
   bench('es-toolkit/shuffle', () => {

--- a/benchmarks/performance/size.bench.ts
+++ b/benchmarks/performance/size.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { size as sizeToolkit_ } from 'es-toolkit/compat';
-import { size as sizeLodash_ } from 'lodash';
+import { size as sizeToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const sizeToolkit = sizeToolkit_;
-const sizeLodash = sizeLodash_;
+const { size: sizeLodash } = lodash;
 
 describe('size', () => {
   bench('es-toolkit/size', () => {

--- a/benchmarks/performance/slice.bench.ts
+++ b/benchmarks/performance/slice.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { slice as sliceToolkitCompat_ } from 'es-toolkit/compat';
-import { slice as sliceLodash_ } from 'lodash';
+import { slice as sliceToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const sliceToolkitCompat = sliceToolkitCompat_;
-const sliceLodash = sliceLodash_;
+const { slice: sliceLodash } = lodash;
 
 describe('slice', () => {
   const array = Array(1000);

--- a/benchmarks/performance/snakeCase.bench.ts
+++ b/benchmarks/performance/snakeCase.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { snakeCase as snakeCaseToolkit_ } from 'es-toolkit';
-import { snakeCase as snakeCaseToolkitCompat_ } from 'es-toolkit/compat';
-import { snakeCase as snakeCaseLodash_ } from 'lodash';
+import { snakeCase as snakeCaseToolkit } from 'es-toolkit';
+import { snakeCase as snakeCaseToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const snakeCaseToolkit = snakeCaseToolkit_;
-const snakeCaseToolkitCompat = snakeCaseToolkitCompat_;
-const snakeCaseLodash = snakeCaseLodash_;
+const { snakeCase: snakeCaseLodash } = lodash;
 
 describe('snakeCase', () => {
   bench('es-toolkit/snakeCase', () => {

--- a/benchmarks/performance/some.bench.ts
+++ b/benchmarks/performance/some.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { some as someToolkit_ } from 'es-toolkit/compat';
-import { some as someLodash_ } from 'lodash';
+import { some as someToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const someToolkit = someToolkit_;
-const someLodash = someLodash_;
+const { some: someLodash } = lodash;
 
 describe('some', () => {
   bench('es-toolkit/some', () => {

--- a/benchmarks/performance/sortBy.bench.ts
+++ b/benchmarks/performance/sortBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { sortBy as sortByToolkit_ } from 'es-toolkit';
-import { sortBy as sortByToolkitCompat_ } from 'es-toolkit/compat';
-import { sortBy as sortByLodash_ } from 'lodash';
+import { sortBy as sortByToolkit } from 'es-toolkit';
+import { sortBy as sortByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const sortByToolkit = sortByToolkit_;
-const sortByToolkitCompat = sortByToolkitCompat_;
-const sortByLodash = sortByLodash_;
+const { sortBy: sortByLodash } = lodash;
 
 const users = [
   { user: 'fred', age: 48, nested: { user: 'fred' } },

--- a/benchmarks/performance/sortedIndex.bench.ts
+++ b/benchmarks/performance/sortedIndex.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { sortedIndex as sortedIndexToolkitCompat_ } from 'es-toolkit/compat';
-import { sortedIndex as sortedIndexLodash_ } from 'lodash';
+import { sortedIndex as sortedIndexToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const sortedIndexToolkitCompat = sortedIndexToolkitCompat_;
-const sortedIndexLodash = sortedIndexLodash_;
+const { sortedIndex: sortedIndexLodash } = lodash;
 
 describe('sortedIndex', () => {
   const largeArray = Array.from({ length: 1000000 }, (_, i) => i * 2);

--- a/benchmarks/performance/sortedIndexBy.bench.ts
+++ b/benchmarks/performance/sortedIndexBy.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { sortedIndexBy as sortedIndexByToolkitCompat_ } from 'es-toolkit/compat';
-import { sortedIndexBy as sortedIndexByLodash_ } from 'lodash';
+import { sortedIndexBy as sortedIndexByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const sortedIndexByToolkitCompat = sortedIndexByToolkitCompat_;
-const sortedIndexByLodash = sortedIndexByLodash_;
+const { sortedIndexBy: sortedIndexByLodash } = lodash;
 
 describe('sortedIndexBy', () => {
   const largeArray = Array.from({ length: 1000000 }, (_, i) => ({ x: i * 2 }));

--- a/benchmarks/performance/sortedIndexOf.bench.ts
+++ b/benchmarks/performance/sortedIndexOf.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { sortedIndexOf as sortedIndexOfByTookitCompat_ } from 'es-toolkit/compat';
-import { sortedIndexOf as sortedIndexOfLodash_ } from 'lodash';
+import { sortedIndexOf as sortedIndexOfToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const sortedIndexOfToolkitCompat = sortedIndexOfByTookitCompat_;
-const sortedIndexOfLodash = sortedIndexOfLodash_;
+const { sortedIndexOf: sortedIndexOfLodash } = lodash;
 
 describe('sortedIndexOf', () => {
   const largeArray = Array.from({ length: 1000000 }, (_, i) => ({ x: i * 2 }));

--- a/benchmarks/performance/sortedLastIndexOf.bench.ts
+++ b/benchmarks/performance/sortedLastIndexOf.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { sortedLastIndexOf as sortedLastIndexOfByTookitCompat_ } from 'es-toolkit/compat';
-import { sortedLastIndexOf as sortedLastIndexOfLodash_ } from 'lodash';
+import { sortedLastIndexOf as sortedLastIndexOfToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const sortedLastIndexOfToolkitCompat = sortedLastIndexOfByTookitCompat_;
-const sortedLastIndexOfLodash = sortedLastIndexOfLodash_;
+const { sortedLastIndexOf: sortedLastIndexOfLodash } = lodash;
 
 describe('sortedLastIndexOf', () => {
   const largeArray = Array.from({ length: 1000000 }, (_, i) => ({ x: i * 2 }));

--- a/benchmarks/performance/split.bench.ts
+++ b/benchmarks/performance/split.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { split as splitToolkitCompat_ } from 'es-toolkit/compat';
-import { split as splitLodash_ } from 'lodash';
+import { split as splitToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const splitToolkitCompat = splitToolkitCompat_;
-const splitLodash = splitLodash_;
+const { split: splitLodash } = lodash;
 
 describe('split', () => {
   const str = 'a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z';

--- a/benchmarks/performance/spread.bench.ts
+++ b/benchmarks/performance/spread.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { spread as spreadToolkit_ } from 'es-toolkit';
-import { spread as spreadCompat_ } from 'es-toolkit/compat';
-import { spread as spreadLodash_ } from 'lodash';
+import { spread as spreadToolkit } from 'es-toolkit';
+import { spread as spreadCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const spreadToolkit = spreadToolkit_;
-const spreadCompat = spreadCompat_;
-const spreadLodash = spreadLodash_;
+const { spread: spreadLodash } = lodash;
 
 describe('spread', () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/benchmarks/performance/startCase.bench.ts
+++ b/benchmarks/performance/startCase.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { startCase as startCaseToolkit_ } from 'es-toolkit';
-import { startCase as startCaseToolkitCompat_ } from 'es-toolkit/compat';
-import { startCase as startCaseLodash_ } from 'lodash';
+import { startCase as startCaseToolkit } from 'es-toolkit';
+import { startCase as startCaseToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const startCaseToolkit = startCaseToolkit_;
-const startCaseToolkitCompat = startCaseToolkitCompat_;
-const startCaseLodash = startCaseLodash_;
+const { startCase: startCaseLodash } = lodash;
 
 describe('startCase', () => {
   bench('es-toolkit/startCase', () => {

--- a/benchmarks/performance/startsWith.bench.ts
+++ b/benchmarks/performance/startsWith.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { startsWith as startsWithToolkit_ } from 'es-toolkit/compat';
-import { startsWith as startsWithLodash_ } from 'lodash';
+import { startsWith as startsWithToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const startsWithToolkit = startsWithToolkit_;
-const startsWithLodash = startsWithLodash_;
+const { startsWith: startsWithLodash } = lodash;
 
 describe('startsWith', () => {
   bench('es-toolkit/startsWith', () => {

--- a/benchmarks/performance/subtract.bench.ts
+++ b/benchmarks/performance/subtract.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { subtract as subtractToolkitCompat_ } from 'es-toolkit/compat';
-import { subtract as subtractLodash_ } from 'lodash';
+import { subtract as subtractToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const subtractToolkitCompat = subtractToolkitCompat_;
-const subtractLodash = subtractLodash_;
+const { subtract: subtractLodash } = lodash;
 
 describe('subtract function benchmark', () => {
   bench('es-toolkit/compat/subtract', () => {

--- a/benchmarks/performance/sum.bench.ts
+++ b/benchmarks/performance/sum.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { sum as sumToolkit_ } from 'es-toolkit';
-import { sum as sumToolkitCompat_ } from 'es-toolkit/compat';
-import { sum as sumLodash_ } from 'lodash';
+import { sum as sumToolkit } from 'es-toolkit';
+import { sum as sumToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const sumToolkit = sumToolkit_;
-const sumToolkitCompat = sumToolkitCompat_;
-const sumLodash = sumLodash_;
+const { sum: sumLodash } = lodash;
 
 describe('sum', () => {
   bench('es-toolkit/sum', () => {

--- a/benchmarks/performance/sumBy.bench.ts
+++ b/benchmarks/performance/sumBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { sumBy as sumByToolkit_ } from 'es-toolkit';
-import { sumBy as sumByToolkitCompat_ } from 'es-toolkit/compat';
-import { sumBy as sumByLodash_ } from 'lodash';
+import { sumBy as sumByToolkit } from 'es-toolkit';
+import { sumBy as sumByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const sumByToolkit = sumByToolkit_;
-const sumByToolkitCompat = sumByToolkitCompat_;
-const sumByLodash = sumByLodash_;
+const { sumBy: sumByLodash } = lodash;
 
 describe('sumBy', () => {
   bench('es-toolkit/sumBy', () => {

--- a/benchmarks/performance/tail.bench.ts
+++ b/benchmarks/performance/tail.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { tail as tailToolkit_ } from 'es-toolkit';
-import { tail as tailToolkitCompat_ } from 'es-toolkit/compat';
-import { tail as tailLodash_ } from 'lodash';
+import { tail as tailToolkit } from 'es-toolkit';
+import { tail as tailToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const tailToolkit = tailToolkit_;
-const tailToolkitCompat = tailToolkitCompat_;
-const tailLodash = tailLodash_;
+const { tail: tailLodash } = lodash;
 
 describe('tail', () => {
   bench('es-toolkit/tail', () => {

--- a/benchmarks/performance/take.bench.ts
+++ b/benchmarks/performance/take.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { take as takeToolkit_ } from 'es-toolkit';
-import { take as takeToolkitCompat_ } from 'es-toolkit/compat';
-import { take as takeLodash_ } from 'lodash';
+import { take as takeToolkit } from 'es-toolkit';
+import { take as takeToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const takeToolkit = takeToolkit_;
-const takeToolkitCompat = takeToolkitCompat_;
-const takeLodash = takeLodash_;
+const { take: takeLodash } = lodash;
 
 describe('take', () => {
   bench('es-toolkit/take', () => {

--- a/benchmarks/performance/takeRight.bench.ts
+++ b/benchmarks/performance/takeRight.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { takeRight as takeRightToolkit_ } from 'es-toolkit';
-import { takeRight as takeRightToolkitCompat_ } from 'es-toolkit/compat';
-import { takeRight as takeRightLodash_ } from 'lodash';
+import { takeRight as takeRightToolkit } from 'es-toolkit';
+import { takeRight as takeRightToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const takeRightToolkit = takeRightToolkit_;
-const takeRightToolkitCompat = takeRightToolkitCompat_;
-const takeRightLodash = takeRightLodash_;
+const { takeRight: takeRightLodash } = lodash;
 
 describe('takeRight', () => {
   bench('es-toolkit/takeRight', () => {

--- a/benchmarks/performance/takeRightWhile.bench.ts
+++ b/benchmarks/performance/takeRightWhile.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { takeRightWhile as takeRightWhileToolkit_ } from 'es-toolkit';
-import { takeRightWhile as takeRightWhileCompatToolkit_ } from 'es-toolkit/compat';
-import { takeRightWhile as takeRightWhileLodash_ } from 'lodash';
+import { takeRightWhile as takeRightWhileToolkit } from 'es-toolkit';
+import { takeRightWhile as takeRightWhileCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const takeRightWhileToolkit = takeRightWhileToolkit_;
-const takeRightWhileCompatToolkit = takeRightWhileCompatToolkit_;
-const takeRightWhileLodash = takeRightWhileLodash_;
+const { takeRightWhile: takeRightWhileLodash } = lodash;
 
 describe('takeRightWhile', () => {
   bench('es-toolkit/takeRightWhile', () => {

--- a/benchmarks/performance/takeWhile.bench.ts
+++ b/benchmarks/performance/takeWhile.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { takeWhile as takeWhileToolkit_ } from 'es-toolkit';
-import { takeWhile as takeWhileCompatToolkit_ } from 'es-toolkit/compat';
-import { takeWhile as takeWhileLodash_ } from 'lodash';
+import { takeWhile as takeWhileToolkit } from 'es-toolkit';
+import { takeWhile as takeWhileCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const takeWhileToolkit = takeWhileToolkit_;
-const takeWhileCompatToolkit = takeWhileCompatToolkit_;
-const takeWhileLodash = takeWhileLodash_;
+const { takeWhile: takeWhileLodash } = lodash;
 
 describe('takeWhile', () => {
   bench('es-toolkit/takeWhile', () => {

--- a/benchmarks/performance/template.bench.ts
+++ b/benchmarks/performance/template.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { template as templateToolkitCompat_ } from 'es-toolkit/compat';
-import { template as templateLodash_ } from 'lodash';
+import { template as templateToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const templateToolkit = templateToolkitCompat_;
-const templateLodash = templateLodash_;
+const { template: templateLodash } = lodash;
 
 describe('template (interpolate)', () => {
   bench('es-toolkit/template', () => {

--- a/benchmarks/performance/throttle.bench.ts
+++ b/benchmarks/performance/throttle.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { throttle as throttleToolkit_ } from 'es-toolkit';
-import { throttle as throttleCompatToolkit_ } from 'es-toolkit/compat';
-import { throttle as throttleLodash_ } from 'lodash';
+import { throttle as throttleToolkit } from 'es-toolkit';
+import { throttle as throttleCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const throttleToolkit = throttleToolkit_;
-const throttleCompatToolkit = throttleCompatToolkit_;
-const throttleLodash = throttleLodash_;
+const { throttle: throttleLodash } = lodash;
 
 describe('throttle', () => {
   bench('es-toolkit/throttle', () => {

--- a/benchmarks/performance/times.bench.ts
+++ b/benchmarks/performance/times.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { times as timesCompatToolkit_ } from 'es-toolkit/compat';
-import { times as timesLodash_ } from 'lodash';
+import { times as timesCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const timesCompatToolkit = timesCompatToolkit_;
-const timesLodash = timesLodash_;
+const { times: timesLodash } = lodash;
 
 describe('times', () => {
   bench('es-toolkit/compat/times', () => {

--- a/benchmarks/performance/toArray.bench.ts
+++ b/benchmarks/performance/toArray.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toArray as toArrayToolkitCompat_ } from 'es-toolkit/compat';
-import { toArray as toArrayLodash_ } from 'lodash';
+import { toArray as toArrayToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toArrayToolkitCompat = toArrayToolkitCompat_;
-const toArrayLodash = toArrayLodash_;
+const { toArray: toArrayLodash } = lodash;
 
 describe('toArray', () => {
   bench('es-toolkit/compat/toArray', () => {

--- a/benchmarks/performance/toCamelCaseKeys.bench.ts
+++ b/benchmarks/performance/toCamelCaseKeys.bench.ts
@@ -1,8 +1,6 @@
 import { bench, describe } from 'vitest';
-import { toCamelCaseKeys as toCamelCaseKeysToolkit_ } from 'es-toolkit';
+import { toCamelCaseKeys as toCamelCaseKeysToolkit } from 'es-toolkit';
 import lodashFp from 'lodash/fp';
-
-const toCamelCaseKeysToolkit = toCamelCaseKeysToolkit_;
 
 const toCamelCaseKeysWithLodashFp = <T extends Record<string, any>>(obj: T) => {
   return lodashFp.mapKeys(lodashFp.camelCase)(obj);

--- a/benchmarks/performance/toFilled.bench.ts
+++ b/benchmarks/performance/toFilled.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toFilled as toFilledToolkit_ } from 'es-toolkit';
-import { fill as fillLodash_ } from 'lodash';
+import { toFilled as toFilledToolkit } from 'es-toolkit';
+import lodash from 'lodash';
 
-const fillLodash = fillLodash_;
-const toFilledToolkit = toFilledToolkit_;
+const { fill: fillLodash } = lodash;
 
 describe('fill function performance comparison', () => {
   bench('es-toolkit/toFilled', () => {

--- a/benchmarks/performance/toFinite.bench.ts
+++ b/benchmarks/performance/toFinite.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toFinite as toFiniteToolkitCompat_ } from 'es-toolkit/compat';
-import { toFinite as toFiniteLodash_ } from 'lodash';
+import { toFinite as toFiniteToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toFiniteToolkitCompat = toFiniteToolkitCompat_;
-const toFiniteLodash = toFiniteLodash_;
+const { toFinite: toFiniteLodash } = lodash;
 
 describe('toFinite', () => {
   bench('es-toolkit/compat/toFinite', () => {

--- a/benchmarks/performance/toInteger.bench.ts
+++ b/benchmarks/performance/toInteger.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toInteger as toIntegerToolkitCompat_ } from 'es-toolkit/compat';
-import { toInteger as toIntegerLodash_ } from 'lodash';
+import { toInteger as toIntegerToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toIntegerToolkitCompat = toIntegerToolkitCompat_;
-const toIntegerLodash = toIntegerLodash_;
+const { toInteger: toIntegerLodash } = lodash;
 
 describe('toInteger', () => {
   bench('es-toolkit/compat/toInteger', () => {

--- a/benchmarks/performance/toLength.bench.ts
+++ b/benchmarks/performance/toLength.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toLength as toLengthToolkitCompat_ } from 'es-toolkit/compat';
-import { toLength as toLengthLodash_ } from 'lodash';
+import { toLength as toLengthToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toLengthToolkitCompat = toLengthToolkitCompat_;
-const toLengthLodash = toLengthLodash_;
+const { toLength: toLengthLodash } = lodash;
 
 describe('toLength', () => {
   bench('es-toolkit/compat/toLength', () => {

--- a/benchmarks/performance/toNumber.bench.ts
+++ b/benchmarks/performance/toNumber.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toNumber as toNumberToolkitCompat_ } from 'es-toolkit/compat';
-import { toNumber as toNumberLodash_ } from 'lodash';
+import { toNumber as toNumberToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toNumberToolkitCompat = toNumberToolkitCompat_;
-const toNumberLodash = toNumberLodash_;
+const { toNumber: toNumberLodash } = lodash;
 
 describe('toNumber', () => {
   bench('es-toolkit/compat/toNumber', () => {

--- a/benchmarks/performance/toPairs.bench.ts
+++ b/benchmarks/performance/toPairs.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toPairs as toPairsToolkit_ } from 'es-toolkit/compat';
-import { toPairs as toPairsLodash_ } from 'lodash';
+import { toPairs as toPairsToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toPairsToolkit = toPairsToolkit_;
-const toPairsLodash = toPairsLodash_;
+const { toPairs: toPairsLodash } = lodash;
 
 describe('toPairs with object', () => {
   bench('es-toolkit/toPairs', () => {

--- a/benchmarks/performance/toPairsIn.bench.ts
+++ b/benchmarks/performance/toPairsIn.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toPairsIn as toPairsInToolkit_ } from 'es-toolkit/compat';
-import { toPairsIn as toPairsInLodash_ } from 'lodash';
+import { toPairsIn as toPairsInToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toPairsInToolkit = toPairsInToolkit_;
-const toPairsInLodash = toPairsInLodash_;
+const { toPairsIn: toPairsInLodash } = lodash;
 
 describe('toPairsIn with object', () => {
   bench('es-toolkit/toPairsIn', () => {

--- a/benchmarks/performance/toPath.bench.ts
+++ b/benchmarks/performance/toPath.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toPath as toPathToolkit_ } from 'es-toolkit/compat';
-import { toPath as toPathLodash_ } from 'lodash';
+import { toPath as toPathToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toPathToolkit = toPathToolkit_;
-const toPathLodash = toPathLodash_;
+const { toPath: toPathLodash } = lodash;
 
 describe('toPath: super simple', () => {
   bench('es-toolkit/toPath', () => {

--- a/benchmarks/performance/toPlainObject.bench.ts
+++ b/benchmarks/performance/toPlainObject.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toPlainObject as toPlainObjectCompatToolkit_ } from 'es-toolkit/compat';
-import { toPlainObject as toPlainObjectLodash_ } from 'lodash';
+import { toPlainObject as toPlainObjectCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toPlainObjectCompatToolkit = toPlainObjectCompatToolkit_;
-const toPlainObjectLodash = toPlainObjectLodash_;
+const { toPlainObject: toPlainObjectLodash } = lodash;
 
 describe('toPlainObject', () => {
   class Foo {

--- a/benchmarks/performance/toSafeInteger.bench.ts
+++ b/benchmarks/performance/toSafeInteger.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toSafeInteger as toSafeIntegerToolkitCompat_ } from 'es-toolkit/compat';
-import { toSafeInteger as toSafeIntegerLodash_ } from 'lodash';
+import { toSafeInteger as toSafeIntegerToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toSafeIntegerToolkitCompat = toSafeIntegerToolkitCompat_;
-const toSafeIntegerLodash = toSafeIntegerLodash_;
+const { toSafeInteger: toSafeIntegerLodash } = lodash;
 
 describe('toSafeInteger', () => {
   bench('es-toolkit/compat/toSafeInteger', () => {

--- a/benchmarks/performance/toSnakeCaseKeys.bench.ts
+++ b/benchmarks/performance/toSnakeCaseKeys.bench.ts
@@ -1,8 +1,6 @@
 import { bench, describe } from 'vitest';
-import { toSnakeCaseKeys as toSnakeCaseKeysToolkit_ } from 'es-toolkit';
+import { toSnakeCaseKeys as toSnakeCaseKeysToolkit } from 'es-toolkit';
 import lodashFp from 'lodash/fp';
-
-const toSnakeCaseKeysToolkit = toSnakeCaseKeysToolkit_;
 
 const toSnakeCaseKeysLodash = <T extends Record<string, any>>(obj: T) => {
   return lodashFp.mapKeys(lodashFp.snakeCase)(obj);

--- a/benchmarks/performance/toString.bench.ts
+++ b/benchmarks/performance/toString.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toString as toStringToolkitCompat_ } from 'es-toolkit/compat';
-import { toString as toStringLodash_ } from 'lodash';
+import { toString as toStringToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toStringToolkitCompat = toStringToolkitCompat_;
-const toStringLodash = toStringLodash_;
+const { toString: toStringLodash } = lodash;
 
 describe('toString', () => {
   const number = -0;

--- a/benchmarks/performance/toUpper.bench.ts
+++ b/benchmarks/performance/toUpper.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { toUpper as toUpperToolkitCompat_ } from 'es-toolkit/compat';
-import { toUpper as toUpperLodash_ } from 'lodash';
+import { toUpper as toUpperToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const toUpperToolkitCompat = toUpperToolkitCompat_;
-const toUpperLodash = toUpperLodash_;
+const { toUpper: toUpperLodash } = lodash;
 
 describe('toUpper', () => {
   const basicStrings = ['foo bar', 'Foo bar', 'foo Bar', 'Foo Bar', 'FOO BAR', 'fooBar', '--foo-bar--', '__foo_bar__'];

--- a/benchmarks/performance/transform.bench.ts
+++ b/benchmarks/performance/transform.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { transform as transformToolkitCompat_ } from 'es-toolkit/compat';
-import { transform as transformLodash_ } from 'lodash';
+import { transform as transformToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const transformToolkitCompat = transformToolkitCompat_;
-const transformLodash = transformLodash_;
+const { transform: transformLodash } = lodash;
 
 const bigObject = Object.fromEntries(Array.from({ length: 1000 }, (_, i) => [i, i]));
 const bigArray = Array.from({ length: 1000 }, (_, i) => i);

--- a/benchmarks/performance/trim.bench.ts
+++ b/benchmarks/performance/trim.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { trim as trimToolkit_ } from 'es-toolkit';
-import { trim as trimCompatToolkit_ } from 'es-toolkit/compat';
-import { trim as trimLodash_ } from 'lodash';
+import { trim as trimToolkit } from 'es-toolkit';
+import { trim as trimCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const trimToolkit = trimToolkit_;
-const trimCompatToolkit = trimCompatToolkit_;
-const trimLodash = trimLodash_;
+const { trim: trimLodash } = lodash;
 
 describe('trim', () => {
   bench('es-toolkit/trim', () => {

--- a/benchmarks/performance/trimEnd.bench.ts
+++ b/benchmarks/performance/trimEnd.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { trimEnd as trimEndToolkit_ } from 'es-toolkit/compat';
-import { trimEnd as trimEndLodash_ } from 'lodash';
+import { trimEnd as trimEndToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const trimEndToolkit = trimEndToolkit_;
-const trimEndLodash = trimEndLodash_;
+const { trimEnd: trimEndLodash } = lodash;
 
 describe('trimEnd', () => {
   bench('es-toolkit/trimEnd', () => {

--- a/benchmarks/performance/trimStart.bench.ts
+++ b/benchmarks/performance/trimStart.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { trimStart as trimStartToolkit_ } from 'es-toolkit/compat';
-import { trimStart as trimStartLodash_ } from 'lodash';
+import { trimStart as trimStartToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const trimStartToolkit = trimStartToolkit_;
-const trimStartLodash = trimStartLodash_;
+const { trimStart: trimStartLodash } = lodash;
 
 describe('trimStart', () => {
   bench('es-toolkit/trimStart', () => {

--- a/benchmarks/performance/truncate.bench.ts
+++ b/benchmarks/performance/truncate.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { truncate as truncateCompatToolkit_ } from 'es-toolkit/compat';
-import { truncate as truncateLodash_ } from 'lodash';
+import { truncate as truncateCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const truncateCompatToolkit = truncateCompatToolkit_;
-const truncateLodash = truncateLodash_;
+const { truncate: truncateLodash } = lodash;
 
 const strAsciiShort = 'hi-diddly-ho there, neighborino';
 const strAsciiLong = strAsciiShort.padEnd(500, 'A').padEnd(1000, '5').padEnd(1500, ' ').padEnd(2000, ', ');

--- a/benchmarks/performance/unary.bench.ts
+++ b/benchmarks/performance/unary.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { unary as unaryToolkit_ } from 'es-toolkit';
-import { unary as unaryLodash_ } from 'lodash';
+import { unary as unaryToolkit } from 'es-toolkit';
+import lodash from 'lodash';
 
-const unaryToolkit = unaryToolkit_;
-const unaryLodash = unaryLodash_;
+const { unary: unaryLodash } = lodash;
 
 describe('ary', () => {
   bench('es-toolkit/unary', () => {

--- a/benchmarks/performance/unescape.bench.ts
+++ b/benchmarks/performance/unescape.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { unescape as unescapeToolkit_ } from 'es-toolkit';
-import { unescape as unescapeCompatToolkit_ } from 'es-toolkit/compat';
-import { unescape as unescapeLodash_ } from 'lodash';
+import { unescape as unescapeToolkit } from 'es-toolkit';
+import { unescape as unescapeCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const unescapeToolkit = unescapeToolkit_;
-const unescapeCompatToolkit = unescapeCompatToolkit_;
-const unescapeLodash = unescapeLodash_;
+const { unescape: unescapeLodash } = lodash;
 
 const longString = 'fred, barney, &amp; pebbles'.repeat(50);
 

--- a/benchmarks/performance/union.bench.ts
+++ b/benchmarks/performance/union.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { union as unionToolkit_ } from 'es-toolkit';
-import { union as unionToolkitCompat_ } from 'es-toolkit/compat';
-import { union as unionLodash_ } from 'lodash';
+import { union as unionToolkit } from 'es-toolkit';
+import { union as unionToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const unionToolkit = unionToolkit_;
-const unionToolkitCompat = unionToolkitCompat_;
-const unionLodash = unionLodash_;
+const { union: unionLodash } = lodash;
 
 describe('union', () => {
   bench('es-toolkit/union', () => {

--- a/benchmarks/performance/unionBy.bench.ts
+++ b/benchmarks/performance/unionBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { unionBy as unionByToolkit_ } from 'es-toolkit';
-import { unionBy as unionByToolkitCompat_ } from 'es-toolkit/compat';
-import { unionBy as unionByLodash_ } from 'lodash';
+import { unionBy as unionByToolkit } from 'es-toolkit';
+import { unionBy as unionByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const unionByToolkit = unionByToolkit_;
-const unionByToolkitCompat = unionByToolkitCompat_;
-const unionByLodash = unionByLodash_;
+const { unionBy: unionByLodash } = lodash;
 
 describe('unionBy', () => {
   const array1 = [{ id: 1 }, { id: 2 }];

--- a/benchmarks/performance/unionWith.bench.ts
+++ b/benchmarks/performance/unionWith.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { unionWith as unionWithToolkit_ } from 'es-toolkit';
-import { unionWith as unionWithToolkitCompat_ } from 'es-toolkit/compat';
-import { unionWith as unionWithLodash_ } from 'lodash';
+import { unionWith as unionWithToolkit } from 'es-toolkit';
+import { unionWith as unionWithToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const unionWithToolkit = unionWithToolkit_;
-const unionWithToolkitCompat = unionWithToolkitCompat_;
-const unionWithLodash = unionWithLodash_;
+const { unionWith: unionWithLodash } = lodash;
 
 describe('unionWith', () => {
   const array1 = [{ id: 1 }, { id: 2 }];

--- a/benchmarks/performance/uniq.bench.ts
+++ b/benchmarks/performance/uniq.bench.ts
@@ -1,12 +1,10 @@
 import { bench, describe } from 'vitest';
-import { uniq as uniqToolkit_ } from 'es-toolkit';
-import { uniq as uniqToolkitCompat_ } from 'es-toolkit/compat';
+import { uniq as uniqToolkit } from 'es-toolkit';
+import { uniq as uniqToolkitCompat } from 'es-toolkit/compat';
 import { randomInt } from 'crypto';
-import { uniq as uniqLodash_ } from 'lodash';
+import lodash from 'lodash';
 
-const uniqToolkit = uniqToolkit_;
-const uniqToolkitCompat = uniqToolkitCompat_;
-const uniqLodash = uniqLodash_;
+const { uniq: uniqLodash } = lodash;
 
 describe('uniq', () => {
   bench('es-toolkit/uniq', () => {

--- a/benchmarks/performance/uniqBy.bench.ts
+++ b/benchmarks/performance/uniqBy.bench.ts
@@ -1,12 +1,10 @@
 import { bench, describe } from 'vitest';
-import { uniqBy as uniqByToolkit_ } from 'es-toolkit';
-import { uniqBy as uniqByToolkitCompat_ } from 'es-toolkit/compat';
+import { uniqBy as uniqByToolkit } from 'es-toolkit';
+import { uniqBy as uniqByToolkitCompat } from 'es-toolkit/compat';
 import { randomInt } from 'crypto';
-import { uniqBy as uniqByLodash_ } from 'lodash';
+import lodash from 'lodash';
 
-const uniqByToolkit = uniqByToolkit_;
-const uniqByToolkitCompat = uniqByToolkitCompat_;
-const uniqByLodash = uniqByLodash_;
+const { uniqBy: uniqByLodash } = lodash;
 
 describe('uniqBy, small arrays', () => {
   bench('es-toolkit/uniqBy', () => {

--- a/benchmarks/performance/uniqWith.bench.ts
+++ b/benchmarks/performance/uniqWith.bench.ts
@@ -1,12 +1,10 @@
 import { bench, describe } from 'vitest';
-import { uniqWith as uniqWithToolkit_ } from 'es-toolkit';
-import { uniqWith as uniqWithToolkitCompat_ } from 'es-toolkit/compat';
+import { uniqWith as uniqWithToolkit } from 'es-toolkit';
+import { uniqWith as uniqWithToolkitCompat } from 'es-toolkit/compat';
 import { randomInt } from 'crypto';
-import { uniqWith as uniqWithLodash_ } from 'lodash';
+import lodash from 'lodash';
 
-const uniqWithToolkit = uniqWithToolkit_;
-const uniqWithToolkitCompat = uniqWithToolkitCompat_;
-const uniqWithLodash = uniqWithLodash_;
+const { uniqWith: uniqWithLodash } = lodash;
 
 describe('uniqWith, small arrays', () => {
   bench('es-toolkit/uniqWith', () => {

--- a/benchmarks/performance/uniqueId.bench.ts
+++ b/benchmarks/performance/uniqueId.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { uniqueId as uniqueIdToolkitCompat_ } from 'es-toolkit/compat';
-import { uniqueId as uniqueIdLodash_ } from 'lodash';
+import { uniqueId as uniqueIdToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const uniqueIdToolkitCompat = uniqueIdToolkitCompat_;
-const uniqueIdLodash = uniqueIdLodash_;
+const { uniqueId: uniqueIdLodash } = lodash;
 
 describe('uniqueId', () => {
   bench('es-toolkit/compat/uniqueId', () => {

--- a/benchmarks/performance/unset.bench.ts
+++ b/benchmarks/performance/unset.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { unset as unsetToolkitCompat_ } from 'es-toolkit/compat';
-import { unset as unsetLodash_ } from 'lodash';
+import { unset as unsetToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const unsetToolkitCompat = unsetToolkitCompat_;
-const unsetLodash = unsetLodash_;
+const { unset: unsetLodash } = lodash;
 
 describe('unset', () => {
   bench('es-toolkit/unset', () => {

--- a/benchmarks/performance/unzip.bench.ts
+++ b/benchmarks/performance/unzip.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { unzip as unzipToolkit_ } from 'es-toolkit';
-import { unzip as unzipToolkitCompat_ } from 'es-toolkit/compat';
-import { unzip as unzipLodash_ } from 'lodash';
+import { unzip as unzipToolkit } from 'es-toolkit';
+import { unzip as unzipToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const unzipToolkit = unzipToolkit_;
-const unzipToolkitCompat = unzipToolkitCompat_;
-const unzipLodash = unzipLodash_;
+const { unzip: unzipLodash } = lodash;
 
 describe('unzip, small arrays', () => {
   bench('es-toolkit/unzip', () => {

--- a/benchmarks/performance/unzipWith.bench.ts
+++ b/benchmarks/performance/unzipWith.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { unzipWith as unzipWithToolkit_ } from 'es-toolkit';
-import { unzipWith as unzipWithCompatToolkit_ } from 'es-toolkit/compat';
-import { unzipWith as unzipWithLodash_ } from 'lodash';
+import { unzipWith as unzipWithToolkit } from 'es-toolkit';
+import { unzipWith as unzipWithCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const unzipWithToolkit = unzipWithToolkit_;
-const unzipWithCompatToolkit = unzipWithCompatToolkit_;
-const unzipWithLodash = unzipWithLodash_;
+const { unzipWith: unzipWithLodash } = lodash;
 
 describe('unzipWith', () => {
   bench('es-toolkit/unzipWith', () => {

--- a/benchmarks/performance/update.bench.ts
+++ b/benchmarks/performance/update.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { update as updateToolkitCompat_ } from 'es-toolkit/compat';
-import { update as lodashUpdate_ } from 'lodash';
+import { update as updateToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const updateToolkitCompat = updateToolkitCompat_;
-const lodashUpdate = lodashUpdate_;
+const { update: lodashUpdate } = lodash;
 
 describe('update - dot notation', () => {
   const obj = { a: { b: { c: 3 } } };

--- a/benchmarks/performance/updateWith.bench.ts
+++ b/benchmarks/performance/updateWith.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { updateWith as updateWithToolkitCompat_ } from 'es-toolkit/compat';
-import { updateWith as lodashUpdateWith_ } from 'lodash';
+import { updateWith as updateWithToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const updateWithToolkitCompat = updateWithToolkitCompat_;
-const lodashUpdateWith = lodashUpdateWith_;
+const { updateWith: lodashUpdateWith } = lodash;
 
 function customizer(value: unknown) {
   if (value == null) {

--- a/benchmarks/performance/upperCase.bench.ts
+++ b/benchmarks/performance/upperCase.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { upperCase as upperCaseToolkit_ } from 'es-toolkit';
-import { upperCase as upperCaseToolkitCompat_ } from 'es-toolkit/compat';
-import { upperCase as upperCaseLodash_ } from 'lodash';
+import { upperCase as upperCaseToolkit } from 'es-toolkit';
+import { upperCase as upperCaseToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const upperCaseToolkit = upperCaseToolkit_;
-const upperCaseToolkitCompat = upperCaseToolkitCompat_;
-const upperCaseLodash = upperCaseLodash_;
+const { upperCase: upperCaseLodash } = lodash;
 
 describe('upperCase', () => {
   describe('short string', () => {

--- a/benchmarks/performance/upperFirst.bench.ts
+++ b/benchmarks/performance/upperFirst.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { upperFirst as upperFirstToolkit_ } from 'es-toolkit';
-import { upperFirst as upperFirstCompatToolkit_ } from 'es-toolkit/compat';
-import { upperFirst as upperFirstLodash_ } from 'lodash';
+import { upperFirst as upperFirstToolkit } from 'es-toolkit';
+import { upperFirst as upperFirstCompatToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const upperFirstToolkit = upperFirstToolkit_;
-const upperFirstCompatToolkit = upperFirstCompatToolkit_;
-const upperFirstLodash = upperFirstLodash_;
+const { upperFirst: upperFirstLodash } = lodash;
 
 describe('upperFirst', () => {
   describe('short string', () => {

--- a/benchmarks/performance/values.bench.ts
+++ b/benchmarks/performance/values.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { values as valuesToolkitCompat_ } from 'es-toolkit/compat';
-import { values as valuesLodash_ } from 'lodash';
+import { values as valuesToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const valuesToolkitCompat = valuesToolkitCompat_;
-const valuesLodash = valuesLodash_;
+const { values: valuesLodash } = lodash;
 
 const object = { a: 1, b: 2, c: 3 };
 

--- a/benchmarks/performance/valuesIn.bench.ts
+++ b/benchmarks/performance/valuesIn.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { valuesIn as valuesInToolkitCompat_ } from 'es-toolkit/compat';
-import { valuesIn as valuesInLodash_ } from 'lodash';
+import { valuesIn as valuesInToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const valuesInToolkitCompat = valuesInToolkitCompat_;
-const valuesInLodash = valuesInLodash_;
+const { valuesIn: valuesInLodash } = lodash;
 
 const object = { a: 1, b: 2, c: 3 };
 

--- a/benchmarks/performance/vitest.config.mts
+++ b/benchmarks/performance/vitest.config.mts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+  test: {
+    name: 'benchmarks',
+    watch: false,
+    // Native module resolution cannot handle the TypeScript sources in
+    // `src/`, so register loader hooks that resolve and transpile them
+    // while keeping real ESM bindings.
+    execArgv: ['--import', fileURLToPath(new URL('./node-ts-loader.mjs', import.meta.url))],
+    benchmark: {
+      include: ['**/*.bench.ts'],
+    },
+    experimental: {
+      // Run benchmarks with native `import` so that imported bindings are not
+      // wrapped in module-runner getters, which would distort measurements.
+      // See https://github.com/vitest-dev/vitest/issues/6543
+      viteModuleRunner: false,
+      // Benchmarks do not use `vi.mock` or `import.meta.vitest`, so Vitest's
+      // Node.js loader hooks are unnecessary; they also conflict with the
+      // Yarn PnP ESM loader.
+      nodeLoader: false,
+    },
+  },
+});

--- a/benchmarks/performance/without.bench.ts
+++ b/benchmarks/performance/without.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { without as withoutEsToolkit_ } from 'es-toolkit';
-import { without as withoutToolkitCompat_ } from 'es-toolkit/compat';
-import { without as withoutLodash_ } from 'lodash';
+import { without as withoutEsToolkit } from 'es-toolkit';
+import { without as withoutToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const withoutEsToolkit = withoutEsToolkit_;
-const withoutToolkitCompat = withoutToolkitCompat_;
-const withoutLodash = withoutLodash_;
+const { without: withoutLodash } = lodash;
 
 const generateArray = (length: number, max: number) => Array.from({ length }, () => Math.floor(Math.random() * max));
 

--- a/benchmarks/performance/words.bench.ts
+++ b/benchmarks/performance/words.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { words as wordsToolkit_ } from 'es-toolkit';
-import { words as wordsToolkitCompat_ } from 'es-toolkit/compat';
-import { words as wordLodash_ } from 'lodash';
+import { words as wordsToolkit } from 'es-toolkit';
+import { words as wordsToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const wordsToolkit = wordsToolkit_;
-const wordsToolkitCompat = wordsToolkitCompat_;
-const wordLodash = wordLodash_;
+const { words: wordLodash } = lodash;
 
 describe('Performance Comparison: es-toolkit words vs lodash words', () => {
   const testString = 'This is a test string with different_cases and UPPERCASE words 🚀 and more symbols';

--- a/benchmarks/performance/wrap.bench.ts
+++ b/benchmarks/performance/wrap.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { wrap as wrapToolkit_ } from 'es-toolkit/compat';
-import { wrap as wrapLodash_ } from 'lodash';
+import { wrap as wrapToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const wrapToolkit = wrapToolkit_;
-const wrapLodash = wrapLodash_;
+const { wrap: wrapLodash } = lodash;
 
 describe('wrap', () => {
   bench('es-toolkit/compat/wrap', () => {

--- a/benchmarks/performance/xor.bench.ts
+++ b/benchmarks/performance/xor.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { xor as xorToolkit_ } from 'es-toolkit';
-import { xor as xorLodash_ } from 'lodash';
+import { xor as xorToolkit } from 'es-toolkit';
+import lodash from 'lodash';
 
-const xorToolkit = xorToolkit_;
-const xorLodash = xorLodash_;
+const { xor: xorLodash } = lodash;
 
 describe('xor', () => {
   bench('es-toolkit/xor', () => {

--- a/benchmarks/performance/xorBy.bench.ts
+++ b/benchmarks/performance/xorBy.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { xorBy as xorByToolkit_ } from 'es-toolkit';
-import { xorBy as xorByToolkitCompat_ } from 'es-toolkit/compat';
-import { xorBy as xorByLodash_ } from 'lodash';
+import { xorBy as xorByToolkit } from 'es-toolkit';
+import { xorBy as xorByToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const xorByToolkit = xorByToolkit_;
-const xorByToolkitCompat = xorByToolkitCompat_;
-const xorByLodash = xorByLodash_;
+const { xorBy: xorByLodash } = lodash;
 
 describe('xorBy', () => {
   bench('es-toolkit/xorBy', () => {

--- a/benchmarks/performance/xorWith.bench.ts
+++ b/benchmarks/performance/xorWith.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { xorWith as xorWithToolkit_ } from 'es-toolkit';
-import { xorWith as xorWithToolkitCompat_ } from 'es-toolkit/compat';
-import { xorWith as xorWithLodash_ } from 'lodash';
+import { xorWith as xorWithToolkit } from 'es-toolkit';
+import { xorWith as xorWithToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const xorWithLodash = xorWithLodash_;
-const xorWithToolkitCompat = xorWithToolkitCompat_;
-const xorWithToolkit = xorWithToolkit_;
+const { xorWith: xorWithLodash } = lodash;
 
 describe('xorWith', () => {
   bench('es-toolkit/xorWith', () => {

--- a/benchmarks/performance/zip.bench.ts
+++ b/benchmarks/performance/zip.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { zip as zipToolkit_ } from 'es-toolkit';
-import { zip as zipToolkitCompat_ } from 'es-toolkit/compat';
-import { zip as zipLodash_ } from 'lodash';
+import { zip as zipToolkit } from 'es-toolkit';
+import { zip as zipToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const zipToolkit = zipToolkit_;
-const zipToolkitCompat = zipToolkitCompat_;
-const zipLodash = zipLodash_;
+const { zip: zipLodash } = lodash;
 
 describe('zip', () => {
   bench('es-toolkit/zip', () => {

--- a/benchmarks/performance/zipObject.bench.ts
+++ b/benchmarks/performance/zipObject.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { zipObject as zipObjectToolkit_ } from 'es-toolkit';
-import { zipObject as zipObjectToolkitCompat_ } from 'es-toolkit/compat';
-import { zipObject as zipObjectLodash_ } from 'lodash';
+import { zipObject as zipObjectToolkit } from 'es-toolkit';
+import { zipObject as zipObjectToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const zipObjectToolkit = zipObjectToolkit_;
-const zipObjectToolkitCompat = zipObjectToolkitCompat_;
-const zipObjectLodash = zipObjectLodash_;
+const { zipObject: zipObjectLodash } = lodash;
 
 describe('zipObject', () => {
   bench('es-toolkit/zipObject', () => {

--- a/benchmarks/performance/zipObjectDeep.bench.ts
+++ b/benchmarks/performance/zipObjectDeep.bench.ts
@@ -1,9 +1,8 @@
 import { bench, describe } from 'vitest';
-import { zipObjectDeep as zipObjectDeepToolkit_ } from 'es-toolkit/compat';
-import { zipObjectDeep as zipObjectDeepLodash_ } from 'lodash';
+import { zipObjectDeep as zipObjectDeepToolkit } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const zipObjectDeepToolkit = zipObjectDeepToolkit_;
-const zipObjectDeepLodash = zipObjectDeepLodash_;
+const { zipObjectDeep: zipObjectDeepLodash } = lodash;
 
 describe('zipObjectDeep', () => {
   bench('es-toolkit/zipObjectDeep', () => {

--- a/benchmarks/performance/zipWith.bench.ts
+++ b/benchmarks/performance/zipWith.bench.ts
@@ -1,11 +1,9 @@
 import { bench, describe } from 'vitest';
-import { zipWith as zipWithToolkit_ } from 'es-toolkit';
-import { zipWith as zipWithToolkitCompat_ } from 'es-toolkit/compat';
-import { zipWith as zipWithLodash_ } from 'lodash';
+import { zipWith as zipWithToolkit } from 'es-toolkit';
+import { zipWith as zipWithToolkitCompat } from 'es-toolkit/compat';
+import lodash from 'lodash';
 
-const zipWithToolkit = zipWithToolkit_;
-const zipWithToolkitCompat = zipWithToolkitCompat_;
-const zipWithLodash = zipWithLodash_;
+const { zipWith: zipWithLodash } = lodash;
 
 describe('zipWith', () => {
   bench('es-toolkit/zipWith', () => {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "tests/types"
   ],
   "scripts": {
-    "bench": "vitest bench",
+    "bench": "yarn workspace benchmarks bench",
     "build": "tsdown && ./.scripts/postbuild.sh",
     "format": "prettier --write .",
     "gen:benchmark": "node ./.scripts/generate-benchmark.mjs",
@@ -79,7 +79,7 @@
     "@types/node": "^24.10.9",
     "@types/tar": "^6.1.13",
     "@typescript-eslint/parser": "^8.26.1",
-    "@vitest/coverage-istanbul": "^4.0.17",
+    "@vitest/coverage-istanbul": "^4.1.10",
     "@vitest/eslint-plugin": "^1.6.6",
     "@vue/compiler-sfc": "^3.5.10",
     "broken-link-checker": "0.7.8",
@@ -103,7 +103,7 @@
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.6.0",
     "vercel": "^54.4.1",
-    "vitest": "^4.0.17"
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public",
@@ -285,7 +285,5 @@
       "unplugged": true
     }
   },
-  "jsdelivr": "./dist/browser.global.js",
-  "react-native": "./dist/index.js",
-  "unpkg": "./dist/browser.global.js"
+  "react-native": "./dist/index.js"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,7 +268,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.23.9, @babel/core@npm:^7.24.7":
+"@babel/core@npm:^7.24.7, @babel/core@npm:^7.29.0":
   version: 7.29.7
   resolution: "@babel/core@npm:7.29.7"
   dependencies:
@@ -633,7 +633,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.20.5, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.25.0, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.25.6, @babel/parser@npm:^7.25.7":
+"@babel/parser@npm:^7.20.5, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.25.0, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.25.6, @babel/parser@npm:^7.25.7":
   version: 7.25.7
   resolution: "@babel/parser@npm:7.25.7"
   dependencies:
@@ -666,7 +666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.29.7":
+"@babel/parser@npm:^7.29.3, @babel/parser@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/parser@npm:7.29.7"
   dependencies:
@@ -962,7 +962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.28.5, @babel/types@npm:^7.28.6":
+"@babel/types@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/types@npm:7.28.6"
   dependencies:
@@ -1508,6 +1508,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/core@npm:1.11.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.2"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/2c6defdac2d1d26090384655d7d6c9614fa553853b1760597686749e9375dc2aa0dae80a2615b81c254600f5d531d07d8466cde0d331a8caae64b93f3ca5937e
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/runtime@npm:1.10.0"
@@ -1517,12 +1527,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/runtime@npm:1.11.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/04332fb62076afc440aa23316c04bec42f584ca8b074e5507d08e2b33a47cbe0493b1aadb8f3c1057b64ae1e17f5bde1a7bc37f7facc9d0bc25c18197cbd366f
+  languageName: node
+  linkType: hard
+
 "@emnapi/wasi-threads@npm:1.2.1":
   version: 1.2.1
   resolution: "@emnapi/wasi-threads@npm:1.2.1"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@emnapi/wasi-threads@npm:1.2.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/f0dc8269d6b20ae5a7c7b36e7a6a333452009d461038ef4febb29da2f3f78c1e2b1576d7e8970a5c5789ed3caedc1f80f5b0c2a5373bdaf8d03b20432bb55747
   languageName: node
   linkType: hard
 
@@ -2660,6 +2688,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.6"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.3"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/344518bf3ef65051dda4c00969f293aa4a21ab7dc7822b3f48519b17cd5eaa3f0bc34898d115d50ba59b1817a0cb905d46f7a7223c8249239cd14c28db388e10
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -2727,6 +2767,13 @@ __metadata:
   version: 0.129.0
   resolution: "@oxc-project/types@npm:0.129.0"
   checksum: 10c0/3714ba117af387992c2e5e779eedc1ccaf5a92c4d5c9b014dcc65d5a53012f8daae7aeb28930fef9eae7516bcdc500a0e689480eb1cb44a2e02830201fce7f1a
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:=0.138.0":
+  version: 0.138.0
+  resolution: "@oxc-project/types@npm:0.138.0"
+  checksum: 10c0/eacd260df0b961cb8863d0a0b3fab00c1f7701edfca28834b54628ca50ce703a4a3e7e6f9932ca11607d0cf876a0e1047b343a4672f1ad86d961017f7501524f
   languageName: node
   linkType: hard
 
@@ -2953,6 +3000,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-android-arm64@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-android-arm64@npm:1.1.4"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-darwin-arm64@npm:1.0.0":
   version: 1.0.0
   resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0"
@@ -2963,6 +3017,13 @@ __metadata:
 "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.1":
   version: 1.0.0-rc.1
   resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.1.4"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -2981,6 +3042,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-darwin-x64@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-darwin-x64@npm:1.1.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-freebsd-x64@npm:1.0.0":
   version: 1.0.0
   resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0"
@@ -2991,6 +3059,13 @@ __metadata:
 "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.1":
   version: 1.0.0-rc.1
   resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.1.4"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -3009,6 +3084,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.1.4"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-arm64-gnu@npm:1.0.0":
   version: 1.0.0
   resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0"
@@ -3019,6 +3101,13 @@ __metadata:
 "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.1":
   version: 1.0.0-rc.1
   resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.1.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3037,6 +3126,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm64-musl@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.1.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0":
   version: 1.0.0
   resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0"
@@ -3044,9 +3140,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-ppc64-gnu@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.1.4"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-s390x-gnu@npm:1.0.0":
   version: 1.0.0
   resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.1.4"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -3065,6 +3175,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-x64-gnu@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.1.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-x64-musl@npm:1.0.0":
   version: 1.0.0
   resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0"
@@ -3079,6 +3196,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-x64-musl@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.1.4"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-openharmony-arm64@npm:1.0.0":
   version: 1.0.0
   resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0"
@@ -3089,6 +3213,13 @@ __metadata:
 "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.1":
   version: 1.0.0-rc.1
   resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.1.4"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -3113,6 +3244,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-wasm32-wasi@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.1.4"
+  dependencies:
+    "@emnapi/core": "npm:1.11.1"
+    "@emnapi/runtime": "npm:1.11.1"
+    "@napi-rs/wasm-runtime": "npm:^1.1.6"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-win32-arm64-msvc@npm:1.0.0":
   version: 1.0.0
   resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0"
@@ -3123,6 +3265,13 @@ __metadata:
 "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.1":
   version: 1.0.0-rc.1
   resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.1.4"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -3141,6 +3290,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-win32-x64-msvc@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.1.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/pluginutils@npm:1.0.0":
   version: 1.0.0
   resolution: "@rolldown/pluginutils@npm:1.0.0"
@@ -3152,6 +3308,13 @@ __metadata:
   version: 1.0.0-rc.1
   resolution: "@rolldown/pluginutils@npm:1.0.0-rc.1"
   checksum: 10c0/6d13bd792c81d7ad218e9b8e842113a1cf8a7908072e0fc62215b8debe9526042e6d823f47dbf1afd020f0287122851f6deb8090c6f03c51bd4082ac796bfcee
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10c0/99d9b06d90196823e4d8c841f258db7a16e5dbba5824a2962b05d907b79f1ba929d56f22dd744fd530936e568c865ee56a719dc31e57e13bc0a8eb4764a8d8dd
   languageName: node
   linkType: hard
 
@@ -3454,7 +3617,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0":
+"@standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
   checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
@@ -3520,6 +3683,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/26165bcd1fd7269f42d7fbe3de318f854a8968de8397e89fc9a423bb3e2da35a52150f382e6323b3367595beb16d9800a6f35971a5599daf76da1742ec3afc25
+  languageName: node
+  linkType: hard
+
+"@tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/fd2bd2a79c6cd8c79ed1cf7a0fa375c64589264c88a27acaf9756d556b453ea222b62a4f68dd2fbb8b3a78b6bab3b1f4fb2431b6afc6aeda8344b53a521a1cd3
   languageName: node
   linkType: hard
 
@@ -4473,23 +4645,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-istanbul@npm:^4.0.17":
-  version: 4.0.17
-  resolution: "@vitest/coverage-istanbul@npm:4.0.17"
+"@vitest/coverage-istanbul@npm:^4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/coverage-istanbul@npm:4.1.10"
   dependencies:
+    "@babel/core": "npm:^7.29.0"
     "@istanbuljs/schema": "npm:^0.1.3"
     "@jridgewell/gen-mapping": "npm:^0.3.13"
     "@jridgewell/trace-mapping": "npm:0.3.31"
     istanbul-lib-coverage: "npm:^3.2.2"
-    istanbul-lib-instrument: "npm:^6.0.3"
     istanbul-lib-report: "npm:^3.0.1"
     istanbul-reports: "npm:^3.2.0"
-    magicast: "npm:^0.5.1"
+    magicast: "npm:^0.5.2"
     obug: "npm:^2.1.1"
-    tinyrainbow: "npm:^3.0.3"
+    tinyrainbow: "npm:^3.1.0"
   peerDependencies:
-    vitest: 4.0.17
-  checksum: 10c0/9422fce545b291f6f1e9c0d0e662687096625d9f3363513b971c6779e944ff26eaa12cbe774a3e66ef23ef922f83cbb17bf9c44583dfa939eba5f4f7a9b8ca40
+    vitest: 4.1.10
+  checksum: 10c0/a426b0aff94482587a100db7e8db4e238fabf9e5bc4d33a319bd9cd4261b8972a7b3d78f2bc7cbc3d11b0b58b5d7cc487f96ab35a96c1c766c54f9b6d5eb4f78
   languageName: node
   linkType: hard
 
@@ -4512,83 +4684,85 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:4.0.17":
-  version: 4.0.17
-  resolution: "@vitest/expect@npm:4.0.17"
+"@vitest/expect@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/expect@npm:4.1.10"
   dependencies:
-    "@standard-schema/spec": "npm:^1.0.0"
+    "@standard-schema/spec": "npm:^1.1.0"
     "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:4.0.17"
-    "@vitest/utils": "npm:4.0.17"
-    chai: "npm:^6.2.1"
-    tinyrainbow: "npm:^3.0.3"
-  checksum: 10c0/cdaa6827aa3a9473d51fd0944bcd698a94507929fa3c98b00bbdb74342319ec04279f01108d7d2dd7cbcd0d8062f65a3f21bb3615c0d5223e61adcc036c8b370
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/a817ad0d9bd6a039776a7228d54fb8319c17e4af15917407f5566ac61781a8511f591d302519d6999217399915bc3c0290028189fc73f5c38f80cb01b6f19c8d
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.0.17":
-  version: 4.0.17
-  resolution: "@vitest/mocker@npm:4.0.17"
+"@vitest/mocker@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/mocker@npm:4.1.10"
   dependencies:
-    "@vitest/spy": "npm:4.0.17"
+    "@vitest/spy": "npm:4.1.10"
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.21"
   peerDependencies:
     msw: ^2.4.9
-    vite: ^6.0.0 || ^7.0.0-0
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     msw:
       optional: true
     vite:
       optional: true
-  checksum: 10c0/54e657fa5b79764926b15aac993528bfe7083f6731209253617b1f27d328aa3297fcbf96b67e84d1a5632553231f795585f2396f563837cf117a574c87f5cef7
+  checksum: 10c0/4aa70b0df58681652e2e28093437fb2e8f4d02a6d03f5619abc266ac1c5ae5f43326148061d13ae6e071e0f6cfcf7634659af63644de8ce098a7c98949a3d1ad
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:4.0.17":
-  version: 4.0.17
-  resolution: "@vitest/pretty-format@npm:4.0.17"
+"@vitest/pretty-format@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/pretty-format@npm:4.1.10"
   dependencies:
-    tinyrainbow: "npm:^3.0.3"
-  checksum: 10c0/10a2dd7e2daf7ee006107d380bbd28b66b09a7014d31087daab0dea7dee0d12868cfcf6b3372729268502fd9065162345b68b9b9c5d225f5c6c2fd2c664a2a86
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/1a5daba730ffe23f2000bff484b4b2842f3b178d93663cb487b215516b8d3b62caa3e2bb2a3c63307b61a9fe58fb9bfff38559bc0c5e49d8aa403d6803a1d918
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:4.0.17":
-  version: 4.0.17
-  resolution: "@vitest/runner@npm:4.0.17"
+"@vitest/runner@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/runner@npm:4.1.10"
   dependencies:
-    "@vitest/utils": "npm:4.0.17"
+    "@vitest/utils": "npm:4.1.10"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/f4ccc236d1ed5ba2186d5f36ff0306d4ac7b711a40d7316ad6fd71c0f7229482b19969a8737e87670f3d4efb08f2138ff5b47a744fd7ae8db6c03cf991293a04
+  checksum: 10c0/554b72639de9694271b99be8ae273fe12ec793093ec91cce143816cd1187d40b7138a4d9d4de4f456cfca9567de986825bff97e107c05b9eb4abc130e854286d
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:4.0.17":
-  version: 4.0.17
-  resolution: "@vitest/snapshot@npm:4.0.17"
+"@vitest/snapshot@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/snapshot@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:4.0.17"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     magic-string: "npm:^0.30.21"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/31a047a097b13eff6c0f5393ea3e7203771ae9a22afe6465cd9023fd2ed516ddccd84523d48504a032c9d04a86a12e3f1235e08bb2ffc7d7a125e372c41ef53d
+  checksum: 10c0/e71398725f51af5fd0c07bb4b957d0f987daf9b4c564ac24cb2a4d1afde1a6939f535ac17761a32dcc41b0a1e6d4088af66dc44df89fdebebb92aabed1a92b5f
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.0.17":
-  version: 4.0.17
-  resolution: "@vitest/spy@npm:4.0.17"
-  checksum: 10c0/c290731ba3392f11eaba8fc7fa08063a3a4d14af6baeec210b260ccd5a46613196fb4a8ff3ac8bf91a9606aef90eee9b6364bda130ce71abff368e35dfe2b265
+"@vitest/spy@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/spy@npm:4.1.10"
+  checksum: 10c0/e5c08012560af6727fd66741c5cda25560d7c5442103d0c83e4276a9b0dd90b9da6cdf823a461195229a16c6ff87768ce788a68d0fa29dea73ee285618668178
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:4.0.17":
-  version: 4.0.17
-  resolution: "@vitest/utils@npm:4.0.17"
+"@vitest/utils@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/utils@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:4.0.17"
-    tinyrainbow: "npm:^3.0.3"
-  checksum: 10c0/1e2e4d7d7709ec022f603a1e12015523a2290f326c0bbe0c6bd5481ec396d4efc6bf8c738d601915d88e74267e9841df1e05157edced10f5048865204aeb86ff
+    "@vitest/pretty-format": "npm:4.1.10"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/05b0ecec6997ec22fc08377e57dbd8fa37992e05961f3a7a916d98b1ab56d15c2a87dbd83d392b628242bdc156b1705e7fa60a3bf0c54bdb51158c153e05fc5d
   languageName: node
   linkType: hard
 
@@ -5414,7 +5588,7 @@ __metadata:
     lodash-es: "npm:4.18.1"
     remeda: "npm:^2.39.0"
     rfdc: "npm:1.4.1"
-    vitest: "npm:4.0.17"
+    vitest: "npm:4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -5719,7 +5893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai@npm:^6.2.1":
+"chai@npm:^6.2.2":
   version: 6.2.2
   resolution: "chai@npm:6.2.2"
   checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
@@ -6301,6 +6475,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-libc@npm:^2.0.3":
+  version: 2.1.2
+  resolution: "detect-libc@npm:2.1.2"
+  checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
+  languageName: node
+  linkType: hard
+
 "dev-null@npm:^0.1.1":
   version: 0.1.1
   resolution: "dev-null@npm:0.1.1"
@@ -6597,10 +6778,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "es-module-lexer@npm:1.7.0"
-  checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
+"es-module-lexer@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "es-module-lexer@npm:2.3.0"
+  checksum: 10c0/14b28d854ec2aec285c481daeea268451e01ab2813f09f98eb1ac432521d8c3b38ce552a49f2e4af3ba188b74acbafe9e8d7271ce912bd98f1651b02bd06717e
   languageName: node
   linkType: hard
 
@@ -6648,7 +6829,7 @@ __metadata:
     "@types/node": "npm:^24.10.9"
     "@types/tar": "npm:^6.1.13"
     "@typescript-eslint/parser": "npm:^8.26.1"
-    "@vitest/coverage-istanbul": "npm:^4.0.17"
+    "@vitest/coverage-istanbul": "npm:^4.1.10"
     "@vitest/eslint-plugin": "npm:^1.6.6"
     "@vue/compiler-sfc": "npm:^3.5.10"
     broken-link-checker: "npm:0.7.8"
@@ -6672,7 +6853,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     typescript-eslint: "npm:^8.6.0"
     vercel: "npm:^54.4.1"
-    vitest: "npm:^4.0.17"
+    vitest: "npm:^4.1.10"
   dependenciesMeta:
     "@trivago/prettier-plugin-sort-imports@4.3.0":
       unplugged: true
@@ -6941,7 +7122,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.27.0, esbuild@npm:~0.27.0":
+"esbuild@npm:~0.27.0":
   version: 0.27.7
   resolution: "esbuild@npm:0.27.7"
   dependencies:
@@ -7411,10 +7592,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect-type@npm:^1.2.2":
-  version: 1.3.0
-  resolution: "expect-type@npm:1.3.0"
-  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
+"expect-type@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "expect-type@npm:1.4.0"
+  checksum: 10c0/d40d76b8570695d36587beb3cc28494da2ca3ec8f04e67f5622ed2d372d850e401a9adef19c6835e1a8173903f157c79540b34c7b3fbd7cd8ce726cc903c57b7
   languageName: node
   linkType: hard
 
@@ -8688,23 +8869,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0, istanbul-lib-coverage@npm:^3.2.2":
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.2":
   version: 3.2.2
   resolution: "istanbul-lib-coverage@npm:3.2.2"
   checksum: 10c0/6c7ff2106769e5f592ded1fb418f9f73b4411fd5a084387a5410538332b6567cd1763ff6b6cadca9b9eb2c443cce2f7ea7d7f1b8d315f9ce58539793b1e0922b
-  languageName: node
-  linkType: hard
-
-"istanbul-lib-instrument@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "istanbul-lib-instrument@npm:6.0.3"
-  dependencies:
-    "@babel/core": "npm:^7.23.9"
-    "@babel/parser": "npm:^7.23.9"
-    "@istanbuljs/schema": "npm:^0.1.3"
-    istanbul-lib-coverage: "npm:^3.2.0"
-    semver: "npm:^7.5.4"
-  checksum: 10c0/a1894e060dd2a3b9f046ffdc87b44c00a35516f5e6b7baf4910369acca79e506fc5323a816f811ae23d82334b38e3ddeb8b3b331bd2c860540793b59a8689128
   languageName: node
   linkType: hard
 
@@ -8989,6 +9157,126 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-android-arm64@npm:1.32.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-darwin-arm64@npm:1.32.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-x64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-darwin-x64@npm:1.32.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-freebsd-x64@npm:1.32.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.32.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-musl@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-musl@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-arm64-msvc@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss@npm:1.32.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.32.0"
+    lightningcss-darwin-arm64: "npm:1.32.0"
+    lightningcss-darwin-x64: "npm:1.32.0"
+    lightningcss-freebsd-x64: "npm:1.32.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.32.0"
+    lightningcss-linux-arm64-gnu: "npm:1.32.0"
+    lightningcss-linux-arm64-musl: "npm:1.32.0"
+    lightningcss-linux-x64-gnu: "npm:1.32.0"
+    lightningcss-linux-x64-musl: "npm:1.32.0"
+    lightningcss-win32-arm64-msvc: "npm:1.32.0"
+    lightningcss-win32-x64-msvc: "npm:1.32.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/70945bd55097af46fc9fab7f5ed09cd5869d85940a2acab7ee06d0117004a1d68155708a2d462531cea2fc3c67aefc9333a7068c80b0b78dd404c16838809e03
+  languageName: node
+  linkType: hard
+
 "limited-request-queue@npm:^2.0.0":
   version: 2.0.0
   resolution: "limited-request-queue@npm:2.0.0"
@@ -9184,14 +9472,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magicast@npm:^0.5.1":
-  version: 0.5.1
-  resolution: "magicast@npm:0.5.1"
+"magicast@npm:^0.5.2":
+  version: 0.5.3
+  resolution: "magicast@npm:0.5.3"
   dependencies:
-    "@babel/parser": "npm:^7.28.5"
-    "@babel/types": "npm:^7.28.5"
+    "@babel/parser": "npm:^7.29.3"
+    "@babel/types": "npm:^7.29.0"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/a00bbf3688b9b3e83c10b3bfe3f106cc2ccbf20c4f2dc1c9020a10556dfe0a6a6605a445ee8e86a6e2b484ec519a657b5e405532684f72678c62e4c0d32f962c
+  checksum: 10c0/e288c027ae5f2a794a59148cb114f4b60f1d5c03090de6c60b4d187f12d1de9158779cd7c39cea391609f4f10cd7ea737929f25f7ce44f7a96ba96ec1a477e39
   languageName: node
   linkType: hard
 
@@ -10808,6 +11096,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.5.16":
+  version: 8.5.16
+  resolution: "postcss@npm:8.5.16"
+  dependencies:
+    nanoid: "npm:^3.3.12"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/625de7a02f662f3a340964d14b487bd5097adf16f5f171e257d19005ba37aea8768ee446557500e88e91ca46b4d14d6cb4a0bf033c6ec0c8c0b660d85719f1ef
+  languageName: node
+  linkType: hard
+
 "preact@npm:^10.0.0":
   version: 10.23.1
   resolution: "preact@npm:10.23.1"
@@ -11485,7 +11784,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.20.0, rollup@npm:^4.43.0":
+"rolldown@npm:~1.1.3":
+  version: 1.1.4
+  resolution: "rolldown@npm:1.1.4"
+  dependencies:
+    "@oxc-project/types": "npm:=0.138.0"
+    "@rolldown/binding-android-arm64": "npm:1.1.4"
+    "@rolldown/binding-darwin-arm64": "npm:1.1.4"
+    "@rolldown/binding-darwin-x64": "npm:1.1.4"
+    "@rolldown/binding-freebsd-x64": "npm:1.1.4"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.1.4"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.1.4"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.1.4"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.1.4"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.1.4"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.1.4"
+    "@rolldown/binding-linux-x64-musl": "npm:1.1.4"
+    "@rolldown/binding-openharmony-arm64": "npm:1.1.4"
+    "@rolldown/binding-wasm32-wasi": "npm:1.1.4"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.1.4"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.1.4"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10c0/58ca78ec0f20f2276db129ac38db3ebe6dd68236be76f0fdf1e76276934ed67abcb2925cdcb297f52a77c0bdc1a508573176e167443ec737c8cb4a1d24083113
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^4.20.0":
   version: 4.60.4
   resolution: "rollup@npm:4.60.4"
   dependencies:
@@ -12036,10 +12393,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"std-env@npm:^3.10.0":
-  version: 3.10.0
-  resolution: "std-env@npm:3.10.0"
-  checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.1.0
+  resolution: "std-env@npm:4.1.0"
+  checksum: 10c0/2e14b6b490db34cb969a48d9cf7c35bca4a47653914aac2814221baae7b867a5b15940d133625c391621971f98cd2266a5dc7036669960e883f1081db2a56558
   languageName: node
   linkType: hard
 
@@ -12483,10 +12840,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyrainbow@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "tinyrainbow@npm:3.0.3"
-  checksum: 10c0/1e799d35cd23cabe02e22550985a3051dc88814a979be02dc632a159c393a998628eacfc558e4c746b3006606d54b00bcdea0c39301133956d10a27aa27e988c
+"tinyglobby@npm:^0.2.17":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "tinyrainbow@npm:3.1.0"
+  checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
   languageName: node
   linkType: hard
 
@@ -13258,22 +13625,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.0.0 || ^7.0.0":
-  version: 7.3.3
-  resolution: "vite@npm:7.3.3"
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.1.3
+  resolution: "vite@npm:8.1.3"
   dependencies:
-    esbuild: "npm:^0.27.0"
-    fdir: "npm:^6.5.0"
     fsevents: "npm:~2.3.3"
-    picomatch: "npm:^4.0.3"
-    postcss: "npm:^8.5.6"
-    rollup: "npm:^4.43.0"
-    tinyglobby: "npm:^0.2.15"
+    lightningcss: "npm:^1.32.0"
+    picomatch: "npm:^4.0.4"
+    postcss: "npm:^8.5.16"
+    rolldown: "npm:~1.1.3"
+    tinyglobby: "npm:^0.2.17"
   peerDependencies:
     "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.3.0
+    esbuild: ^0.27.0 || ^0.28.0
     jiti: ">=1.21.0"
     less: ^4.0.0
-    lightningcss: ^1.21.0
     sass: ^1.70.0
     sass-embedded: ^1.70.0
     stylus: ">=0.54.8"
@@ -13287,11 +13654,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/node":
       optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
     jiti:
       optional: true
     less:
-      optional: true
-    lightningcss:
       optional: true
     sass:
       optional: true
@@ -13309,7 +13678,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/44fed2591d5d0a9d1f6313e0a4330659b7f1eec57e542558f12a924c53b450a84b9fad6d57ac28ec739eca1cf5ff0f62e41b965e3806c47eefdbbe13b74ec9ae
+  checksum: 10c0/e3c95e95f9c19b36be3c9d1c4de7f57d24d5af71613a221cfa22f1fd1568adebdb640e30ef9a7f2361fbb15478883955c9d8932e4fa5566280dd7a16bffa64f9
   languageName: node
   linkType: hard
 
@@ -13393,40 +13762,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:4.0.17, vitest@npm:^4.0.17":
-  version: 4.0.17
-  resolution: "vitest@npm:4.0.17"
+"vitest@npm:4.1.10, vitest@npm:^4.0.17, vitest@npm:^4.1.10":
+  version: 4.1.10
+  resolution: "vitest@npm:4.1.10"
   dependencies:
-    "@vitest/expect": "npm:4.0.17"
-    "@vitest/mocker": "npm:4.0.17"
-    "@vitest/pretty-format": "npm:4.0.17"
-    "@vitest/runner": "npm:4.0.17"
-    "@vitest/snapshot": "npm:4.0.17"
-    "@vitest/spy": "npm:4.0.17"
-    "@vitest/utils": "npm:4.0.17"
-    es-module-lexer: "npm:^1.7.0"
-    expect-type: "npm:^1.2.2"
+    "@vitest/expect": "npm:4.1.10"
+    "@vitest/mocker": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/runner": "npm:4.1.10"
+    "@vitest/snapshot": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
     magic-string: "npm:^0.30.21"
     obug: "npm:^2.1.1"
     pathe: "npm:^2.0.3"
     picomatch: "npm:^4.0.3"
-    std-env: "npm:^3.10.0"
+    std-env: "npm:^4.0.0-rc.1"
     tinybench: "npm:^2.9.0"
     tinyexec: "npm:^1.0.2"
     tinyglobby: "npm:^0.2.15"
-    tinyrainbow: "npm:^3.0.3"
-    vite: "npm:^6.0.0 || ^7.0.0"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
     why-is-node-running: "npm:^2.3.0"
   peerDependencies:
     "@edge-runtime/vm": "*"
     "@opentelemetry/api": ^1.9.0
     "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.0.17
-    "@vitest/browser-preview": 4.0.17
-    "@vitest/browser-webdriverio": 4.0.17
-    "@vitest/ui": 4.0.17
+    "@vitest/browser-playwright": 4.1.10
+    "@vitest/browser-preview": 4.1.10
+    "@vitest/browser-webdriverio": 4.1.10
+    "@vitest/coverage-istanbul": 4.1.10
+    "@vitest/coverage-v8": 4.1.10
+    "@vitest/ui": 4.1.10
     happy-dom: "*"
     jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     "@edge-runtime/vm":
       optional: true
@@ -13440,15 +13812,21 @@ __metadata:
       optional: true
     "@vitest/browser-webdriverio":
       optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
     "@vitest/ui":
       optional: true
     happy-dom:
       optional: true
     jsdom:
       optional: true
+    vite:
+      optional: false
   bin:
-    vitest: vitest.mjs
-  checksum: 10c0/e1648bbfe2d01e23ceb6856863344035d2a1c139f39e8b15859e6ea8dc510ac3ba425df7c45486492d85ca516472aa892540dfd11ab6ad0613be98fd56d40716
+    vitest: ./vitest.mjs
+  checksum: 10c0/ff07294a57f9c62f3b503f7cf88a52ee0753ed26389a49cda430387a3898f39d80af47180b0af19e27acab5bd11ae95706bd4b44ce8befc97d3ae49af6ca4fc1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

Every benchmark file carried this workaround:

```ts
import { add as addToolkitCompat_ } from 'es-toolkit/compat';
import { add as addLodash_ } from 'lodash';

const addToolkitCompat = addToolkitCompat_;
const addLodash = addLodash_;
```

It exists because vitest's module runner wraps imported bindings in getters, and that getter overhead dominates measurements when a function is called millions of times per sample (vitest-dev/vitest#6543). Reassigning to a local variable bypassed the getter.

Vitest 4.1 ships `test.experimental.viteModuleRunner: false`, which runs test files with native ESM imports — no getters, so the workaround is no longer needed. See the [Module runner overhead](https://main.vitest.dev/guide/benchmarking.html#module-runner-overhead) section of the vitest benchmarking guide.

## What changed

- **vitest 4.0.17 → 4.1.10** (root and benchmarks workspace; the `viteModuleRunner` option exists since 4.1).
- **New `benchmarks/performance/vitest.config.mts`** — a dedicated config for performance benchmarks with `experimental.viteModuleRunner: false` and `experimental.nodeLoader: false`. `benchmarks/bundle-size` intentionally keeps running with vitest defaults as before.
- **New `benchmarks/performance/node-ts-loader.mjs`** — native ESM alone cannot load our sources, so a minimal `module.registerHooks` loader:
  - retries extensionless relative imports (`./predicate/isNumber`) and extensionless lodash subpaths (`lodash/fp`) with explicit extensions;
  - transpiles `.ts` with esbuild (drops type-only imports that Node's own type stripping chokes on) while keeping real ESM bindings;
  - reads CommonJS sources explicitly because the Yarn PnP ESM loader defers them with `source: undefined`, which Node rejects when a sync load hook is registered.
- **Removed the underscore-reassignment pattern from all 280 bench files.** ESM sources (`es-toolkit`, `es-toolkit/compat`, `es-toolkit/fp`, `remeda`) now use direct named imports. `lodash` is CJS, and named imports from it don't exist under native ESM (cjs-module-lexer cannot detect its dynamic exports), so those became:

  ```ts
  import lodash from 'lodash';

  const { add: addLodash } = lodash;
  ```

- `yarn bench` now delegates to the benchmarks workspace (`vitest bench --root performance`), and `.scripts/generate-benchmark.mjs` was updated accordingly.

## Verification

- **Overhead parity**: under the new setup, a direct import and a reassigned local measure at exactly 1.00x of each other, confirming the getter overhead is gone and the reassignment is obsolete.
- All 282 bench files were swept with a non-matching `-t` filter (imports and collection run, benchmarks skipped) — zero failures.
- Sample benchmarks (`add`, `chunk`, `cloneDeep`, `template`, `isEqual`, `fp/pipe`) plus the 10 functions in `generate-benchmark.mjs` run end-to-end with plausible ratios (e.g. chunk 1.23x, cloneDeep 4.65x vs lodash).
- Unit tests, `yarn lint`, and `tsc --noEmit` pass. `check-bundle-size` behaves identically to `main` (its snapshot staleness is pre-existing and unrelated).

## Notes

- `experimental.viteModuleRunner` is an experimental flag; the benchmark-specific config isolates it from the unit-test setup.
- Running benchmarks now requires a Node version with `--experimental-strip-types`-era loader APIs (`module.registerHooks`, Node ≥ 22.15); the repo's `.nvmrc` (24.13.0) is fine.
