### PR TITLE
fix(compat/orderBy): read the criterion property from primitive values

### DIFF
--- a/src/compat/array/orderBy.spec.ts
+++ b/src/compat/array/orderBy.spec.ts
@@ -202,6 +202,8 @@ describe('orderBy', () => {
   });
 
   it('should work as an iteratee for methods like `_.map`', () => {
+    // `map` passes the index as `iteratees` and the array as `orders`, so the index is used as a
+    // criterion. Numbers have no such property, so the collections are returned in their original order.
     expect(
       [
         [2, 1, 3],
@@ -209,8 +211,8 @@ describe('orderBy', () => {
         // @ts-expect-error - type mismatch
       ].map(orderBy)
     ).toEqual([
-      [1, 2, 3],
-      [1, 2, 3],
+      [2, 1, 3],
+      [3, 2, 1],
     ]);
   });
 
@@ -238,5 +240,16 @@ describe('orderBy', () => {
 
     expect(orderBy(['A', 'a'])).toEqual(['A', 'a']);
     expect(orderBy(['ABC', 'abc'])).toEqual(['ABC', 'abc']);
+  });
+
+  it('should read the property of primitive values', () => {
+    expect(orderBy(['b', 'aa'], 'length')).toEqual(['b', 'aa']);
+    expect(orderBy(['b', 'aa'], 'length', 'desc')).toEqual(['aa', 'b']);
+    expect(orderBy(['ba', 'ab', 'b'], 0)).toEqual(['ab', 'ba', 'b']);
+  });
+
+  it('should keep the original order when primitive values lack the property', () => {
+    expect(orderBy([3, 1, 2], 'b')).toEqual([3, 1, 2]);
+    expect(orderBy(['c', 'a', 'b'], 'x')).toEqual(['c', 'a', 'b']);
   });
 });

--- a/src/compat/array/orderBy.ts
+++ b/src/compat/array/orderBy.ts
@@ -192,11 +192,7 @@ export function orderBy<T = any>(collection: any, criteria?: any, orders?: any, 
       return getValueByNestedPath(object, criterion);
     }
 
-    if (typeof object === 'object') {
-      return object[criterion as keyof typeof object];
-    }
-
-    return object;
+    return object[criterion as keyof typeof object];
   };
 
   // Prepare all cases for criteria

--- a/src/compat/array/sortBy.spec.ts
+++ b/src/compat/array/sortBy.spec.ts
@@ -191,4 +191,15 @@ describe('sortBy', () => {
     expect(sortBy(['A', 'a'])).toEqual(['A', 'a']);
     expect(sortBy(['ABC', 'abc'])).toEqual(['ABC', 'abc']);
   });
+
+  it('should read the property of primitive values', () => {
+    expect(sortBy(['bb', 'a', 'ccc'], 'length')).toEqual(['a', 'bb', 'ccc']);
+    expect(sortBy(['b', 'aa'], 'length')).toEqual(['b', 'aa']);
+    expect(sortBy(['ba', 'ab', 'b'], 0)).toEqual(['ab', 'ba', 'b']);
+  });
+
+  it('should keep the original order when primitive values lack the property', () => {
+    expect(sortBy([3, 1, 2], 'b')).toEqual([3, 1, 2]);
+    expect(sortBy(['c', 'a', 'b'], 'x')).toEqual(['c', 'a', 'b']);
+  });
 });


### PR DESCRIPTION
## Summary

I was diffing `es-toolkit/compat` against lodash 4.17.21 and hit this on `sortBy`:

```js
sortBy(['b', 'aa'], 'length');   // compat: ['aa', 'b']   lodash: ['b', 'aa']
orderBy(['ba', 'ab', 'b'], 0);   // compat: ['ab', 'b', 'ba']   lodash: ['ab', 'ba', 'b']
```

`getValueByCriterion` only looked the criterion up when the element was an object, and returned the element itself otherwise, so the criterion was silently dropped for strings and numbers and the collection got sorted by its own values. `map(['b', 'aa'], 'length')` already returns `[1, 2]`, so compat was inconsistent with itself here too.

Reading the property directly is enough — primitives box on property access, so `'aa'.length` is `2` and `(3).b` is `undefined`, which is what lodash's property iteratee produces. When no element has the key every criterion is `undefined` and the input order is kept, same as lodash.

This is compat-only; `es-toolkit/orderBy` is untouched, so #1096 / #1552 (primitive support in the main library) stay closed as they were.

## Changes

- `src/compat/array/orderBy.ts`: drop the `typeof object === 'object'` guard around the criterion lookup.
- Tests for the property read and for the "no element has the key" case, in both specs.
- Updated the existing `_.map` iteratee expectation in `orderBy.spec.ts`. `map` passes the index as the criterion, and numbers have no such property, so lodash returns the collections unsorted:

  ```js
  [[2, 1, 3], [3, 2, 1]].map(_.orderBy)   // [[2, 1, 3], [3, 2, 1]]
  [[2, 1, 3], [3, 2, 1]].map(_.sortBy)    // [[1, 2, 3], [1, 2, 3]]
  ```

  `sortBy` differs because it clears the criteria via `isIterateeCall`; `orderBy` has no such guard. The old expectation only passed because the criterion was being ignored.

## Test results

```
Test Files  641 passed (641)
     Tests  4436 passed | 2 skipped (4438)
```

`tsc --noEmit`, `yarn lint` and `prettier -c` on the changed files are clean, and re-running the differential fuzz over `sortBy`/`orderBy` (80k random inputs) now shows no value differences against lodash.
