### PR TITLE
refactor(compat/partition): rename source parameter to collection for consistency

### DIFF
--- a/docs/compat/reference/array/partition.md
+++ b/docs/compat/reference/array/partition.md
@@ -16,7 +16,7 @@ const [truthy, falsy] = partition(collection, predicate);
 
 ## Usage
 
-### `partition(collection, predicate)`
+### `partition(collection, predicate?)`
 
 Splits the elements of an array or object into two groups based on a given predicate function. The first group contains elements where the predicate is true, and the second group contains elements where the predicate is false.
 

--- a/docs/ja/compat/reference/array/partition.md
+++ b/docs/ja/compat/reference/array/partition.md
@@ -16,7 +16,7 @@ const [truthy, falsy] = partition(collection, predicate);
 
 ## 使用法
 
-### `partition(collection, predicate)`
+### `partition(collection, predicate?)`
 
 与えられた条件関数に基づいて、配列またはオブジェクトの要素を2つのグループに分けます。最初のグループには条件が真である要素が含まれ、2番目のグループには条件が偽である要素が含まれます。
 

--- a/docs/ko/compat/reference/array/partition.md
+++ b/docs/ko/compat/reference/array/partition.md
@@ -16,7 +16,7 @@ const [truthy, falsy] = partition(collection, predicate);
 
 ## 사용법
 
-### `partition(collection, predicate)`
+### `partition(collection, predicate?)`
 
 배열이나 객체의 요소들을 주어진 조건 함수에 따라 두 그룹으로 나누어요. 첫 번째 그룹은 조건이 참인 요소들이고, 두 번째 그룹은 조건이 거짓인 요소들이에요.
 

--- a/docs/zh_hans/compat/reference/array/partition.md
+++ b/docs/zh_hans/compat/reference/array/partition.md
@@ -16,7 +16,7 @@ const [truthy, falsy] = partition(collection, predicate);
 
 ## 用法
 
-### `partition(collection, predicate)`
+### `partition(collection, predicate?)`
 
 根据给定的条件函数将数组或对象的元素分成两组。第一组包含条件为真的元素,第二组包含条件为假的元素。
 

--- a/src/compat/array/partition.ts
+++ b/src/compat/array/partition.ts
@@ -64,7 +64,7 @@ export function partition<T extends object>(
  * `predicate` returns falsy for. The predicate is invoked with one argument: (value).
  *
  * @template T
- * @param source - The array or object to iterate over.
+ * @param collection - The array or object to iterate over.
  * @param [predicate=identity] - The function invoked per iteration.
  * @returns Returns the array of grouped elements.
  *
@@ -82,22 +82,22 @@ export function partition<T extends object>(
  * // => [[{ a: 2 }], [{ a: 1 }, { a: 3 }]]
  */
 export function partition<T>(
-  source: ArrayLike<T> | T | null | undefined,
+  collection: ArrayLike<T> | T | null | undefined,
   predicate: ((value: T) => unknown) | Partial<T> | [PropertyKey, any] | PropertyKey = identity
 ): [T[], T[]] {
-  if (!source) {
+  if (!collection) {
     return [[], []];
   }
 
-  const collection = isArrayLike(source) ? source : Object.values(source);
+  const values = isArrayLike(collection) ? collection : Object.values(collection);
 
   predicate = iteratee(predicate);
 
   const matched: T[] = [];
   const unmatched: T[] = [];
 
-  for (let i = 0; i < collection.length; i++) {
-    const value = collection[i] as T;
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i] as T;
 
     if (predicate(value)) {
       matched.push(value);


### PR DESCRIPTION
## Summary

Add the optional marker to the predicate parameter in the documentation. 
Also, rename the source parameter to collection for consistency with the rest of the documentation.