### PR TITLE
fix(compat/maxBy, compat/minBy): restore lodash compatible comparison behavior

### DIFF
--- a/docs/compat/reference/math/maxBy.md
+++ b/docs/compat/reference/math/maxBy.md
@@ -16,7 +16,7 @@ const maxItem = maxBy(array, iteratee);
 
 ## Usage
 
-### `maxBy(array, iteratee)`
+### `maxBy(array, iteratee?)`
 
 Finds the element in an array that has the largest value when computed by a function.
 
@@ -107,7 +107,7 @@ maxBy(undefined);
 #### Parameters
 
 - `array` (`ArrayLike<T> | null | undefined`): The array to search.
-- `iteratee` (`ValueIteratee<T>`, optional): The function, property name, or condition to apply to each element.
+- `iteratee` (`ValueIteratee<T>`, optional): The function, property name, or condition to apply to each element. Default is `identity`.
 
 #### Returns
 

--- a/docs/compat/reference/math/minBy.md
+++ b/docs/compat/reference/math/minBy.md
@@ -16,7 +16,7 @@ const minItem = minBy(array, iteratee);
 
 ## Usage
 
-### `minBy(array, iteratee)`
+### `minBy(array, iteratee?)`
 
 Finds the element in an array that has the smallest value when computed by a function.
 
@@ -107,7 +107,7 @@ minBy(undefined);
 #### Parameters
 
 - `array` (`ArrayLike<T> | null | undefined`): The array to search.
-- `iteratee` (`ValueIteratee<T>`, optional): The function, property name, or condition to apply to each element.
+- `iteratee` (`ValueIteratee<T>`, optional): The function, property name, or condition to apply to each element. Default is `identity`.
 
 #### Returns
 

--- a/docs/ja/compat/reference/math/maxBy.md
+++ b/docs/ja/compat/reference/math/maxBy.md
@@ -16,7 +16,7 @@ const maxItem = maxBy(array, iteratee);
 
 ## 使用法
 
-### `maxBy(array, iteratee)`
+### `maxBy(array, iteratee?)`
 
 配列から関数で計算した値が最も大きい要素を見つけます。
 
@@ -107,7 +107,7 @@ maxBy(undefined);
 #### パラメータ
 
 - `array` (`ArrayLike<T> | null | undefined`): 検索する配列です。
-- `iteratee` (`ValueIteratee<T>`, オプション): 各要素に適用する関数、プロパティ名、または条件です。
+- `iteratee` (`ValueIteratee<T>`, オプション): 各要素に適用する関数、プロパティ名、または条件です。デフォルトは `identity` です。
 
 #### 戻り値
 

--- a/docs/ja/compat/reference/math/minBy.md
+++ b/docs/ja/compat/reference/math/minBy.md
@@ -16,7 +16,7 @@ const minItem = minBy(array, iteratee);
 
 ## 使用法
 
-### `minBy(array, iteratee)`
+### `minBy(array, iteratee?)`
 
 配列から関数で計算した値が最小の要素を見つけます。
 
@@ -107,7 +107,7 @@ minBy(undefined);
 #### パラメータ
 
 - `array` (`ArrayLike<T> | null | undefined`): 検索する配列です。
-- `iteratee` (`ValueIteratee<T>`, オプション): 各要素に適用する関数、プロパティ名、または条件です。
+- `iteratee` (`ValueIteratee<T>`, オプション): 各要素に適用する関数、プロパティ名、または条件です。デフォルトは `identity` です。
 
 #### 戻り値
 

--- a/docs/ko/compat/reference/math/maxBy.md
+++ b/docs/ko/compat/reference/math/maxBy.md
@@ -16,7 +16,7 @@ const maxItem = maxBy(array, iteratee);
 
 ## 사용법
 
-### `maxBy(array, iteratee)`
+### `maxBy(array, iteratee?)`
 
 배열에서 함수로 계산한 값이 가장 큰 요소를 찾아요.
 
@@ -107,7 +107,7 @@ maxBy(undefined);
 #### 파라미터
 
 - `array` (`ArrayLike<T> | null | undefined`): 검색할 배열이에요.
-- `iteratee` (`ValueIteratee<T>`, 선택): 각 요소에 적용할 함수, 속성명, 또는 조건이에요.
+- `iteratee` (`ValueIteratee<T>`, 선택): 각 요소에 적용할 함수, 속성명, 또는 조건이에요. 기본값은 `identity`예요.
 
 #### 반환 값
 

