### PR TITLE
fix(compat/map): make iteratee optional with identity default

### DIFF
--- a/docs/compat/reference/array/map.md
+++ b/docs/compat/reference/array/map.md
@@ -16,7 +16,7 @@ const mapped = map(collection, iteratee);
 
 ## Usage
 
-### `map(collection, iteratee)`
+### `map(collection, iteratee?)`
 
 Use `map` when you want to transform each element of an array, object, or array-like object. It executes an iteratee function on each element and returns the results as a new array.
 
@@ -75,9 +75,9 @@ map(users, { age: 30 });
 
 #### Parameters
 
-- `collection` (`T[] | ArrayLike<T> | Record<string, T> | null | undefined`): The array or object to iterate over.
-- `iteratee` (`function | string | object`, optional): The function to execute on each element, a property path, or an object to match. If not provided, returns each element as is.
-  - When it's a function, it's called in the form `(value, key, collection)`.
+- `collection` (`any[] | ArrayLike<any> | Record<any, any> | null | undefined`): The array or object to iterate over.
+- `iteratee` (`function | PropertyKey | object`, optional): The function to execute on each element, a property path, or an object to match. If not provided, returns each element as is.
+  - When it's a function, it's called in the form `(value, key, collection)`. Defaults to the `identity` function.
   - When it's a string, it extracts that property.
   - When it's an object, it checks if each element matches the object.
 

--- a/docs/compat/reference/array/map.md
+++ b/docs/compat/reference/array/map.md
@@ -75,7 +75,7 @@ map(users, { age: 30 });
 
 #### Parameters
 
-- `collection` (`any[] | ArrayLike<any> | Record<any, any> | null | undefined`): The array or object to iterate over.
+- `collection` (`T[] | ArrayLike<T> | Record<string, T> | null | undefined`): The array or object to iterate over.
 - `iteratee` (`function | PropertyKey | object`, optional): The function to execute on each element, a property path, or an object to match. If not provided, returns each element as is.
   - When it's a function, it's called in the form `(value, key, collection)`. Defaults to the `identity` function.
   - When it's a string, it extracts that property.

--- a/docs/ja/compat/reference/array/map.md
+++ b/docs/ja/compat/reference/array/map.md
@@ -16,7 +16,7 @@ const mapped = map(collection, iteratee);
 
 ## 使用法
 
-### `map(collection, iteratee)`
+### `map(collection, iteratee?)`
 
 配列、オブジェクト、または配列風オブジェクトの各要素を変換したいときに`map`を使用してください。各要素に対して反復関数を実行し、結果を新しい配列として返します。
 
@@ -75,9 +75,9 @@ map(users, { age: 30 });
 
 #### パラメータ
 
-- `collection` (`T[] | ArrayLike<T> | Record<string, T> | null | undefined`): 反復処理する配列またはオブジェクトです。
-- `iteratee` (`function | string | object`, オプション): 各要素に対して実行する関数、プロパティパス、または一致させるオブジェクトです。提供しない場合、各要素をそのまま返します。
-  - 関数の場合、`(value, key, collection)`の形式で呼び出されます。
+- `collection` (`any[] | ArrayLike<any> | Record<any, any> | null | undefined`): 反復処理する配列またはオブジェクトです。
+- `iteratee` (`function | PropertyKey | object`, オプション): 各要素に対して実行する関数、プロパティパス、または一致させるオブジェクトです。提供しない場合、各要素をそのまま返します。
+  - 関数の場合、`(value, key, collection)`の形式で呼び出されます。デフォルトは`identity`関数です。
   - 文字列の場合、そのプロパティを抽出します。
   - オブジェクトの場合、各要素がオブジェクトと一致するかを確認します。
 

--- a/docs/ja/compat/reference/array/map.md
+++ b/docs/ja/compat/reference/array/map.md
@@ -75,7 +75,7 @@ map(users, { age: 30 });
 
 #### パラメータ
 
-- `collection` (`any[] | ArrayLike<any> | Record<any, any> | null | undefined`): 反復処理する配列またはオブジェクトです。
+- `collection` (`T[] | ArrayLike<T> | Record<string, T> | null | undefined`): 反復処理する配列またはオブジェクトです。
 - `iteratee` (`function | PropertyKey | object`, オプション): 各要素に対して実行する関数、プロパティパス、または一致させるオブジェクトです。提供しない場合、各要素をそのまま返します。
   - 関数の場合、`(value, key, collection)`の形式で呼び出されます。デフォルトは`identity`関数です。
   - 文字列の場合、そのプロパティを抽出します。

--- a/docs/ko/compat/reference/array/map.md
+++ b/docs/ko/compat/reference/array/map.md
@@ -16,7 +16,7 @@ const mapped = map(collection, iteratee);
 
 ## 사용법
 
-### `map(collection, iteratee)`
+### `map(collection, iteratee?)`
 
 배열, 객체, 또는 배열 형태의 객체의 각 요소를 변환하고 싶을 때 `map`을 사용하세요. 각 요소에 대해 반복 함수를 실행하고 결과를 새 배열로 반환해요.
 
@@ -75,9 +75,9 @@ map(users, { age: 30 });
 
 #### 파라미터
 
