### PR TITLE
docs: capitalize Lodash and fix contributions phrasing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ es-toolkit is a state-of-the-art, high-performance JavaScript utility library wi
 - es-toolkit offers a variety of everyday utility functions with modern implementations, such as [debounce](https://es-toolkit.dev/reference/function/debounce.html), [delay](https://es-toolkit.dev/reference/promise/delay.html), [chunk](https://es-toolkit.dev/reference/array/chunk.html), [sum](https://es-toolkit.dev/reference/math/sum.html), and [pick](https://es-toolkit.dev/reference/object/pick.html).
 - Designed with performance in mind, es-toolkit achieves [2-3× better performance](https://es-toolkit.dev/performance.html) in modern JavaScript environments.
 - es-toolkit supports tree shaking out of the box, and [reduces JavaScript code by up to 97%](https://es-toolkit.dev/bundle-size.html) compared to other libraries.
-- es-toolkit offers a complete compatibility layer to seamlessly replace lodash, available as [es-toolkit/compat](https://es-toolkit.dev/compatibility.html).
+- es-toolkit offers a complete compatibility layer to seamlessly replace Lodash, available as [es-toolkit/compat](https://es-toolkit.dev/compatibility.html).
 - es-toolkit includes built-in TypeScript support, with straightforward yet robust types. It also provides useful type guards such as [isNotNil](https://es-toolkit.dev/reference/predicate/isNotNil.html).
 - es-toolkit is trusted and used by popular open-source projects like [Storybook](https://github.com/storybookjs/storybook/blob/9d862798d666678cc4822e857c00bbd744169ced/code/core/package.json#L358), [Recharts](https://github.com/recharts/recharts/blob/0fa4cc325da403b6fa1c6be0f820896ed92f806a/package.json#L94), [ink](https://github.com/vadimdemedes/ink/blob/2090ad9779be59dea71d173eb49785b7bd4495d0/package.json#L55), and [CKEditor](https://github.com/ckeditor/ckeditor5/blob/60d5fac804643cb4d359767ee2f94e3d92d1fcc5/packages/ckeditor5-core/package.json#L53).
 - es-toolkit is battle-tested with 100% test coverage, ensuring reliability and robustness.
@@ -53,7 +53,7 @@ For more details, see the [AI Integration guide](https://es-toolkit.dev/ai-integ
 
 ## Contributing
 
-We welcome contribution from everyone in the community. Read below for detailed contribution guide.
+We welcome contributions from everyone in the community. Read below for a detailed contribution guide.
 
 [CONTRIBUTING](https://github.com/toss/es-toolkit/blob/main/.github/CONTRIBUTING.md)
 


### PR DESCRIPTION
## Description
This PR fixes brand capitalization and grammar phrasing in `README.md`.

## Details
1. Capitalized proper noun `lodash` -> `Lodash`.
2. Fixed plural noun and missing article (`welcome contribution` -> `welcome contributions`, `detailed contribution guide` -> `a detailed contribution guide`).