### PR TITLE
 fix(compat/fill): truncate negative fractional positions like Lodash

### DIFF
--- a/src/compat/array/fill.spec.ts
+++ b/src/compat/array/fill.spec.ts
@@ -115,6 +115,11 @@ describe('fill', () => {
     ]);
   });
 
+  it('should truncate negative fractional `start` and `end` toward zero', () => {
+    expect(fill([1, 2, 3], 'a', -1.5)).toEqual([1, 2, 'a']);
+    expect(fill([1, 2, 3], 'a', 0, -1.5)).toEqual(['a', 'a', 3]);
+  });
+
   it('should work as an iteratee for methods like `_.map`', () => {
     const array = [
       [1, 2],

--- a/src/compat/array/fill.ts
+++ b/src/compat/array/fill.ts
@@ -3,6 +3,7 @@ import type { MutableList } from '../_internal/MutableList.d.ts';
 import type { RejectReadonly } from '../_internal/RejectReadonly.d.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { isString } from '../predicate/isString.ts';
+import { toInteger } from '../util/toInteger.ts';
 
 /**
  * Fills an array with a value.
@@ -104,8 +105,8 @@ export function fill<T, U>(
     // prevent TypeError: Cannot assign to read only property of string
     return array;
   }
-  start = Math.floor(start);
-  end = Math.floor(end);
+  start = toInteger(start);
+  end = toInteger(end);
 
   if (!start) {
     start = 0;


### PR DESCRIPTION
## Summary                                                                                                                                                                                      
                                                                                                                                                                                              
compat/fill converted start and end with Math.floor. While this produces the expected result for positive fractional values, it rounds negative fractions toward negative infinity. For example, -1.5 became -2, whereas Lodash truncates it to -1.                                                                                                                                  
                                                                                                                                                                                              
This change uses the existing compat toInteger helper so that negative fractional positions are truncated toward zero, matching Lodash’s behavior and the integer-coercion pattern used by other compat array utilities.                                                                                                                                                                
                                                                                                                                                                                               #Changes                                                                                                                                                                                      
                                                                                                                                                                                              
- Replaced Math.floor with the shared toInteger helper for start and end.                                                                                                                    
- Added regression coverage for negative fractional start and end values.                                                                                                                    
- Kept the public API, mutation behavior, and return types unchanged.                                                                                                                        
                                                                                                                                                                                              
For example:                                                                                                                                                                                 
                                                                                                                                                                                              
 ```ts                                                                                                                                                                                        
   fill([1, 2, 3, 4], 0, -1.5);                                                                                                                                                               
 ```                                                                                                                                                                                          
                                                                                                                                                                                              
Before:                                                                                                                                                                                      
                                                                                                                                                                                              
 ```ts                                                                                                                                                                                        
   [1, 2, 0, 0]                                                                                                                                                                               
 ```                                                                                                                                                                                          
                                                                                                                                                                                              
 After, matching Lodash:                                                                                                                                                                      
                                                                                                                                                                                              
 ```ts                                                                                                                                                                                        
   [1, 2, 3, 0]                                                                                                                                                                               
 ```                                                                                                                                                                                          
                                                                                                                                                                                             Test results                                                                                                                                                                                 
                                                                                                                                                                                              
 - yarn vitest run src/compat/array/fill.spec.ts                                                                                                                                              
   - 1 test file passed                                                                                                                                                                       
   - 19 tests passed                                                                                                                                                                          
 - Compared 12 boundary cases directly against Lodash 4.18.1                                                                                                                                  
   - 0 mismatches after the change                                                                                                                                                            
 - yarn typecheck                                                                                                                                                                             
 - yarn eslint --config eslint.config.mjs src/compat/array/fill.ts src/compat/array/fill.spec.ts                                                                                              
   - 0 errors                                                                                                                                                                                 
   - 4 existing no-explicit-any warnings                                                                                                                                                      
 - yarn prettier --check src/compat/array/fill.ts src/compat/array/fill.spec.ts                                                                                                               
                                                                                                                                                                                              
Repository-wide checks currently report failures outside this diff:                                                                                                                          
                                                                                                                                                                                              
 - yarn vitest run                                                                                                                                                                            
   - 639 test files and 4,431 tests passed                                                                                                                                                    
   - src/compat/array/intersectionBy.spec.ts failed on duplicate removal, which is being addressed separately in #1935                                                                        
   - tests/check-dist.spec.ts could not pack the project because tsdown failed to import unrun                                                                                                
 - yarn lint                                                                                                                                                                                  
   - Failed on 8 existing curly errors in docs/.vitepress/components/FpLazySimulation.vue         