### PR TITLE
feat: iterator chain / concatenation (lazy concat of iterables)

### DIFF
--- a/src/array/chain.ts
+++ b/src/array/chain.ts
@@ -1,0 +1,28 @@
+/**
+ * Chains multiple iterables together into a single lazy iterator (Python's
+ * `itertools.chain`). Like `Array.prototype.concat`, but lazy — it yields
+ * elements from each iterable in order without building an intermediate array,
+ * and works with any iterable (not only `Symbol.isConcatSpreadable` ones).
+ *
+ * @template T - The element type.
+ * @param iterables - The iterables to chain.
+ * @returns A lazy iterator over every element of every iterable, in order.
+ *
+ * @example
+ * Array.from(chain('ABC', [1, 2, 3])) // ['A', 'B', 'C', 1, 2, 3]
+ * @example
+ * const evens = [2, 4, 6]
+ * const odds = [1, 3, 5]
+ * Array.from(chain(evens, odds)) // [2, 4, 6, 1, 3, 5]
+ *
+ * @group array
+ */
+export function chain<T>(...iterables: ReadonlyArray<Iterable<T>>): IterableIterator<T> {
+  return (function* () {
+    for (let i = 0; i < iterables.length; i++) {
+      for (const item of iterables[i]) {
+        yield item;
+      }
+    }
+  })();
+}

--- a/src/array/index.ts
+++ b/src/array/index.ts
@@ -1,5 +1,6 @@
 export { at } from './at.ts';
 export { cartesianProduct } from './cartesianProduct.ts';
+export { chain } from './chain.ts';
 export { chunk } from './chunk.ts';
 export { chunkBy } from './chunkBy.ts';
 export { combinations } from './combinations.ts';


### PR DESCRIPTION
Closes #771.

Add chain(...iterables): a lazy generator that yields every element of every iterable, in order, without an intermediate array. Works with any iterable: arrays, strings, Sets, generators. Returns an IterableIterator, so callers can `Array.from(chain(...))`, spread it, or use `.next()`.