### PR TITLE
test(compat/lastIndexOf): add falsey fromIndex handling test case

### DIFF
--- a/src/compat/array/lastIndexOf.spec.ts
+++ b/src/compat/array/lastIndexOf.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { lastIndexOf } from './lastIndexOf';
+import { falsey } from '../_internal/falsey';
 
 /**
  * @see https://github.com/lodash/lodash/blob/v5-wip/test/findLastIndex-and-lastIndexOf.spec.js
@@ -41,6 +42,14 @@ describe('lastIndexOf', () => {
     const expected = values.map(() => 0);
 
     const actual = values.map(fromIndex => lastIndexOf(array, 1, fromIndex));
+
+    expect(actual).toEqual(expected);
+  });
+
+  it(`should treat falsey \`fromIndex\` values correctly`, () => {
+    const expected = falsey.map(value => (value === undefined ? 5 : -1));
+
+    const actual = falsey.map((fromIndex: any) => lastIndexOf(array, 3, fromIndex));
 
     expect(actual).toEqual(expected);
   });


### PR DESCRIPTION
## Summary

It looks like we're missing the Lodash test case that covers a falsey fromIndex.

https://github.com/lodash/lodash/blob/6a2cc1dfcf7634fea70d1bc5bd22db453df67b42/test/findLastIndex-and-lastIndexOf.spec.js#L54