### PR TITLE
fix(compat/includes): exclude 'length' property from array like value matching

### DIFF
--- a/src/compat/array/includes.spec.ts
+++ b/src/compat/array/includes.spec.ts
@@ -12,6 +12,13 @@ describe('includes', () => {
     expect(includes(obj, 'value')).toBe(false);
   });
 
+  it(`should not match arrayLike 'length' property value`, () => {
+    const arrayLike = { 0: 'a', 1: 'b', length: 2 };
+    expect(includes(arrayLike, 2)).toBeFalsy();
+    expect(includes(arrayLike, 'a')).toBeTruthy();
+    expect(includes(arrayLike, 'b')).toBeTruthy();
+  });
+
   Object.entries({
     'an `arguments` object': toArgs([1, 2, 3, 4]),
     'an array': [1, 2, 3, 4],

--- a/src/compat/array/includes.ts
+++ b/src/compat/array/includes.ts
@@ -1,3 +1,4 @@
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { isString } from '../predicate/isString.ts';
 import { eq } from '../util/eq.ts';
 import { toInteger } from '../util/toInteger.ts';
@@ -73,6 +74,19 @@ export function includes(
 
   if (Array.isArray(source)) {
     return source.includes(target, fromIndex);
+  }
+
+  if (isArrayLike(source)) {
+    if (fromIndex < 0) {
+      fromIndex = Math.max(0, source.length + fromIndex);
+    }
+
+    for (let i = fromIndex; i < source.length; i++) {
+      if (eq((source as unknown[])[i], target)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   const keys = Object.keys(source);


### PR DESCRIPTION
## Summary

When `includes` is used with an array like object, the value of the `length` property itself is also included in the search.
This causes a compatibility issue with Lodash, which only checks the elements and does not consider the `length` property itself.

```js
    function includes(collection, value, fromIndex, guard) {
      collection = isArrayLike(collection) ? collection : values(collection);
      fromIndex = (fromIndex && !guard) ? toInteger(fromIndex) : 0;

      var length = collection.length;
      if (fromIndex < 0) {
        fromIndex = nativeMax(length + fromIndex, 0);
      }
      return isString(collection)
        ? (fromIndex <= length && collection.indexOf(value, fromIndex) > -1)
        : (!!length && baseIndexOf(collection, value, fromIndex) > -1);
    }
```

-> Lodash treats array like objects the same way as arrays, while es-toolkit compat treats them as regular objects.

## Reproduce

```ts
import { includes as loIncludes } from 'lodash';
import { includes as esIncludes } from './src/compat/array/includes';

const arrayLike = { length: 2, 0: 'a', 1: 'b' };

console.log(loIncludes.includes(arrayLike, 2)); // false
console.log(esIncludes.includes(arrayLike, 2)); // true
```