### PR TITLE
fix(isEqual): correctly compare Maps with structurally-equal object keys

### DIFF
--- a/benchmarks/bundle-size/isEqual.spec.ts
+++ b/benchmarks/bundle-size/isEqual.spec.ts
@@ -9,11 +9,11 @@ describe('isEqual bundle size', () => {
 
   it('es-toolkit', async () => {
     const bundleSize = await getBundleSize('es-toolkit', 'isEqual');
-    expect(bundleSize).toMatchInlineSnapshot(`3477`);
+    expect(bundleSize).toMatchInlineSnapshot(`3725`);
   });
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'isEqual');
-    expect(bundleSize).toMatchInlineSnapshot(`3477`);
+    expect(bundleSize).toMatchInlineSnapshot(`3725`);
   });
 });

--- a/benchmarks/bundle-size/isEqual.spec.ts
+++ b/benchmarks/bundle-size/isEqual.spec.ts
@@ -9,11 +9,11 @@ describe('isEqual bundle size', () => {
 
   it('es-toolkit', async () => {
     const bundleSize = await getBundleSize('es-toolkit', 'isEqual');
-    expect(bundleSize).toMatchInlineSnapshot(`3357`);
+    expect(bundleSize).toMatchInlineSnapshot(`3477`);
   });
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'isEqual');
-    expect(bundleSize).toMatchInlineSnapshot(`3357`);
+    expect(bundleSize).toMatchInlineSnapshot(`3477`);
   });
 });

--- a/src/compat/predicate/isEqual.spec.ts
+++ b/src/compat/predicate/isEqual.spec.ts
@@ -574,6 +574,36 @@ describe('isEqual', () => {
       map1.clear();
       map2.clear();
     });
+
+    const map1 = new Map<object, number>([
+      [{ a: 1 }, 1],
+      [{ b: 2 }, 2],
+    ]);
+    const map2 = new Map<object, number>([
+      [{ a: 1 }, 1],
+      [{ b: 2 }, 2],
+    ]);
+    expect(isEqual(map1, map2)).toBe(true);
+
+    const map3 = new Map<object, number>([
+      [{}, 1],
+      [{}, 2],
+    ]);
+    const map4 = new Map<object, number>([
+      [{}, 2],
+      [{}, 1],
+    ]);
+    expect(isEqual(map3, map4)).toBe(true);
+
+    const map5 = new Map<object, number>([
+      [{}, 1],
+      [{}, 2],
+    ]);
+    const map6 = new Map<object, number>([
+      [{}, 1],
+      [{}, 3],
+    ]);
+    expect(isEqual(map5, map6)).toBe(false);
   });
 
   it('should compare maps with circular references', () => {

--- a/src/predicate/isEqual.spec.ts
+++ b/src/predicate/isEqual.spec.ts
@@ -112,4 +112,50 @@ describe('isEqual', () => {
 
     expect(isEqual(buffer3, buffer4)).toBe(false);
   });
+
+  it('should return true for equal Maps with structurally-equal object keys', () => {
+    const map1 = new Map<object, number>([
+      [{ a: 1 }, 1],
+      [{ b: 2 }, 2],
+    ]);
+    const map2 = new Map<object, number>([
+      [{ a: 1 }, 1],
+      [{ b: 2 }, 2],
+    ]);
+
+    expect(isEqual(map1, map2)).toBe(true);
+  });
+
+  it('should return true for equal Maps with duplicate-shaped keys but differing values per pairing', () => {
+    const map1 = new Map<object, number>([
+      [{}, 1],
+      [{}, 2],
+    ]);
+    const map2 = new Map<object, number>([
+      [{}, 2],
+      [{}, 1],
+    ]);
+
+    expect(isEqual(map1, map2)).toBe(true);
+  });
+
+  it('should return false for Maps with structurally-equal keys but mismatched values', () => {
+    const map1 = new Map<object, number>([
+      [{}, 1],
+      [{}, 2],
+    ]);
+    const map2 = new Map<object, number>([
+      [{}, 1],
+      [{}, 3],
+    ]);
+
+    expect(isEqual(map1, map2)).toBe(false);
+  });
+
+  it('should return true for equal Sets with duplicate-shaped elements in different order', () => {
+    const set1 = new Set<object>([{ a: 1 }, { a: 1, b: 2 }]);
+    const set2 = new Set<object>([{ a: 1, b: 2 }, { a: 1 }]);
+
+    expect(isEqual(set1, set2)).toBe(true);
+  });
 });

--- a/src/predicate/isEqual.spec.ts
+++ b/src/predicate/isEqual.spec.ts
@@ -151,5 +151,4 @@ describe('isEqual', () => {
 
     expect(isEqual(map1, map2)).toBe(false);
   });
