### PR TITLE
feat: normalize a number to [0, 1]

### DIFF
--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -4,6 +4,7 @@ export { mean } from './mean.ts';
 export { meanBy } from './meanBy.ts';
 export { median } from './median.ts';
 export { medianBy } from './medianBy.ts';
+export { normalize } from './normalize.ts';
 export { percentile } from './percentile.ts';
 export { random } from './random.ts';
 export { randomInt } from './randomInt.ts';

--- a/src/math/normalize.ts
+++ b/src/math/normalize.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalizes a number from a given `[min, max]` range to the `[0, 1]` range.
+ *
+ * The result is `(value - min) / (max - min)`. Values outside `[min, max]` are
+ * mapped outside `[0, 1]` (no clamping is performed); use {@link clamp} first
+ * if you need the output bounded. See issue #550.
+ *
+ * @param value - The number to normalize.
+ * @param min - The lower bound of the source range.
+ * @param max - The upper bound of the source range.
+ * @returns The value normalised to the `[0, 1]` range.
+ * @throws {RangeError} `max` must not be less than `min`.
+ *
+ * @example
+ * normalize(5, 0, 10); // 0.5
+ * normalize(0, 0, 10); // 0
+ * normalize(10, 0, 10); // 1
+ * normalize(15, 10, 20); // 0.5
+ */
+export function normalize(value: number, min: number, max: number): number {
+  if (max < min) {
+    throw new RangeError('max must not be less than min');
+  }
+  return (value - min) / (max - min);
+}


### PR DESCRIPTION
Closes #550.

Add normalize(value, min, max) returning (value min) / (max min). Values outside [min,max] map outside [0,1] (no clamping: pair with clamp to bound). Throws RangeError when max < min.