### PR TITLE
fix(compat/last): return undefined for empty array like input

### DIFF
--- a/src/compat/array/last.spec.ts
+++ b/src/compat/array/last.spec.ts
@@ -46,4 +46,11 @@ describe('last', () => {
     expect(last('123')).toBe('3');
     expect(last(args)).toBe(3);
   });
+
+  it('should ignore negative index properties when the array is empty', () => {
+    const array: number[] = [];
+    array['-1'] = 1;
+
+    expect(last(array)).toBe(undefined);
+  });
 });

--- a/src/compat/array/last.ts
+++ b/src/compat/array/last.ts
@@ -25,7 +25,7 @@ import { isArrayLike } from '../predicate/isArrayLike.ts';
  * // noElement will be undefined
  */
 export function last<T>(array: ArrayLike<T> | null | undefined): T | undefined {
-  if (!isArrayLike(array)) {
+  if (!isArrayLike(array) || array.length === 0) {
     return undefined;
   }
   return lastToolkit(toArray(array));


### PR DESCRIPTION
## Summary

The test was copied directly from Lodash, but I think it may actually be incorrect in Lodash itself. 
```ts
it('should return `undefined` when querying empty arrays', () => {
        const array = [];
        array['-1'] = 1;

        expect(last([])).toBe(undefined); // Shouldn't this be `array`(variable) instead? 
    });
```
That discrepancy caused a compatibility issue here. 
So I kept the original Lodash test as-is and added a separate test case to cover the compatibility issue.

## Reproduce

```ts
import { last as loLast } from 'lodash';
import { last as esLast } from './src/compat/array/last.ts';

const array: number[] = [];
array['-1'] = 1;

console.log(loLast(array)); // undefined
console.log(esLast(array)); // 1
```