### PR TITLE
fix(compat/every): treat falsy doesMatch as property shorthand, not identity

### DIFF
--- a/src/compat/array/every.spec.ts
+++ b/src/compat/array/every.spec.ts
@@ -126,6 +126,17 @@ describe('every', () => {
     expect(every(objects, Symbol.for('c'))).toBe(true);
   });
 
+  it('should treat falsy, non-nullish `doesMatch` values as `_.property` shorthands', () => {
+    expect(every([{ 0: '' }, { 0: 'x' }], 0)).toBe(false);
+    expect(every([{ 0: 'a' }, { 0: 'b' }], 0)).toBe(true);
+
+    expect(every([{ '': '' }, { '': 'x' }], '')).toBe(false);
+    expect(every([{ '': 'a' }, { '': 'b' }], '')).toBe(true);
+
+    expect(every([{ NaN: '' }, { NaN: 'x' }], NaN)).toBe(false);
+    expect(every([{ NaN: 'a' }, { NaN: 'b' }], NaN)).toBe(true);
+  });
+
   it('should work with `_.matches` shorthands', () => {
     const objects = [
       { a: 0, b: 0 },

--- a/src/compat/array/every.ts
+++ b/src/compat/array/every.ts
@@ -2,10 +2,8 @@ import { identity } from '../../function/identity.ts';
 import { isIterateeCall } from '../_internal/isIterateeCall.ts';
 import { ListIterateeCustom } from '../_internal/ListIterateeCustom.ts';
 import { ObjectIterateeCustom } from '../_internal/ObjectIteratee.ts';
-import { property } from '../object/property.ts';
+import { iteratee } from '../compat.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
-import { matches } from '../predicate/matches.ts';
-import { matchesProperty } from '../predicate/matchesProperty.ts';
 
 /**
  * Checks if all elements in a collection pass the predicate check.
@@ -102,33 +100,7 @@ export function every<T>(
     doesMatch = undefined;
   }
 
-  if (!doesMatch) {
-    doesMatch = identity;
-  }
-
-  let predicate: (value: any, index: number, collection: any) => boolean;
-
-  switch (typeof doesMatch) {
-    case 'function': {
-      predicate = doesMatch as any;
-      break;
-    }
-    case 'object': {
-      if (Array.isArray(doesMatch) && doesMatch.length === 2) {
-        const key = doesMatch[0];
-        const value = doesMatch[1];
-        predicate = matchesProperty(key, value);
-      } else {
-        predicate = matches(doesMatch);
-      }
-      break;
-    }
-    case 'symbol':
-    case 'number':
-    case 'string': {
-      predicate = property(doesMatch);
-    }
-  }
+  const predicate = iteratee(doesMatch ?? identity);
 
   if (!isArrayLike(source)) {
     const keys = Object.keys(source) as Array<keyof typeof source>;


### PR DESCRIPTION
## Summary

When determining the `predicate`, I changed the code that previously overwrote `doesMatch` with `identity` via an `if (!doesMatch)` condition — before going through the switch-case that determined it based on doesMatch's type — when doesMatch was a `falsy` value, to instead reuse the `iteratee()` util used by the same logic elsewhere (map, ...).

The previous problem, where `falsy` values such as `0, false, NaN, '', etc`. passed as `doesMatch` were all overwritten with `identity`, was designed such that it ignored the `falsy` value that should have been checked in a case like the one below, and unconditionally returned true, causing a problem where it returned a different result from lodash.

```tsx
// true
compat.every(
    [
      { 0: '', b: 1 },
      { 0: 'x', b: 1 },
    ],
    0
  )
```
```tsx
// false
lodash.every(
    [
      { 0: '', b: 1 },
      { 0: 'x', b: 1 },
    ],
    0
  )
```
In the `iteratee()` util, this problem can be resolved with the following code, which returns `identity` only when value is exactly null:
```tsx
if (value == null) {
    return identity;
}
```

[@3b6aa71](https://github.com/toss/es-toolkit/pull/1940/changes/3b6aa71421232beed07d1411b9281e4c5358ed02)
Added test cases to verify the scenario where, as in the code prior to this change, using a falsy value as the key would get caught by the wrong branch.