### PR TITLE
fix(compat/findIndex): convert fromIndex to an integer like lodash

### DIFF
--- a/src/compat/array/findIndex.spec.ts
+++ b/src/compat/array/findIndex.spec.ts
@@ -64,6 +64,12 @@ describe('findIndex', () => {
     expect(findIndex(arr, x => x === 1, NaN)).toBe(0);
   });
 
+  it('findIndex should convert fromIndex to an integer like lodash', () => {
+    const arr = [1, 2, 3, 4, 5];
+    expect(findIndex(arr, x => x >= 3, 1.5)).toBe(2);
+    expect(findIndex(arr, x => x >= 3, 2.9)).toBe(2);
+  });
+
   it('should return `-1` when provided `null` or `undefined`', () => {
     expect(findIndex(null, 'a')).toBe(-1);
     expect(findIndex(undefined, 'a')).toBe(-1);

--- a/src/compat/array/findIndex.ts
+++ b/src/compat/array/findIndex.ts
@@ -3,6 +3,7 @@ import { identity } from '../function/identity.ts';
 import { property } from '../object/property.ts';
 import { matches } from '../predicate/matches.ts';
 import { matchesProperty } from '../predicate/matchesProperty.ts';
+import { toInteger } from '../util/toInteger.ts';
 
 /**
  * Finds the index of the first item in an array that has a specific property, where the property name is provided as a PropertyKey.
@@ -27,9 +28,7 @@ export function findIndex<T>(
   if (!arr) {
     return -1;
   }
-  if (Number.isNaN(fromIndex)) {
-    fromIndex = 0;
-  }
+  fromIndex = toInteger(fromIndex);
   if (fromIndex < 0) {
     fromIndex = Math.max(arr.length + fromIndex, 0);
   }


### PR DESCRIPTION
## Summary

`compat/findIndex` did not convert `fromIndex` with `toInteger` like lodash.
`Array.prototype.slice` truncates a float start index, but the relative index
was added back with the original float, so the result could be non-integer
(e.g. `2.5`).

```ts
findIndex([1, 2, 3, 4, 5], x => x >= 3, 1.5);
// before: 2.5
// lodash / after: 2