### PR TITLE
test(check-dist): skip declaration-only ./types in CJS/ESM check

### DIFF
--- a/tests/check-dist.spec.ts
+++ b/tests/check-dist.spec.ts
@@ -67,7 +67,8 @@ describe(`es-toolkit's package tarball`, () => {
     await execa('npm', ['install'], { cwd: tmpdir });
 
     for (const entrypoint of ENTRYPOINTS) {
-      if (entrypoint.includes('*')) {
+      // `./types` is declaration-only (no runtime export), so it can't be required or imported.
+      if (entrypoint.includes('*') || entrypoint === './types') {
         continue;
       }
 


### PR DESCRIPTION
## Why

Follow-up to #1948. That PR added `./types` to the entrypoint list, but the **`exports identical functions in CJS and ESM`** test then tries to `require('es-toolkit/types')` / `import('es-toolkit/types')` for every entrypoint. `./types` is **declaration-only** (no runtime JS — postbuild strips it, publishConfig exposes only the `types` condition), so it fails with `MODULE_NOT_FOUND` and still breaks the Release workflow on main.

## What

Skip `./types` in that runtime comparison loop, just like the wildcard entrypoints. The entrypoint-list assertion from #1948 still covers its presence in `exports`.

## Verified

Built the real tarball locally (Node 24.13.0) and ran the full gate:
- `tests/check-dist.spec.ts`: **2/2 pass**
- Full `vitest run --typecheck`: **648 files, 4457 pass, 0 fail, no type errors**

Unblocks the v1.50.0 release.