### PR TITLE
feat: Async/Promise memoization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Released on June 26th, 2026.
 
+- Added `memoizePromise` for sharing in-flight Promise calls and caching their
+  resolved values without retaining settled Promise objects.
+  ([#1910](https://github.com/toss/es-toolkit/pull/1910))
 - Added the `es-toolkit/fp` entrypoint with data-last, pipeable utilities,
   documentation, benchmarks, and bundle-size checks. ([#1781])
 - Added a broad set of array utilities to `es-toolkit/fp`, covering slicing,
@@ -20,8 +23,8 @@ Released on June 26th, 2026.
   references. ([#1785], [#1786], [#1788], [#1790], [#1791], [#1792], [#1793],
   [#1795], [#1800])
 
-We sincerely thank @Antoliny0919, @D-Sketon, @eunwoo-levi, and @raon0211 for
-their contributions. We appreciate your great efforts!
+We sincerely thank @Antoliny0919, @D-Sketon, @eunwoo-levi, @hazrid93, and
+@raon0211 for their contributions. We appreciate your great efforts!
 
 ## Version v1.48.1
 

--- a/benchmarks/performance/memoizePromise.bench.ts
+++ b/benchmarks/performance/memoizePromise.bench.ts
@@ -1,0 +1,11 @@
+import { bench, describe } from 'vitest';
+import { memoizePromise } from 'es-toolkit';
+
+describe('memoizePromise', () => {
+  bench('shares concurrent calls and caches the resolved value', async () => {
+    const memoized = memoizePromise(async (value: number) => value);
+
+    await Promise.all([memoized(1), memoized(1)]);
+    await memoized(1);
+  });
+});

--- a/docs/ja/reference/function/memoizePromise.md
+++ b/docs/ja/reference/function/memoizePromise.md
@@ -62,9 +62,9 @@ await memoizedFetch({ id: 1, name: 'Grace' }); // キャッシュされた結果
 
 - `func` (`F`): メモ化する Promise を返す関数です。引数を取らないか、1つの引数だけを取る必要があります。
 - `options` (`object`, オプション): メモ化のオプションです。
-  - `cache` (`MemoizeCache<any, Awaited<ReturnType<F>>>`, オプション): 解決された値を保存するキャッシュです。デフォルトは新しい `Map` です。
+  - `cache` (`MemoizeCache<any, ReturnType<F> | Awaited<ReturnType<F>>>`, オプション): 処理中の `Promise` と解決された値を保存するキャッシュです。デフォルトは新しい `Map` です。
   - `getCacheKey` (`(arg: Parameters<F>[0]) => unknown`, オプション): 引数からキャッシュキーを生成する関数です。デフォルトでは引数自体をキーとして使用します。
 
 #### 戻り値
 
-(`F & { cache: MemoizeCache<any, Awaited<ReturnType<F>>> }`): 解決された値を保持する `cache` プロパティが追加されたメモ化関数です。
+(`F & { cache: MemoizeCache<any, ReturnType<F> | Awaited<ReturnType<F>>> }`): 処理中の `Promise` または解決された値を保持する `cache` プロパティが追加されたメモ化関数です。

--- a/docs/ja/reference/function/memoizePromise.md
+++ b/docs/ja/reference/function/memoizePromise.md
@@ -1,0 +1,70 @@
+# memoizePromise
+
+Promise を返す関数をメモ化します。同じ引数で同時に呼び出された場合は、実行中の同じ Promise を共有します。Promise が解決されると、キャッシュには完了した Promise ではなく解決された値だけが保存されます。
+
+```typescript
+const memoizedFunc = memoizePromise(func, options);
+```
+
+## 使用法
+
+### `memoizePromise(func, options?)`
+
+同じ引数に対する非同期処理の重複実行を避けたい場合は `memoizePromise` を使用します。たとえば、同じ API リクエストが何度も発生するのを防げます。最初のリクエストが実行中の場合は同じ Promise を共有し、解決後はキャッシュされた値を使用します。
+
+```typescript
+import { memoizePromise } from 'es-toolkit/function';
+
+const fetchUser = async (id: number) => {
+  const response = await fetch(`/users/${id}`);
+  return response.json();
+};
+
+const memoizedFetchUser = memoizePromise(fetchUser);
+
+const first = memoizedFetchUser(1);
+const second = memoizedFetchUser(1);
+
+console.log(first === second); // true (リクエストの実行中)
+console.log(await first); // リクエストの結果
+console.log(await memoizedFetchUser(1)); // キャッシュされた結果
+console.log(memoizedFetchUser.cache.get(1)); // Promise ではなく解決された値
+```
+
+拒否された Promise はキャッシュされません。呼び出しが失敗した場合、同じキーで次に呼び出すと関数が再度実行されます。
+
+```typescript
+const memoizedFetch = memoizePromise(async (id: number) => {
+  return fetchUser(id);
+});
+
+try {
+  await memoizedFetch(1);
+} catch {
+  // 失敗した呼び出しはキャッシュから削除されます。
+}
+
+await memoizedFetch(1); // 再試行します
+```
+
+プリミティブではない引数に対しては、キャッシュキーを生成する関数を指定できます。
+
+```typescript
+const memoizedFetch = memoizePromise(async (user: { id: number; name: string }) => fetchUser(user.id), {
+  getCacheKey: user => user.id,
+});
+
+await memoizedFetch({ id: 1, name: 'Ada' });
+await memoizedFetch({ id: 1, name: 'Grace' }); // キャッシュされた結果を使用します
+```
+
+#### パラメータ
+
+- `func` (`F`): メモ化する Promise を返す関数です。引数を取らないか、1つの引数だけを取る必要があります。
+- `options` (`object`, オプション): メモ化のオプションです。
+  - `cache` (`MemoizeCache<any, Awaited<ReturnType<F>>>`, オプション): 解決された値を保存するキャッシュです。デフォルトは新しい `Map` です。
+  - `getCacheKey` (`(arg: Parameters<F>[0]) => unknown`, オプション): 引数からキャッシュキーを生成する関数です。デフォルトでは引数自体をキーとして使用します。
+
+#### 戻り値
+
+(`F & { cache: MemoizeCache<any, Awaited<ReturnType<F>>> }`): 解決された値を保持する `cache` プロパティが追加されたメモ化関数です。

--- a/docs/ko/reference/function/memoizePromise.md
+++ b/docs/ko/reference/function/memoizePromise.md
@@ -62,9 +62,9 @@ await memoizedFetch({ id: 1, name: 'Grace' }); // 캐시된 결과를 사용해�
 
 - `func` (`F`): 메모이제이션할 Promise 반환 함수예요. 인수를 받지 않거나 하나의 인수만 받아야 해요.
 - `options` (`object`, 선택): 메모이제이션 옵션이에요.
-  - `cache` (`MemoizeCache<any, Awaited<ReturnType<F>>>`, 선택): 해결된 값을 저장할 캐시예요. 기본값은 새로운 `Map`이에요.
+  - `cache` (`MemoizeCache<any, ReturnType<F> | Awaited<ReturnType<F>>>`, 선택): 진행 중인 `Promise`와 해결된 값을 저장할 캐시예요. 기본값은 새로운 `Map`이에요.
   - `getCacheKey` (`(arg: Parameters<F>[0]) => unknown`, 선택): 인수에서 캐시 키를 만드는 함수예요. 기본값은 인수 자체를 키로 사용해요.
 
 #### 반환 값
 
-(`F & { cache: MemoizeCache<any, Awaited<ReturnType<F>>> }`): 해결된 값을 포함하는 `cache` 속성이 추가된 메모이제이션 함수예요.
+(`F & { cache: MemoizeCache<any, ReturnType<F> | Awaited<ReturnType<F>>> }`): 진행 중인 `Promise` 또는 해결된 값을 포함하는 `cache` 속성이 추가된 메모이제이션 함수예요.

--- a/docs/ko/reference/function/memoizePromise.md
+++ b/docs/ko/reference/function/memoizePromise.md
@@ -1,0 +1,70 @@
+# memoizePromise
+
+Promise를 반환하는 함수를 메모이제이션해요. 같은 인수로 동시에 호출하면 실행 중인 동일한 Promise를 함께 사용해요. Promise가 완료되면 캐시에는 완료된 Promise 대신 해결된 값만 저장돼요.
+
+```typescript
+const memoizedFunc = memoizePromise(func, options);
+```
+
+## 사용법
+
+### `memoizePromise(func, options?)`
+
+같은 인수에 대한 비동기 작업의 중복 실행을 피하고 싶을 때 `memoizePromise`를 사용하세요. 예를 들어 같은 API 요청이 여러 번 발생하는 것을 막을 수 있어요. 첫 번째 요청이 진행 중일 때 호출하면 동일한 Promise를 공유하고, 요청이 완료된 후에는 캐시된 값을 사용해요.
+
+```typescript
+import { memoizePromise } from 'es-toolkit/function';
+
+const fetchUser = async (id: number) => {
+  const response = await fetch(`/users/${id}`);
+  return response.json();
+};
+
+const memoizedFetchUser = memoizePromise(fetchUser);
+
+const first = memoizedFetchUser(1);
+const second = memoizedFetchUser(1);
+
+console.log(first === second); // true (요청이 진행 중일 때)
+console.log(await first); // 요청 결과
+console.log(await memoizedFetchUser(1)); // 캐시된 결과
+console.log(memoizedFetchUser.cache.get(1)); // Promise가 아닌 해결된 값
+```
+
+거부된 Promise는 캐시되지 않아요. 호출이 실패하면 같은 키로 다음 호출을 할 때 함수를 다시 실행해요.
+
+```typescript
+const memoizedFetch = memoizePromise(async (id: number) => {
+  return fetchUser(id);
+});
+
+try {
+  await memoizedFetch(1);
+} catch {
+  // 실패한 호출은 캐시에서 제거돼요.
+}
+
+await memoizedFetch(1); // 다시 시도해요.
+```
+
+기본 키로 사용할 수 없는 객체 인수를 위해 캐시 키를 만드는 함수를 지정할 수 있어요.
+
+```typescript
+const memoizedFetch = memoizePromise(async (user: { id: number; name: string }) => fetchUser(user.id), {
+  getCacheKey: user => user.id,
+});
+
+await memoizedFetch({ id: 1, name: 'Ada' });
+await memoizedFetch({ id: 1, name: 'Grace' }); // 캐시된 결과를 사용해요.
+```
+
+#### 파라미터
+
+- `func` (`F`): 메모이제이션할 Promise 반환 함수예요. 인수를 받지 않거나 하나의 인수만 받아야 해요.
+- `options` (`object`, 선택): 메모이제이션 옵션이에요.
+  - `cache` (`MemoizeCache<any, Awaited<ReturnType<F>>>`, 선택): 해결된 값을 저장할 캐시예요. 기본값은 새로운 `Map`이에요.
+  - `getCacheKey` (`(arg: Parameters<F>[0]) => unknown`, 선택): 인수에서 캐시 키를 만드는 함수예요. 기본값은 인수 자체를 키로 사용해요.
+
+#### 반환 값
+
+(`F & { cache: MemoizeCache<any, Awaited<ReturnType<F>>> }`): 해결된 값을 포함하는 `cache` 속성이 추가된 메모이제이션 함수예요.

--- a/docs/reference/function/memoizePromise.md
+++ b/docs/reference/function/memoizePromise.md
@@ -1,0 +1,70 @@
+# memoizePromise
+
+Memoizes a Promise-returning function. Concurrent calls with the same argument share the same in-flight Promise. After the Promise resolves, the cache stores the resolved value instead of the settled Promise.
+
+```typescript
+const memoizedFunc = memoizePromise(func, options);
+```
+
+## Usage
+
+### `memoizePromise(func, options?)`
+
+Use `memoizePromise` when you want to avoid duplicate asynchronous work for the same argument, such as repeated API requests. Calls made while the first request is pending share the same Promise. Once it resolves, later calls use the cached value.
+
+```typescript
+import { memoizePromise } from 'es-toolkit/function';
+
+const fetchUser = async (id: number) => {
+  const response = await fetch(`/users/${id}`);
+  return response.json();
+};
+
+const memoizedFetchUser = memoizePromise(fetchUser);
+
+const first = memoizedFetchUser(1);
+const second = memoizedFetchUser(1);
+
+console.log(first === second); // true (while the request is in flight)
+console.log(await first); // The request result
+console.log(await memoizedFetchUser(1)); // The cached result
+console.log(memoizedFetchUser.cache.get(1)); // The resolved value, not a Promise
+```
+
+Rejected Promises are not cached. If a call fails, the next call with the same key runs the function again.
+
+```typescript
+const memoizedFetch = memoizePromise(async (id: number) => {
+  return fetchUser(id);
+});
+
+try {
+  await memoizedFetch(1);
+} catch {
+  // The failed call is removed from the cache.
+}
+
+await memoizedFetch(1); // Tries again
+```
+
+You can provide a custom function to generate cache keys for non-primitive arguments.
+
+```typescript
+const memoizedFetch = memoizePromise(async (user: { id: number; name: string }) => fetchUser(user.id), {
+  getCacheKey: user => user.id,
+});
+
+await memoizedFetch({ id: 1, name: 'Ada' });
+await memoizedFetch({ id: 1, name: 'Grace' }); // Uses the cached result
+```
+
+#### Parameters
+
+- `func` (`F`): The Promise-returning function to memoize. It must accept zero or one argument.
+- `options` (`object`, optional): Options for configuring memoization.
+  - `cache` (`MemoizeCache<any, Awaited<ReturnType<F>>>`, optional): The cache used to store resolved values. Defaults to a new `Map`.
+  - `getCacheKey` (`(arg: Parameters<F>[0]) => unknown`, optional): A function that generates a cache key from the argument. By default, the argument itself is used as the key.
+
+#### Returns
+
+(`F & { cache: MemoizeCache<any, Awaited<ReturnType<F>>> }`): The memoized function with a `cache` property containing resolved values.

--- a/docs/reference/function/memoizePromise.md
+++ b/docs/reference/function/memoizePromise.md
@@ -62,9 +62,9 @@ await memoizedFetch({ id: 1, name: 'Grace' }); // Uses the cached result
 
 - `func` (`F`): The Promise-returning function to memoize. It must accept zero or one argument.
 - `options` (`object`, optional): Options for configuring memoization.
-  - `cache` (`MemoizeCache<any, Awaited<ReturnType<F>>>`, optional): The cache used to store resolved values. Defaults to a new `Map`.
+  - `cache` (`MemoizeCache<any, ReturnType<F> | Awaited<ReturnType<F>>>`, optional): The cache used to store in-flight Promises and resolved values. Defaults to a new `Map`.
   - `getCacheKey` (`(arg: Parameters<F>[0]) => unknown`, optional): A function that generates a cache key from the argument. By default, the argument itself is used as the key.
 
 #### Returns
 
-(`F & { cache: MemoizeCache<any, Awaited<ReturnType<F>>> }`): The memoized function with a `cache` property containing resolved values.
+(`F & { cache: MemoizeCache<any, ReturnType<F> | Awaited<ReturnType<F>>> }`): The memoized function with a `cache` property containing in-flight Promises or resolved values.

--- a/docs/zh_hans/reference/function/memoizePromise.md
+++ b/docs/zh_hans/reference/function/memoizePromise.md
@@ -1,0 +1,70 @@
+# memoizePromise
+
+对返回 Promise 的函数进行记忆化。同一参数的并发调用会共享同一个正在执行的 Promise。Promise 解决后,缓存中只保存解决后的值,而不是已完成的 Promise。
+
+```typescript
+const memoizedFunc = memoizePromise(func, options);
+```
+
+## 用法
+
+### `memoizePromise(func, options?)`
+
+当您想避免相同参数导致的重复异步操作时,请使用 `memoizePromise`,例如避免重复发送相同的 API 请求。第一次请求进行期间的调用会共享同一个 Promise,请求完成后会使用缓存的值。
+
+```typescript
+import { memoizePromise } from 'es-toolkit/function';
+
+const fetchUser = async (id: number) => {
+  const response = await fetch(`/users/${id}`);
+  return response.json();
+};
+
+const memoizedFetchUser = memoizePromise(fetchUser);
+
+const first = memoizedFetchUser(1);
+const second = memoizedFetchUser(1);
+
+console.log(first === second); // true (请求进行期间)
+console.log(await first); // 请求结果
+console.log(await memoizedFetchUser(1)); // 缓存的结果
+console.log(memoizedFetchUser.cache.get(1)); // 已解决的值,而不是 Promise
+```
+
+被拒绝的 Promise 不会被缓存。如果调用失败,下次使用相同键调用时会再次执行函数。
+
+```typescript
+const memoizedFetch = memoizePromise(async (id: number) => {
+  return fetchUser(id);
+});
+
+try {
+  await memoizedFetch(1);
+} catch {
+  // 失败的调用会从缓存中移除。
+}
+
+await memoizedFetch(1); // 再次尝试
+```
+
+对于非原始类型的参数,可以指定用于生成缓存键的函数。
+
+```typescript
+const memoizedFetch = memoizePromise(async (user: { id: number; name: string }) => fetchUser(user.id), {
+  getCacheKey: user => user.id,
+});
+
+await memoizedFetch({ id: 1, name: 'Ada' });
+await memoizedFetch({ id: 1, name: 'Grace' }); // 使用缓存的结果
+```
+
+#### 参数
+
+- `func` (`F`): 要记忆化的 Promise 返回函数。必须不接收参数或只接收一个参数。
+- `options` (`object`, 可选): 记忆化选项。
+  - `cache` (`MemoizeCache<any, Awaited<ReturnType<F>>>`, 可选): 用于保存解决后值的缓存。默认为新的 `Map`。
+  - `getCacheKey` (`(arg: Parameters<F>[0]) => unknown`, 可选): 从参数生成缓存键的函数。默认使用参数本身作为键。
+
+#### 返回值
+
+(`F & { cache: MemoizeCache<any, Awaited<ReturnType<F>>> }`): 返回带有 `cache` 属性的记忆化函数,其中包含解决后的值。

--- a/docs/zh_hans/reference/function/memoizePromise.md
+++ b/docs/zh_hans/reference/function/memoizePromise.md
@@ -62,9 +62,9 @@ await memoizedFetch({ id: 1, name: 'Grace' }); // 使用缓存的结果
 
 - `func` (`F`): 要记忆化的 Promise 返回函数。必须不接收参数或只接收一个参数。
 - `options` (`object`, 可选): 记忆化选项。
-  - `cache` (`MemoizeCache<any, Awaited<ReturnType<F>>>`, 可选): 用于保存解决后值的缓存。默认为新的 `Map`。
+  - `cache` (`MemoizeCache<any, ReturnType<F> | Awaited<ReturnType<F>>>`, 可选): 用于保存进行中的 `Promise` 和解决后值的缓存。默认为新的 `Map`。
   - `getCacheKey` (`(arg: Parameters<F>[0]) => unknown`, 可选): 从参数生成缓存键的函数。默认使用参数本身作为键。
 
 #### 返回值
 
-(`F & { cache: MemoizeCache<any, Awaited<ReturnType<F>>> }`): 返回带有 `cache` 属性的记忆化函数,其中包含解决后的值。
+(`F & { cache: MemoizeCache<any, ReturnType<F> | Awaited<ReturnType<F>>> }`): 返回带有 `cache` 属性的记忆化函数,其中包含进行中的 `Promise` 或解决后的值。

--- a/src/function/index.ts
+++ b/src/function/index.ts
@@ -9,6 +9,7 @@ export { flow } from './flow.ts';
 export { flowRight } from './flowRight.ts';
 export { identity } from './identity.ts';
 export { memoize, type MemoizeCache } from './memoize.ts';
+export { memoizePromise } from './memoizePromise.ts';
 export { negate } from './negate.ts';
 export { noop } from './noop.ts';
 export { once } from './once.ts';

--- a/src/function/memoizePromise.spec.ts
+++ b/src/function/memoizePromise.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { memoizePromise } from './memoizePromise';
+
+describe('memoizePromise', () => {
+  it('shares the in-flight Promise and caches the resolved value', async () => {
+    const fn = vi.fn(async (id: number) => ({ id }));
+    const memoized = memoizePromise(fn);
+
+    const first = memoized(1);
+    const second = memoized(1);
+
+    expect(second).toBe(first);
+    expect(await first).toEqual({ id: 1 });
+    expect(memoized.cache.get(1)).toEqual({ id: 1 });
+    expect(memoized.cache.get(1)).not.toBeInstanceOf(Promise);
+
+    expect(await memoized(1)).toEqual({ id: 1 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache rejected Promises', async () => {
+    const error = new Error('failed');
+    const fn = vi.fn(async (key: string) => {
+      void key;
+      throw error;
+    });
+    const memoized = memoizePromise(fn);
+
+    await expect(memoized('key')).rejects.toBe(error);
+    expect(memoized.cache.has('key')).toBe(false);
+
+    await expect(memoized('key')).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses a custom cache key resolver', async () => {
+    const fn = vi.fn(async (user: { id: number; name: string }) => user.name);
+    const memoized = memoizePromise(fn, { getCacheKey: user => user.id });
+
+    await expect(memoized({ id: 1, name: 'Ada' })).resolves.toBe('Ada');
+    await expect(memoized({ id: 1, name: 'Grace' })).resolves.toBe('Ada');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(memoized.cache.get(1)).toBe('Ada');
+  });
+
+  it('uses a custom cache', async () => {
+    const cache = new Map<number, string>();
+    const fn = vi.fn(async (id: number) => `user-${id}`);
+    const memoized = memoizePromise(fn, { cache });
+
+    await expect(memoized(1)).resolves.toBe('user-1');
+
+    expect(memoized.cache).toBe(cache);
+    expect(cache.get(1)).toBe('user-1');
+  });
+});

--- a/src/function/memoizePromise.spec.ts
+++ b/src/function/memoizePromise.spec.ts
@@ -7,6 +7,8 @@ describe('memoizePromise', () => {
     const memoized = memoizePromise(fn);
 
     const first = memoized(1);
+    expect(memoized.cache.get(1)).toBe(first);
+
     const second = memoized(1);
 
     expect(second).toBe(first);
@@ -45,7 +47,7 @@ describe('memoizePromise', () => {
   });
 
   it('uses a custom cache', async () => {
-    const cache = new Map<number, string>();
+    const cache = new Map<number, string | Promise<string>>();
     const fn = vi.fn(async (id: number) => `user-${id}`);
     const memoized = memoizePromise(fn, { cache });
 

--- a/src/function/memoizePromise.ts
+++ b/src/function/memoizePromise.ts
@@ -1,0 +1,64 @@
+import type { MemoizeCache } from './memoize.ts';
+
+/**
+ * Creates a memoized version of an async (Promise-returning) function.
+ *
+ * Unlike {@link memoize}, which caches the resolved value, `memoizePromise`
+ * caches the **in-flight Promise** itself, so concurrent calls with the same
+ * argument share a single execution. Crucially, when a Promise rejects the
+ * cache entry is deleted, so a failed call is retried on the next invocation
+ * instead of caching the rejection forever (which would leak memory and
+ * freeze the cache — see issue #1739).
+ *
+ * Like {@link memoize}, this works with functions that take zero or just one
+ * argument; provide a `getCacheKey` for non-primitive arguments.
+ *
+ * @template F - The async function to memoize.
+ * @param fn - The async function to memoize.
+ * @param [options={}] - Optional configuration.
+ * @param [options.cache] - The cache object. Defaults to a new `Map`.
+ * @param [options.getCacheKey] - An optional function to generate a cache key.
+ * @returns The memoized async function with a `.cache` property.
+ *
+ * @example
+ * const fetchUser = async (id: number) => api.load(id);
+ * const memoized = memoizePromise(fetchUser);
+ * await memoized(1); // calls api.load(1)
+ * await memoized(1); // returns the cached promise (api.load not called again)
+ * console.log(memoized.cache.size); // 1
+ */
+export function memoizePromise<F extends (arg: any) => Promise<any>>(
+  fn: F,
+  options: {
+    cache?: MemoizeCache<any, ReturnType<F>>;
+    getCacheKey?: (args: Parameters<F>[0]) => unknown;
+  } = {}
+): F & { cache: MemoizeCache<any, ReturnType<F>> } {
+  const { cache = new Map<unknown, ReturnType<F>>(), getCacheKey } = options;
+
+  const memoizedFn = function (this: unknown, arg: Parameters<F>[0]): ReturnType<F> {
+    const key = getCacheKey ? getCacheKey(arg) : arg;
+
+    if (cache.has(key)) {
+      return cache.get(key)! as ReturnType<F>;
+    }
+
+    // Cache the in-flight promise, and clear the entry on rejection so a
+    // failed call is retried next time instead of being cached forever.
+    const promise = fn.call(this, arg).then(
+      (value: any) => value,
+      (error: unknown) => {
+        cache.delete(key);
+        throw error;
+      }
+    ) as ReturnType<F>;
+
+    cache.set(key, promise);
+
+    return promise;
+  };
+
+  memoizedFn.cache = cache;
+
+  return memoizedFn as unknown as F & { cache: MemoizeCache<any, ReturnType<F>> };
+}

--- a/src/function/memoizePromise.ts
+++ b/src/function/memoizePromise.ts
@@ -1,7 +1,7 @@
 import type { MemoizeCache } from './memoize.ts';
 
 type MemoizedPromise<F extends (arg: any) => Promise<any>> = F & {
-  cache: MemoizeCache<any, Awaited<ReturnType<F>>>;
+  cache: MemoizeCache<any, ReturnType<F> | Awaited<ReturnType<F>>>;
 };
 
 /**
@@ -18,9 +18,9 @@ type MemoizedPromise<F extends (arg: any) => Promise<any>> = F & {
  * @template F - The async function to memoize.
  * @param fn - The async function to memoize.
  * @param [options={}] - Optional configuration.
- * @param [options.cache] - The cache object used to store resolved values. Defaults to a new `Map`.
+ * @param [options.cache] - The cache used to store in-flight Promises and resolved values. Defaults to a new `Map`.
  * @param [options.getCacheKey] - An optional function to generate a unique cache key for each argument.
- * @returns The memoized async function with an additional `cache` property that exposes the cache of resolved values.
+ * @returns The memoized async function with an additional `cache` property that exposes its cache.
  *
  * @example
  * const fetchUser = async (id: number) => api.load(id);
@@ -43,36 +43,32 @@ type MemoizedPromise<F extends (arg: any) => Promise<any>> = F & {
 export function memoizePromise<F extends (arg: any) => Promise<any>>(
   fn: F,
   options: {
-    cache?: MemoizeCache<any, Awaited<ReturnType<F>>>;
+    cache?: MemoizeCache<any, ReturnType<F> | Awaited<ReturnType<F>>>;
     getCacheKey?: (arg: Parameters<F>[0]) => unknown;
   } = {}
 ): MemoizedPromise<F> {
-  const cache: MemoizeCache<any, Awaited<ReturnType<F>>> = options.cache ?? new Map<unknown, Awaited<ReturnType<F>>>();
+  const cache = options.cache ?? new Map<unknown, ReturnType<F> | Awaited<ReturnType<F>>>();
   const { getCacheKey } = options;
-  const promiseCache = new Map<unknown, ReturnType<F>>();
 
   const memoizedFn = function (this: unknown, arg: Parameters<F>[0]): ReturnType<F> {
     const key = getCacheKey ? getCacheKey(arg) : arg;
-
-    if (promiseCache.has(key)) {
-      return promiseCache.get(key)!;
-    }
 
     if (cache.has(key)) {
       return Promise.resolve(cache.get(key)) as ReturnType<F>;
     }
 
-    const promise = fn
-      .call(this, arg)
-      .then(value => {
+    const promise = fn.call(this, arg).then(
+      value => {
         cache.set(key, value);
         return value;
-      })
-      .finally(() => {
-        promiseCache.delete(key);
-      }) as ReturnType<F>;
+      },
+      error => {
+        cache.delete(key);
+        throw error;
+      }
+    ) as ReturnType<F>;
 
-    promiseCache.set(key, promise);
+    cache.set(key, promise);
 
     return promise;
   };

--- a/src/function/memoizePromise.ts
+++ b/src/function/memoizePromise.ts
@@ -1,14 +1,16 @@
 import type { MemoizeCache } from './memoize.ts';
 
+type MemoizedPromise<F extends (arg: any) => Promise<any>> = F & {
+  cache: MemoizeCache<any, Awaited<ReturnType<F>>>;
+};
+
 /**
  * Creates a memoized version of an async (Promise-returning) function.
  *
- * Unlike {@link memoize}, which caches the resolved value, `memoizePromise`
- * caches the **in-flight Promise** itself, so concurrent calls with the same
- * argument share a single execution. Crucially, when a Promise rejects the
- * cache entry is deleted, so a failed call is retried on the next invocation
- * instead of caching the rejection forever (which would leak memory and
- * freeze the cache — see issue #1739).
+ * Concurrent calls with the same argument share the same in-flight Promise. Once
+ * the Promise resolves, only its resolved value is kept in the cache. This avoids
+ * retaining settled Promise objects, which can cause memory leaks. Rejected
+ * Promises are not cached, so a failed call is retried on the next invocation.
  *
  * Like {@link memoize}, this works with functions that take zero or just one
  * argument; provide a `getCacheKey` for non-primitive arguments.
@@ -16,49 +18,66 @@ import type { MemoizeCache } from './memoize.ts';
  * @template F - The async function to memoize.
  * @param fn - The async function to memoize.
  * @param [options={}] - Optional configuration.
- * @param [options.cache] - The cache object. Defaults to a new `Map`.
- * @param [options.getCacheKey] - An optional function to generate a cache key.
- * @returns The memoized async function with a `.cache` property.
+ * @param [options.cache] - The cache object used to store resolved values. Defaults to a new `Map`.
+ * @param [options.getCacheKey] - An optional function to generate a unique cache key for each argument.
+ * @returns The memoized async function with an additional `cache` property that exposes the cache of resolved values.
  *
  * @example
  * const fetchUser = async (id: number) => api.load(id);
  * const memoized = memoizePromise(fetchUser);
- * await memoized(1); // calls api.load(1)
- * await memoized(1); // returns the cached promise (api.load not called again)
- * console.log(memoized.cache.size); // 1
+ *
+ * const first = memoized(1);
+ * const second = memoized(1);
+ * console.log(first === second); // true (while the request is in flight)
+ * await first;
+ * await memoized(1); // uses the cached resolved value
+ *
+ * @example
+ * // Rejected Promises are not cached
+ * const fetchData = memoizePromise(async () => {
+ *   return await fetchDataFromApi();
+ * });
+ *
+ * await fetchData(); // If this rejects, the next call tries again
  */
 export function memoizePromise<F extends (arg: any) => Promise<any>>(
   fn: F,
   options: {
-    cache?: MemoizeCache<any, ReturnType<F>>;
-    getCacheKey?: (args: Parameters<F>[0]) => unknown;
+    cache?: MemoizeCache<any, Awaited<ReturnType<F>>>;
+    getCacheKey?: (arg: Parameters<F>[0]) => unknown;
   } = {}
-): F & { cache: MemoizeCache<any, ReturnType<F>> } {
-  const { cache = new Map<unknown, ReturnType<F>>(), getCacheKey } = options;
+): MemoizedPromise<F> {
+  const cache: MemoizeCache<any, Awaited<ReturnType<F>>> = options.cache ?? new Map<unknown, Awaited<ReturnType<F>>>();
+  const { getCacheKey } = options;
+  const promiseCache = new Map<unknown, ReturnType<F>>();
 
   const memoizedFn = function (this: unknown, arg: Parameters<F>[0]): ReturnType<F> {
     const key = getCacheKey ? getCacheKey(arg) : arg;
 
-    if (cache.has(key)) {
-      return cache.get(key)! as ReturnType<F>;
+    if (promiseCache.has(key)) {
+      return promiseCache.get(key)!;
     }
 
-    // Cache the in-flight promise, and clear the entry on rejection so a
-    // failed call is retried next time instead of being cached forever.
-    const promise = fn.call(this, arg).then(
-      (value: any) => value,
-      (error: unknown) => {
-        cache.delete(key);
-        throw error;
-      }
-    ) as ReturnType<F>;
+    if (cache.has(key)) {
+      return Promise.resolve(cache.get(key)) as ReturnType<F>;
+    }
 
-    cache.set(key, promise);
+    const promise = fn
+      .call(this, arg)
+      .then(value => {
+        cache.set(key, value);
+        return value;
+      })
+      .finally(() => {
+        promiseCache.delete(key);
+      }) as ReturnType<F>;
+
+    promiseCache.set(key, promise);
 
     return promise;
   };
 
   memoizedFn.cache = cache;
 
-  return memoizedFn as unknown as F & { cache: MemoizeCache<any, ReturnType<F>> };
+  return memoizedFn as unknown as MemoizedPromise<F>;
 }


### PR DESCRIPTION
Closes #1739.

Add memoizePromise(fn, options) that caches the in flight Promise (so concurrent calls with the same argument share a single execution) and deletes the cache entry on rejection so a failed call is retried on the next invocation. Supports the same options as memoize (cache, getCacheKey) and exposes a .cache property. Existing memoize is unchanged.