### PR TITLE
fix(compat/values): treat sparse array holes as undefined for compatibility

### DIFF
--- a/src/compat/object/values.spec.ts
+++ b/src/compat/object/values.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import * as lodashStable from 'es-toolkit/compat';
+import { keys } from './keys';
 import { values } from './values';
 import { args } from '../_internal/args';
 import { strictArgs } from '../_internal/strictArgs';
@@ -45,5 +46,14 @@ describe('values', () => {
   it('should return an empty array for null or undefined', () => {
     expect(values(null)).toEqual([]);
     expect(values(undefined)).toEqual([]);
+  });
+
+  it(`should treat sparse array holes as \`undefined\``, () => {
+    // eslint-disable-next-line
+    const array = [10, , 30];
+
+    expect(values(array)).toEqual([10, undefined, 30]);
+    // `keys` materializes every index, so the two must stay the same length
+    expect(values(array).length).toBe(keys(array).length);
   });
 });

--- a/src/compat/object/values.ts
+++ b/src/compat/object/values.ts
@@ -1,3 +1,5 @@
+import { keys } from './keys.ts';
+
 /**
  * Creates an array of the own enumerable property values of `object`.
  *
@@ -50,5 +52,14 @@ export function values(object: any): any[] {
     return [];
   }
 
-  return Object.values(object);
+  // Read through `keys` rather than `Object.values`: the built-in skips array
+  // holes, which would make `values` shorter than `keys` for a sparse array.
+  const objectKeys = keys(object);
+  const result = new Array(objectKeys.length);
+
+  for (let i = 0; i < objectKeys.length; i++) {
+    result[i] = object[objectKeys[i]];
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary

`compat/values` disagrees with lodash on sparse arrays. `values` returns `Object.values(object)`, and the built-in skips holes; lodash's `values` is `baseValues(object, keys(object))`, which materializes every index.

This is the same class of fix as #1773 (`compat/difference`), applied to `values`.

## Reproduce

```ts
import { values as loValues } from 'lodash';
import { values as esCompatValues } from './src/compat/object/values';

const array = [10, , 30];

console.log(loValues(array));       // [10, undefined, 30]
console.log(esCompatValues(array)); // [10, 30]
```

It also breaks an invariant *inside* compat, without needing lodash as a reference — `keys` and `values` disagree about the same object:

```ts
import { keys, values, toPairs } from './src/compat/index';

const array = [10, , 30];

keys(array);    // ['0', '1', '2']                       length 3
toPairs(array); // [['0',10], ['1',undefined], ['2',30]] length 3
values(array);  // [10, 30]                              length 2   ← the odd one out
```

So `zipObject(keys(o), values(o))` pairs key `'1'` with `30` and key `'2'` with `undefined`.

## Changes

- `values` now reads through `keys` instead of `Object.values`. `keys`/`arrayLikeKeys` already builds `times(object.length, ...)` and returns every index for an array, so this makes `values` use the same iteration model rather than adding a second one.
- Uses a `for` loop and adds no dependencies.
- Added a regression test in `values.spec.ts`, mirroring the one from #1773. It asserts both the lodash-matching value and the `keys().length === values().length` invariant.

Behavior for dense arrays, plain objects, array-likes (`{0:'a',1:'b',length:2}` → `['a','b',2]`, the `length` leaking in exactly as lodash does), strings, and `arguments` objects is unchanged — the existing tests cover all of those and still pass.

## Test results

```
$ yarn vitest run src/compat/object/values
 Test Files  1 passed (1)
      Tests  10 passed (10)

$ yarn vitest run
 Test Files  641 passed (641)
      Tests  4425 passed | 2 skipped (4427)
```

Baseline on `main` is 4424 passed | 2 skipped; the extra passing test is the new one. `yarn tsc --noEmit` is clean. I didn't run `yarn lint --fix`: `yarn lint` reports the same 2477 problems (8 errors, 2469 warnings) on untouched `main` as it does with this change, so none of them are from this PR.

---

Disclosure: I found this with the help of an AI coding assistant, by differential-testing `compat` against lodash 4.18.1. The repros and test runs above are ones I ran myself against this branch.
