### PR TITLE
docs(compat/head): remove duplicate undefined return note from summary

### DIFF
--- a/docs/compat/reference/array/head.md
+++ b/docs/compat/reference/array/head.md
@@ -18,7 +18,7 @@ const firstElement = head(array);
 
 ### `head(array)`
 
-Returns the first element of an array or array-like object. Returns `undefined` if the array is empty or invalid.
+Returns the first element of an array or array-like object.
 
 ```typescript
 import { head } from 'es-toolkit/compat';

--- a/docs/ja/compat/reference/array/head.md
+++ b/docs/ja/compat/reference/array/head.md
@@ -18,7 +18,7 @@ const firstElement = head(array);
 
 ### `head(array)`
 
-配列または配列のようなオブジェクトの最初の要素を返します。配列が空または無効な場合は`undefined`を返します。
+配列または配列のようなオブジェクトの最初の要素を返します。
 
 ```typescript
 import { head } from 'es-toolkit/compat';

--- a/docs/ko/compat/reference/array/head.md
+++ b/docs/ko/compat/reference/array/head.md
@@ -18,7 +18,7 @@ const firstElement = head(array);
 
 ### `head(array)`
 
-배열이나 배열 형태 객체의 첫 번째 요소를 반환해요. 배열이 비어있거나 유효하지 않으면 `undefined`를 반환해요.
+배열이나 배열 형태 객체의 첫 번째 요소를 반환해요.
 
 ```typescript
 import { head } from 'es-toolkit/compat';

--- a/docs/zh_hans/compat/reference/array/head.md
+++ b/docs/zh_hans/compat/reference/array/head.md
@@ -18,7 +18,7 @@ const firstElement = head(array);
 
 ### `head(array)`
 
-返回数组或类数组对象的第一个元素。如果数组为空或无效，则返回 `undefined`。
+返回数组或类数组对象的第一个元素。
 
 ```typescript
 import { head } from 'es-toolkit/compat';


### PR DESCRIPTION
## Summary

<img width="1215" height="1380" alt="head-duplicate" src="https://github.com/user-attachments/assets/c29cabb6-abcd-415a-9775-28299e54b584" />

It looks like there are some duplicate messages. I think we can remove the one above!