### PR TITLE
feat: call / callAsync (expression oriented blocks, named IIFE replacement)

### DIFF
--- a/src/function/call.ts
+++ b/src/function/call.ts
@@ -1,0 +1,40 @@
+/**
+ * Invokes the given function and returns its result. This is a named
+ * replacement for an immediately-invoked function expression (IIFE), making
+ * expression-oriented blocks readable: `call(() => …)` communicates intent
+ * where `(() => …)()` hides it in punctuation. See issue #1659.
+ *
+ * @template R - The type of the value returned by `fn`.
+ * @param fn - The function to invoke.
+ * @returns The value returned by `fn`.
+ *
+ * @example
+ * const result = call(() => {
+ *   if (user.role === 'admin') return 'full';
+ *   if (user.role === 'editor') return 'partial';
+ *   return 'none';
+ * });
+ */
+export function call<R>(fn: () => R): R {
+  return fn();
+}
+
+/**
+ * Invokes the given async function and returns its resolved value, as a
+ * Promise. This is the async counterpart of {@link call}, a named
+ * replacement for the async IIFE `(async () => { … })()`. See issue #1659.
+ *
+ * @template R - The type of the value resolved by `fn`.
+ * @param fn - The async function to invoke.
+ * @returns A Promise that resolves to the value returned by `fn`.
+ *
+ * @example
+ * const result = await callAsync(async () => {
+ *   const perms = await fetchPerms(user.id);
+ *   const roles = await fetchRoles(user.id);
+ *   return merge(perms, roles);
+ * });
+ */
+export async function callAsync<R>(fn: () => Promise<R>): Promise<R> {
+  return await fn();
+}

--- a/src/function/index.ts
+++ b/src/function/index.ts
@@ -2,6 +2,7 @@ export { after } from './after.ts';
 export { ary } from './ary.ts';
 export { asyncNoop } from './asyncNoop.ts';
 export { before } from './before.ts';
+export { call, callAsync } from './call.ts';
 export { curry } from './curry.ts';
 export { curryRight } from './curryRight.ts';
 export { debounce, type DebouncedFunction, type DebounceOptions } from './debounce.ts';


### PR DESCRIPTION
Closes #1659.

Add call(fn) which invokes fn and returns its result (a named IIFE replacement), and callAsync(fn) which invokes an async fn and returns its resolved Promise (the async counterpart). call(() => …) communicates intent where (() => …)() hides it in punctuation.