### PR TITLE
feat: isTreeData: validate tree structured data

### DIFF
--- a/src/predicate/index.ts
+++ b/src/predicate/index.ts
@@ -27,6 +27,7 @@ export { isRegExp } from './isRegExp.ts';
 export { isSet } from './isSet.ts';
 export { isString } from './isString.ts';
 export { isSymbol } from './isSymbol.ts';
+export { isTreeData } from './isTreeData.ts';
 export { isTypedArray } from './isTypedArray.ts';
 export { isUndefined } from './isUndefined.ts';
 export { isWeakMap } from './isWeakMap.ts';

--- a/src/predicate/isTreeData.ts
+++ b/src/predicate/isTreeData.ts
@@ -1,0 +1,45 @@
+/**
+ * Checks whether `value` is tree-structured data: either a single tree node
+ * (a plain object whose optional `children` array contains further tree
+ * nodes) or an array (a forest) of such nodes. A leaf node is any plain object
+ * without the children key.
+ *
+ * The children key is configurable via the `childrenKey` option (default
+ * `'children'`). Primitive values and `null` are never tree data. See
+ * issue #1598.
+ *
+ * @template T - The node value type.
+ * @param value - The value to check.
+ * @param options - Optional configuration.
+ * @param options.childrenKey - The property name that holds the child nodes.
+ * @returns `true` if `value` is tree-structured data, `false` otherwise.
+ *
+ * @example
+ * isTreeData({ name: 'root', children: [{ name: 'a' }, { name: 'b' }] }) // true
+ * isTreeData({ name: 'leaf' }) // true
+ * isTreeData({ nodes: [{ name: 'x' }] }, { childrenKey: 'nodes' }) // true
+ * isTreeData({ children: 'not an array' }) // false
+ * isTreeData(42) // false
+ *
+ * @group predicate
+ */
+export function isTreeData(value: unknown, options: { childrenKey?: string } = {}): boolean {
+  const childrenKey = options.childrenKey ?? 'children';
+
+  if (Array.isArray(value)) {
+    return value.every(node => isTreeData(node, options));
+  }
+
+  if (value !== null && typeof value === 'object') {
+    if (childrenKey in value) {
+      const children = (value as Record<string, unknown>)[childrenKey];
+      if (!Array.isArray(children)) {
+        return false;
+      }
+      return children.every(child => isTreeData(child, options));
+    }
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Closes #1598.

Add isTreeData(value, { childrenKey? = 'children' }): returns true when value is a plain object whose optional childrenKey array contains further valid tree nodes, OR an array (a forest) of such nodes. A leaf is any plain object without the children key.