### PR TITLE
test(compat/head): replace first alias usage with head in tests

### DIFF
--- a/src/compat/array/head.spec.ts
+++ b/src/compat/array/head.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { args } from '../_internal/args';
-import { first, head } from '../index';
+import { head } from '../index';
 
 /**
  * @see https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/head.spec.js#L1
@@ -24,19 +24,19 @@ describe('head', () => {
   });
 
   it('should return an empty array when the collection is null or undefined', () => {
-    expect(first(null)).toBeUndefined();
+    expect(head(null)).toBeUndefined();
   });
 
   it('should return an empty array when the collection is not array-like', () => {
     // @ts-expect-error - invalid argument
-    expect(first(1)).toBeUndefined();
+    expect(head(1)).toBeUndefined();
     // @ts-expect-error - invalid argument
-    expect(first(true)).toBeUndefined();
+    expect(head(true)).toBeUndefined();
   });
 
   it('should support array-like', () => {
-    expect(first({ 0: 1, 1: null, 2: 3, length: 3 })).toEqual(1);
-    expect(first('123')).toEqual('1');
-    expect(first(args)).toEqual(1);
+    expect(head({ 0: 1, 1: null, 2: 3, length: 3 })).toEqual(1);
+    expect(head('123')).toEqual('1');
+    expect(head(args)).toEqual(1);
   });
 });


### PR DESCRIPTION
## Summary

The `head` tests are currently using its alias, `first`, to test the behavior. :(
I think we should test head directly, while `first` only needs a test to verify that it behaves the same as `head`.