### PR TITLE
fix(compat/forEach): delete unnecessary array check

### DIFF
--- a/src/compat/array/forEach.ts
+++ b/src/compat/array/forEach.ts
@@ -152,8 +152,7 @@ export function forEach<T>(
     return collection;
   }
 
-  const keys: PropertyKey[] =
-    isArrayLike(collection) || Array.isArray(collection) ? range(0, collection.length) : Object.keys(collection);
+  const keys: PropertyKey[] = isArrayLike(collection) ? range(0, collection.length) : Object.keys(collection);
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];


### PR DESCRIPTION
## Summary 

Both `isArrayLike` and `Array.isArray` are being checked, but the `Array.isArray` check is redundant because arrays already satisfy the conditions of `isArrayLike`.
Additionally, unnecessary checks for objects have been removed to improve performance.
