### PR TITLE
fix(types): register ./types entrypoint in check-dist test

### DIFF
--- a/tests/check-dist.spec.ts
+++ b/tests/check-dist.spec.ts
@@ -36,6 +36,7 @@ const ENTRYPOINTS = [
   './promise',
   './set',
   './string',
+  './types',
   './util',
 ];
 


### PR DESCRIPTION
## Why

`#1818` added the `./types` export but left it out of the `ENTRYPOINTS` list in `tests/check-dist.spec.ts`. The `configures all entrypoints correctly` test now fails (15 actual vs 14 expected), which **breaks the Release workflow on main** (`yarn test`) — the `-dev` publish fails and a version tag would fail at the same step.

## What

Add `'./types'` to `ENTRYPOINTS` between `'./string'` and `'./util'`, matching `publishConfig.exports` order. Verified the list is now identical to `publishConfig.exports` keys.

## Note

Blocking a v1.50.0 release — should land before tagging.