### PR TITLE
fix(compat): skip null/undefined iteratee values in maxBy/minBy

### DIFF
--- a/src/compat/math/maxBy.spec.ts
+++ b/src/compat/math/maxBy.spec.ts
@@ -68,9 +68,20 @@ describe('maxBy', () => {
     expect(maxBy([NaN, NaN], x => x)).toBeUndefined();
   });
 
+  it('should skip symbol values', () => {
+    const sym = Symbol('a');
+    expect(maxBy([sym, 1, 3, 2], x => x)).toBe(3);
+    expect(maxBy([1, sym, 3, 2], x => x)).toBe(3);
+  });
+
+  it('should return undefined when every value is a symbol', () => {
+    expect(maxBy([Symbol('a'), Symbol('b')], x => x)).toBeUndefined();
+  });
+
   it('should skip null and undefined values, matching lodash', () => {
-    expect(maxBy([{ a: undefined }, { a: 5 }, { a: null }], 'a')).toEqual({ a: 5 });
-    expect(maxBy([5, undefined, 3, null], x => x)).toBe(5);
+    // Negative values so `null` (coerced to 0) would wrongly win as the max on the old code.
+    expect(maxBy([{ a: undefined }, { a: -5 }, { a: null }], 'a')).toEqual({ a: -5 });
+    expect(maxBy([-5, undefined, -3, null], x => x)).toBe(-3);
   });
 
   it('should return undefined when the iteratee yields no comparable value', () => {

--- a/src/compat/math/maxBy.spec.ts
+++ b/src/compat/math/maxBy.spec.ts
@@ -67,4 +67,16 @@ describe('maxBy', () => {
   it('should return undefined when every value is NaN', () => {
     expect(maxBy([NaN, NaN], x => x)).toBeUndefined();
   });
+
+  it('should skip null and undefined values, matching lodash', () => {
+    expect(maxBy([{ a: undefined }, { a: 5 }, { a: null }], 'a')).toEqual({ a: 5 });
+    expect(maxBy([5, undefined, 3, null], x => x)).toBe(5);
+  });
+
+  it('should return undefined when the iteratee yields no comparable value', () => {
+    // A missing key makes the iteratee return `undefined` for every element.
+    expect(maxBy([{ a: 1 }, { a: 2 }], 'b')).toBeUndefined();
+    expect(maxBy([{ a: undefined }, { a: undefined }], 'a')).toBeUndefined();
+    expect(maxBy([{ a: null }, { a: null }], 'a')).toBeUndefined();
+  });
 });

--- a/src/compat/math/maxBy.ts
+++ b/src/compat/math/maxBy.ts
@@ -51,7 +51,7 @@ export function maxBy<T>(items: ArrayLike<T> | null | undefined, iteratee: Value
     const element = array[i];
     const current = getValue(element, i, array);
 
-    if (Number.isNaN(current)) {
+    if (current == null || Number.isNaN(current) || typeof current === 'symbol') {
       continue;
     }
 

--- a/src/compat/math/minBy.spec.ts
+++ b/src/compat/math/minBy.spec.ts
@@ -68,7 +68,18 @@ describe('minBy', () => {
     expect(minBy([NaN, NaN], x => x)).toBeUndefined();
   });
 
+  it('should skip symbol values', () => {
+    const sym = Symbol('a');
+    expect(minBy([sym, 3, 1, 2], x => x)).toBe(1);
+    expect(minBy([3, sym, 1, 2], x => x)).toBe(1);
+  });
+
+  it('should return undefined when every value is a symbol', () => {
+    expect(minBy([Symbol('a'), Symbol('b')], x => x)).toBeUndefined();
+  });
+
   it('should skip null and undefined values, matching lodash', () => {
+    // Positive values so `null` (coerced to 0) would wrongly win as the min on the old code.
     expect(minBy([{ a: undefined }, { a: 5 }, { a: null }], 'a')).toEqual({ a: 5 });
     expect(minBy([5, undefined, 3, null], x => x)).toBe(3);
   });

--- a/src/compat/math/minBy.spec.ts
+++ b/src/compat/math/minBy.spec.ts
@@ -67,4 +67,16 @@ describe('minBy', () => {
   it('should return undefined when every value is NaN', () => {
     expect(minBy([NaN, NaN], x => x)).toBeUndefined();
   });
+
+  it('should skip null and undefined values, matching lodash', () => {
+    expect(minBy([{ a: undefined }, { a: 5 }, { a: null }], 'a')).toEqual({ a: 5 });
+    expect(minBy([5, undefined, 3, null], x => x)).toBe(3);
+  });
+
+  it('should return undefined when the iteratee yields no comparable value', () => {
+    // A missing key makes the iteratee return `undefined` for every element.
+    expect(minBy([{ a: 1 }, { a: 2 }], 'b')).toBeUndefined();
+    expect(minBy([{ a: undefined }, { a: undefined }], 'a')).toBeUndefined();
+    expect(minBy([{ a: null }, { a: null }], 'a')).toBeUndefined();
+  });
 });

--- a/src/compat/math/minBy.ts
+++ b/src/compat/math/minBy.ts
@@ -51,7 +51,7 @@ export function minBy<T>(items: ArrayLike<T> | null | undefined, iteratee: Value
     const element = array[i];
     const current = getValue(element, i, array);
 
-    if (Number.isNaN(current)) {
+    if (current == null || Number.isNaN(current) || typeof current === 'symbol') {
       continue;
     }
 


### PR DESCRIPTION
## Summary

`compat`'s `maxBy`/`minBy` diverge from lodash (and from their own sibling `max`/`min`) when the iteratee yields `null` or `undefined` for elements — e.g. a missing/optional key.

They only skip `NaN`:

```ts
if (Number.isNaN(current)) {
  continue;
}
```

but `max`/`min` skip `current == null` (and symbols) as well. Two problems follow:

1. `max`/`min` is initialised to `undefined` **and** reused as the "not yet seen" sentinel (`max === undefined`). An `undefined` iteratee result sets the sentinel back to `undefined`, so it never flips and every later element overwrites the result — the function returns the **last** element instead of `undefined`.
2. A `null` result is coerced to `0` by the `>` / `<` comparison, so it can be picked as the extremum.

### Reproduction

```ts
import { maxBy, minBy } from 'es-toolkit/compat';
import _ from 'lodash';

maxBy([{ a: 1 }, { a: 2 }], 'b');        // es-toolkit: { a: 2 }   lodash: undefined
maxBy([{ a: null }, { a: null }], 'a');  // es-toolkit: { a: null } lodash: undefined
minBy([5, undefined, 3, null], x => x);  // es-toolkit: null        lodash: 3
```

## Fix

Mirror the guard already used by `max`/`min` so `null`, `undefined`, and symbol values are skipped. With those values skipped, the existing `=== undefined` sentinel becomes reliable again (it can only ever be set from a real comparable value).

```ts
if (current == null || Number.isNaN(current) || typeof current === 'symbol') {
  continue;
}
```

## Verification

- All existing `maxBy`/`minBy` specs still pass (Date, ±Infinity, string iteratees, NaN skipping, single/large arrays).
- Added regression tests covering missing keys and mixed `null`/`undefined`/numeric values; they fail on `main` and pass with the fix.
- Differentially fuzz-tested the patched functions against lodash over several thousand combinations of `undefined`/`null`/`NaN`/`±Infinity`/number/string values (property, function, and identity iteratees) with zero divergences.