### PR TITLE
docs(compat): document individual function entry points

### DIFF
--- a/docs/compat/intro.md
+++ b/docs/compat/intro.md
@@ -23,6 +23,20 @@ Recommended path for removing Lodash from an existing codebase:
 1. Swap the import path from `lodash` / `lodash-es` to `es-toolkit/compat`. Leave call sites as they are.
 2. Clean up call sites over time and switch the import to [`es-toolkit`](/intro). Once done, you get a smaller bundle and faster runtime.
 
+## Importing individual functions
+
+Like `lodash/merge`, every compat function is also available as its own entry point. It loads only the files that function needs, instead of the entire `es-toolkit/compat` module.
+
+```ts
+import merge from 'es-toolkit/compat/merge';
+```
+
+This helps in environments where tree-shaking is not available, such as CommonJS `require()` calls, React Native, or code running directly on Node.js without a bundler.
+
+```ts
+const merge = require('es-toolkit/compat/merge');
+```
+
 ## How it differs from `es-toolkit`
 
 - **API shape**: matches Lodash 1:1, including implicit type coercions, multiple argument shapes, and deprecated helpers. [`es-toolkit`](/intro) only exposes the type-safe, modern forms.

--- a/docs/ja/compat/intro.md
+++ b/docs/ja/compat/intro.md
@@ -23,6 +23,20 @@ chunk([1, 2, 3, 4], 0);
 1. `lodash` / `lodash-es`のimportパスを`es-toolkit/compat`に変えてください。呼び出し側のコードはそのままで大丈夫です。
 2. 時間をかけて呼び出し側を整理しつつ、importを[`es-toolkit`](/ja/intro)に切り替えてください。すべて移行できれば、バンドルがより小さく、より高速になります。
 
+## 関数を個別にインポートする
+
+`lodash/merge`と同じように、compatのすべての関数は関数ごとのエントリーポイントからもインポートできます。`es-toolkit/compat`全体ではなく、その関数に必要なファイルだけが読み込まれます。
+
+```ts
+import merge from 'es-toolkit/compat/merge';
+```
+
+CommonJSの`require()`やReact Nativeのようにツリーシェイキングが使えない環境や、バンドラーなしでNode.js上で直接実行するコードで特に役立ちます。
+
+```ts
+const merge = require('es-toolkit/compat/merge');
+```
+
 ## `es-toolkit`との違い
 
 - **APIの形**: Lodashと1:1で一致しています。暗黙的な型変換、さまざまな引数の形、非推奨のヘルパーまでそのまま含まれます。[`es-toolkit`](/ja/intro)は型安全で整理された形だけを提供します。

--- a/docs/ko/compat/intro.md
+++ b/docs/ko/compat/intro.md
@@ -23,6 +23,20 @@ chunk([1, 2, 3, 4], 0);
 1. `lodash` / `lodash-es`의 import 경로를 `es-toolkit/compat`으로 바꿔주세요. 호출하는 코드는 그대로 두면 돼요.
 2. 시간을 두고 호출하는 부분을 정리해 가며 import를 [`es-toolkit`](/ko/intro)으로 바꿔주세요. 다 옮기고 나면 번들이 더 작고 더 빨라져요.
 
+## 함수를 하나씩 불러오기
+
+`lodash/merge`처럼, compat의 모든 함수는 함수별 경로로도 불러올 수 있어요. `es-toolkit/compat` 전체 대신 그 함수에 필요한 파일만 로드해요.
+
+```ts
+import merge from 'es-toolkit/compat/merge';
+```
+
+CommonJS의 `require()`, React Native처럼 트리 셰이킹을 쓸 수 없는 환경이나, 번들러 없이 Node.js에서 바로 실행하는 코드에서 특히 유용해요.
+
+```ts
+const merge = require('es-toolkit/compat/merge');
+```
+
 ## `es-toolkit`과의 차이점
 
 - **API 모양**: Lodash와 1:1로 일치해요. 자동 타입 변환, 여러 가지 인자 형태, 더 이상 권장되지 않는 함수까지 그대로 들어 있어요. [`es-toolkit`](/ko/intro)은 타입이 안전하고 깔끔한 형태만 제공해요.

--- a/docs/zh_hans/compat/intro.md
+++ b/docs/zh_hans/compat/intro.md
@@ -23,6 +23,20 @@ chunk([1, 2, 3, 4], 0);
 1. 将 `lodash` / `lodash-es` 的 import 路径替换为 `es-toolkit/compat`。调用代码可以保持不变。
 2. 慢慢整理调用代码，并将 import 切换为 [`es-toolkit`](/zh_hans/intro)。完成迁移后，你将获得更小的包体积和更快的运行速度。
 
+## 单独导入函数
+
+与 `lodash/merge` 类似，compat 的每个函数也可以通过独立的入口点导入。这样只会加载该函数所需的文件，而不是整个 `es-toolkit/compat` 模块。
+
+```ts
+import merge from 'es-toolkit/compat/merge';
+```
+
+这在无法使用 tree-shaking 的环境中特别有用，例如 CommonJS 的 `require()`、React Native，或不经打包直接在 Node.js 上运行的代码。
+
+```ts
+const merge = require('es-toolkit/compat/merge');
+```
+
 ## 与 `es-toolkit` 的区别
 
 - **API 形态**：与 Lodash 1:1 一致，包括隐式类型转换、多种参数形态以及已弃用的辅助函数。[`es-toolkit`](/zh_hans/intro) 只暴露类型安全的现代形态。


### PR DESCRIPTION
## Context

`es-toolkit/compat` has long supported per-function imports like `es-toolkit/compat/merge`, but the docs never mention it — it has only come up in issue comments (e.g. [#1298 (comment)](https://github.com/toss/es-toolkit/issues/1298#issuecomment-4515885960)). Loading a single function this way brings in ~20 files instead of the ~435 that the full `es-toolkit/compat` barrel loads, so it's worth guiding users to it.

## Changes

Add an **Importing individual functions** section to the compat intro in all four languages (en / ko / ja / zh_hans), right after the migration flow:

- shows `import merge from 'es-toolkit/compat/merge'` and the `require()` form
- explains when it helps: environments without tree-shaking such as CommonJS `require()`, React Native, or running directly on Node.js without a bundler

Related: #1298, #1536