### PR TITLE
fix(compat/forEach): remove redundant array check in key resolution

### DIFF
--- a/src/compat/array/forEach.ts
+++ b/src/compat/array/forEach.ts
@@ -152,8 +152,7 @@ export function forEach<T>(
     return collection;
   }
 
-  const keys: PropertyKey[] =
-    isArrayLike(collection) || Array.isArray(collection) ? range(0, collection.length) : Object.keys(collection);
+  const keys: PropertyKey[] = isArrayLike(collection) ? range(0, collection.length) : Object.keys(collection);
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];


### PR DESCRIPTION
Since arrays and array like objects are handled the same way, I think `isArrayLike` alone should be sufficient.