### PR TITLE
fix(compat/iteratee): treat boolean as a property shorthand, matching lodash

### DIFF
--- a/benchmarks/bundle-size/find.spec.ts
+++ b/benchmarks/bundle-size/find.spec.ts
@@ -9,6 +9,6 @@ describe('find bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'find');
-    expect(bundleSize).toMatchInlineSnapshot(`8295`);
+    expect(bundleSize).toMatchInlineSnapshot(`8264`);
   });
 });

--- a/benchmarks/bundle-size/findKey.spec.ts
+++ b/benchmarks/bundle-size/findKey.spec.ts
@@ -14,6 +14,6 @@ describe('findKey bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'findKey');
-    expect(bundleSize).toMatchInlineSnapshot(`8220`);
+    expect(bundleSize).toMatchInlineSnapshot(`8189`);
   });
 });

--- a/benchmarks/bundle-size/mapKeys.spec.ts
+++ b/benchmarks/bundle-size/mapKeys.spec.ts
@@ -14,6 +14,6 @@ describe('mapKeys bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'mapKeys');
-    expect(bundleSize).toMatchInlineSnapshot(`8233`);
+    expect(bundleSize).toMatchInlineSnapshot(`8202`);
   });
 });

--- a/benchmarks/bundle-size/mapValues.spec.ts
+++ b/benchmarks/bundle-size/mapValues.spec.ts
@@ -14,6 +14,6 @@ describe('mapValues bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'mapValues');
-    expect(bundleSize).toMatchInlineSnapshot(`8233`);
+    expect(bundleSize).toMatchInlineSnapshot(`8202`);
   });
 });

--- a/src/compat/array/find.spec.ts
+++ b/src/compat/array/find.spec.ts
@@ -123,15 +123,18 @@ describe('find', () => {
     expect(find(args)).toBe(1);
   });
 
-  it('should throw error when boolean predicate is used', () => {
+  it('should treat a boolean predicate as a `_.property` shorthand, matching lodash', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
-    expect(() => find({ a: 1, b: 2, c: 3 }, true)).toThrow('doesMatch is not a function');
+    expect(find({ a: 1, b: 2, c: 3 }, true)).toBe(undefined);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
-    expect(() => find({ a: 1, b: 2, c: 3 }, false)).toThrow('doesMatch is not a function');
-    expect(() => find([1, 2, 3], true)).toThrow('undefined is not a function');
-    expect(() => find([1, 2, 3], false)).toThrow('undefined is not a function');
+    expect(find({ a: 1, b: 2, c: 3 }, false)).toBe(undefined);
+    expect(find([1, 2, 3], true)).toBe(undefined);
+    expect(find([1, 2, 3], false)).toBe(undefined);
+
+    const objects = [{ true: 'a' }, { true: 'b' }];
+    expect(find(objects, true)).toBe(objects[0]);
   });
 
   it('should return undefined when object matcher has only undefined values for keys', () => {

--- a/src/compat/array/findLast.spec.ts
+++ b/src/compat/array/findLast.spec.ts
@@ -169,15 +169,17 @@ describe('findLast', () => {
     expect(findLast(args)).toBe(3);
   });
 
-  it('should throw error when boolean predicate is used', () => {
+  it('should treat a boolean predicate as a `_.property` shorthand, matching lodash', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
-    expect(() => findLast({ a: 1, b: 2, c: 3 }, true)).toThrow('doesMatch is not a function');
+    expect(findLast({ a: 1, b: 2, c: 3 }, true)).toBe(undefined);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
-    expect(() => findLast({ a: 1, b: 2, c: 3 }, false)).toThrow('doesMatch is not a function');
-    expect(() => findLast([1, 2, 3], true)).toThrow('undefined is not a function');
-    expect(() => findLast([1, 2, 3], false)).toThrow('undefined is not a function');
+    expect(findLast({ a: 1, b: 2, c: 3 }, false)).toBe(undefined);
+    expect(findLast([1, 2, 3], true)).toBe(undefined);
+    expect(findLast([1, 2, 3], false)).toBe(undefined);
+    const objects = [{ true: 'a' }, { true: 'b' }];
+    expect(findLast(objects, true)).toBe(objects[1]);
   });
 
   it('should work with no predicate (uses identity)', () => {

--- a/src/compat/util/iteratee.spec.ts
+++ b/src/compat/util/iteratee.spec.ts
@@ -117,6 +117,16 @@ describe('iteratee', () => {
     expect(prop(array)).toBe('a');
   });
 
+  it('should return an iteratee created by `_.property` when `func` is a boolean', () => {
+    const object = { true: 'yes', false: 'no' };
+
+    let prop = iteratee(true);
+    expect(prop(object)).toBe('yes');
+
+    prop = iteratee(false);
+    expect(prop(object)).toBe('no');
+  });
+
   it('should support deep paths for `_.property` shorthands', () => {
     const object = { a: { b: 2 } };
     const prop = iteratee('a.b');

--- a/src/compat/util/iteratee.spec.ts
+++ b/src/compat/util/iteratee.spec.ts
@@ -120,9 +120,11 @@ describe('iteratee', () => {
   it('should return an iteratee created by `_.property` when `func` is a boolean', () => {
     const object = { true: 'yes', false: 'no' };
 
+    // @ts-expect-error - `boolean` isn't part of `iteratee`'s public type, matching `@types/lodash`
     let prop = iteratee(true);
     expect(prop(object)).toBe('yes');
 
+    // @ts-expect-error - `boolean` isn't part of `iteratee`'s public type, matching `@types/lodash`
     prop = iteratee(false);
     expect(prop(object)).toBe('no');
   });

--- a/src/compat/util/iteratee.ts
+++ b/src/compat/util/iteratee.ts
@@ -84,10 +84,8 @@ export function iteratee(
 
       return matches(value);
     }
-    case 'string':
-    case 'symbol':
-    case 'number': {
-      return property(value);
+    default: {
+      return property(value as PropertyKey);
     }
   }
 }

--- a/src/compat/util/iteratee.ts
+++ b/src/compat/util/iteratee.ts
@@ -85,7 +85,7 @@ export function iteratee(
       return matches(value);
     }
     default: {
-      return property(value as PropertyKey);
+      return property(value);
     }
   }
 }


### PR DESCRIPTION
## Summary

- In the implementation of iteratee(), I added a test case to reveal the problem that, unlike string, symbol, and number types which were already being used as property name values, the boolean type was not being checked.
- To make that case pass, I changed the previous approach — defining separate cases for string, symbol, and number each — to using the default keyword instead. This is the same way lodash's baseIteratee handles the return when a value doesn't pass any of the conditionals.
- find and findLast use the iteratee fixed in this PR as is. However, there was a test in find and findLast that had asserted "an error should be thrown when a boolean predicate is used." But checking against real lodash, it returns undefined instead of an error. So I removed the existing test asserting "it should throw an error," and modified it to test that a boolean predicate behaves the same way as lodash.