### PR TITLE
feat: iterable aware firstValue / head helper

### DIFF
--- a/src/array/firstValue.ts
+++ b/src/array/firstValue.ts
@@ -1,0 +1,22 @@
+/**
+ * Returns the first value produced by `iterable`, or `undefined` if the
+ * iterable is empty. Unlike {@link head} (array-oriented), this works with any
+ * iterable — arrays, sets, maps, generators, strings, etc. — and is lazy: it
+ * pulls a single value and does not consume the rest. See issue #1796.
+ *
+ * @template T - The element type.
+ * @param iterable - The iterable to read the first value from.
+ * @returns The first value, or `undefined` if the iterable is empty.
+ *
+ * @example
+ * firstValue([1, 2, 3]) // 1
+ * firstValue(new Set([1, 2])) // 1
+ * firstValue([]) // undefined
+ *
+ * @group array
+ */
+export function firstValue<T>(iterable: Iterable<T>): T | undefined {
+  const iterator = iterable[Symbol.iterator]();
+  const result = iterator.next();
+  return result.done ? undefined : result.value;
+}

--- a/src/array/index.ts
+++ b/src/array/index.ts
@@ -14,6 +14,7 @@ export { dropRightWhile } from './dropRightWhile.ts';
 export { dropWhile } from './dropWhile.ts';
 export { fill } from './fill.ts';
 export { filterAsync } from './filterAsync.ts';
+export { firstValue } from './firstValue.ts';
 export { flatMap } from './flatMap.ts';
 export { flatMapAsync } from './flatMapAsync.ts';
 export { flatMapDeep } from './flatMapDeep.ts';


### PR DESCRIPTION
Closes #1796.

Add firstValue(iterable) that pulls a single value via the iterator protocol (Symbol.iterator().next().value), returning the first value of any iterable (arrays, sets, maps, generators, strings) or undefined if empty. Lazy: does not consume the rest of the iterable.