--- a/docs/ko/compat/reference/math/minBy.md
+++ b/docs/ko/compat/reference/math/minBy.md
@@ -16,7 +16,7 @@ const minItem = minBy(array, iteratee);
 
 ## 사용법
 
-### `minBy(array, iteratee)`
+### `minBy(array, iteratee?)`
 
 배열에서 함수로 계산한 값이 가장 작은 요소를 찾아요.
 
@@ -107,7 +107,7 @@ minBy(undefined);
 #### 파라미터
 
 - `array` (`ArrayLike<T> | null | undefined`): 검색할 배열이에요.
-- `iteratee` (`ValueIteratee<T>`, 선택): 각 요소에 적용할 함수, 속성명, 또는 조건이에요.
+- `iteratee` (`ValueIteratee<T>`, 선택): 각 요소에 적용할 함수, 속성명, 또는 조건이에요. 기본값은 `identity`예요.
 
 #### 반환 값
 

--- a/docs/zh_hans/compat/reference/math/maxBy.md
+++ b/docs/zh_hans/compat/reference/math/maxBy.md
@@ -16,7 +16,7 @@ const maxItem = maxBy(array, iteratee);
 
 ## 用法
 
-### `maxBy(array, iteratee)`
+### `maxBy(array, iteratee?)`
 
 在数组中查找函数计算值最大的元素。
 
@@ -107,7 +107,7 @@ maxBy(undefined);
 #### 参数
 
 - `array` (`ArrayLike<T> | null | undefined`): 要搜索的数组。
-- `iteratee` (`ValueIteratee<T>`, 可选): 应用于每个元素的函数、属性名或条件。
+- `iteratee` (`ValueIteratee<T>`, 可选): 应用于每个元素的函数、属性名或条件。默认值为 `identity`。
 
 #### 返回值
 

--- a/docs/zh_hans/compat/reference/math/minBy.md
+++ b/docs/zh_hans/compat/reference/math/minBy.md
@@ -16,7 +16,7 @@ const minItem = minBy(array, iteratee);
 
 ## 用法
 
-### `minBy(array, iteratee)`
+### `minBy(array, iteratee?)`
 
 在数组中找到通过函数计算后值最小的元素。
 
@@ -107,7 +107,7 @@ minBy(undefined);
 #### 参数
 
 - `array` (`ArrayLike<T> | null | undefined`): 要搜索的数组。
-- `iteratee` (`ValueIteratee<T>`, 可选): 应用于每个元素的函数、属性名或条件。
+- `iteratee` (`ValueIteratee<T>`, 可选): 应用于每个元素的函数、属性名或条件。默认值为 `identity`。
 
 #### 返回值
 

--- a/src/compat/math/maxBy.spec.ts
+++ b/src/compat/math/maxBy.spec.ts
@@ -52,4 +52,10 @@ describe('maxBy', () => {
 
     expect(maxBy(numbers)).toBe(3);
   });
+
+  it('should work with string values returned by iteratee', () => {
+    const items = [{ v: 'a' }, { v: 'b' }];
+    const result = maxBy(items, item => item.v);
+    expect(result).toEqual({ v: 'b' });
+  });
 });

--- a/src/compat/math/maxBy.spec.ts
+++ b/src/compat/math/maxBy.spec.ts
@@ -58,4 +58,13 @@ describe('maxBy', () => {
     const result = maxBy(items, item => item.v);
     expect(result).toEqual({ v: 'b' });
   });
+
+  it('should skip NaN values, matching lodash', () => {
+    expect(maxBy([NaN, 1, 3, 2], x => x)).toBe(3);
+    expect(maxBy([1, NaN, 3, 2], x => x)).toBe(3);
+  });
+
+  it('should return undefined when every value is NaN', () => {
+    expect(maxBy([NaN, NaN], x => x)).toBeUndefined();
+  });
 });

--- a/src/compat/math/maxBy.ts
+++ b/src/compat/math/maxBy.ts
@@ -9,7 +9,7 @@ import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
  *
  * @template T - The type of elements in the array.
  * @param items The array of elements to search.
- * @param iteratee
+ * @param [iteratee=identity]
  * The criteria used to determine the maximum value.
  *  - If a **function** is provided, it extracts a numeric value from each element.
  *  - If a **string** is provided, it is treated as a key to extract values from the objects.
@@ -31,7 +31,7 @@ import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
  * maxBy([{ a: 1 }, { a: 2 }], ['a', 1]); // Returns: { a: 1 }
  * maxBy([{ a: 1 }, { a: 2 }], { a: 1 }); // Returns: { a: 1 }
  */
