### PR TITLE
 fix(compat/find): convert fromIndex to an integer

### DIFF
--- a/benchmarks/bundle-size/find.spec.ts
+++ b/benchmarks/bundle-size/find.spec.ts
@@ -9,6 +9,6 @@ describe('find bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'find');
-    expect(bundleSize).toMatchInlineSnapshot(`8295`);
+    expect(bundleSize).toMatchInlineSnapshot(`8555`);
   });
 });

--- a/src/compat/array/find.spec.ts
+++ b/src/compat/array/find.spec.ts
@@ -92,6 +92,14 @@ describe('find', () => {
     expect(find(objects, { b: 2 }, 4)).toBe(undefined);
   });
 
+  it('find should coerce `fromIndex` to an integer', () => {
+    const array = [1, 2, 3, 1, 2, 3];
+
+    expect(find(array, x => x === 1, 2.7)).toBe(1);
+    expect(find(array, x => x === 1, -2.7)).toBe(undefined);
+    expect(find(array, x => x === 1, -0.5)).toBe(1);
+  });
+
   it('should return `undefined` when provided `null` or `undefined`', () => {
     expect(find(null, 'a')).toBe(undefined);
     expect(find(undefined, 'a')).toBe(undefined);

--- a/src/compat/array/find.ts
+++ b/src/compat/array/find.ts
@@ -4,6 +4,7 @@ import { ListIteratorTypeGuard } from '../_internal/ListIteratorTypeGuard.ts';
 import { ObjectIterateeCustom } from '../_internal/ObjectIteratee.ts';
 import { ObjectIteratorTypeGuard } from '../_internal/ObjectIterator.ts';
 import { iteratee } from '../util/iteratee.ts';
+import { toInteger } from '../util/toInteger.ts';
 
 /**
  * Finds the first element in an array-like object that matches a type guard predicate.
@@ -114,6 +115,8 @@ export function find<T>(
   if (!source) {
     return undefined;
   }
+
+  fromIndex = toInteger(fromIndex);
   if (fromIndex < 0) {
     fromIndex = Math.max(source.length + fromIndex, 0);
   }


### PR DESCRIPTION
## Summary

Unlike lodash, `compat/find` does not convert `fromIndex` with `toInteger`,
so a float is used as is. For a negative value the fraction is kept when it
is added to the array length, and the search starts at the wrong index.

```typescript
find([1, 2, 3, 1, 2, 3], x => x === 1, -2.7);
// lodash: undefined  (-2.7 -> -2, 6 + (-2) = 4)
// es-toolkit/compat: 1  (6 + (-2.7) = 3.3)
```

## Changes

- Convert fromIndex with toInteger before handling negative values
- Add tests for float fromIndex