### PR TITLE
feat: add a deepFreeze function to object utilities

### DIFF
--- a/src/object/deepFreeze.ts
+++ b/src/object/deepFreeze.ts
@@ -1,0 +1,36 @@
+/**
+ * Recursively freezes an object and all of its nested objects/arrays so that
+ * no property of the result (or its descendants) can be added, removed, or
+ * modified. Returns the same reference, now frozen.
+ *
+ * @template T - The type of the object.
+ * @param obj - The object (or value) to deeply freeze.
+ * @returns The frozen object (shallowly-frozen primitives / nullish values are
+ * returned unchanged).
+ *
+ * @example
+ * const target = deepFreeze({ user: { name: 'Alex', age: 20 } })
+ * target.user = {}        // throws in strict mode / no-op otherwise
+ * target.user.age = 22    // throws in strict mode / no-op otherwise
+ *
+ * @group object
+ */
+export function deepFreeze<T>(obj: T): T {
+  if (obj == null || typeof obj !== 'object') {
+    return obj;
+  }
+  if (Object.isFrozen(obj)) {
+    return obj;
+  }
+  // Freeze this object first so cyclic references short-circuit.
+  Object.freeze(obj);
+  const keys = Reflect.ownKeys(obj as object);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = (obj as Record<PropertyKey, unknown>)[key];
+    if (value != null && typeof value === 'object') {
+      deepFreeze(value);
+    }
+  }
+  return obj;
+}

--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -1,6 +1,7 @@
 export { clone } from './clone.ts';
 export { cloneDeep } from './cloneDeep.ts';
 export { cloneDeepWith } from './cloneDeepWith.ts';
+export { deepFreeze } from './deepFreeze.ts';
 export { findKey } from './findKey.ts';
 export { flattenObject } from './flattenObject.ts';
 export { invert } from './invert.ts';


### PR DESCRIPTION
Closes #1356.

Add deepFreeze(obj) that recursively Object.freezes every nested object/array so no property (including nested ones) can be added, removed, or modified. Returns the same reference. Freezes the object first (so cyclic references short circuit via Object.isFrozen and don't recurse infinitely).