### PR TITLE
fix(compat/pullAll): return array as is when values is nullish

### DIFF
--- a/src/compat/array/pullAll.spec.ts
+++ b/src/compat/array/pullAll.spec.ts
@@ -53,4 +53,10 @@ describe('pullAll', () => {
     expect(result).toBe(array);
     expect(array).toEqual([1, 2, 3]);
   });
+
+  it('should return the array as is when `values` is `null` or `undefined`', () => {
+    const array = [1, 2, 3];
+    expect(pullAll(array, null as any)).toBe(array);
+    expect(pullAll(array, undefined)).toBe(array);
+  });
 });

--- a/src/compat/array/pullAll.ts
+++ b/src/compat/array/pullAll.ts
@@ -1,4 +1,5 @@
 import { pull as pullToolkit } from '../../array/pull.ts';
+import { isNil } from '../../predicate/isNil.ts';
 import type { MutableList } from '../_internal/MutableList.d.ts';
 import type { RejectReadonly } from '../_internal/RejectReadonly.d.ts';
 
@@ -57,5 +58,9 @@ export function pullAll<L extends MutableList<any>>(array: RejectReadonly<L>, va
  * console.log(numbers); // [1, 3, 5]
  */
 export function pullAll<T>(arr: T[], valuesToRemove: ArrayLike<T> = []): T[] {
+  if (isNil(valuesToRemove)) {
+    return arr;
+  }
+
   return pullToolkit(arr, Array.from(valuesToRemove));
 }


### PR DESCRIPTION
## Summary

Fix a compatibility issue when a nullish value is passed. 
The current implementation throws an error, but Lodash returns the original array.

## Reproduce

```ts
import { pullAll as loPullAll} from 'lodash';
import { pullAll as esPullAll } from './src/compat/array/pullAll';

console.log(loPullAll([1, 2, 3], null)) // [1, 2, 3]
console.log(esPullAll([1, 2, 3], null)) // Error
```