### PR TITLE
feat: capitalCase (Start Case)

### DIFF
--- a/src/string/capitalCase.ts
+++ b/src/string/capitalCase.ts
@@ -1,0 +1,26 @@
+import { capitalize } from './capitalize.ts';
+import { words as getWords } from './words.ts';
+
+/**
+ * Converts a string to capital case (also known as "start case"), in which
+ * the first letter of each word is capitalised and the rest are lower-cased,
+ * with words separated by a single space. Not to be confused with
+ * {@link capitalize}, which only capitalises the first letter of the whole
+ * string. See issue #306.
+ *
+ * @param str - The string to convert to capital case.
+ * @returns The converted string to capital case.
+ *
+ * @example
+ * capitalCase('hello world') // 'Hello World'
+ * capitalCase('some whitespace') // 'Some Whitespace'
+ * capitalCase('hyphen-text') // 'Hyphen Text'
+ * capitalCase('camelCase') // 'Camel Case'
+ */
+export function capitalCase(str: string): string {
+  const words = getWords(str);
+  if (words.length === 0) {
+    return '';
+  }
+  return words.map(word => capitalize(word)).join(' ');
+}

--- a/src/string/index.ts
+++ b/src/string/index.ts
@@ -1,4 +1,5 @@
 export { camelCase } from './camelCase.ts';
+export { capitalCase } from './capitalCase.ts';
 export { capitalize } from './capitalize.ts';
 export { constantCase } from './constantCase.ts';
 export { deburr } from './deburr.ts';


### PR DESCRIPTION
Closes #306.

Add capitalCase(str) that capitalises the first letter of each word and lower cases the rest, joining words with a single space: "hello world" to "Hello World", "camelCase" to "Camel Case", "hyphen text" to "Hyphen Text". Distinct from capitalize (which only capitalises the first letter of the whole string). Reuses the existing words and capitalize helpers.