### PR TITLE
docs(compat/findIndex): mark optional parameters in function signature

### DIFF
--- a/docs/compat/reference/array/findIndex.md
+++ b/docs/compat/reference/array/findIndex.md
@@ -16,7 +16,7 @@ const index = findIndex(arr, doesMatch, fromIndex);
 
 ## Usage
 
-### `findIndex(arr, doesMatch, fromIndex)`
+### `findIndex(arr, doesMatch?, fromIndex?)`
 
 Use `findIndex` when you want to find the position of the first element in an array that matches a specific condition. You can specify the condition in various ways. If no element matches the condition, it returns `-1`.
 

--- a/docs/ja/compat/reference/array/findIndex.md
+++ b/docs/ja/compat/reference/array/findIndex.md
@@ -16,7 +16,7 @@ const index = findIndex(arr, doesMatch, fromIndex);
 
 ## 使用法
 
-### `findIndex(arr, doesMatch, fromIndex)`
+### `findIndex(arr, doesMatch?, fromIndex?)`
 
 配列内で特定の条件に一致する最初の要素の位置を見つけたい場合は `findIndex` を使用してください。さまざまな方法で条件を指定できます。条件に一致する要素がない場合は `-1` を返します。
 

--- a/docs/ko/compat/reference/array/findIndex.md
+++ b/docs/ko/compat/reference/array/findIndex.md
@@ -16,7 +16,7 @@ const index = findIndex(arr, doesMatch, fromIndex);
 
 ## 사용법
 
-### `findIndex(arr, doesMatch, fromIndex)`
+### `findIndex(arr, doesMatch?, fromIndex?)`
 
 배열에서 특정 조건에 맞는 첫 번째 요소의 위치를 찾고 싶을 때 `findIndex`를 사용하세요. 다양한 방식으로 조건을 지정할 수 있어요. 조건에 맞는 요소가 없으면 `-1`을 반환해요.
 

--- a/docs/zh_hans/compat/reference/array/findIndex.md
+++ b/docs/zh_hans/compat/reference/array/findIndex.md
@@ -16,7 +16,7 @@ const index = findIndex(arr, doesMatch, fromIndex);
 
 ## 用法
 
-### `findIndex(arr, doesMatch, fromIndex)`
+### `findIndex(arr, doesMatch?, fromIndex?)`
 
 当您想要查找数组中满足特定条件的第一个元素的位置时,使用 `findIndex`。您可以通过多种方式指定条件。如果没有元素满足条件,则返回 `-1`。
 


### PR DESCRIPTION
## Summary

The `### \findIndex(arr, doesMatch, fromIndex)`signature heading of the `findIndex` docs was missing the optional parameter marker (`?`). The sibling function docs in the same category (`find`, `findLast`, `findLastIndex`, `indexOf`, `includes`) are all marking `?`like `predicate?`, `fromIndex?`, so the part where only `findIndex` was out of consistency — I fixed it to match the actual implementation.