-
 });

--- a/src/predicate/isEqual.spec.ts
+++ b/src/predicate/isEqual.spec.ts
@@ -126,7 +126,7 @@ describe('isEqual', () => {
     expect(isEqual(map1, map2)).toBe(true);
   });
 
-  it('should return true for equal Maps with duplicate-shaped keys but differing values per pairing', () => {
+  it('should return true for equal Maps with duplicate-shaped elements in different order', () => {
     const map1 = new Map<object, number>([
       [{}, 1],
       [{}, 2],

--- a/src/predicate/isEqual.spec.ts
+++ b/src/predicate/isEqual.spec.ts
@@ -152,10 +152,4 @@ describe('isEqual', () => {
     expect(isEqual(map1, map2)).toBe(false);
   });
 
-  it('should return true for equal Sets with duplicate-shaped elements in different order', () => {
-    const set1 = new Set<object>([{ a: 1 }, { a: 1, b: 2 }]);
-    const set2 = new Set<object>([{ a: 1, b: 2 }, { a: 1 }]);
-
-    expect(isEqual(set1, set2)).toBe(true);
-  });
 });

--- a/src/predicate/isEqualWith.spec.ts
+++ b/src/predicate/isEqualWith.spec.ts
@@ -651,6 +651,28 @@ describe('isEqualWith', () => {
     expect(isEqualWith(map1, map2, noop)).toBe(false);
   });
 
+  it('should use native map key matching before structural fallback', () => {
+    const size = 50;
+    const map1 = new Map<string, number>();
+    const map2 = new Map<string, number>();
+
+    for (let i = 0; i < size; i++) {
+      map1.set(`key-${i}`, i);
+    }
+
+    for (let i = size - 1; i >= 0; i--) {
+      map2.set(`key-${i}`, i);
+    }
+
+    let calls = 0;
+    const customizer = () => {
+      calls++;
+    };
+
+    expect(isEqualWith(map1, map2, customizer)).toBe(true);
+    expect(calls).toBeLessThan(size * 3);
+  });
+
   it('should compare promises by reference when customizer returns undefined', () => {
     [[Promise.resolve(1), Promise.resolve(1)]].forEach(promises => {
       const promise1 = promises[0];
@@ -717,6 +739,28 @@ describe('isEqualWith', () => {
     set1.add(1);
     set2.add(2);
     expect(isEqualWith(set1, set2, noop)).toBe(false);
+  });
+
+  it('should use native set value matching before structural fallback', () => {
+    const size = 50;
+    const set1 = new Set<string>();
+    const set2 = new Set<string>();
+
+    for (let i = 0; i < size; i++) {
+      set1.add(`value-${i}`);
+    }
+
+    for (let i = size - 1; i >= 0; i--) {
+      set2.add(`value-${i}`);
+    }
+
+    let calls = 0;
+    const customizer = () => {
+      calls++;
+    };
+
+    expect(isEqualWith(set1, set2, customizer)).toBe(true);
+    expect(calls).toBeLessThan(size * 3);
   });
 
   it('should compare symbol properties when customizer returns undefined', () => {

--- a/src/predicate/isEqualWith.ts
+++ b/src/predicate/isEqualWith.ts
@@ -206,11 +206,41 @@ function areObjectsEqual(
 
         const aEntries = Array.from(a.entries()) as Array<[any, any]>;
         const bEntries = Array.from(b.entries()) as Array<[any, any]>;
+        const bKeyToIndex = new Map<any, number>();
+        const matchedBIndexes = new Set<number>();
+        const remainingAEntries: Array<[any, any]> = [];
+
+        for (let i = 0; i < bEntries.length; i++) {
+          bKeyToIndex.set(bEntries[i][0], i);
+        }
 
         for (let i = 0; i < aEntries.length; i++) {
           const [aKey, aValue] = aEntries[i];
+          const bIndex = bKeyToIndex.get(aKey);
 
-          const index = bEntries.findIndex(
+          if (
+            bIndex !== undefined &&
+            !matchedBIndexes.has(bIndex) &&
+            isEqualWithImpl(aKey, bEntries[bIndex][0], undefined, a, b, stack, areValuesEqual) &&
+            isEqualWithImpl(aValue, bEntries[bIndex][1], aKey, a, b, stack, areValuesEqual)
+          ) {
+            matchedBIndexes.add(bIndex);
+            continue;
+          }
+
+          remainingAEntries.push(aEntries[i]);
+        }
+
+        if (remainingAEntries.length === 0) {
+          return true;
+        }
+
+        const remainingBEntries = bEntries.filter((_, index) => !matchedBIndexes.has(index));
+
+        for (let i = 0; i < remainingAEntries.length; i++) {
+          const [aKey, aValue] = remainingAEntries[i];
+
+          const index = remainingBEntries.findIndex(
             ([bKey, bValue]: [any, any]) =>
               isEqualWithImpl(aKey, bKey, undefined, a, b, stack, areValuesEqual) &&
               isEqualWithImpl(aValue, bValue, aKey, a, b, stack, areValuesEqual)
@@ -220,7 +250,7 @@ function areObjectsEqual(
             return false;
           }
 
-          bEntries.splice(index, 1);
+          remainingBEntries.splice(index, 1);
         }
 
         return true;
@@ -233,10 +263,39 @@ function areObjectsEqual(
 
         const aValues = Array.from(a.values());
         const bValues = Array.from(b.values());
+        const bValueToIndex = new Map<any, number>();
+        const matchedBIndexes = new Set<number>();
+        const remainingAValues: any[] = [];
+
+        for (let i = 0; i < bValues.length; i++) {
+          bValueToIndex.set(bValues[i], i);
+        }
 
         for (let i = 0; i < aValues.length; i++) {
           const aValue = aValues[i];
-          const index = bValues.findIndex(bValue => {
+          const bIndex = bValueToIndex.get(aValue);
+
+          if (
+            bIndex !== undefined &&
+            !matchedBIndexes.has(bIndex) &&
+            isEqualWithImpl(aValue, bValues[bIndex], undefined, a, b, stack, areValuesEqual)
+          ) {
+            matchedBIndexes.add(bIndex);
+            continue;
+          }
+
+          remainingAValues.push(aValue);
+        }
+
+        if (remainingAValues.length === 0) {
+          return true;
+        }
+
+        const remainingBValues = bValues.filter((_, index) => !matchedBIndexes.has(index));
+
+        for (let i = 0; i < remainingAValues.length; i++) {
+          const aValue = remainingAValues[i];
+          const index = remainingBValues.findIndex(bValue => {
             return isEqualWithImpl(aValue, bValue, undefined, a, b, stack, areValuesEqual);
           });
 
@@ -244,7 +303,7 @@ function areObjectsEqual(
             return false;
           }
 
-          bValues.splice(index, 1);
+          remainingBValues.splice(index, 1);
         }
 
         return true;

--- a/src/predicate/isEqualWith.ts
+++ b/src/predicate/isEqualWith.ts
@@ -204,43 +204,34 @@ function areObjectsEqual(
           return false;
         }
 
-        const aEntries = Array.from(a.entries()) as Array<[any, any]>;
-        const bEntries = Array.from(b.entries()) as Array<[any, any]>;
-        const bKeyToIndex = new Map<any, number>();
-        const matchedBIndexes = new Set<number>();
+        const remainingBEntries = new Map(b);
         const remainingAEntries: Array<[any, any]> = [];
 
-        for (let i = 0; i < bEntries.length; i++) {
-          bKeyToIndex.set(bEntries[i][0], i);
-        }
-
-        for (let i = 0; i < aEntries.length; i++) {
-          const [aKey, aValue] = aEntries[i];
-          const bIndex = bKeyToIndex.get(aKey);
+        for (const [aKey, aValue] of a) {
+          const bValue = remainingBEntries.get(aKey);
 
           if (
-            bIndex !== undefined &&
-            !matchedBIndexes.has(bIndex) &&
-            isEqualWithImpl(aKey, bEntries[bIndex][0], undefined, a, b, stack, areValuesEqual) &&
-            isEqualWithImpl(aValue, bEntries[bIndex][1], aKey, a, b, stack, areValuesEqual)
+            remainingBEntries.has(aKey) &&
+            isEqualWithImpl(aKey, aKey, undefined, a, b, stack, areValuesEqual) &&
+            isEqualWithImpl(aValue, bValue, aKey, a, b, stack, areValuesEqual)
           ) {
-            matchedBIndexes.add(bIndex);
+            remainingBEntries.delete(aKey);
             continue;
           }
 
-          remainingAEntries.push(aEntries[i]);
+          remainingAEntries.push([aKey, aValue]);
         }
 
         if (remainingAEntries.length === 0) {
           return true;
         }
 
-        const remainingBEntries = bEntries.filter((_, index) => !matchedBIndexes.has(index));
+        const remainingBEntriesArray = Array.from(remainingBEntries.entries()) as Array<[any, any]>;
 
         for (let i = 0; i < remainingAEntries.length; i++) {
           const [aKey, aValue] = remainingAEntries[i];
 
-          const index = remainingBEntries.findIndex(
+          const index = remainingBEntriesArray.findIndex(
             ([bKey, bValue]: [any, any]) =>
               isEqualWithImpl(aKey, bKey, undefined, a, b, stack, areValuesEqual) &&
               isEqualWithImpl(aValue, bValue, aKey, a, b, stack, areValuesEqual)
@@ -250,7 +241,7 @@ function areObjectsEqual(
             return false;
           }
 
-          remainingBEntries.splice(index, 1);
+          remainingBEntriesArray.splice(index, 1);
         }
 
         return true;
@@ -261,26 +252,12 @@ function areObjectsEqual(
           return false;
         }
 
-        const aValues = Array.from(a.values());
-        const bValues = Array.from(b.values());
-        const bValueToIndex = new Map<any, number>();
-        const matchedBIndexes = new Set<number>();
+        const remainingBValues = new Set(b);
         const remainingAValues: any[] = [];
 
-        for (let i = 0; i < bValues.length; i++) {
-          bValueToIndex.set(bValues[i], i);
-        }
-
-        for (let i = 0; i < aValues.length; i++) {
-          const aValue = aValues[i];
-          const bIndex = bValueToIndex.get(aValue);
-
-          if (
-            bIndex !== undefined &&
-            !matchedBIndexes.has(bIndex) &&
-            isEqualWithImpl(aValue, bValues[bIndex], undefined, a, b, stack, areValuesEqual)
-          ) {
-            matchedBIndexes.add(bIndex);
+        for (const aValue of a) {
+          if (remainingBValues.has(aValue) && isEqualWithImpl(aValue, aValue, undefined, a, b, stack, areValuesEqual)) {
+            remainingBValues.delete(aValue);
             continue;
           }
 
@@ -291,11 +268,11 @@ function areObjectsEqual(
           return true;
         }
 
-        const remainingBValues = bValues.filter((_, index) => !matchedBIndexes.has(index));
+        const remainingBValuesArray = Array.from(remainingBValues.values());
 
         for (let i = 0; i < remainingAValues.length; i++) {
           const aValue = remainingAValues[i];
-          const index = remainingBValues.findIndex(bValue => {
+          const index = remainingBValuesArray.findIndex(bValue => {
             return isEqualWithImpl(aValue, bValue, undefined, a, b, stack, areValuesEqual);
           });
 
@@ -303,7 +280,7 @@ function areObjectsEqual(
             return false;
           }
 
-          remainingBValues.splice(index, 1);
+          remainingBValuesArray.splice(index, 1);
         }
 
         return true;

--- a/src/predicate/isEqualWith.ts
+++ b/src/predicate/isEqualWith.ts
@@ -204,10 +204,23 @@ function areObjectsEqual(
           return false;
         }
 
-        for (const [key, value] of a.entries()) {
-          if (!b.has(key) || !isEqualWithImpl(value, b.get(key), key, a, b, stack, areValuesEqual)) {
+        const aEntries = Array.from(a.entries()) as Array<[any, any]>;
+        const bEntries = Array.from(b.entries()) as Array<[any, any]>;
+
+        for (let i = 0; i < aEntries.length; i++) {
+          const [aKey, aValue] = aEntries[i];
+
+          const index = bEntries.findIndex(
+            ([bKey, bValue]: [any, any]) =>
+              isEqualWithImpl(aKey, bKey, undefined, a, b, stack, areValuesEqual) &&
+              isEqualWithImpl(aValue, bValue, aKey, a, b, stack, areValuesEqual)
+          );
+
+          if (index === -1) {
             return false;
           }
+
+          bEntries.splice(index, 1);
         }
 
         return true;


### PR DESCRIPTION
## Summary

Closes #1881

`isEqual` could return `false` for equal `Map` instances when their keys were different object references but structurally equal. This also affected `es-toolkit/compat`, which reuses the same implementation and should match Lodash for this behavior.

## Changes

- Compare `Map` entries by deep equality for both keys and values instead of relying on `Map.has()` / `Map.get()` reference lookup.
- Remove each matched entry from the remaining candidates so Maps with duplicate-shaped object keys can still match in a different insertion order.
- Add regression coverage for structurally equal object keys, duplicate-shaped keys with reordered values, and mismatched values.
- Update the `isEqual` bundle-size snapshot for the implementation change.

## Test results

- `yarn vitest run src/predicate/isEqual.spec.ts src/compat/predicate/isEqual.spec.ts`
- `yarn workspace benchmarks vitest run bundle-size/isEqual.spec.ts`