-- `collection` (`T[] | ArrayLike<T> | Record<string, T> | null | undefined`): 순회할 배열이나 객체예요.
-- `iteratee` (`function | string | object`, 선택): 각 요소에 대해 실행할 함수나 속성 경로, 또는 일치시킬 객체예요. 제공하지 않으면 각 요소를 그대로 반환해요.
-  - 함수인 경우 `(value, key, collection)` 형태로 호출돼요.
+- `collection` (`any[] | ArrayLike<any> | Record<any, any> | null | undefined`): 순회할 배열이나 객체예요.
+- `iteratee` (`function | PropertyKey | object`, 선택): 각 요소에 대해 실행할 함수나 속성 경로, 또는 일치시킬 객체예요. 제공하지 않으면 각 요소를 그대로 반환해요.
+  - 함수인 경우 `(value, key, collection)` 형태로 호출돼요. 기본값은 `identity` 함수예요.
   - 문자열인 경우 해당 속성을 추출해요.
   - 객체인 경우 각 요소가 객체와 일치하는지 확인해요.
 

--- a/docs/ko/compat/reference/array/map.md
+++ b/docs/ko/compat/reference/array/map.md
@@ -75,7 +75,7 @@ map(users, { age: 30 });
 
 #### 파라미터
 
-- `collection` (`any[] | ArrayLike<any> | Record<any, any> | null | undefined`): 순회할 배열이나 객체예요.
+- `collection` (`T[] | ArrayLike<T> | Record<string, T> | null | undefined`): 순회할 배열이나 객체예요.
 - `iteratee` (`function | PropertyKey | object`, 선택): 각 요소에 대해 실행할 함수나 속성 경로, 또는 일치시킬 객체예요. 제공하지 않으면 각 요소를 그대로 반환해요.
   - 함수인 경우 `(value, key, collection)` 형태로 호출돼요. 기본값은 `identity` 함수예요.
   - 문자열인 경우 해당 속성을 추출해요.

--- a/docs/zh_hans/compat/reference/array/map.md
+++ b/docs/zh_hans/compat/reference/array/map.md
@@ -16,7 +16,7 @@ const mapped = map(collection, iteratee);
 
 ## 用法
 
-### `map(collection, iteratee)`
+### `map(collection, iteratee?)`
 
 当您想要转换数组、对象或类数组对象的每个元素时使用`map`。它对每个元素执行迭代函数，并将结果作为新数组返回。
 
@@ -75,9 +75,9 @@ map(users, { age: 30 });
 
 #### 参数
 
-- `collection` (`T[] | ArrayLike<T> | Record<string, T> | null | undefined`): 要遍历的数组或对象。
-- `iteratee` (`function | string | object`, 可选): 对每个元素执行的函数、属性路径或要匹配的对象。如果不提供，则按原样返回每个元素。
-  - 当它是函数时，以`(value, key, collection)`的形式调用。
+- `collection` (`any[] | ArrayLike<any> | Record<any, any> | null | undefined`): 要遍历的数组或对象。
+- `iteratee` (`function | PropertyKey | object`, 可选): 对每个元素执行的函数、属性路径或要匹配的对象。如果不提供，则按原样返回每个元素。
+  - 当它是函数时，以`(value, key, collection)`的形式调用。默认为`identity`函数。
   - 当它是字符串时，提取该属性。
   - 当它是对象时，检查每个元素是否与对象匹配。
 

--- a/docs/zh_hans/compat/reference/array/map.md
+++ b/docs/zh_hans/compat/reference/array/map.md
@@ -75,7 +75,7 @@ map(users, { age: 30 });
 
 #### 参数
 
-- `collection` (`any[] | ArrayLike<any> | Record<any, any> | null | undefined`): 要遍历的数组或对象。
+- `collection` (`T[] | ArrayLike<T> | Record<string, T> | null | undefined`): 要遍历的数组或对象。
 - `iteratee` (`function | PropertyKey | object`, 可选): 对每个元素执行的函数、属性路径或要匹配的对象。如果不提供，则按原样返回每个元素。
   - 当它是函数时，以`(value, key, collection)`的形式调用。默认为`identity`函数。
   - 当它是字符串时，提取该属性。

--- a/src/compat/array/map.ts
+++ b/src/compat/array/map.ts
@@ -135,8 +135,7 @@ export function map(
     return [];
   }
 
-  const keys: PropertyKey[] =
-    isArrayLike(collection) || Array.isArray(collection) ? range(0, collection.length) : Object.keys(collection);
+  const keys: PropertyKey[] = isArrayLike(collection) ? range(0, collection.length) : Object.keys(collection);
 
   const iteratee = iterateeToolkit(_iteratee);
 

--- a/src/compat/array/map.ts
+++ b/src/compat/array/map.ts
@@ -129,7 +129,7 @@ export function map<T>(
 
 export function map(
   collection: any[] | ArrayLike<any> | Record<any, any> | null | undefined,
-  _iteratee?: ((value: any, index: PropertyKey, collection: any) => any) | PropertyKey | object | null
+  _iteratee: ((value: any, index: PropertyKey, collection: any) => any) | PropertyKey | object = identity
 ): any[] {
   if (!collection) {
     return [];
@@ -138,7 +138,7 @@ export function map(
   const keys: PropertyKey[] =
     isArrayLike(collection) || Array.isArray(collection) ? range(0, collection.length) : Object.keys(collection);
 
-  const iteratee = iterateeToolkit(_iteratee ?? identity);
+  const iteratee = iterateeToolkit(_iteratee);
 
   const result: any[] = new Array(keys.length);
 


### PR DESCRIPTION
## Summary

- Simplified the code by replacing the approach of providing the identity default value via the Nullish Coalescing Operator with explicitly specifying the identity default value in the _iteratee implementation signature.
- Applied the implementation signature to the map doc's type signature, and specified that _iteratee is optional along with its default value.