### PR TITLE
refactor(compat/intersection): use shared toArray helper instead of Array.from

### DIFF
--- a/src/compat/array/intersection.ts
+++ b/src/compat/array/intersection.ts
@@ -1,5 +1,6 @@
 import { intersection as intersectionToolkit } from '../../array/intersection.ts';
 import { uniq } from '../../array/uniq.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 
 /**
@@ -28,7 +29,7 @@ export function intersection<T>(...arrays: Array<ArrayLike<T> | null | undefined
     return [];
   }
 
-  let result: T[] = uniq(Array.from(arrays[0]));
+  let result: T[] = uniq(toArray(arrays[0]));
 
   for (let i = 1; i < arrays.length; i++) {
     const array = arrays[i];
@@ -37,7 +38,7 @@ export function intersection<T>(...arrays: Array<ArrayLike<T> | null | undefined
       return [];
     }
 
-    result = intersectionToolkit(result, Array.from(array));
+    result = intersectionToolkit(result, toArray(array));
   }
 
   return result;


### PR DESCRIPTION
## Change

Replace `Array.from` with `toArray`. 
Also, if the value is already an array, it would be more efficient to use it as is rather than applying `Array.from`.