### PR TITLE
test(compat/array): verify forEach skips non-enumerable properties

### DIFF
--- a/src/compat/array/forEach.spec.ts
+++ b/src/compat/array/forEach.spec.ts
@@ -243,4 +243,16 @@ describe('forEach', () => {
 
     expect(values.length).toBe(1);
   });
+
+  it(`\`_.${methodName}\` should not iterate over non-enumerable properties`, () => {
+    const object = { a: 1 };
+    Object.defineProperty(object, 'b', { value: 2, enumerable: false });
+
+    const keys: any[] = [];
+    func(object, (value, key) => {
+      keys.push(key);
+    });
+
+    expect(keys).toEqual(['a']);
+  });
 });


### PR DESCRIPTION
## Summary

The docs for each state that "it iterates through enumerable properties," but forEach.spec.ts doesn't have a test case covering this.

The current implementation is correct as-is since Object.keys(collection) only extracts enumerable keys, but this assumption could silently break if someone later changes the implementation to a method that also iterates non-enumerable properties. So I added a test case that creates a non-enumerable property with Object.defineProperty and verifies that forEach skips it.