-export function maxBy<T>(items: ArrayLike<T> | null | undefined, iteratee?: ValueIteratee<T>): T | undefined {
+export function maxBy<T>(items: ArrayLike<T> | null | undefined, iteratee: ValueIteratee<T> = identity): T | undefined {
   if (items == null) {
     return undefined;
   }
@@ -42,7 +42,7 @@ export function maxBy<T>(items: ArrayLike<T> | null | undefined, iteratee?: Valu
     return undefined;
   }
 
-  const getValue = iterateeToolkit(iteratee ?? identity);
+  const getValue = iterateeToolkit(iteratee);
 
   let maxElement: T | undefined;
   let max: unknown;

--- a/src/compat/math/maxBy.ts
+++ b/src/compat/math/maxBy.ts
@@ -44,22 +44,18 @@ export function maxBy<T>(items: ArrayLike<T> | null | undefined, iteratee?: Valu
 
   const getValue = iterateeToolkit(iteratee ?? identity);
 
-  let maxElement = array[0];
-  let max = getValue(maxElement, 0, array);
+  let maxElement: T | undefined;
+  let max: unknown;
 
-  if (Number.isNaN(max)) {
-    return maxElement;
-  }
-
-  for (let i = 1; i < array.length; i++) {
+  for (let i = 0; i < array.length; i++) {
     const element = array[i];
     const current = getValue(element, i, array);
 
     if (Number.isNaN(current)) {
-      return element;
+      continue;
     }
 
-    if (current > max) {
+    if (max === undefined || current > (max as number)) {
       max = current;
       maxElement = element;
     }

--- a/src/compat/math/maxBy.ts
+++ b/src/compat/math/maxBy.ts
@@ -1,5 +1,5 @@
-import { maxBy as maxByToolkit } from '../../array/maxBy.ts';
 import { identity } from '../../function/identity.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
 import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
 
@@ -36,5 +36,34 @@ export function maxBy<T>(items: ArrayLike<T> | null | undefined, iteratee?: Valu
     return undefined;
   }
 
-  return maxByToolkit(Array.from(items), iterateeToolkit(iteratee ?? identity));
+  const array = toArray(items);
+
+  if (array.length === 0) {
+    return undefined;
+  }
+
+  const getValue = iterateeToolkit(iteratee ?? identity);
+
+  let maxElement = array[0];
+  let max = getValue(maxElement, 0, array);
+
+  if (Number.isNaN(max)) {
+    return maxElement;
+  }
+
+  for (let i = 1; i < array.length; i++) {
+    const element = array[i];
+    const current = getValue(element, i, array);
+
+    if (Number.isNaN(current)) {
+      return element;
+    }
+
+    if (current > max) {
+      max = current;
+      maxElement = element;
+    }
+  }
+
+  return maxElement;
 }

--- a/src/compat/math/minBy.spec.ts
+++ b/src/compat/math/minBy.spec.ts
@@ -52,4 +52,10 @@ describe('minBy', () => {
 
     expect(minBy(numbers)).toBe(1);
   });
+
+  it('should work with string values returned by iteratee', () => {
+    const items = [{ v: 'b' }, { v: 'a' }];
+    const result = minBy(items, item => item.v);
+    expect(result).toEqual({ v: 'a' });
+  });
 });

--- a/src/compat/math/minBy.spec.ts
+++ b/src/compat/math/minBy.spec.ts
@@ -58,4 +58,13 @@ describe('minBy', () => {
     const result = minBy(items, item => item.v);
     expect(result).toEqual({ v: 'a' });
   });
+
+  it('should skip NaN values, matching lodash', () => {
+    expect(minBy([NaN, 3, 1, 2], x => x)).toBe(1);
+    expect(minBy([3, NaN, 1, 2], x => x)).toBe(1);
+  });
+
+  it('should return undefined when every value is NaN', () => {
+    expect(minBy([NaN, NaN], x => x)).toBeUndefined();
+  });
 });

--- a/src/compat/math/minBy.ts
+++ b/src/compat/math/minBy.ts
@@ -1,5 +1,5 @@
-import { minBy as minByToolkit } from '../../array/minBy.ts';
 import { identity } from '../../function/identity.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
 import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
 
@@ -36,5 +36,34 @@ export function minBy<T>(items: ArrayLike<T> | null | undefined, iteratee?: Valu
     return undefined;
   }
 
-  return minByToolkit(Array.from(items), iterateeToolkit(iteratee ?? identity));
+  const array = toArray(items);
+
+  if (array.length === 0) {
+    return undefined;
+  }
+
+  const getValue = iterateeToolkit(iteratee ?? identity);
+
+  let minElement = array[0];
+  let min = getValue(minElement, 0, array);
+
+  if (Number.isNaN(min)) {
+    return minElement;
+  }
+
+  for (let i = 1; i < array.length; i++) {
+    const element = array[i];
+    const current = getValue(element, i, array);
+
+    if (Number.isNaN(current)) {
+      return element;
+    }
+
+    if (current < min) {
+      min = current;
+      minElement = element;
+    }
+  }
+
+  return minElement;
 }

