### PR TITLE
fix(compat/mergeWith): assign null values in array sources

### DIFF
--- a/benchmarks/bundle-size/merge.spec.ts
+++ b/benchmarks/bundle-size/merge.spec.ts
@@ -14,6 +14,6 @@ describe('merge bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'merge');
-    expect(bundleSize).toMatchInlineSnapshot(`6377`);
+    expect(bundleSize).toMatchInlineSnapshot(`6381`);
   });
 });

--- a/benchmarks/bundle-size/mergeWith.spec.ts
+++ b/benchmarks/bundle-size/mergeWith.spec.ts
@@ -14,6 +14,6 @@ describe('mergeWith bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'mergeWith');
-    expect(bundleSize).toMatchInlineSnapshot(`6321`);
+    expect(bundleSize).toMatchInlineSnapshot(`6325`);
   });
 });

--- a/src/compat/object/merge.spec.ts
+++ b/src/compat/object/merge.spec.ts
@@ -217,6 +217,20 @@ describe('merge', () => {
     expect(actual.a).toBe(null);
   });
 
+  it('should assign `null` values in array sources', () => {
+    expect(merge([1, 2], [null])).toEqual([null, 2]);
+    expect(merge([1, 2], [null, 3])).toEqual([null, 3]);
+    expect(merge({ a: [1, 2] }, { a: [null] })).toEqual({ a: [null, 2] });
+    expect(merge([{ x: 1 }], [null])).toEqual([null]);
+    expect(merge({}, ['a', null])).toEqual({ 0: 'a', 1: null });
+  });
+
+  it('should skip `undefined` values and holes in array sources', () => {
+    expect(merge([1, 2], [undefined, 3])).toEqual([1, 3]);
+    // eslint-disable-next-line no-sparse-arrays
+    expect(merge([1, 2], [, 3])).toEqual([1, 3]);
+  });
+
   it('should assign non array/buffer/typed-array/plain-object source values directly', () => {
     function Foo() {}
 

--- a/src/compat/object/mergeWith.spec.ts
+++ b/src/compat/object/mergeWith.spec.ts
@@ -27,6 +27,13 @@ describe('mergeWith', () => {
     expect(actual).toEqual([undefined]);
   });
 
+  it('should assign `null` values in array sources when `customizer` returns `undefined`', () => {
+    expect(mergeWith([1, 2], [null], noop)).toEqual([null, 2]);
+    expect(mergeWith({ a: [1, 2] }, { a: [null, 3] }, noop)).toEqual({
+      a: [null, 3],
+    });
+  });
+
   it('should clone sources when `customizer` returns `undefined`', () => {
     const source1 = { a: { b: { c: 1 } } };
     const source2 = { a: { b: { d: 2 } } };

--- a/src/compat/object/mergeWith.ts
+++ b/src/compat/object/mergeWith.ts
@@ -259,7 +259,9 @@ function mergeWithDeep(
   if (Array.isArray(source)) {
     source = source.slice();
     for (let i = 0; i < source.length; i++) {
-      source[i] = source[i] ?? undefined;
+      if (!(i in source)) {
+        source[i] = undefined;
+      }
     }
   }
 


### PR DESCRIPTION
`merge`/`mergeWith` drop `null` elements of array sources, diverging from lodash:

```js
_.merge([1, 2], [null]);  // [null, 2]  (lodash)
merge([1, 2], [null]);    // [1, 2]     (es-toolkit/compat)
```

The loop that densifies sparse array sources uses `source[i] ?? undefined`, which also rewrites explicit `null` to `undefined`, so it gets skipped like an undefined value. lodash only skips `undefined` and holes — `null` should overwrite the target (as it already does for object sources: `merge({ a: 1 }, { a: null })` → `{ a: null }`).

Fixed by only filling actual holes (`!(i in source)`). Added regression tests; the full compat suite still passes, including the sparse-array tests.
