### PR TITLE
fix(compat/intersectionWith): apply comparator when deduplicating first array

### DIFF
--- a/src/compat/array/intersectionWith.spec.ts
+++ b/src/compat/array/intersectionWith.spec.ts
@@ -119,4 +119,14 @@ describe('intersectionWith', () => {
 
     expect(actual).toEqual(expected);
   });
+
+  it('should apply the comparator when deduplicating the first array', () => {
+    const actual = func([1, 2, 3], [4, 5, 6], () => true);
+    expect(actual).toEqual([1]);
+  });
+
+  it('should preserve the sign of `-0` when compared with `Object.is`', () => {
+    const actual = func([-0, 0], [0], (a, b) => Object.is(a, b));
+    expect(actual).toEqual([0]);
+  });
 });

--- a/src/compat/array/intersectionWith.ts
+++ b/src/compat/array/intersectionWith.ts
@@ -1,6 +1,8 @@
 import { last } from './last.ts';
 import { intersectionWith as intersectionWithToolkit } from '../../array/intersectionWith.ts';
-import { uniq as uniqToolkit } from '../array/uniq.ts';
+import { uniq as uniqToolkit } from '../../array/uniq.ts';
+import { uniqWith } from '../../array/uniqWith.ts';
+import { toArray } from '../_internal/toArray.ts';
 import { eq } from '../util/eq.ts';
 
 /**
@@ -115,11 +117,11 @@ export function intersectionWith<T>(firstArr: ArrayLike<T> | null | undefined, .
 
   if (typeof _comparator === 'function') {
     comparator = _comparator;
-    uniq = uniqPreserve0;
+    uniq = arr => uniqWith(arr, comparator);
     otherArrs.pop();
   }
 
-  let result = uniq(Array.from(firstArr));
+  let result = uniq(toArray(firstArr));
 
   for (let i = 0; i < otherArrs.length; ++i) {
     const otherArr = otherArrs[i] as ArrayLike<T>;
@@ -128,28 +130,7 @@ export function intersectionWith<T>(firstArr: ArrayLike<T> | null | undefined, .
       return [];
     }
 
-    result = intersectionWithToolkit(result, Array.from(otherArr), comparator);
-  }
-
-  return result;
-}
-
-/**
- * This function is to preserve the sign of `-0`, which is a behavior in lodash.
- */
-function uniqPreserve0<T>(arr: T[]): T[] {
-  const result = [];
-  const added = new Set();
-
-  for (let i = 0; i < arr.length; i++) {
-    const item = arr[i];
-
-    if (added.has(item)) {
-      continue;
-    }
-
-    result.push(item);
-    added.add(item);
+    result = intersectionWithToolkit(result, toArray(otherArr), comparator);
   }
 
   return result;


### PR DESCRIPTION
## Summary

Fixes cases that were incompatible with Lodash (the comparator was not applied to the first array).
Additionally, removes unnecessary code and optimizes using toArray.

## Reproduce

```ts
import { intersectionWith as loIntersectionWith } from 'lodash';
import { intersectionWith as esIntersectionWith } from 'src/compat/array/intersectionWith';


loIntersectionWith([1,2,3], [4,5,6], () => true) // [1]
esIntersectionWith([1,2,3], [4,5,6], () => true) // [1,2,3]

loIntersectionWith([-0,0], [0], (a,b) => Object.is(a,b)) // [0]
esIntersectionWith([-0,0], [0], (a,b) => Object.is(a,b)) // []
```

## Bench

### Before

<img width="948" height="368" alt="스크린샷 2026-07-26 오후 5 19 04" src="https://github.com/user-attachments/assets/8a73aa53-536e-45d0-a331-5cce5dc27884" />

### After

<img width="952" height="376" alt="스크린샷 2026-07-26 오후 5 17 53" src="https://github.com/user-attachments/assets/2009926c-06ca-4a73-84c5-8beaeece7559" />