--- a/src/compat/math/minBy.ts
+++ b/src/compat/math/minBy.ts
@@ -9,7 +9,7 @@ import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
  *
  * @template T - The type of elements in the array.
  * @param items The array of elements to search.
- * @param iteratee
+ * @param [iteratee=identity]
  * The criteria used to determine the minimum value.
  *  - If a **function** is provided, it extracts a numeric value from each element.
  *  - If a **string** is provided, it is treated as a key to extract values from the objects.
@@ -31,7 +31,7 @@ import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
  * minBy([{ a: 1 }, { a: 2 }], ['a', 1]); // Returns: { a: 2 }
  * minBy([{ a: 1 }, { a: 2 }], { a: 1 }); // Returns: { a: 2 }
  */
-export function minBy<T>(items: ArrayLike<T> | null | undefined, iteratee?: ValueIteratee<T>): T | undefined {
+export function minBy<T>(items: ArrayLike<T> | null | undefined, iteratee: ValueIteratee<T> = identity): T | undefined {
   if (items == null) {
     return undefined;
   }
@@ -42,7 +42,7 @@ export function minBy<T>(items: ArrayLike<T> | null | undefined, iteratee?: Valu
     return undefined;
   }
 
-  const getValue = iterateeToolkit(iteratee ?? identity);
+  const getValue = iterateeToolkit(iteratee);
 
   let minElement: T | undefined;
   let min: unknown;

--- a/src/compat/math/minBy.ts
+++ b/src/compat/math/minBy.ts
@@ -44,22 +44,18 @@ export function minBy<T>(items: ArrayLike<T> | null | undefined, iteratee?: Valu
 
   const getValue = iterateeToolkit(iteratee ?? identity);
 
-  let minElement = array[0];
-  let min = getValue(minElement, 0, array);
+  let minElement: T | undefined;
+  let min: unknown;
 
-  if (Number.isNaN(min)) {
-    return minElement;
-  }
-
-  for (let i = 1; i < array.length; i++) {
+  for (let i = 0; i < array.length; i++) {
     const element = array[i];
     const current = getValue(element, i, array);
 
     if (Number.isNaN(current)) {
-      return element;
+      continue;
     }
 
-    if (current < min) {
+    if (min === undefined || current < (min as number)) {
       min = current;
       minElement = element;
     }


### PR DESCRIPTION
## Summary

Closes: https://github.com/toss/es-toolkit/issues/1890

regression in https://github.com/toss/es-toolkit/commit/e319b3b2826a7101d423ba4dc27bf802ad05b508 

This change fixes the issue where comparisons weren't being performed correctly for string values.
Additionally, it updates the behavior so that NaN values are skipped when present during comparison, and undefined is returned when the array contains only NaN values.
These were additional compatibility issues.

## Reproduce

### e911de8

```ts
console.log(lodash.maxBy([{ v: 'a' }, { v: 'b' }], item => item.v)); // { v: 'b' }
console.log(maxBy([{ v: 'a' }, { v: 'b' }], item => item.v)); // { v: 'a' }
console.log(lodash.minBy([{ v: 'b' }, { v: 'a' }], item => item.v)); // { v: 'a' }
console.log(minBy([{ v: 'b' }, { v: 'a' }], item => item.v)); // { v: 'b' }
```

### aeaad75

```ts
console.log(lodash.maxBy([3, NaN, 1, 2], x => x)); // 3
console.log(maxBy([3, NaN, 1, 2], x => x)); // NaN
console.log(lodash.minBy([3, NaN, 1, 2], x => x)); // 1
console.log(minBy([3, NaN, 1, 2], x => x)); // NaN

console.log(lodash.maxBy([NaN, NaN], x => x)); // undefined
console.log(maxBy([NaN, NaN], x => x)); // MaN
console.log(lodash.minBy([NaN, NaN], x => x)); // undefined
console.log(minBy([NaN, NaN], x => x)); // NaN
```