### PR TITLE
fix(compat/indexOf): convert fromIndex to an integer when searching for NaN

### DIFF
--- a/src/compat/array/indexOf.spec.ts
+++ b/src/compat/array/indexOf.spec.ts
@@ -45,6 +45,13 @@ describe('indexOf', () => {
     expect(indexOf([1, NaN, 3, NaN], NaN, -32)).toBe(1);
   });
 
+  it('should convert fromIndex to an integer when searching for NaN', () => {
+    expect(indexOf([1, NaN, 2], NaN, 1.5)).toBe(1);
+    expect(indexOf([1, NaN, 2], NaN, 2.9)).toBe(-1);
+    expect(indexOf([NaN, 1, NaN, 2], NaN, 1.9)).toBe(2);
+    expect(indexOf([1, NaN, 3, NaN], NaN, -1.2)).toBe(3);
+  });
+
   it('should work with a negative `fromIndex` <= `-length`', () => {
     const values = [-6, -8, -Infinity];
     const expected = values.map(stubZero);

--- a/src/compat/array/indexOf.ts
+++ b/src/compat/array/indexOf.ts
@@ -1,4 +1,5 @@
 import { isArrayLike } from '../predicate/isArrayLike.ts';
+import { toInteger } from '../util/toInteger.ts';
 
 /**
  * Finds the index of the first occurrence of a value in an array.
@@ -24,7 +25,7 @@ export function indexOf<T>(array: ArrayLike<T> | null | undefined, searchElement
 
   // `Array.prototype.indexOf` doesn't find `NaN` values, so we need to handle that case separately.
   if (Number.isNaN(searchElement)) {
-    fromIndex = fromIndex ?? 0;
+    fromIndex = toInteger(fromIndex ?? 0);
 
     if (fromIndex < 0) {
       fromIndex = Math.max(0, array.length + fromIndex);


### PR DESCRIPTION
## Summary
The NaN search path in `compat/indexOf` did not convert `fromIndex` with `toInteger`, unlike lodash. A float `fromIndex` could skip the matching `NaN` or start at the wrong index.
The normal path still uses `Array.from(array).indexOf(searchElement, fromIndex)`. Native `Array.prototype.indexOf` already applies ToInteger to `fromIndex`, so that path does not need `toInteger`.

## Changes
- Apply `toInteger` to `fromIndex` in the NaN search branch
- Add tests for truncated / negative float `fromIndex` when searching for `NaN`