### PR TITLE
refactor(compat/lastIndexOf): use internal toArray helper for array like conversion

### DIFF
--- a/benchmarks/bundle-size/lastIndexOf.spec.ts
+++ b/benchmarks/bundle-size/lastIndexOf.spec.ts
@@ -9,6 +9,6 @@ describe('lastIndexOf bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'lastIndexOf');
-    expect(bundleSize).toMatchInlineSnapshot(`636`);
+    expect(bundleSize).toMatchInlineSnapshot(`681`);
   });
 });

--- a/src/compat/array/lastIndexOf.ts
+++ b/src/compat/array/lastIndexOf.ts
@@ -1,3 +1,4 @@
+import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
@@ -51,5 +52,5 @@ export function lastIndexOf<T>(
     }
   }
 
-  return Array.from(array).lastIndexOf(searchElement, index);
+  return toArray(array).lastIndexOf(searchElement, index);
 }


### PR DESCRIPTION
## Summary

Use toArray to avoid unnecessary conversions for arrays.

## Bench

### Before

<img width="862" height="316" alt="스크린샷 2026-07-26 오후 6 01 40" src="https://github.com/user-attachments/assets/3a4169de-dfff-4a33-94b1-2f7607507e0d" />

### After

<img width="849" height="314" alt="스크린샷 2026-07-26 오후 6 02 00" src="https://github.com/user-attachments/assets/2cac0272-b636-45d3-85b9-5aadd9bcf606" />
