### PR TITLE
fix(compat/size): count combined Unicode symbols as single characters to match lodash

### DIFF
--- a/src/compat/_internal/unicodeSize.ts
+++ b/src/compat/_internal/unicodeSize.ts
@@ -1,0 +1,44 @@
+/**
+ * Counts the number of visible symbols (grapheme clusters) in a Unicode `string`,
+ * combining surrogate pairs, combining marks, variation selectors, Fitzpatrick
+ * modifiers, regional-indicator pairs, and zero-width-joiner sequences into a
+ * single symbol.
+ *
+ * Ported from lodash to preserve identical behavior.
+ * @link https://github.com/lodash/lodash/blob/4.17.21-es/_unicodeSize.js
+ */
+
+const rsAstralRange = '\\ud800-\\udfff';
+const rsComboMarksRange = '\\u0300-\\u036f';
+const reComboHalfMarksRange = '\\ufe20-\\ufe2f';
+const rsComboSymbolsRange = '\\u20d0-\\u20ff';
+const rsComboRange = rsComboMarksRange + reComboHalfMarksRange + rsComboSymbolsRange;
+const rsVarRange = '\\ufe0e\\ufe0f';
+
+const rsAstral = `[${rsAstralRange}]`;
+const rsCombo = `[${rsComboRange}]`;
+const rsFitz = '\\ud83c[\\udffb-\\udfff]';
+const rsModifier = `(?:${rsCombo}|${rsFitz})`;
+const rsNonAstral = `[^${rsAstralRange}]`;
+const rsRegional = '(?:\\ud83c[\\udde6-\\uddff]){2}';
+const rsSurrPair = '[\\ud800-\\udbff][\\udc00-\\udfff]';
+const rsZWJ = '\\u200d';
+
+const reOptMod = `${rsModifier}?`;
+const rsOptVar = `[${rsVarRange}]?`;
+const rsOptJoin = `(?:${rsZWJ}(?:${[rsNonAstral, rsRegional, rsSurrPair].join('|')})${rsOptVar}${reOptMod})*`;
+const rsSeq = rsOptVar + reOptMod + rsOptJoin;
+const rsSymbol = `(?:${[`${rsNonAstral}${rsCombo}?`, rsCombo, rsRegional, rsSurrPair, rsAstral].join('|')})`;
+
+const reUnicode = RegExp(`${rsFitz}(?=${rsFitz})|${rsSymbol}${rsSeq}`, 'g');
+
+export function unicodeSize(str: string): number {
+  let result = 0;
+  reUnicode.lastIndex = 0;
+
+  while (reUnicode.test(str)) {
+    ++result;
+  }
+
+  return result;
+}

--- a/src/compat/array/size.spec.ts
+++ b/src/compat/array/size.spec.ts
@@ -70,6 +70,14 @@ describe('size', () => {
     expect(size('a😀b')).toBe(3);
   });
 
+  it('should count combined Unicode symbols as a single character, matching lodash', () => {
+    expect(size('🇺🇸')).toBe(1); // regional-indicator flag pair
+    expect(size('👍🏽')).toBe(1); // emoji + Fitzpatrick skin-tone modifier
+    expect(size('👨‍👩‍👧‍👦')).toBe(1); // zero-width-joiner family sequence
+    expect(size('❤️')).toBe(1); // emoji + variation selector
+    expect(size('é')).toBe(1); // base letter + combining acute accent
+  });
+
   it('should return the `length` of array-like objects', () => {
     expect(size({ length: 3 })).toBe(3);
     expect(size({ 0: 'a', 1: 'b', length: 2 })).toBe(2);

--- a/src/compat/array/size.ts
+++ b/src/compat/array/size.ts
@@ -1,5 +1,6 @@
 import { isNil } from '../../predicate/isNil.ts';
 import { regexMultiByte } from '../_internal/regexMultiByte.ts';
+import { unicodeSize } from '../_internal/unicodeSize.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 
 /**
@@ -50,7 +51,7 @@ export function size(target: any): number {
   }
 
   if (typeof target === 'string') {
-    return regexMultiByte.test(target) ? Array.from(target).length : target.length;
+    return regexMultiByte.test(target) ? unicodeSize(target) : target.length;
   }
 
   if (isArrayLike(target)) {


### PR DESCRIPTION
## Summary

`compat/size` counted code points, not grapheme clusters, so combined Unicode sequences were over-counted relative to lodash:

```js
size('🇺🇸')            // 2, lodash: 1  (regional-indicator flag)
size('👍🏽')            // 2, lodash: 1  (Fitzpatrick skin-tone modifier)
size('👨‍👩‍👧‍👦')  // 7, lodash: 1  (ZWJ family sequence)
size('❤️')             // 2, lodash: 1  (variation selector)
size('é')  // NFD       // 2, lodash: 1  (base + combining accent)
```

`compat` mirrors lodash, and lodash's `size` counts grapheme clusters (its `_unicodeSize` helper). PR #1853 moved `size` from UTF-16 code units to code points "matching lodash", but stopped short of graphemes, so combined sequences are still over-counted.

## Changes

- Add `src/compat/_internal/unicodeSize.ts` — a port of lodash's `_unicodeSize` (its `reUnicode` grapheme regex + count loop).
- `size.ts` calls `unicodeSize(target)` instead of `Array.from(target).length` on the multibyte branch. Independent emoji are unchanged (`size('😀😁😂') === 3`).

## Test results

- Added 5 combined-sequence cases to `size.spec.ts` (flag, skin-tone, ZWJ family, variation selector, NFD combining) asserting `1`, matching lodash 4.17.21. The existing `'😀😁😂' -> 3` case still passes.
- `vitest run src/compat` → 2861 passed. `tsc --noEmit` clean. `eslint` clean on changed files.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, verified the counts against lodash 4.17.21, ported the helper, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
