### PR TITLE
fix(partition): accept any predicate return value like Array.prototype.filter

### DIFF
--- a/docs/ja/reference/array/partition.md
+++ b/docs/ja/reference/array/partition.md
@@ -45,7 +45,7 @@ const [truthy, falsy] = partition([], x => x > 0);
 #### パラメータ
 
 - `arr` (`T[]`): 2つのグループに分ける配列です。
-- `isInTruthy` (`(value: T, index: number, array: readonly T[]) => boolean`): 各要素が最初の配列(truthy)に含まれるか、2番目の配列(falsy)に含まれるかを決定する条件関数です。値、インデックス、配列全体と共に呼び出されます。
+- `isInTruthy` (`(value: T, index: number, array: readonly T[]) => unknown`): 各要素が最初の配列(truthy)に含まれるか、2番目の配列(falsy)に含まれるかを決定する条件関数です。値、インデックス、配列全体と共に呼び出されます。
 
 #### 戻り値
 

--- a/docs/ko/reference/array/partition.md
+++ b/docs/ko/reference/array/partition.md
@@ -45,7 +45,7 @@ const [truthy, falsy] = partition([], x => x > 0);
 #### 파라미터
 
 - `arr` (`T[]`): 두 그룹으로 나눌 배열이에요.
-- `isInTruthy` (`(value: T, index: number, array: readonly T[]) => boolean`): 각 요소가 첫 번째 배열(truthy)에 포함될지, 두 번째 배열(falsy)에 포함될지를 결정하는 조건 함수예요. 값, 인덱스, 전체 배열과 함께 호출돼요.
+- `isInTruthy` (`(value: T, index: number, array: readonly T[]) => unknown`): 각 요소가 첫 번째 배열(truthy)에 포함될지, 두 번째 배열(falsy)에 포함될지를 결정하는 조건 함수예요. 값, 인덱스, 전체 배열과 함께 호출돼요.
 
 #### 반환 값
 

--- a/docs/reference/array/partition.md
+++ b/docs/reference/array/partition.md
@@ -45,7 +45,7 @@ const [truthy, falsy] = partition([], x => x > 0);
 #### Parameters
 
 - `arr` (`T[]`): The array to split into two groups.
-- `isInTruthy` (`(value: T, index: number, array: readonly T[]) => boolean`): A condition function that determines whether each element should be included in the first array (truthy) or the second array (falsy). The function is called with the value, its index, and the entire array.
+- `isInTruthy` (`(value: T, index: number, array: readonly T[]) => unknown`): A condition function that determines whether each element should be included in the first array (truthy) or the second array (falsy). The function is called with the value, its index, and the entire array.
 
 #### Returns
 

--- a/docs/zh_hans/reference/array/partition.md
+++ b/docs/zh_hans/reference/array/partition.md
@@ -45,7 +45,7 @@ const [truthy, falsy] = partition([], x => x > 0);
 #### 参数
 
 - `arr` (`T[]`): 要分为两组的数组。
-- `isInTruthy` (`(value: T, index: number, array: readonly T[]) => boolean`): 决定每个元素应包含在第一个数组(truthy)还是第二个数组(falsy)中的条件函数。该函数接收值、索引和整个数组作为参数。
+- `isInTruthy` (`(value: T, index: number, array: readonly T[]) => unknown`): 决定每个元素应包含在第一个数组(truthy)还是第二个数组(falsy)中的条件函数。该函数接收值、索引和整个数组作为参数。
 
 #### 返回值
 

--- a/src/array/partition.spec.ts
+++ b/src/array/partition.spec.ts
@@ -75,4 +75,21 @@ describe('partition', () => {
       expect(array).toBe(arr);
     });
   });
+
+  it('should accept a predicate that returns any truthy or falsy value, like Array.prototype.filter', () => {
+    interface Value {
+      name: string;
+      good?: boolean;
+    }
+
+    const values: Value[] = [{ name: 'a', good: true }, { name: 'b', good: false }, { name: 'c' }];
+
+    const [good, bad] = partition(values, i => i.good);
+
+    expect(good).toEqual([{ name: 'a', good: true }]);
+    expect(bad).toEqual([{ name: 'b', good: false }, { name: 'c' }]);
+
+    expectTypeOf(good).toEqualTypeOf<Value[]>();
+    expectTypeOf(bad).toEqualTypeOf<Value[]>();
+  });
 });

--- a/src/array/partition.ts
+++ b/src/array/partition.ts
@@ -36,11 +36,12 @@ export function partition<T, U extends T>(
  * @template T - The type of elements in the array.
  * @param arr - The array to partition.
  * @param isInTruthy - A predicate function that determines
- * whether an element should be placed in the truthy array. The function is called with each
+ * whether an element should be placed in the truthy array. An element is placed in the truthy
+ * array when the function returns a truthy value. The function is called with each
  * element of the array and its index.
  * @returns A tuple containing two arrays: the first array contains elements for
- * which the predicate returned true, and the second array contains elements for which the
- * predicate returned false.
+ * which the predicate returned a truthy value, and the second array contains elements for which the
+ * predicate returned a falsy value.
  *
  * @example
  * const array = [1, 2, 3, 4, 5];
@@ -50,11 +51,11 @@ export function partition<T, U extends T>(
  */
 export function partition<T>(
   arr: readonly T[],
-  isInTruthy: (value: T, index: number, array: readonly T[]) => boolean
+  isInTruthy: (value: T, index: number, array: readonly T[]) => unknown
 ): [truthy: T[], falsy: T[]];
 export function partition<T>(
   arr: readonly T[],
-  isInTruthy: (value: T, index: number, array: readonly T[]) => boolean
+  isInTruthy: (value: T, index: number, array: readonly T[]) => unknown
 ): [truthy: T[], falsy: T[]] {
   const truthy: T[] = [];
   const falsy: T[] = [];


### PR DESCRIPTION
## Summary

Closes #1926.

`partition`'s fallback overload required the predicate to return a strict `boolean`, so common truthiness predicates like `partition(values, i => i.good)` (returning `boolean | undefined`) failed to compile — even though the implementation already branches on truthiness. This widens the fallback overload's return type from `boolean` to `unknown`, matching:

- TypeScript's own `Array.prototype.filter` signature (`predicate: (value, index, array) => unknown`), and
- `es-toolkit/compat`'s `partition`, which already types its callback as `(value: T) => unknown`.

The type-guard overload (`value is U`) is unchanged, so narrowing behavior is identical. The change is source-compatible (it strictly accepts more programs) and has no runtime effect.

## Changes

- `src/array/partition.ts`: fallback overload + implementation signature `=> boolean` → `=> unknown`, with JSDoc wording adjusted to "truthy/falsy value"
- `src/array/partition.spec.ts`: regression test using an optional-boolean property predicate (compile + runtime partitioning + `expectTypeOf`)
- `docs/**/array/partition.md` (en / ko / ja / zh_hans): parameter type updated to `=> unknown`

## Scope note

The issue title mentions "(and other functions?)" — other predicate-style callbacks (`dropWhile`/`dropRightWhile`, `takeWhile`/`takeRightWhile`, `remove`, `findKey`, `omitBy`/`pickBy`) have the same strict `boolean` requirement. This PR is scoped to `partition` per the issue's primary ask; happy to follow up on the others if you'd like the same treatment.

## Test results

- [x] `yarn vitest run src/array/partition.spec.ts` — 6 passed, including the new regression test
- [x] `yarn tsc --noEmit`
- [x] `yarn eslint src/array/partition.ts src/array/partition.spec.ts`
- [x] `yarn prettier --check` on all touched files
