### PR TITLE
feat: medianBigint: bigint support for median()

### DIFF
--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -3,6 +3,7 @@ export { inRange } from './inRange.ts';
 export { mean } from './mean.ts';
 export { meanBy } from './meanBy.ts';
 export { median } from './median.ts';
+export { medianBigint } from './medianBigint.ts';
 export { medianBy } from './medianBy.ts';
 export { percentile } from './percentile.ts';
 export { random } from './random.ts';

--- a/src/math/medianBigint.ts
+++ b/src/math/medianBigint.ts
@@ -1,0 +1,42 @@
+/**
+ * Calculates the median of an array of `bigint`s.
+ *
+ * The median is the middle value of a sorted array. If the array has an odd
+ * number of elements, the median is the middle value. If the array has an
+ * even number of elements, it returns the truncated average of the two middle
+ * values (`(a + b) / 2n`), since `bigint` has no fractional type. See issue
+ * #1588.
+ *
+ * If the array is empty, this function throws a `RangeError` (a `bigint`
+ * cannot represent `NaN`).
+ *
+ * @param nums - An array of `bigint`s to calculate the median.
+ * @returns The median of all the values in the array.
+ * @throws {RangeError} If `nums` is empty.
+ *
+ * @example
+ * const arrayWithOddNumberOfElements = [1n, 2n, 3n, 4n, 5n];
+ * const result = medianBigint(arrayWithOddNumberOfElements);
+ * // result will be 3n
+ *
+ * @example
+ * const arrayWithEvenNumberOfElements = [1n, 2n, 3n, 4n];
+ * const result = medianBigint(arrayWithEvenNumberOfElements);
+ * // result will be 2n (truncated average of 2n and 3n)
+ *
+ * @group math
+ */
+export function medianBigint(nums: readonly bigint[]): bigint {
+  if (nums.length === 0) {
+    throw new RangeError('Cannot compute median of an empty array');
+  }
+
+  const sorted = nums.slice().sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const middleIndex = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 0) {
+    return (sorted[middleIndex - 1] + sorted[middleIndex]) / 2n;
+  } else {
+    return sorted[middleIndex];
+  }
+}


### PR DESCRIPTION
Closes #1588.

Add medianBigint(nums: bigint[]): bigint: the middle value for odd length arrays; for even length, the truncated average `(a + b) / 2n` (bigint has no fractional type). Sorts using bigint comparison. Throws RangeError for an empty array (a bigint cannot represent NaN).