### PR TITLE
feat(bigint): add es-toolkit/bigint entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ umd
 .vercel
 /compat
 /array.js
+/bigint.js
 /compat.js
 /error.js
 /fp.js

--- a/.scripts/postbuild.sh
+++ b/.scripts/postbuild.sh
@@ -39,7 +39,7 @@ create_compat_alias() {
 }
 
 # Create root exports
-for module in array server error compat fp function math map object predicate promise set string util; do
+for module in array bigint server error compat fp function math map object predicate promise set string util; do
     create_root_export $module
 done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ tests/types/                  Type tests comparing `es-toolkit/compat` with `@ty
 CHANGELOG.md                  User-facing changelog
 ```
 
-Categories include `array`, `function`, `math`, `object`, `predicate`, `promise`, `set`, `string`, `util`, `error`, and `map`.
+Categories include `array`, `bigint`, `function`, `math`, `object`, `predicate`, `promise`, `set`, `string`, `util`, `error`, and `map`.
 
 ## Principles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ tsc --noEmit                      # Typecheck
 ## Structure
 
 ```
-src/{category}/{fn}.ts            # Implementation (array, function, math, object, predicate, promise, set, string, util, error, map)
+src/{category}/{fn}.ts            # Implementation (array, bigint, function, math, object, predicate, promise, set, string, util, error, map)
 src/{category}/{fn}.spec.ts       # Tests (vitest)
 src/compat/{category}/{fn}.ts     # Lodash-compatible variant
 tests/types/compat.spec-d.ts      # Type tests against @types/lodash (yarn workspace type-tests test)

--- a/docs/.vitepress/data/playground.data.mts
+++ b/docs/.vitepress/data/playground.data.mts
@@ -24,6 +24,7 @@ const LOCALES = ['en', 'ko', 'ja', 'zh_hans'];
 
 const CATEGORY_ORDER = [
   'array',
+  'bigint',
   'function',
   'math',
   'object',
@@ -114,7 +115,7 @@ function parseMarkdown(content: string, fnName: string): ParseResult | null {
 
   // Normalize import paths: 'es-toolkit/array' → 'es-toolkit'
   // Keep subpath imports for categories not re-exported from main entry (map, set)
-  const SUBPATH_ONLY = ['map', 'set'];
+  const SUBPATH_ONLY = ['bigint', 'map', 'set'];
   code = code.replace(/from 'es-toolkit\/([^']+)'/g, (match, subpath) => {
     if (SUBPATH_ONLY.includes(subpath)) {
       return match;

--- a/docs/.vitepress/en.mts
+++ b/docs/.vitepress/en.mts
@@ -13,6 +13,7 @@ const labels: SidebarLabels = {
   },
   categories: {
     array: 'Array Utilities',
+    bigint: 'BigInt Utilities',
     function: 'Function Utilities',
     map: 'Map Utilities',
     math: 'Math Utilities',

--- a/docs/.vitepress/ja.mts
+++ b/docs/.vitepress/ja.mts
@@ -13,6 +13,7 @@ const labels: SidebarLabels = {
   },
   categories: {
     array: '配列',
+    bigint: 'BigInt',
     function: '関数',
     map: 'Map',
     math: '数学',

--- a/docs/.vitepress/ko.mts
+++ b/docs/.vitepress/ko.mts
@@ -13,6 +13,7 @@ const labels: SidebarLabels = {
   },
   categories: {
     array: '배열',
+    bigint: 'BigInt',
     function: '함수',
     map: 'Map',
     math: '숫자',

--- a/docs/.vitepress/libs/flavors.mts
+++ b/docs/.vitepress/libs/flavors.mts
@@ -81,6 +81,7 @@ export const flavors = [
     ],
     categories: [
       'array',
+      'bigint',
       'function',
       'map',
       'math',

--- a/docs/.vitepress/zh_hans.mts
+++ b/docs/.vitepress/zh_hans.mts
@@ -13,6 +13,7 @@ const labels: SidebarLabels = {
   },
   categories: {
     array: '数组工具',
+    bigint: 'BigInt 工具',
     function: '函数工具',
     map: 'Map 工具',
     math: '数学工具',

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -26,7 +26,7 @@ Use these terms consistently across translations:
 | Usage      | 사용법          | 使用法     | 用法    |
 | Parameters | 파라미터        | パラメータ | 参数    |
 | Returns    | 반환 값         | 戻り値     | 返回值  |
-| Throws     | 에러            | エラー     | 异常    |
+| Throws     | 에러            | エラー     | 错误    |
 | Examples   | 예시            | 例         | 示例    |
 
 ## Korean style

--- a/docs/ja/reference/bigint/clamp.md
+++ b/docs/ja/reference/bigint/clamp.md
@@ -1,0 +1,74 @@
+# clamp (`BigInt`)
+
+`BigInt`を指定された範囲に制限します。
+
+```typescript
+const clamped = clamp(value, maximum);
+const clamped = clamp(value, minimum, maximum);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `clamp(value, maximum)`
+
+上限だけを設定したい場合は、引数2つの `clamp` を使用してください。最大値を超える値は最大値として返され、それ以外の値はそのまま返されます。
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+console.log(clamp(10n, 5n)); // 5n、10nは最大値を超えているため
+console.log(clamp(3n, 5n)); // 3n、すでに上限内にあるため
+```
+
+#### パラメータ
+
+- `value` (`bigint`): 制限する`BigInt`です。
+- `maximum` (`bigint`): 上限値(含む)です。
+
+#### 戻り値
+
+(`bigint`): 最大値を上限として制限した`BigInt`を返します。
+
+### `clamp(value, minimum, maximum)`
+
+下限と上限の両方を設定したい場合は、引数3つの `clamp` を使用してください。`Math.min` と `Math.max` は`BigInt`を受け取れないため、この関数を使用します。
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+console.log(clamp(10n, 0n, 5n)); // 5n、最大値を超えている
+console.log(clamp(-10n, 0n, 5n)); // 0n、最小値を下回っている
+console.log(clamp(3n, 0n, 5n)); // 3n、すでに範囲内にある
+
+// 両方の境界値は範囲に含まれます
+console.log(clamp(0n, 0n, 5n)); // 0n
+console.log(clamp(5n, 0n, 5n)); // 5n
+
+// 負数の範囲でも使用できます
+console.log(clamp(-10n, -5n, -1n)); // -5n
+```
+
+`BigInt`は正確に比較されるため、`Number.MAX_SAFE_INTEGER`をはるかに超える境界値でも期待どおりに動作します。
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+const maxUint64 = 18446744073709551615n;
+console.log(clamp(20000000000000000000n, 0n, maxUint64)); // 18446744073709551615n
+```
+
+#### パラメータ
+
+- `value` (`bigint`): 制限する`BigInt`です。
+- `minimum` (`bigint`): 下限値(含む)です。
+- `maximum` (`bigint`): 上限値(含む)です。
+
+#### 戻り値
+
+(`bigint`): 範囲内に制限した`BigInt`を返します。

--- a/docs/ja/reference/bigint/inRange.md
+++ b/docs/ja/reference/bigint/inRange.md
@@ -1,0 +1,81 @@
+# inRange (`BigInt`)
+
+`BigInt`が指定された範囲内にあるかを確認します。
+
+```typescript
+const result = inRange(value, maximum);
+const result = inRange(value, minimum, maximum);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `inRange(value, maximum)`
+
+`0n`以上、最大値未満の範囲を確認したい場合は、引数2つの `inRange` を使用してください。最小値は自動的に`0n`になります。
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+console.log(inRange(3n, 5n)); // true、0n <= 3n < 5nであるため
+console.log(inRange(5n, 5n)); // false、最大値は範囲に含まれないため
+console.log(inRange(-1n, 5n)); // false、-1nは0nを下回るため
+```
+
+#### パラメータ
+
+- `value` (`bigint`): 確認する`BigInt`です。
+- `maximum` (`bigint`): 範囲の上限値(含まない)です。
+
+#### 戻り値
+
+(`boolean`): `BigInt`が`0n`以上かつ最大値未満の場合は `true`、そうでない場合は `false` を返します。
+
+#### エラー
+
+最大値が`0n`より大きくない場合、エラーをスローします。
+
+### `inRange(value, minimum, maximum)`
+
+範囲を明示的に指定して確認したい場合は、引数3つの `inRange` を使用してください。下限値は範囲に含まれ、上限値は含まれません。
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+console.log(inRange(5n, 0n, 10n)); // true
+console.log(inRange(0n, 0n, 10n)); // true、下限値は範囲に含まれる
+console.log(inRange(10n, 0n, 10n)); // false、上限値は範囲に含まれない
+
+// 負数の範囲でも使用できます
+console.log(inRange(-3n, -5n, -1n)); // true
+```
+
+`BigInt`の比較はどれほど大きな値でも正確なため、値を保存する前に整数型やデータベースのカラムに収まるかを確認するのに便利です。
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+// 符号なし64ビットのカラムに収まるでしょうか?
+const maxUint64Exclusive = 18446744073709551616n;
+console.log(inRange(18446744073709551615n, 0n, maxUint64Exclusive)); // true
+console.log(inRange(18446744073709551616n, 0n, maxUint64Exclusive)); // false
+```
+
+#### パラメータ
+
+- `value` (`bigint`): 確認する`BigInt`です。
+- `minimum` (`bigint`): 範囲の下限値(含む)です。
+- `maximum` (`bigint`): 範囲の上限値(含まない)です。
+
+#### 戻り値
+
+(`boolean`): `BigInt`が範囲内にある場合は `true`、そうでない場合は `false` を返します。
+
+#### エラー
+
+最小値が最大値より大きいか等しい場合、エラーをスローします。

--- a/docs/ja/reference/bigint/max.md
+++ b/docs/ja/reference/bigint/max.md
@@ -1,0 +1,58 @@
+# max (`BigInt`)
+
+配列の中で最も大きい`BigInt`を返します。
+
+```typescript
+const largest = max(numbers);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `max(nums)`
+
+複数の`BigInt`の中で最も大きい値を求めたい場合は `max` を使用してください。`Math.max` は`BigInt`をまったく受け取れないため、比較にはこの関数を使用します。
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+const largest = max([1n, 5n, 3n]);
+console.log(largest); // 5n
+
+// 負の値でも動作します
+console.log(max([-5n, -1n, -3n])); // -1n
+```
+
+`BigInt`は正確に比較されるため、`number`では同じ値に丸められてしまう値も区別されたままになります。
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+// `number`では、どちらも9007199254740992になります
+console.log(max([9007199254740992n, 9007199254740993n])); // 9007199254740993n
+```
+
+`BigInt`には`NaN`も`-Infinity`もないため、「最大値がない」ことを表す`BigInt`は存在しません。そのため、空配列は代替値を返す代わりにエラーをスローします。
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+max([]); // RangeError: Cannot find the maximum of an empty array.
+```
+
+#### パラメータ
+
+- `nums` (`readonly bigint[]`): 探索する`BigInt`の配列です。
+
+#### 戻り値
+
+(`bigint`): 配列の中で最も大きい`BigInt`を返します。
+
+#### エラー
+
+配列が空の場合、`RangeError`をスローします。

--- a/docs/ja/reference/bigint/maxBy.md
+++ b/docs/ja/reference/bigint/maxBy.md
@@ -1,0 +1,68 @@
+# maxBy (`BigInt`)
+
+配列の要素のうち、導出された`BigInt`の値が最も大きい要素を返します。
+
+```typescript
+const largest = maxBy(items, getValue);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `maxBy(items, getValue)`
+
+比較したい`BigInt`がオブジェクトの中にあり、数値だけでなくオブジェクト全体を受け取りたい場合は `maxBy` を使用してください。各要素から値を取り出す関数を渡します。
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+const accounts = [
+  { owner: 'alice', balance: 10n },
+  { owner: 'bob', balance: 30n },
+  { owner: 'carol', balance: 20n },
+];
+
+const richest = maxBy(accounts, account => account.balance);
+console.log(richest); // { owner: 'bob', balance: 30n }
+```
+
+複数の要素が最大値で並んだ場合は、最初の要素が返されます。`getValue` はインデックスと配列全体も受け取ります。
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+const first = { id: 'a', score: 30n };
+const second = { id: 'b', score: 30n };
+console.log(maxBy([first, second], item => item.score)); // { id: 'a', score: 30n }
+
+// 要素とその位置の両方から導出した値で比較します
+const rounds = [{ points: 5n }, { points: 5n }, { points: 5n }];
+const best = maxBy(rounds, (round, index) => round.points * BigInt(index + 1));
+console.log(best); // 3番目のラウンド。乗数が最も大きいため
+```
+
+空配列には返す要素がないため、エラーをスローします。
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+maxBy([], () => 0n); // RangeError: Cannot find the maximum of an empty array.
+```
+
+#### パラメータ
+
+- `items` (`readonly T[]`): 探索する要素の配列です。
+- `getValue` (`(element: T, index: number, array: readonly T[]) => bigint`): 比較に使用する`BigInt`を返す関数です。
+
+#### 戻り値
+
+(`T`): 導出された`BigInt`が最も大きい要素を返します。複数の要素が並んだ場合は最初の要素を返します。
+
+#### エラー
+
+配列が空の場合、`RangeError`をスローします。

--- a/docs/ja/reference/bigint/median.md
+++ b/docs/ja/reference/bigint/median.md
@@ -1,0 +1,64 @@
+# median (`BigInt`)
+
+`BigInt`の配列の中央値を返します。
+
+```typescript
+const middle = median(numbers);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `median(nums)`
+
+`BigInt`の集合の中央値を求めたい場合は `median` を使用してください。配列のコピーをソートし——元の配列は変更されません——中央にある値を返します。
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+const middle = median([1n, 2n, 3n, 4n, 5n]);
+console.log(middle); // 3n
+
+// 配列は事前にソートされている必要はありません
+console.log(median([5n, 1n, 4n, 2n, 3n])); // 3n
+```
+
+配列の要素数が偶数の場合、中央の2つの値の平均が求められます。`BigInt`には小数部がないため、その平均は**0方向に切り捨て**られます。
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+// (2n + 3n) / 2n は2.5ではなく2nになります
+console.log(median([1n, 2n, 3n, 4n])); // 2n
+
+// (1n + 2n) / 2n は1nになります
+console.log(median([1n, 2n])); // 1n
+
+// 切り捨ては0方向に行われるため、-3nではなく-2nになります
+console.log(median([-3n, -2n])); // -2n
+```
+
+`BigInt`には`NaN`がないため、「中央値がない」ことを表す`BigInt`は存在しません。そのため、空配列は代替値を返す代わりにエラーをスローします。
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+median([]); // RangeError: Cannot compute the median of an empty array.
+```
+
+#### パラメータ
+
+- `nums` (`readonly bigint[]`): 中央値を計算する`BigInt`の配列です。
+
+#### 戻り値
+
+(`bigint`): 配列の中央値を返します。要素数が偶数の場合は、中央の2つの値の平均を0方向に切り捨てて返します。
+
+#### エラー
+
+配列が空の場合、`RangeError`をスローします。

--- a/docs/ja/reference/bigint/medianBy.md
+++ b/docs/ja/reference/bigint/medianBy.md
@@ -1,0 +1,51 @@
+# medianBy (`BigInt`)
+
+配列の各要素から関数が導出した`BigInt`の中央値を返します。
+
+```typescript
+const middle = medianBy(items, getValue);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `medianBy(items, getValue)`
+
+中央値を求めたい`BigInt`がオブジェクトの中にある場合は `medianBy` を使用してください。各要素から値を取り出す関数を渡すと、その関数が返すすべての値の中央値を求めます。
+
+```typescript
+import { medianBy } from 'es-toolkit/bigint';
+
+const accounts = [{ balance: 10n }, { balance: 30n }, { balance: 20n }];
+const middle = medianBy(accounts, account => account.balance);
+console.log(middle); // 20n
+```
+
+`median` と同様に、要素数が偶数の場合は中央の2つの値の平均を0方向に切り捨て、空配列の場合はエラーをスローします。
+
+```typescript
+import { medianBy } from 'es-toolkit/bigint';
+
+const payments = [{ amount: 1n }, { amount: 2n }, { amount: 3n }, { amount: 4n }];
+console.log(medianBy(payments, payment => payment.amount)); // 2n
+
+medianBy([], () => 0n); // RangeError: Cannot compute the median of an empty array.
+```
+
+#### パラメータ
+
+- `items` (`readonly T[]`): 中央値を計算する要素の配列です。
+- `getValue` (`(element: T) => bigint`): 各要素に対して使用する`BigInt`を返す関数です。
+
+#### 戻り値
+
+(`bigint`): `getValue` が返したすべての値の中央値を返します。要素数が偶数の場合は、中央の2つの値の平均を0方向に切り捨てて返します。
+
+#### エラー
+
+配列が空の場合、`RangeError`をスローします。

--- a/docs/ja/reference/bigint/min.md
+++ b/docs/ja/reference/bigint/min.md
@@ -1,0 +1,58 @@
+# min (`BigInt`)
+
+配列の中で最も小さい`BigInt`を返します。
+
+```typescript
+const smallest = min(numbers);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `min(nums)`
+
+複数の`BigInt`の中で最も小さい値を求めたい場合は `min` を使用してください。`Math.min` は`BigInt`をまったく受け取れないため、比較にはこの関数を使用します。
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+const smallest = min([1n, 5n, 3n]);
+console.log(smallest); // 1n
+
+// 負の値でも動作します
+console.log(min([-5n, -1n, -3n])); // -5n
+```
+
+`BigInt`は正確に比較されるため、`number`では同じ値に丸められてしまう値も区別されたままになります。
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+// `number`では、どちらも9007199254740992になります
+console.log(min([9007199254740993n, 9007199254740992n])); // 9007199254740992n
+```
+
+`BigInt`には`NaN`も`Infinity`もないため、「最小値がない」ことを表す`BigInt`は存在しません。そのため、空配列は代替値を返す代わりにエラーをスローします。
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+min([]); // RangeError: Cannot find the minimum of an empty array.
+```
+
+#### パラメータ
+
+- `nums` (`readonly bigint[]`): 探索する`BigInt`の配列です。
+
+#### 戻り値
+
+(`bigint`): 配列の中で最も小さい`BigInt`を返します。
+
+#### エラー
+
+配列が空の場合、`RangeError`をスローします。

--- a/docs/ja/reference/bigint/minBy.md
+++ b/docs/ja/reference/bigint/minBy.md
@@ -1,0 +1,63 @@
+# minBy (`BigInt`)
+
+配列の要素のうち、導出された`BigInt`の値が最も小さい要素を返します。
+
+```typescript
+const smallest = minBy(items, getValue);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `minBy(items, getValue)`
+
+比較したい`BigInt`がオブジェクトの中にあり、数値だけでなくオブジェクト全体を受け取りたい場合は `minBy` を使用してください。各要素から値を取り出す関数を渡します。
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+const accounts = [
+  { owner: 'alice', balance: 10n },
+  { owner: 'bob', balance: 30n },
+  { owner: 'carol', balance: 20n },
+];
+
+const poorest = minBy(accounts, account => account.balance);
+console.log(poorest); // { owner: 'alice', balance: 10n }
+```
+
+複数の要素が最小値で並んだ場合は、最初の要素が返されます。`getValue` はインデックスと配列全体も受け取ります。
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+const first = { id: 'a', score: 10n };
+const second = { id: 'b', score: 10n };
+console.log(minBy([first, second], item => item.score)); // { id: 'a', score: 10n }
+```
+
+空配列には返す要素がないため、エラーをスローします。
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+minBy([], () => 0n); // RangeError: Cannot find the minimum of an empty array.
+```
+
+#### パラメータ
+
+- `items` (`readonly T[]`): 探索する要素の配列です。
+- `getValue` (`(element: T, index: number, array: readonly T[]) => bigint`): 比較に使用する`BigInt`を返す関数です。
+
+#### 戻り値
+
+(`T`): 導出された`BigInt`が最も小さい要素を返します。複数の要素が並んだ場合は最初の要素を返します。
+
+#### エラー
+
+配列が空の場合、`RangeError`をスローします。

--- a/docs/ja/reference/bigint/percentile.md
+++ b/docs/ja/reference/bigint/percentile.md
@@ -1,0 +1,67 @@
+# percentile (`BigInt`)
+
+配列の指定されたパーセンタイルに位置する`BigInt`を返します。
+
+```typescript
+const value = percentile(numbers, 90);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `percentile(arr, percentile)`
+
+データの一定の割合がその値以下に収まる境界の値——たとえばp90レイテンシ——を知りたい場合は `percentile` を使用してください。配列のコピーをソートし——元の配列は変更されません——対応する順位の値を選びます。
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+const latencies = [1n, 2n, 3n, 4n, 5n];
+
+console.log(percentile(latencies, 50)); // 3n
+console.log(percentile(latencies, 90)); // 5n
+
+// 配列は事前にソートされている必要はありません
+console.log(percentile([30n, 10n, 20n], 50)); // 20n
+```
+
+この関数は[最近順位法(nearest-rank method)](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method)を使用するため、結果は必ず配列にすでに存在する値になります。2つの値の間を補間することはないので、丸めが発生することもありません。
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+// 1nと2nの中間は1.5になりますが、BigIntでは表現できないため、
+// 代わりに最近順位の値が返されます。
+console.log(percentile([1n, 2n], 50)); // 1n
+
+// 0は常に最小値を、100は常に最大値を返します
+console.log(percentile([5n, 1n, 3n], 0)); // 1n
+console.log(percentile([5n, 1n, 3n], 100)); // 5n
+```
+
+パーセンタイル自体は測定対象の量ではなく百分率であるため、`BigInt`ではなく`0`から`100`までの通常の`number`です。
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+percentile([1n, 2n, 3n], 101); // Error: Expected percentile to be <= 100 but got "101".
+percentile([], 50); // RangeError: Cannot compute the percentile of an empty array.
+```
+
+#### パラメータ
+
+- `arr` (`readonly bigint[]`): パーセンタイルを計算する`BigInt`の配列です。
+- `percentile` (`number`): 求めるパーセンタイルで、`0`から`100`までの値です。
+
+#### 戻り値
+
+(`bigint`): 指定されたパーセンタイルに位置する`BigInt`を返します。必ず配列にすでに存在する値のいずれかです。
+
+#### エラー
+
+`percentile` が`NaN`、`0`未満、または`100`を超える場合、エラーをスローします。配列が空の場合、`RangeError`をスローします。

--- a/docs/ja/reference/bigint/range.md
+++ b/docs/ja/reference/bigint/range.md
@@ -1,0 +1,103 @@
+# range (`BigInt`)
+
+開始値から終了値の手前までを数え上げた`BigInt`の配列を返します。
+
+```typescript
+const numbers = range(end);
+const numbers = range(start, end);
+const numbers = range(start, end, step);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `range(end)`
+
+`0n`から終了値の手前までを数え上げたい場合は、引数1つの `range` を使用してください。
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(4n)); // [0n, 1n, 2n, 3n]
+console.log(range(0n)); // []
+```
+
+#### パラメータ
+
+- `end` (`bigint`): 範囲の終了値(含まない)です。
+
+#### 戻り値
+
+(`bigint[]`): `0n`から `end` の手前までの`BigInt`の配列を返します。
+
+### `range(start, end)`
+
+`0n`ではなく指定した開始値から数え上げたい場合は、引数2つの `range` を使用してください。
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(2n, 5n)); // [2n, 3n, 4n]
+console.log(range(-3n, 0n)); // [-3n, -2n, -1n]
+
+// 開始値と終了値が同じ場合、数え上げる値はありません
+console.log(range(3n, 3n)); // []
+```
+
+`BigInt`はどれほど大きな値でも正確なままなので、値が知らないうちに衝突することなく`Number.MAX_SAFE_INTEGER`を超える範囲を作成できます。
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(9007199254740993n, 9007199254740996n));
+// [9007199254740993n, 9007199254740994n, 9007199254740995n]
+```
+
+#### パラメータ
+
+- `start` (`bigint`): 範囲の開始値(含む)です。
+- `end` (`bigint`): 範囲の終了値(含まない)です。
+
+#### 戻り値
+
+(`bigint[]`): `start` から `end` の手前までの`BigInt`の配列を返します。
+
+### `range(start, end, step)`
+
+`1n`以外の間隔で数え上げたい場合は、引数3つの `range` を使用してください。負のステップを指定すると降順で数え上げます。
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(0n, 10n, 2n)); // [0n, 2n, 4n, 6n, 8n]
+console.log(range(5n, 0n, -1n)); // [5n, 4n, 3n, 2n, 1n]
+console.log(range(5n, 0n, -2n)); // [5n, 3n, 1n]
+```
+
+ステップが終了値から遠ざかる方向を向いている場合、生成される値はなく、空配列が返されます。
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(0n, 5n, -1n)); // []
+console.log(range(5n, 0n, 1n)); // []
+```
+
+#### パラメータ
+
+- `start` (`bigint`): 範囲の開始値(含む)です。
+- `end` (`bigint`): 範囲の終了値(含まない)です。
+- `step` (`bigint`, オプション): 数え上げる間隔です。デフォルトは `1n` です。
+
+#### 戻り値
+
+(`bigint[]`): `start` から `end` の手前までを `step` 間隔で数え上げた`BigInt`の配列を返します。
+
+#### エラー
+
+`step` が `0n` の場合、エラーをスローします。

--- a/docs/ja/reference/bigint/rangeRight.md
+++ b/docs/ja/reference/bigint/rangeRight.md
@@ -1,0 +1,93 @@
+# rangeRight (`BigInt`)
+
+[range](./range.md)と同じ`BigInt`を降順で返します。
+
+```typescript
+const numbers = rangeRight(end);
+const numbers = rangeRight(start, end);
+const numbers = rangeRight(start, end, step);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `rangeRight(end)`
+
+終了値のすぐ手前から`0n`まで降順で数え上げたい場合は、引数1つの `rangeRight` を使用してください。
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(4n)); // [3n, 2n, 1n, 0n]
+console.log(rangeRight(0n)); // []
+```
+
+#### パラメータ
+
+- `end` (`bigint`): 範囲の終了値(含まない)です。
+
+#### 戻り値
+
+(`bigint[]`): `end` のすぐ手前から`0n`までの`BigInt`の配列を返します。
+
+### `rangeRight(start, end)`
+
+`0n`以外の開始値まで降順で数え上げたい場合は、引数2つの `rangeRight` を使用してください。
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(2n, 5n)); // [4n, 3n, 2n]
+console.log(rangeRight(-3n, 0n)); // [-1n, -2n, -3n]
+```
+
+#### パラメータ
+
+- `start` (`bigint`): 範囲の開始値(含む)です。
+- `end` (`bigint`): 範囲の終了値(含まない)です。
+
+#### 戻り値
+
+(`bigint[]`): `end` のすぐ手前から `start` までの`BigInt`の配列を返します。
+
+### `rangeRight(start, end, step)`
+
+`1n`以外の間隔で数え上げたい場合は、引数3つの `rangeRight` を使用してください。返される値は、同じ引数を渡した `range` の結果を反転したものと完全に一致します。
+
+```typescript
+import { range, rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(0n, 10n, 2n)); // [8n, 6n, 4n, 2n, 0n]
+console.log(rangeRight(5n, 0n, -1n)); // [1n, 2n, 3n, 4n, 5n]
+
+// 常に同じ引数を渡したrangeの逆順になります
+console.log(rangeRight(0n, 10n, 3n)); // [9n, 6n, 3n, 0n]
+console.log(range(0n, 10n, 3n)); // [0n, 3n, 6n, 9n]
+```
+
+ステップが終了値から遠ざかる方向を向いている場合、生成される値はなく、空配列が返されます。
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(0n, 5n, -1n)); // []
+```
+
+#### パラメータ
+
+- `start` (`bigint`): 範囲の開始値(含む)です。
+- `end` (`bigint`): 範囲の終了値(含まない)です。
+- `step` (`bigint`, オプション): 数え上げる間隔です。デフォルトは `1n` です。
+
+#### 戻り値
+
+(`bigint[]`): `range(start, end, step)` の値を降順で返します。
+
+#### エラー
+
+`step` が `0n` の場合、エラーをスローします。

--- a/docs/ja/reference/bigint/sum.md
+++ b/docs/ja/reference/bigint/sum.md
@@ -1,0 +1,68 @@
+# sum (`BigInt`)
+
+`BigInt`の配列のすべての要素を足した合計を返します。
+
+```typescript
+const total = sum(numbers);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `sum(nums)`
+
+`BigInt`を足し合わせたい場合は `sum` を使用してください。配列のすべての要素を足して合計を返します。
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+// 基本的な合計
+const numbers = [1n, 2n, 3n, 4n, 5n];
+const total = sum(numbers);
+console.log(total); // 15n
+
+// 負の値と正の値が混在した合計
+const values = [-10n, 5n, -3n, 8n];
+const result = sum(values);
+console.log(result); // 0n
+```
+
+空配列は `0n` を返すため、配列を分割してそれぞれの合計を足しても、全体の合計と常に同じ結果になります。
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+const empty = sum([]);
+console.log(empty); // 0n
+
+const first = [1n, 2n];
+const second = [3n, 4n];
+console.log(sum(first) + sum(second) === sum([...first, ...second])); // true
+```
+
+`number`とは異なり、`BigInt`は値がどれほど大きくなっても正確なままです。そのため、最小通貨単位の金額、トークンの量、データベースの識別子などに適しています。
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+// Number.MAX_SAFE_INTEGERをはるかに超えても正確です
+const balances = [9007199254740993n, 9007199254740993n];
+console.log(sum(balances)); // 18014398509481986n
+
+// 最小通貨単位で保存された支払いの合計
+const paymentsInCents = [129999n, 4550n, 87500n];
+console.log(sum(paymentsInCents)); // 222049n
+```
+
+#### パラメータ
+
+- `nums` (`readonly bigint[]`): 合計を計算する`BigInt`の配列です。
+
+#### 戻り値
+
+(`bigint`): 配列内のすべての`BigInt`の合計を返します。空配列の場合は `0n` を返します。

--- a/docs/ja/reference/bigint/sumBy.md
+++ b/docs/ja/reference/bigint/sumBy.md
@@ -1,0 +1,52 @@
+# sumBy (`BigInt`)
+
+配列の各要素から関数が導出した`BigInt`の合計を返します。
+
+```typescript
+const total = sumBy(items, getValue);
+```
+
+::: info
+
+この関数は、他の数値型の類似関数との潜在的な競合を避けるため、`es-toolkit/bigint`から独占的に利用できます。
+
+:::
+
+## 使用法
+
+### `sumBy(items, getValue)`
+
+足し合わせたい`BigInt`がオブジェクトの中にある場合は `sumBy` を使用してください。各要素から値を取り出す関数を渡すと、その関数が返すすべての値を足し合わせます。
+
+```typescript
+import { sumBy } from 'es-toolkit/bigint';
+
+// 各オブジェクトのフィールドを合計します
+const accounts = [{ balance: 10n }, { balance: 20n }, { balance: 30n }];
+const total = sumBy(accounts, account => account.balance);
+console.log(total); // 60n
+
+// インデックスは2番目の引数として渡されます
+const weights = sumBy(['a', 'b', 'c'], (_, index) => BigInt(index));
+console.log(weights); // 3n
+```
+
+空配列は `0n` を返し、値は負の数でもかまいません。
+
+```typescript
+import { sumBy } from 'es-toolkit/bigint';
+
+console.log(sumBy([], () => 1n)); // 0n
+
+const entries = [{ amount: -500n }, { amount: 1200n }, { amount: -200n }];
+console.log(sumBy(entries, entry => entry.amount)); // 500n
+```
+
+#### パラメータ
+
+- `items` (`readonly T[]`): 合計を計算する要素の配列です。
+- `getValue` (`(element: T, index: number) => bigint`): 各要素に対して加算する`BigInt`を返す関数です。
+
+#### 戻り値
+
+(`bigint`): `getValue` が返したすべての値の合計を返します。空配列の場合は `0n` を返します。

--- a/docs/ko/reference/bigint/clamp.md
+++ b/docs/ko/reference/bigint/clamp.md
@@ -1,0 +1,74 @@
+# clamp (`BigInt`)
+
+`BigInt`를 주어진 범위로 제한해요.
+
+```typescript
+const clamped = clamp(value, maximum);
+const clamped = clamp(value, minimum, maximum);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `clamp(value, maximum)`
+
+최댓값만 제한하고 싶을 때 `clamp`에 인자를 두 개 넘겨서 사용하세요. 최댓값보다 큰 값은 최댓값으로 돌아오고, 나머지는 그대로 반환돼요.
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+console.log(clamp(10n, 5n)); // 5n, 10n이 최댓값보다 크기 때문이에요
+console.log(clamp(3n, 5n)); // 3n, 이미 범위 안에 있어요
+```
+
+#### 파라미터
+
+- `value` (`bigint`): 제한할 `BigInt`예요.
+- `maximum` (`bigint`): 범위의 최댓값(포함)이에요.
+
+#### 반환 값
+
+(`bigint`): 최댓값을 넘지 않도록 제한된 `BigInt`를 반환해요.
+
+### `clamp(value, minimum, maximum)`
+
+최솟값과 최댓값을 모두 제한하고 싶을 때 `clamp`에 인자를 세 개 넘겨서 사용하세요. `Math.min`과 `Math.max`는 `BigInt`를 받을 수 없기 때문에, 이 함수를 사용해야 해요.
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+console.log(clamp(10n, 0n, 5n)); // 5n, 최댓값보다 커요
+console.log(clamp(-10n, 0n, 5n)); // 0n, 최솟값보다 작아요
+console.log(clamp(3n, 0n, 5n)); // 3n, 이미 범위 안에 있어요
+
+// 최솟값과 최댓값은 모두 포함돼요
+console.log(clamp(0n, 0n, 5n)); // 0n
+console.log(clamp(5n, 0n, 5n)); // 5n
+
+// 음수 범위에서도 사용할 수 있어요
+console.log(clamp(-10n, -5n, -1n)); // -5n
+```
+
+`BigInt`는 정확하게 비교되기 때문에, `Number.MAX_SAFE_INTEGER`를 훨씬 넘어서는 경계값도 기대한 대로 동작해요.
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+const maxUint64 = 18446744073709551615n;
+console.log(clamp(20000000000000000000n, 0n, maxUint64)); // 18446744073709551615n
+```
+
+#### 파라미터
+
+- `value` (`bigint`): 제한할 `BigInt`예요.
+- `minimum` (`bigint`): 범위의 최솟값(포함)이에요.
+- `maximum` (`bigint`): 범위의 최댓값(포함)이에요.
+
+#### 반환 값
+
+(`bigint`): 범위 안으로 제한된 `BigInt`를 반환해요.

--- a/docs/ko/reference/bigint/inRange.md
+++ b/docs/ko/reference/bigint/inRange.md
@@ -1,0 +1,81 @@
+# inRange (`BigInt`)
+
+`BigInt`가 범위 안에 있는지 확인해요.
+
+```typescript
+const result = inRange(value, maximum);
+const result = inRange(value, minimum, maximum);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `inRange(value, maximum)`
+
+`0n`부터 최댓값 미만까지의 범위를 확인하고 싶을 때 `inRange`에 인자를 두 개 넘겨서 사용하세요. 최솟값은 자동으로 `0n`이 돼요.
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+console.log(inRange(3n, 5n)); // true, 0n <= 3n < 5n이기 때문이에요
+console.log(inRange(5n, 5n)); // false, 최댓값은 포함되지 않기 때문이에요
+console.log(inRange(-1n, 5n)); // false, -1n이 0n보다 작기 때문이에요
+```
+
+#### 파라미터
+
+- `value` (`bigint`): 확인할 `BigInt`예요.
+- `maximum` (`bigint`): 범위의 최댓값(미포함)이에요.
+
+#### 반환 값
+
+(`boolean`): `BigInt`가 `0n` 이상이고 최댓값 미만이면 `true`를, 그렇지 않으면 `false`를 반환해요.
+
+#### 에러
+
+최댓값이 `0n`보다 크지 않으면 에러를 던져요.
+
+### `inRange(value, minimum, maximum)`
+
+범위를 직접 지정해서 확인하고 싶을 때 `inRange`에 인자를 세 개 넘겨서 사용하세요. 최솟값은 포함되고, 최댓값은 포함되지 않아요.
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+console.log(inRange(5n, 0n, 10n)); // true
+console.log(inRange(0n, 0n, 10n)); // true, 최솟값은 포함돼요
+console.log(inRange(10n, 0n, 10n)); // false, 최댓값은 포함되지 않아요
+
+// 음수 범위에서도 사용할 수 있어요
+console.log(inRange(-3n, -5n, -1n)); // true
+```
+
+`BigInt` 비교는 값이 아무리 커져도 정확하기 때문에, 값을 저장하기 전에 정수 타입이나 데이터베이스 컬럼에 들어갈 수 있는지 확인할 때 유용해요.
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+// 부호 없는 64비트 컬럼에 들어갈 수 있을까요?
+const maxUint64Exclusive = 18446744073709551616n;
+console.log(inRange(18446744073709551615n, 0n, maxUint64Exclusive)); // true
+console.log(inRange(18446744073709551616n, 0n, maxUint64Exclusive)); // false
+```
+
+#### 파라미터
+
+- `value` (`bigint`): 확인할 `BigInt`예요.
+- `minimum` (`bigint`): 범위의 최솟값(포함)이에요.
+- `maximum` (`bigint`): 범위의 최댓값(미포함)이에요.
+
+#### 반환 값
+
+(`boolean`): `BigInt`가 범위 안에 있으면 `true`를, 그렇지 않으면 `false`를 반환해요.
+
+#### 에러
+
+최솟값이 최댓값보다 크거나 같으면 에러를 던져요.

--- a/docs/ko/reference/bigint/max.md
+++ b/docs/ko/reference/bigint/max.md
@@ -1,0 +1,58 @@
+# max (`BigInt`)
+
+배열에서 가장 큰 `BigInt`를 반환해요.
+
+```typescript
+const largest = max(numbers);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `max(nums)`
+
+여러 `BigInt` 중에서 가장 큰 값을 구하고 싶을 때 `max`를 사용하세요. `Math.max`는 `BigInt`를 아예 받을 수 없기 때문에, 이 함수로 비교해야 해요.
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+const largest = max([1n, 5n, 3n]);
+console.log(largest); // 5n
+
+// 음수에서도 동작해요
+console.log(max([-5n, -1n, -3n])); // -1n
+```
+
+`BigInt`는 정확하게 비교되기 때문에, `number`였다면 같은 값으로 반올림됐을 값들도 서로 구분돼요.
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+// `number`로는 두 값 모두 9007199254740992예요
+console.log(max([9007199254740992n, 9007199254740993n])); // 9007199254740993n
+```
+
+`BigInt`에는 `NaN`도 `-Infinity`도 없어서 "최댓값이 없다"를 뜻하는 `BigInt`가 없기 때문에, 빈 배열은 대체 값을 반환하는 대신 에러를 던져요.
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+max([]); // RangeError: Cannot find the maximum of an empty array.
+```
+
+#### 파라미터
+
+- `nums` (`readonly bigint[]`): 탐색할 `BigInt` 배열이에요.
+
+#### 반환 값
+
+(`bigint`): 배열에서 가장 큰 `BigInt`를 반환해요.
+
+#### 에러
+
+배열이 비어 있으면 `RangeError`를 던져요.

--- a/docs/ko/reference/bigint/maxBy.md
+++ b/docs/ko/reference/bigint/maxBy.md
@@ -1,0 +1,68 @@
+# maxBy (`BigInt`)
+
+배열에서 함수가 계산한 `BigInt` 값이 가장 큰 요소를 반환해요.
+
+```typescript
+const largest = maxBy(items, getValue);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `maxBy(items, getValue)`
+
+비교하고 싶은 `BigInt`가 객체 안에 있고 숫자가 아니라 객체 전체를 돌려받고 싶을 때 `maxBy`를 사용하세요. 각 요소에서 값을 꺼내는 함수를 넘겨주세요.
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+const accounts = [
+  { owner: 'alice', balance: 10n },
+  { owner: 'bob', balance: 30n },
+  { owner: 'carol', balance: 20n },
+];
+
+const richest = maxBy(accounts, account => account.balance);
+console.log(richest); // { owner: 'bob', balance: 30n }
+```
+
+가장 큰 값이 여러 개로 같으면, 가장 먼저 나온 요소가 반환돼요. `getValue`는 인덱스와 배열 전체도 함께 받아요.
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+const first = { id: 'a', score: 30n };
+const second = { id: 'b', score: 30n };
+console.log(maxBy([first, second], item => item.score)); // { id: 'a', score: 30n }
+
+// 요소와 그 위치를 함께 사용해서 계산한 값으로 비교해요
+const rounds = [{ points: 5n }, { points: 5n }, { points: 5n }];
+const best = maxBy(rounds, (round, index) => round.points * BigInt(index + 1));
+console.log(best); // 세 번째 라운드예요. 곱해지는 값이 가장 크기 때문이에요
+```
+
+빈 배열은 반환할 요소가 없기 때문에 에러를 던져요.
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+maxBy([], () => 0n); // RangeError: Cannot find the maximum of an empty array.
+```
+
+#### 파라미터
+
+- `items` (`readonly T[]`): 탐색할 요소 배열이에요.
+- `getValue` (`(element: T, index: number, array: readonly T[]) => bigint`): 비교 기준이 되는 `BigInt`를 반환하는 함수예요.
+
+#### 반환 값
+
+(`T`): 계산된 `BigInt`가 가장 큰 요소를 반환해요. 값이 같은 요소가 여러 개면 그중 첫 번째 요소를 반환해요.
+
+#### 에러
+
+배열이 비어 있으면 `RangeError`를 던져요.

--- a/docs/ko/reference/bigint/median.md
+++ b/docs/ko/reference/bigint/median.md
@@ -1,0 +1,64 @@
+# median (`BigInt`)
+
+`BigInt` 배열의 중앙값을 반환해요.
+
+```typescript
+const middle = median(numbers);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `median(nums)`
+
+여러 `BigInt`의 중앙값을 구하고 싶을 때 `median`을 사용하세요. 배열의 복사본을 정렬해서 가운데 값을 반환하기 때문에, 원래 배열은 그대로 유지돼요.
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+const middle = median([1n, 2n, 3n, 4n, 5n]);
+console.log(middle); // 3n
+
+// 배열을 미리 정렬해둘 필요는 없어요
+console.log(median([5n, 1n, 4n, 2n, 3n])); // 3n
+```
+
+배열의 요소 개수가 짝수면 가운데 두 값의 평균을 구해요. `BigInt`에는 소수 부분이 없기 때문에, 이 평균은 **0 방향으로 버려져요**.
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+// (2n + 3n) / 2n은 2.5가 아니라 2n이에요
+console.log(median([1n, 2n, 3n, 4n])); // 2n
+
+// (1n + 2n) / 2n은 1n이에요
+console.log(median([1n, 2n])); // 1n
+
+// 0 방향으로 버려지기 때문에, -3n이 아니라 -2n이에요
+console.log(median([-3n, -2n])); // -2n
+```
+
+`BigInt`에는 `NaN`이 없어서 "중앙값이 없다"를 뜻하는 `BigInt`가 없기 때문에, 빈 배열은 대체 값을 반환하는 대신 에러를 던져요.
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+median([]); // RangeError: Cannot compute the median of an empty array.
+```
+
+#### 파라미터
+
+- `nums` (`readonly bigint[]`): 중앙값을 계산할 `BigInt` 배열이에요.
+
+#### 반환 값
+
+(`bigint`): 배열의 중앙값을 반환해요. 요소 개수가 짝수면 가운데 두 값의 평균을 0 방향으로 버린 값을 반환해요.
+
+#### 에러
+
+배열이 비어 있으면 `RangeError`를 던져요.

--- a/docs/ko/reference/bigint/medianBy.md
+++ b/docs/ko/reference/bigint/medianBy.md
@@ -1,0 +1,51 @@
+# medianBy (`BigInt`)
+
+배열의 각 요소에서 함수가 계산한 `BigInt` 값들의 중앙값을 반환해요.
+
+```typescript
+const middle = medianBy(items, getValue);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `medianBy(items, getValue)`
+
+중앙값을 구하고 싶은 `BigInt`가 객체 안에 있을 때 `medianBy`를 사용하세요. 각 요소에서 값을 꺼내는 함수를 넘겨주면, 그 함수가 반환한 값들의 중앙값을 구해줘요.
+
+```typescript
+import { medianBy } from 'es-toolkit/bigint';
+
+const accounts = [{ balance: 10n }, { balance: 30n }, { balance: 20n }];
+const middle = medianBy(accounts, account => account.balance);
+console.log(middle); // 20n
+```
+
+`median`과 마찬가지로, 요소 개수가 짝수면 가운데 두 값의 평균을 0 방향으로 버리고, 빈 배열이면 에러를 던져요.
+
+```typescript
+import { medianBy } from 'es-toolkit/bigint';
+
+const payments = [{ amount: 1n }, { amount: 2n }, { amount: 3n }, { amount: 4n }];
+console.log(medianBy(payments, payment => payment.amount)); // 2n
+
+medianBy([], () => 0n); // RangeError: Cannot compute the median of an empty array.
+```
+
+#### 파라미터
+
+- `items` (`readonly T[]`): 중앙값을 계산할 요소 배열이에요.
+- `getValue` (`(element: T) => bigint`): 각 요소에 사용할 `BigInt`를 반환하는 함수예요.
+
+#### 반환 값
+
+(`bigint`): `getValue`가 반환한 모든 값의 중앙값을 반환해요. 요소 개수가 짝수면 가운데 두 값의 평균을 0 방향으로 버린 값을 반환해요.
+
+#### 에러
+
+배열이 비어 있으면 `RangeError`를 던져요.

--- a/docs/ko/reference/bigint/min.md
+++ b/docs/ko/reference/bigint/min.md
@@ -1,0 +1,58 @@
+# min (`BigInt`)
+
+배열에서 가장 작은 `BigInt`를 반환해요.
+
+```typescript
+const smallest = min(numbers);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `min(nums)`
+
+여러 `BigInt` 중에서 가장 작은 값을 구하고 싶을 때 `min`을 사용하세요. `Math.min`은 `BigInt`를 아예 받을 수 없기 때문에, 이 함수로 비교해야 해요.
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+const smallest = min([1n, 5n, 3n]);
+console.log(smallest); // 1n
+
+// 음수에서도 동작해요
+console.log(min([-5n, -1n, -3n])); // -5n
+```
+
+`BigInt`는 정확하게 비교되기 때문에, `number`였다면 같은 값으로 반올림됐을 값들도 서로 구분돼요.
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+// `number`로는 두 값 모두 9007199254740992예요
+console.log(min([9007199254740993n, 9007199254740992n])); // 9007199254740992n
+```
+
+`BigInt`에는 `NaN`도 `Infinity`도 없어서 "최솟값이 없다"를 뜻하는 `BigInt`가 없기 때문에, 빈 배열은 대체 값을 반환하는 대신 에러를 던져요.
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+min([]); // RangeError: Cannot find the minimum of an empty array.
+```
+
+#### 파라미터
+
+- `nums` (`readonly bigint[]`): 탐색할 `BigInt` 배열이에요.
+
+#### 반환 값
+
+(`bigint`): 배열에서 가장 작은 `BigInt`를 반환해요.
+
+#### 에러
+
+배열이 비어 있으면 `RangeError`를 던져요.

--- a/docs/ko/reference/bigint/minBy.md
+++ b/docs/ko/reference/bigint/minBy.md
@@ -1,0 +1,63 @@
+# minBy (`BigInt`)
+
+배열에서 함수가 계산한 `BigInt` 값이 가장 작은 요소를 반환해요.
+
+```typescript
+const smallest = minBy(items, getValue);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `minBy(items, getValue)`
+
+비교하고 싶은 `BigInt`가 객체 안에 있고 숫자가 아니라 객체 전체를 돌려받고 싶을 때 `minBy`를 사용하세요. 각 요소에서 값을 꺼내는 함수를 넘겨주세요.
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+const accounts = [
+  { owner: 'alice', balance: 10n },
+  { owner: 'bob', balance: 30n },
+  { owner: 'carol', balance: 20n },
+];
+
+const poorest = minBy(accounts, account => account.balance);
+console.log(poorest); // { owner: 'alice', balance: 10n }
+```
+
+가장 작은 값이 여러 개로 같으면, 가장 먼저 나온 요소가 반환돼요. `getValue`는 인덱스와 배열 전체도 함께 받아요.
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+const first = { id: 'a', score: 10n };
+const second = { id: 'b', score: 10n };
+console.log(minBy([first, second], item => item.score)); // { id: 'a', score: 10n }
+```
+
+빈 배열은 반환할 요소가 없기 때문에 에러를 던져요.
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+minBy([], () => 0n); // RangeError: Cannot find the minimum of an empty array.
+```
+
+#### 파라미터
+
+- `items` (`readonly T[]`): 탐색할 요소 배열이에요.
+- `getValue` (`(element: T, index: number, array: readonly T[]) => bigint`): 비교 기준이 되는 `BigInt`를 반환하는 함수예요.
+
+#### 반환 값
+
+(`T`): 계산된 `BigInt`가 가장 작은 요소를 반환해요. 값이 같은 요소가 여러 개면 그중 첫 번째 요소를 반환해요.
+
+#### 에러
+
+배열이 비어 있으면 `RangeError`를 던져요.

--- a/docs/ko/reference/bigint/percentile.md
+++ b/docs/ko/reference/bigint/percentile.md
@@ -1,0 +1,67 @@
+# percentile (`BigInt`)
+
+배열에서 주어진 백분위수에 해당하는 `BigInt`를 반환해요.
+
+```typescript
+const value = percentile(numbers, 90);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `percentile(arr, percentile)`
+
+데이터의 일정 비율이 그 아래에 놓이는 값을 알고 싶을 때, 예를 들어 p90 응답 시간을 구할 때 `percentile`을 사용하세요. 배열의 복사본을 정렬해서 해당 순위의 값을 골라주기 때문에, 원래 배열은 그대로 유지돼요.
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+const latencies = [1n, 2n, 3n, 4n, 5n];
+
+console.log(percentile(latencies, 50)); // 3n
+console.log(percentile(latencies, 90)); // 5n
+
+// 배열을 미리 정렬해둘 필요는 없어요
+console.log(percentile([30n, 10n, 20n], 50)); // 20n
+```
+
+이 함수는 [최근접 순위 방법](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method)을 사용하기 때문에, 결과는 항상 배열에 이미 들어 있는 값이에요. 두 값 사이를 보간하지 않기 때문에, 반올림할 일도 없어요.
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+// 1n과 2n의 중간값은 1.5인데 어떤 BigInt로도 표현할 수 없기 때문에,
+// 대신 가장 가까운 순위의 값이 반환돼요.
+console.log(percentile([1n, 2n], 50)); // 1n
+
+// 0은 항상 가장 작은 값을, 100은 항상 가장 큰 값을 반환해요
+console.log(percentile([5n, 1n, 3n], 0)); // 1n
+console.log(percentile([5n, 1n, 3n], 100)); // 5n
+```
+
+백분위수 자체는 `BigInt`가 아니라 `0`부터 `100` 사이의 일반적인 `number`예요. 측정 대상이 되는 양이 아니라 비율이기 때문이에요.
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+percentile([1n, 2n, 3n], 101); // Error: Expected percentile to be <= 100 but got "101".
+percentile([], 50); // RangeError: Cannot compute the percentile of an empty array.
+```
+
+#### 파라미터
+
+- `arr` (`readonly bigint[]`): 백분위수를 계산할 `BigInt` 배열이에요.
+- `percentile` (`number`): 찾으려는 백분위수예요. `0`부터 `100` 사이의 값이에요.
+
+#### 반환 값
+
+(`bigint`): 주어진 백분위수에 해당하는 `BigInt`를 반환해요. 항상 배열에 이미 들어 있는 값 중 하나예요.
+
+#### 에러
+
+`percentile`이 `NaN`이거나, `0`보다 작거나, `100`보다 크면 에러를 던져요. 배열이 비어 있으면 `RangeError`를 던져요.

--- a/docs/ko/reference/bigint/range.md
+++ b/docs/ko/reference/bigint/range.md
@@ -1,0 +1,103 @@
+# range (`BigInt`)
+
+시작 값부터 끝 값 직전까지 세어 나가는 `BigInt` 배열을 반환해요.
+
+```typescript
+const numbers = range(end);
+const numbers = range(start, end);
+const numbers = range(start, end, step);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `range(end)`
+
+`0n`부터 끝 값 직전까지 세고 싶을 때 `range`에 인자를 하나 넘겨서 사용하세요.
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(4n)); // [0n, 1n, 2n, 3n]
+console.log(range(0n)); // []
+```
+
+#### 파라미터
+
+- `end` (`bigint`): 범위의 끝이에요. 포함되지 않아요.
+
+#### 반환 값
+
+(`bigint[]`): `0n`부터 `end` 직전까지의 `BigInt` 배열을 반환해요.
+
+### `range(start, end)`
+
+`0n` 대신 원하는 시작 값부터 세고 싶을 때 `range`에 인자를 두 개 넘겨서 사용하세요.
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(2n, 5n)); // [2n, 3n, 4n]
+console.log(range(-3n, 0n)); // [-3n, -2n, -1n]
+
+// 시작 값과 끝 값이 같으면 셀 것이 없어요
+console.log(range(3n, 3n)); // []
+```
+
+`BigInt`는 값이 아무리 커져도 정확하기 때문에, `Number.MAX_SAFE_INTEGER`를 넘어서는 범위도 값이 조용히 겹치는 일 없이 만들 수 있어요.
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(9007199254740993n, 9007199254740996n));
+// [9007199254740993n, 9007199254740994n, 9007199254740995n]
+```
+
+#### 파라미터
+
+- `start` (`bigint`): 범위의 시작이에요. 포함돼요.
+- `end` (`bigint`): 범위의 끝이에요. 포함되지 않아요.
+
+#### 반환 값
+
+(`bigint[]`): `start`부터 `end` 직전까지의 `BigInt` 배열을 반환해요.
+
+### `range(start, end, step)`
+
+`1n`이 아닌 간격으로 세고 싶을 때 `range`에 인자를 세 개 넘겨서 사용하세요. 간격이 음수면 값이 줄어들어요.
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(0n, 10n, 2n)); // [0n, 2n, 4n, 6n, 8n]
+console.log(range(5n, 0n, -1n)); // [5n, 4n, 3n, 2n, 1n]
+console.log(range(5n, 0n, -2n)); // [5n, 3n, 1n]
+```
+
+간격이 끝 값에서 멀어지는 방향이면 만들 수 있는 값이 없어서 빈 배열이 반환돼요.
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(0n, 5n, -1n)); // []
+console.log(range(5n, 0n, 1n)); // []
+```
+
+#### 파라미터
+
+- `start` (`bigint`): 범위의 시작이에요. 포함돼요.
+- `end` (`bigint`): 범위의 끝이에요. 포함되지 않아요.
+- `step` (`bigint`, 선택): 세어 나갈 간격이에요. 기본값은 `1n`이에요.
+
+#### 반환 값
+
+(`bigint[]`): `start`부터 `end` 직전까지 `step` 간격으로 센 `BigInt` 배열을 반환해요.
+
+#### 에러
+
+`step`이 `0n`이면 에러를 던져요.

--- a/docs/ko/reference/bigint/rangeRight.md
+++ b/docs/ko/reference/bigint/rangeRight.md
@@ -1,0 +1,93 @@
+# rangeRight (`BigInt`)
+
+[range](./range.md)와 같은 `BigInt`들을 내림차순으로 반환해요.
+
+```typescript
+const numbers = rangeRight(end);
+const numbers = rangeRight(start, end);
+const numbers = rangeRight(start, end, step);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `rangeRight(end)`
+
+끝 값 바로 아래부터 `0n`까지 거꾸로 세고 싶을 때 `rangeRight`에 인자를 하나 넘겨서 사용하세요.
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(4n)); // [3n, 2n, 1n, 0n]
+console.log(rangeRight(0n)); // []
+```
+
+#### 파라미터
+
+- `end` (`bigint`): 범위의 끝이에요. 포함되지 않아요.
+
+#### 반환 값
+
+(`bigint[]`): `end` 바로 아래부터 `0n`까지의 `BigInt` 배열을 반환해요.
+
+### `rangeRight(start, end)`
+
+`0n`이 아닌 시작 값까지 거꾸로 세고 싶을 때 `rangeRight`에 인자를 두 개 넘겨서 사용하세요.
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(2n, 5n)); // [4n, 3n, 2n]
+console.log(rangeRight(-3n, 0n)); // [-1n, -2n, -3n]
+```
+
+#### 파라미터
+
+- `start` (`bigint`): 범위의 시작이에요. 포함돼요.
+- `end` (`bigint`): 범위의 끝이에요. 포함되지 않아요.
+
+#### 반환 값
+
+(`bigint[]`): `end` 바로 아래부터 `start`까지의 `BigInt` 배열을 반환해요.
+
+### `rangeRight(start, end, step)`
+
+`1n`이 아닌 간격으로 세고 싶을 때 `rangeRight`에 인자를 세 개 넘겨서 사용하세요. 같은 인자로 `range`를 호출한 결과를 그대로 뒤집은 값이에요.
+
+```typescript
+import { range, rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(0n, 10n, 2n)); // [8n, 6n, 4n, 2n, 0n]
+console.log(rangeRight(5n, 0n, -1n)); // [1n, 2n, 3n, 4n, 5n]
+
+// 항상 같은 인자로 호출한 range의 역순이에요
+console.log(rangeRight(0n, 10n, 3n)); // [9n, 6n, 3n, 0n]
+console.log(range(0n, 10n, 3n)); // [0n, 3n, 6n, 9n]
+```
+
+간격이 끝 값에서 멀어지는 방향이면 만들 수 있는 값이 없어서 빈 배열이 반환돼요.
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(0n, 5n, -1n)); // []
+```
+
+#### 파라미터
+
+- `start` (`bigint`): 범위의 시작이에요. 포함돼요.
+- `end` (`bigint`): 범위의 끝이에요. 포함되지 않아요.
+- `step` (`bigint`, 선택): 세어 나갈 간격이에요. 기본값은 `1n`이에요.
+
+#### 반환 값
+
+(`bigint[]`): `range(start, end, step)`의 값들을 내림차순으로 반환해요.
+
+#### 에러
+
+`step`이 `0n`이면 에러를 던져요.

--- a/docs/ko/reference/bigint/sum.md
+++ b/docs/ko/reference/bigint/sum.md
@@ -1,0 +1,68 @@
+# sum (`BigInt`)
+
+`BigInt` 배열의 모든 요소를 더한 합계를 반환해요.
+
+```typescript
+const total = sum(numbers);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `sum(nums)`
+
+`BigInt`들을 더하고 싶을 때 `sum`을 사용하세요. 배열의 모든 요소를 더해서 총합을 반환해요.
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+// 기본적인 합계
+const numbers = [1n, 2n, 3n, 4n, 5n];
+const total = sum(numbers);
+console.log(total); // 15n
+
+// 음수와 양수 섞인 합계
+const values = [-10n, 5n, -3n, 8n];
+const result = sum(values);
+console.log(result); // 0n
+```
+
+빈 배열은 `0n`을 반환하기 때문에, 배열을 나눠서 각각 더한 값은 전체를 한 번에 더한 값과 항상 같아요.
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+const empty = sum([]);
+console.log(empty); // 0n
+
+const first = [1n, 2n];
+const second = [3n, 4n];
+console.log(sum(first) + sum(second) === sum([...first, ...second])); // true
+```
+
+`number`와 달리 `BigInt`는 값이 아무리 커져도 정확하기 때문에, 최소 화폐 단위로 저장한 금액이나 토큰 수량, 데이터베이스 식별자를 다루기에 적합해요.
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+// Number.MAX_SAFE_INTEGER를 훨씬 넘어서도 여전히 정확해요
+const balances = [9007199254740993n, 9007199254740993n];
+console.log(sum(balances)); // 18014398509481986n
+
+// 최소 화폐 단위로 저장한 결제 금액의 총합
+const paymentsInCents = [129999n, 4550n, 87500n];
+console.log(sum(paymentsInCents)); // 222049n
+```
+
+#### 파라미터
+
+- `nums` (`readonly bigint[]`): 합계를 계산할 `BigInt` 배열이에요.
+
+#### 반환 값
+
+(`bigint`): 배열에 있는 모든 `BigInt`의 합계를 반환해요. 빈 배열인 경우 `0n`을 반환해요.

--- a/docs/ko/reference/bigint/sumBy.md
+++ b/docs/ko/reference/bigint/sumBy.md
@@ -1,0 +1,52 @@
+# sumBy (`BigInt`)
+
+배열의 각 요소에서 함수가 계산한 `BigInt` 값들의 합계를 반환해요.
+
+```typescript
+const total = sumBy(items, getValue);
+```
+
+::: info
+
+이 함수는 다른 숫자 타입의 유사한 함수와의 잠재적 충돌을 피하기 위해 `es-toolkit/bigint`에서만 사용할 수 있어요.
+
+:::
+
+## 사용법
+
+### `sumBy(items, getValue)`
+
+더하고 싶은 `BigInt`가 객체 안에 있을 때 `sumBy`를 사용하세요. 각 요소에서 값을 꺼내는 함수를 넘겨주면, 그 함수가 반환한 값들을 모두 더해줘요.
+
+```typescript
+import { sumBy } from 'es-toolkit/bigint';
+
+// 각 객체의 특정 필드를 더해요
+const accounts = [{ balance: 10n }, { balance: 20n }, { balance: 30n }];
+const total = sumBy(accounts, account => account.balance);
+console.log(total); // 60n
+
+// 두 번째 인자로 인덱스가 전달돼요
+const weights = sumBy(['a', 'b', 'c'], (_, index) => BigInt(index));
+console.log(weights); // 3n
+```
+
+빈 배열은 `0n`을 반환하고, 값은 음수여도 괜찮아요.
+
+```typescript
+import { sumBy } from 'es-toolkit/bigint';
+
+console.log(sumBy([], () => 1n)); // 0n
+
+const entries = [{ amount: -500n }, { amount: 1200n }, { amount: -200n }];
+console.log(sumBy(entries, entry => entry.amount)); // 500n
+```
+
+#### 파라미터
+
+- `items` (`readonly T[]`): 합계를 계산할 요소 배열이에요.
+- `getValue` (`(element: T, index: number) => bigint`): 각 요소에서 더할 `BigInt`를 반환하는 함수예요.
+
+#### 반환 값
+
+(`bigint`): `getValue`가 반환한 모든 값의 합계를 반환해요. 빈 배열인 경우 `0n`을 반환해요.

--- a/docs/reference/bigint/clamp.md
+++ b/docs/reference/bigint/clamp.md
@@ -1,0 +1,74 @@
+# clamp (for `BigInt`s)
+
+Restricts a `BigInt` to a given range.
+
+```typescript
+const clamped = clamp(value, maximum);
+const clamped = clamp(value, minimum, maximum);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `clamp(value, maximum)`
+
+Use `clamp` with two arguments when you only want an upper limit. Anything above the maximum comes back as the maximum, and anything else is returned unchanged.
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+console.log(clamp(10n, 5n)); // 5n, because 10n is above the maximum
+console.log(clamp(3n, 5n)); // 3n, already within the limit
+```
+
+#### Parameters
+
+- `value` (`bigint`): The `BigInt` to clamp.
+- `maximum` (`bigint`): The upper bound, inclusive.
+
+#### Returns
+
+(`bigint`): Returns the `BigInt`, capped at the maximum.
+
+### `clamp(value, minimum, maximum)`
+
+Use `clamp` with three arguments when you want both a lower and an upper limit. `Math.min` and `Math.max` cannot accept `BigInt`s, so this is the way to do it.
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+console.log(clamp(10n, 0n, 5n)); // 5n, above the maximum
+console.log(clamp(-10n, 0n, 5n)); // 0n, below the minimum
+console.log(clamp(3n, 0n, 5n)); // 3n, already within the range
+
+// Both bounds are inclusive
+console.log(clamp(0n, 0n, 5n)); // 0n
+console.log(clamp(5n, 0n, 5n)); // 5n
+
+// Negative ranges work too
+console.log(clamp(-10n, -5n, -1n)); // -5n
+```
+
+Because `BigInt`s are compared exactly, bounds far past `Number.MAX_SAFE_INTEGER` still behave the way you would expect.
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+const maxUint64 = 18446744073709551615n;
+console.log(clamp(20000000000000000000n, 0n, maxUint64)); // 18446744073709551615n
+```
+
+#### Parameters
+
+- `value` (`bigint`): The `BigInt` to clamp.
+- `minimum` (`bigint`): The lower bound, inclusive.
+- `maximum` (`bigint`): The upper bound, inclusive.
+
+#### Returns
+
+(`bigint`): Returns the `BigInt`, constrained to the range.

--- a/docs/reference/bigint/inRange.md
+++ b/docs/reference/bigint/inRange.md
@@ -1,0 +1,81 @@
+# inRange (for `BigInt`s)
+
+Checks whether a `BigInt` falls within a range.
+
+```typescript
+const result = inRange(value, maximum);
+const result = inRange(value, minimum, maximum);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `inRange(value, maximum)`
+
+Use `inRange` with two arguments to check the range from `0n` up to, but not including, the maximum. The minimum is automatically `0n`.
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+console.log(inRange(3n, 5n)); // true, because 0n <= 3n < 5n
+console.log(inRange(5n, 5n)); // false, because the maximum is exclusive
+console.log(inRange(-1n, 5n)); // false, because -1n is below 0n
+```
+
+#### Parameters
+
+- `value` (`bigint`): The `BigInt` to check.
+- `maximum` (`bigint`): The upper bound of the range, exclusive.
+
+#### Returns
+
+(`boolean`): Returns `true` if the `BigInt` is at least `0n` and below the maximum, otherwise `false`.
+
+#### Throws
+
+Throws an error if the maximum is not greater than `0n`.
+
+### `inRange(value, minimum, maximum)`
+
+Use `inRange` with three arguments to check an explicit range. The lower bound is inclusive and the upper bound is exclusive.
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+console.log(inRange(5n, 0n, 10n)); // true
+console.log(inRange(0n, 0n, 10n)); // true, the lower bound is inclusive
+console.log(inRange(10n, 0n, 10n)); // false, the upper bound is exclusive
+
+// Negative ranges work too
+console.log(inRange(-3n, -5n, -1n)); // true
+```
+
+This is useful for checking that a value fits an integer type or a database column before you store it, since `BigInt` comparisons stay exact at any size.
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+// Does this fit in an unsigned 64-bit column?
+const maxUint64Exclusive = 18446744073709551616n;
+console.log(inRange(18446744073709551615n, 0n, maxUint64Exclusive)); // true
+console.log(inRange(18446744073709551616n, 0n, maxUint64Exclusive)); // false
+```
+
+#### Parameters
+
+- `value` (`bigint`): The `BigInt` to check.
+- `minimum` (`bigint`): The lower bound of the range, inclusive.
+- `maximum` (`bigint`): The upper bound of the range, exclusive.
+
+#### Returns
+
+(`boolean`): Returns `true` if the `BigInt` is within the range, otherwise `false`.
+
+#### Throws
+
+Throws an error if the minimum is greater than or equal to the maximum.

--- a/docs/reference/bigint/max.md
+++ b/docs/reference/bigint/max.md
@@ -1,0 +1,58 @@
+# max (for `BigInt`s)
+
+Returns the largest `BigInt` in an array.
+
+```typescript
+const largest = max(numbers);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `max(nums)`
+
+Use `max` when you want the largest of several `BigInt`s. `Math.max` cannot accept `BigInt`s at all, so this is the way to compare them.
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+const largest = max([1n, 5n, 3n]);
+console.log(largest); // 5n
+
+// Works with negative values
+console.log(max([-5n, -1n, -3n])); // -1n
+```
+
+Because `BigInt`s are compared exactly, values that `number` would round to the same thing stay distinguishable.
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+// As `number`, both of these are 9007199254740992
+console.log(max([9007199254740992n, 9007199254740993n])); // 9007199254740993n
+```
+
+There is no `BigInt` that means "no maximum" — `BigInt` has no `NaN` and no `-Infinity` — so an empty array throws instead of returning a placeholder.
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+max([]); // RangeError: Cannot find the maximum of an empty array.
+```
+
+#### Parameters
+
+- `nums` (`readonly bigint[]`): The array of `BigInt`s to search.
+
+#### Returns
+
+(`bigint`): Returns the largest `BigInt` in the array.
+
+#### Throws
+
+Throws a `RangeError` if the array is empty.

--- a/docs/reference/bigint/maxBy.md
+++ b/docs/reference/bigint/maxBy.md
@@ -1,0 +1,68 @@
+# maxBy (for `BigInt`s)
+
+Returns the element of an array whose derived `BigInt` value is the largest.
+
+```typescript
+const largest = maxBy(items, getValue);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `maxBy(items, getValue)`
+
+Use `maxBy` when the `BigInt`s you want to compare are inside objects and you want the whole object back, not just the number. Pass a function that pulls the value out of each element.
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+const accounts = [
+  { owner: 'alice', balance: 10n },
+  { owner: 'bob', balance: 30n },
+  { owner: 'carol', balance: 20n },
+];
+
+const richest = maxBy(accounts, account => account.balance);
+console.log(richest); // { owner: 'bob', balance: 30n }
+```
+
+When several elements tie for the largest value, the first one wins. `getValue` also receives the index and the whole array.
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+const first = { id: 'a', score: 30n };
+const second = { id: 'b', score: 30n };
+console.log(maxBy([first, second], item => item.score)); // { id: 'a', score: 30n }
+
+// Compare by a value derived from both the element and its position
+const rounds = [{ points: 5n }, { points: 5n }, { points: 5n }];
+const best = maxBy(rounds, (round, index) => round.points * BigInt(index + 1));
+console.log(best); // the third round, because its multiplier is the largest
+```
+
+An empty array has no element to return, so it throws.
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+maxBy([], () => 0n); // RangeError: Cannot find the maximum of an empty array.
+```
+
+#### Parameters
+
+- `items` (`readonly T[]`): The array of elements to search.
+- `getValue` (`(element: T, index: number, array: readonly T[]) => bigint`): A function that returns the `BigInt` to compare by.
+
+#### Returns
+
+(`T`): Returns the element with the largest derived `BigInt`. Returns the first of several elements that tie.
+
+#### Throws
+
+Throws a `RangeError` if the array is empty.

--- a/docs/reference/bigint/median.md
+++ b/docs/reference/bigint/median.md
@@ -1,0 +1,64 @@
+# median (for `BigInt`s)
+
+Returns the middle value of an array of `BigInt`s.
+
+```typescript
+const middle = median(numbers);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `median(nums)`
+
+Use `median` when you want the middle value of a set of `BigInt`s. It sorts a copy of the array — your array is left untouched — and returns the value in the middle.
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+const middle = median([1n, 2n, 3n, 4n, 5n]);
+console.log(middle); // 3n
+
+// The array does not need to be sorted beforehand
+console.log(median([5n, 1n, 4n, 2n, 3n])); // 3n
+```
+
+When the array has an even number of elements, the two middle values are averaged. `BigInt` has no fractional part, so that average is **truncated toward zero**.
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+// (2n + 3n) / 2n is 2n, not 2.5
+console.log(median([1n, 2n, 3n, 4n])); // 2n
+
+// (1n + 2n) / 2n is 1n
+console.log(median([1n, 2n])); // 1n
+
+// Truncation goes toward zero, so this is -2n rather than -3n
+console.log(median([-3n, -2n])); // -2n
+```
+
+There is no `BigInt` that means "no median" — `BigInt` has no `NaN` — so an empty array throws instead of returning a placeholder.
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+median([]); // RangeError: Cannot compute the median of an empty array.
+```
+
+#### Parameters
+
+- `nums` (`readonly bigint[]`): The array of `BigInt`s to calculate the median of.
+
+#### Returns
+
+(`bigint`): Returns the median of the array. For an even number of elements, returns the average of the two middle values, truncated toward zero.
+
+#### Throws
+
+Throws a `RangeError` if the array is empty.

--- a/docs/reference/bigint/medianBy.md
+++ b/docs/reference/bigint/medianBy.md
@@ -1,0 +1,51 @@
+# medianBy (for `BigInt`s)
+
+Returns the middle of the `BigInt`s that a function derives from each element of an array.
+
+```typescript
+const middle = medianBy(items, getValue);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `medianBy(items, getValue)`
+
+Use `medianBy` when the `BigInt`s you want the median of are inside objects. Pass a function that pulls the value out of each element, and it takes the median of everything that function returns.
+
+```typescript
+import { medianBy } from 'es-toolkit/bigint';
+
+const accounts = [{ balance: 10n }, { balance: 30n }, { balance: 20n }];
+const middle = medianBy(accounts, account => account.balance);
+console.log(middle); // 20n
+```
+
+Just like `median`, an even number of elements averages the two middle values and truncates toward zero, and an empty array throws.
+
+```typescript
+import { medianBy } from 'es-toolkit/bigint';
+
+const payments = [{ amount: 1n }, { amount: 2n }, { amount: 3n }, { amount: 4n }];
+console.log(medianBy(payments, payment => payment.amount)); // 2n
+
+medianBy([], () => 0n); // RangeError: Cannot compute the median of an empty array.
+```
+
+#### Parameters
+
+- `items` (`readonly T[]`): The array of elements to calculate the median of.
+- `getValue` (`(element: T) => bigint`): A function that returns the `BigInt` to use for each element.
+
+#### Returns
+
+(`bigint`): Returns the median of every value returned by `getValue`. For an even number of elements, returns the average of the two middle values, truncated toward zero.
+
+#### Throws
+
+Throws a `RangeError` if the array is empty.

--- a/docs/reference/bigint/min.md
+++ b/docs/reference/bigint/min.md
@@ -1,0 +1,58 @@
+# min (for `BigInt`s)
+
+Returns the smallest `BigInt` in an array.
+
+```typescript
+const smallest = min(numbers);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `min(nums)`
+
+Use `min` when you want the smallest of several `BigInt`s. `Math.min` cannot accept `BigInt`s at all, so this is the way to compare them.
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+const smallest = min([1n, 5n, 3n]);
+console.log(smallest); // 1n
+
+// Works with negative values
+console.log(min([-5n, -1n, -3n])); // -5n
+```
+
+Because `BigInt`s are compared exactly, values that `number` would round to the same thing stay distinguishable.
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+// As `number`, both of these are 9007199254740992
+console.log(min([9007199254740993n, 9007199254740992n])); // 9007199254740992n
+```
+
+There is no `BigInt` that means "no minimum" — `BigInt` has no `NaN` and no `Infinity` — so an empty array throws instead of returning a placeholder.
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+min([]); // RangeError: Cannot find the minimum of an empty array.
+```
+
+#### Parameters
+
+- `nums` (`readonly bigint[]`): The array of `BigInt`s to search.
+
+#### Returns
+
+(`bigint`): Returns the smallest `BigInt` in the array.
+
+#### Throws
+
+Throws a `RangeError` if the array is empty.

--- a/docs/reference/bigint/minBy.md
+++ b/docs/reference/bigint/minBy.md
@@ -1,0 +1,63 @@
+# minBy (for `BigInt`s)
+
+Returns the element of an array whose derived `BigInt` value is the smallest.
+
+```typescript
+const smallest = minBy(items, getValue);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `minBy(items, getValue)`
+
+Use `minBy` when the `BigInt`s you want to compare are inside objects and you want the whole object back, not just the number. Pass a function that pulls the value out of each element.
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+const accounts = [
+  { owner: 'alice', balance: 10n },
+  { owner: 'bob', balance: 30n },
+  { owner: 'carol', balance: 20n },
+];
+
+const poorest = minBy(accounts, account => account.balance);
+console.log(poorest); // { owner: 'alice', balance: 10n }
+```
+
+When several elements tie for the smallest value, the first one wins. `getValue` also receives the index and the whole array.
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+const first = { id: 'a', score: 10n };
+const second = { id: 'b', score: 10n };
+console.log(minBy([first, second], item => item.score)); // { id: 'a', score: 10n }
+```
+
+An empty array has no element to return, so it throws.
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+minBy([], () => 0n); // RangeError: Cannot find the minimum of an empty array.
+```
+
+#### Parameters
+
+- `items` (`readonly T[]`): The array of elements to search.
+- `getValue` (`(element: T, index: number, array: readonly T[]) => bigint`): A function that returns the `BigInt` to compare by.
+
+#### Returns
+
+(`T`): Returns the element with the smallest derived `BigInt`. Returns the first of several elements that tie.
+
+#### Throws
+
+Throws a `RangeError` if the array is empty.

--- a/docs/reference/bigint/percentile.md
+++ b/docs/reference/bigint/percentile.md
@@ -1,0 +1,67 @@
+# percentile (for `BigInt`s)
+
+Returns the `BigInt` at a given percentile of an array.
+
+```typescript
+const value = percentile(numbers, 90);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `percentile(arr, percentile)`
+
+Use `percentile` when you want to know the value below which a given share of your data falls — a p90 latency, for example. It sorts a copy of the array — your array is left untouched — and picks the value at the matching rank.
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+const latencies = [1n, 2n, 3n, 4n, 5n];
+
+console.log(percentile(latencies, 50)); // 3n
+console.log(percentile(latencies, 90)); // 5n
+
+// The array does not need to be sorted beforehand
+console.log(percentile([30n, 10n, 20n], 50)); // 20n
+```
+
+This uses the [nearest-rank method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method), so the answer is always a value that is already in the array. It never interpolates between two values, which means it never has to round.
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+// The midpoint of 1n and 2n would be 1.5, which no BigInt can hold,
+// so the nearest rank is returned instead.
+console.log(percentile([1n, 2n], 50)); // 1n
+
+// 0 always gives the smallest value and 100 always gives the largest
+console.log(percentile([5n, 1n, 3n], 0)); // 1n
+console.log(percentile([5n, 1n, 3n], 100)); // 5n
+```
+
+The percentile itself is an ordinary `number` between `0` and `100`, not a `BigInt`, because it is a percentage rather than a quantity being measured.
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+percentile([1n, 2n, 3n], 101); // Error: Expected percentile to be <= 100 but got "101".
+percentile([], 50); // RangeError: Cannot compute the percentile of an empty array.
+```
+
+#### Parameters
+
+- `arr` (`readonly bigint[]`): The array of `BigInt`s to calculate the percentile of.
+- `percentile` (`number`): The percentile to look up, between `0` and `100`.
+
+#### Returns
+
+(`bigint`): Returns the `BigInt` at the given percentile. Always one of the values already in the array.
+
+#### Throws
+
+Throws an error if `percentile` is `NaN`, less than `0`, or greater than `100`. Throws a `RangeError` if the array is empty.

--- a/docs/reference/bigint/range.md
+++ b/docs/reference/bigint/range.md
@@ -1,0 +1,103 @@
+# range (for `BigInt`s)
+
+Returns an array of `BigInt`s counting from a start value up to, but not including, an end value.
+
+```typescript
+const numbers = range(end);
+const numbers = range(start, end);
+const numbers = range(start, end, step);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `range(end)`
+
+Use `range` with one argument to count from `0n` up to, but not including, the end value.
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(4n)); // [0n, 1n, 2n, 3n]
+console.log(range(0n)); // []
+```
+
+#### Parameters
+
+- `end` (`bigint`): The end of the range, exclusive.
+
+#### Returns
+
+(`bigint[]`): Returns an array of `BigInt`s from `0n` up to, but not including, `end`.
+
+### `range(start, end)`
+
+Use `range` with two arguments to count from a start value instead of `0n`.
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(2n, 5n)); // [2n, 3n, 4n]
+console.log(range(-3n, 0n)); // [-3n, -2n, -1n]
+
+// Nothing to count when start and end are the same
+console.log(range(3n, 3n)); // []
+```
+
+Because `BigInt`s stay exact at any size, you can build ranges past `Number.MAX_SAFE_INTEGER` without values silently colliding.
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(9007199254740993n, 9007199254740996n));
+// [9007199254740993n, 9007199254740994n, 9007199254740995n]
+```
+
+#### Parameters
+
+- `start` (`bigint`): The start of the range, inclusive.
+- `end` (`bigint`): The end of the range, exclusive.
+
+#### Returns
+
+(`bigint[]`): Returns an array of `BigInt`s from `start` up to, but not including, `end`.
+
+### `range(start, end, step)`
+
+Use `range` with three arguments to count by something other than `1n`. A negative step counts down.
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(0n, 10n, 2n)); // [0n, 2n, 4n, 6n, 8n]
+console.log(range(5n, 0n, -1n)); // [5n, 4n, 3n, 2n, 1n]
+console.log(range(5n, 0n, -2n)); // [5n, 3n, 1n]
+```
+
+If the step points away from the end value, there is nothing to produce and you get an empty array.
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(0n, 5n, -1n)); // []
+console.log(range(5n, 0n, 1n)); // []
+```
+
+#### Parameters
+
+- `start` (`bigint`): The start of the range, inclusive.
+- `end` (`bigint`): The end of the range, exclusive.
+- `step` (`bigint`, optional): The amount to count by. Defaults to `1n`.
+
+#### Returns
+
+(`bigint[]`): Returns an array of `BigInt`s from `start` up to, but not including, `end`, counting by `step`.
+
+#### Throws
+
+Throws an error if `step` is `0n`.

--- a/docs/reference/bigint/rangeRight.md
+++ b/docs/reference/bigint/rangeRight.md
@@ -1,0 +1,93 @@
+# rangeRight (for `BigInt`s)
+
+Returns the same `BigInt`s as [range](./range.md), but in descending order.
+
+```typescript
+const numbers = rangeRight(end);
+const numbers = rangeRight(start, end);
+const numbers = rangeRight(start, end, step);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `rangeRight(end)`
+
+Use `rangeRight` with one argument to count down from just below the end value to `0n`.
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(4n)); // [3n, 2n, 1n, 0n]
+console.log(rangeRight(0n)); // []
+```
+
+#### Parameters
+
+- `end` (`bigint`): The end of the range, exclusive.
+
+#### Returns
+
+(`bigint[]`): Returns an array of `BigInt`s from just below `end` down to `0n`.
+
+### `rangeRight(start, end)`
+
+Use `rangeRight` with two arguments to count down to a start value other than `0n`.
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(2n, 5n)); // [4n, 3n, 2n]
+console.log(rangeRight(-3n, 0n)); // [-1n, -2n, -3n]
+```
+
+#### Parameters
+
+- `start` (`bigint`): The start of the range, inclusive.
+- `end` (`bigint`): The end of the range, exclusive.
+
+#### Returns
+
+(`bigint[]`): Returns an array of `BigInt`s from just below `end` down to `start`.
+
+### `rangeRight(start, end, step)`
+
+Use `rangeRight` with three arguments to step by something other than `1n`. The values are exactly those of `range` with the same arguments, reversed.
+
+```typescript
+import { range, rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(0n, 10n, 2n)); // [8n, 6n, 4n, 2n, 0n]
+console.log(rangeRight(5n, 0n, -1n)); // [1n, 2n, 3n, 4n, 5n]
+
+// Always the reverse of range with the same arguments
+console.log(rangeRight(0n, 10n, 3n)); // [9n, 6n, 3n, 0n]
+console.log(range(0n, 10n, 3n)); // [0n, 3n, 6n, 9n]
+```
+
+If the step points away from the end value, there is nothing to produce and you get an empty array.
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(0n, 5n, -1n)); // []
+```
+
+#### Parameters
+
+- `start` (`bigint`): The start of the range, inclusive.
+- `end` (`bigint`): The end of the range, exclusive.
+- `step` (`bigint`, optional): The amount to count by. Defaults to `1n`.
+
+#### Returns
+
+(`bigint[]`): Returns the values of `range(start, end, step)` in descending order.
+
+#### Throws
+
+Throws an error if `step` is `0n`.

--- a/docs/reference/bigint/sum.md
+++ b/docs/reference/bigint/sum.md
@@ -1,0 +1,68 @@
+# sum (for `BigInt`s)
+
+Returns the sum of all elements in an array of `BigInt`s.
+
+```typescript
+const total = sum(numbers);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `sum(nums)`
+
+Use `sum` when you want to add up `BigInt`s. It adds every element of the array together and returns the total.
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+// Basic sum
+const numbers = [1n, 2n, 3n, 4n, 5n];
+const total = sum(numbers);
+console.log(total); // 15n
+
+// Negative and positive values mixed
+const values = [-10n, 5n, -3n, 8n];
+const result = sum(values);
+console.log(result); // 0n
+```
+
+An empty array returns `0n`, so splitting an array and summing the parts always gives the same answer as summing the whole.
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+const empty = sum([]);
+console.log(empty); // 0n
+
+const first = [1n, 2n];
+const second = [3n, 4n];
+console.log(sum(first) + sum(second) === sum([...first, ...second])); // true
+```
+
+Unlike `number`, `BigInt` stays exact no matter how large the values get, which makes it a good fit for money in the smallest currency unit, token amounts, or database identifiers.
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+// Well past Number.MAX_SAFE_INTEGER, still exact
+const balances = [9007199254740993n, 9007199254740993n];
+console.log(sum(balances)); // 18014398509481986n
+
+// Total of payments stored in the smallest currency unit
+const paymentsInCents = [129999n, 4550n, 87500n];
+console.log(sum(paymentsInCents)); // 222049n
+```
+
+#### Parameters
+
+- `nums` (`readonly bigint[]`): The array of `BigInt`s to sum.
+
+#### Returns
+
+(`bigint`): Returns the sum of all `BigInt`s in the array. Returns `0n` for empty arrays.

--- a/docs/reference/bigint/sumBy.md
+++ b/docs/reference/bigint/sumBy.md
@@ -1,0 +1,52 @@
+# sumBy (for `BigInt`s)
+
+Returns the sum of the `BigInt`s that a function derives from each element of an array.
+
+```typescript
+const total = sumBy(items, getValue);
+```
+
+::: info
+
+This function is available exclusively from `es-toolkit/bigint` to avoid potential conflicts with similar functions for other numeric types.
+
+:::
+
+## Usage
+
+### `sumBy(items, getValue)`
+
+Use `sumBy` when the `BigInt`s you want to add up are inside objects. Pass a function that pulls the value out of each element, and it adds up everything that function returns.
+
+```typescript
+import { sumBy } from 'es-toolkit/bigint';
+
+// Sum a field of each object
+const accounts = [{ balance: 10n }, { balance: 20n }, { balance: 30n }];
+const total = sumBy(accounts, account => account.balance);
+console.log(total); // 60n
+
+// The index is passed as the second argument
+const weights = sumBy(['a', 'b', 'c'], (_, index) => BigInt(index));
+console.log(weights); // 3n
+```
+
+An empty array returns `0n`, and values can be negative.
+
+```typescript
+import { sumBy } from 'es-toolkit/bigint';
+
+console.log(sumBy([], () => 1n)); // 0n
+
+const entries = [{ amount: -500n }, { amount: 1200n }, { amount: -200n }];
+console.log(sumBy(entries, entry => entry.amount)); // 500n
+```
+
+#### Parameters
+
+- `items` (`readonly T[]`): The array of elements to sum.
+- `getValue` (`(element: T, index: number) => bigint`): A function that returns the `BigInt` to add for each element.
+
+#### Returns
+
+(`bigint`): Returns the sum of every value returned by `getValue`. Returns `0n` for empty arrays.

--- a/docs/zh_hans/reference/bigint/clamp.md
+++ b/docs/zh_hans/reference/bigint/clamp.md
@@ -1,0 +1,74 @@
+# clamp (`BigInt`)
+
+将 `BigInt` 限制在给定的范围内。
+
+```typescript
+const clamped = clamp(value, maximum);
+const clamped = clamp(value, minimum, maximum);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `clamp(value, maximum)`
+
+当您只需要一个上限时,请使用带两个参数的 `clamp`。任何超过最大值的值都会返回最大值,其他值则原样返回。
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+console.log(clamp(10n, 5n)); // 5n,因为 10n 超过了最大值
+console.log(clamp(3n, 5n)); // 3n,已经在限制范围内
+```
+
+#### 参数
+
+- `value` (`bigint`): 要限制的 `BigInt`。
+- `maximum` (`bigint`): 上限(包括)。
+
+#### 返回值
+
+(`bigint`): 返回被限制在最大值以内的 `BigInt`。
+
+### `clamp(value, minimum, maximum)`
+
+当您同时需要下限和上限时,请使用带三个参数的 `clamp`。`Math.min` 和 `Math.max` 无法接受 `BigInt`,所以只能这样做。
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+console.log(clamp(10n, 0n, 5n)); // 5n,超过了最大值
+console.log(clamp(-10n, 0n, 5n)); // 0n,低于最小值
+console.log(clamp(3n, 0n, 5n)); // 3n,已经在范围内
+
+// 两个边界都包括在内
+console.log(clamp(0n, 0n, 5n)); // 0n
+console.log(clamp(5n, 0n, 5n)); // 5n
+
+// 负数范围同样适用
+console.log(clamp(-10n, -5n, -1n)); // -5n
+```
+
+由于 `BigInt` 是精确比较的,即使边界远远超过 `Number.MAX_SAFE_INTEGER`,行为也与您预期的一致。
+
+```typescript
+import { clamp } from 'es-toolkit/bigint';
+
+const maxUint64 = 18446744073709551615n;
+console.log(clamp(20000000000000000000n, 0n, maxUint64)); // 18446744073709551615n
+```
+
+#### 参数
+
+- `value` (`bigint`): 要限制的 `BigInt`。
+- `minimum` (`bigint`): 下限(包括)。
+- `maximum` (`bigint`): 上限(包括)。
+
+#### 返回值
+
+(`bigint`): 返回被限制在该范围内的 `BigInt`。

--- a/docs/zh_hans/reference/bigint/inRange.md
+++ b/docs/zh_hans/reference/bigint/inRange.md
@@ -1,0 +1,81 @@
+# inRange (`BigInt`)
+
+检查 `BigInt` 是否在指定范围内。
+
+```typescript
+const result = inRange(value, maximum);
+const result = inRange(value, minimum, maximum);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `inRange(value, maximum)`
+
+使用带两个参数的 `inRange` 来检查从 `0n` 到小于最大值的范围。最小值自动为 `0n`。
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+console.log(inRange(3n, 5n)); // true,因为 0n <= 3n < 5n
+console.log(inRange(5n, 5n)); // false,因为不包括最大值
+console.log(inRange(-1n, 5n)); // false,因为 -1n 低于 0n
+```
+
+#### 参数
+
+- `value` (`bigint`): 要检查的 `BigInt`。
+- `maximum` (`bigint`): 范围的上限(不包括)。
+
+#### 返回值
+
+(`boolean`): 如果 `BigInt` 大于等于 `0n` 且小于最大值,则返回 `true`,否则返回 `false`。
+
+#### 错误
+
+如果最大值不大于 `0n`,则抛出错误。
+
+### `inRange(value, minimum, maximum)`
+
+使用带三个参数的 `inRange` 来检查明确指定的范围。下限包括在内,上限不包括在内。
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+console.log(inRange(5n, 0n, 10n)); // true
+console.log(inRange(0n, 0n, 10n)); // true,包括下限
+console.log(inRange(10n, 0n, 10n)); // false,不包括上限
+
+// 负数范围同样适用
+console.log(inRange(-3n, -5n, -1n)); // true
+```
+
+由于 `BigInt` 的比较在任何大小下都保持精确,这非常适合在存储之前检查值是否适合某个整数类型或数据库列。
+
+```typescript
+import { inRange } from 'es-toolkit/bigint';
+
+// 这个值能放进无符号 64 位的列吗?
+const maxUint64Exclusive = 18446744073709551616n;
+console.log(inRange(18446744073709551615n, 0n, maxUint64Exclusive)); // true
+console.log(inRange(18446744073709551616n, 0n, maxUint64Exclusive)); // false
+```
+
+#### 参数
+
+- `value` (`bigint`): 要检查的 `BigInt`。
+- `minimum` (`bigint`): 范围的下限(包括)。
+- `maximum` (`bigint`): 范围的上限(不包括)。
+
+#### 返回值
+
+(`boolean`): 如果 `BigInt` 在该范围内,则返回 `true`,否则返回 `false`。
+
+#### 错误
+
+如果最小值大于或等于最大值,则抛出错误。

--- a/docs/zh_hans/reference/bigint/max.md
+++ b/docs/zh_hans/reference/bigint/max.md
@@ -1,0 +1,58 @@
+# max (`BigInt`)
+
+返回数组中最大的 `BigInt`。
+
+```typescript
+const largest = max(numbers);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `max(nums)`
+
+当您想从多个 `BigInt` 中取出最大值时,请使用 `max`。`Math.max` 完全无法接受 `BigInt`,所以只能这样比较它们。
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+const largest = max([1n, 5n, 3n]);
+console.log(largest); // 5n
+
+// 对负数同样适用
+console.log(max([-5n, -1n, -3n])); // -1n
+```
+
+由于 `BigInt` 是精确比较的,那些用 `number` 会舍入成同一个值的数字仍然可以区分。
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+// 作为 `number`,这两个值都是 9007199254740992
+console.log(max([9007199254740992n, 9007199254740993n])); // 9007199254740993n
+```
+
+没有任何 `BigInt` 可以表示“没有最大值”,因为 `BigInt` 既没有 `NaN` 也没有 `-Infinity`,所以空数组会抛出错误,而不是返回一个占位值。
+
+```typescript
+import { max } from 'es-toolkit/bigint';
+
+max([]); // RangeError: Cannot find the maximum of an empty array.
+```
+
+#### 参数
+
+- `nums` (`readonly bigint[]`): 要搜索的 `BigInt` 数组。
+
+#### 返回值
+
+(`bigint`): 返回数组中最大的 `BigInt`。
+
+#### 错误
+
+如果数组为空,则抛出 `RangeError`。

--- a/docs/zh_hans/reference/bigint/maxBy.md
+++ b/docs/zh_hans/reference/bigint/maxBy.md
@@ -1,0 +1,68 @@
+# maxBy (`BigInt`)
+
+返回数组中派生出的 `BigInt` 值最大的元素。
+
+```typescript
+const largest = maxBy(items, getValue);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `maxBy(items, getValue)`
+
+当您要比较的 `BigInt` 位于对象内部,并且想拿回整个对象而不仅仅是数字时,请使用 `maxBy`。传入一个从每个元素中取出该值的函数。
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+const accounts = [
+  { owner: 'alice', balance: 10n },
+  { owner: 'bob', balance: 30n },
+  { owner: 'carol', balance: 20n },
+];
+
+const richest = maxBy(accounts, account => account.balance);
+console.log(richest); // { owner: 'bob', balance: 30n }
+```
+
+当多个元素的最大值相同时,返回第一个。`getValue` 还会接收索引和整个数组。
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+const first = { id: 'a', score: 30n };
+const second = { id: 'b', score: 30n };
+console.log(maxBy([first, second], item => item.score)); // { id: 'a', score: 30n }
+
+// 按同时依赖元素及其位置的值进行比较
+const rounds = [{ points: 5n }, { points: 5n }, { points: 5n }];
+const best = maxBy(rounds, (round, index) => round.points * BigInt(index + 1));
+console.log(best); // 第三轮,因为它的乘数最大
+```
+
+空数组没有可返回的元素,所以会抛出错误。
+
+```typescript
+import { maxBy } from 'es-toolkit/bigint';
+
+maxBy([], () => 0n); // RangeError: Cannot find the maximum of an empty array.
+```
+
+#### 参数
+
+- `items` (`readonly T[]`): 要搜索的元素数组。
+- `getValue` (`(element: T, index: number, array: readonly T[]) => bigint`): 返回用于比较的 `BigInt` 的函数。
+
+#### 返回值
+
+(`T`): 返回派生出的 `BigInt` 最大的元素。如果有多个元素并列,则返回其中的第一个。
+
+#### 错误
+
+如果数组为空,则抛出 `RangeError`。

--- a/docs/zh_hans/reference/bigint/median.md
+++ b/docs/zh_hans/reference/bigint/median.md
@@ -1,0 +1,64 @@
+# median (`BigInt`)
+
+返回 `BigInt` 数组的中间值。
+
+```typescript
+const middle = median(numbers);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `median(nums)`
+
+当您想要一组 `BigInt` 的中间值时,请使用 `median`。它会对数组的副本进行排序(您的数组保持不变),并返回位于中间的值。
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+const middle = median([1n, 2n, 3n, 4n, 5n]);
+console.log(middle); // 3n
+
+// 数组不需要事先排序
+console.log(median([5n, 1n, 4n, 2n, 3n])); // 3n
+```
+
+当数组的元素个数为偶数时,会取中间两个值的平均值。`BigInt` 没有小数部分,所以该平均值会**向零截断**。
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+// (2n + 3n) / 2n 是 2n,而不是 2.5
+console.log(median([1n, 2n, 3n, 4n])); // 2n
+
+// (1n + 2n) / 2n 是 1n
+console.log(median([1n, 2n])); // 1n
+
+// 截断是向零进行的,所以结果是 -2n 而不是 -3n
+console.log(median([-3n, -2n])); // -2n
+```
+
+没有任何 `BigInt` 可以表示“没有中位数”,因为 `BigInt` 没有 `NaN`,所以空数组会抛出错误,而不是返回一个占位值。
+
+```typescript
+import { median } from 'es-toolkit/bigint';
+
+median([]); // RangeError: Cannot compute the median of an empty array.
+```
+
+#### 参数
+
+- `nums` (`readonly bigint[]`): 要计算中位数的 `BigInt` 数组。
+
+#### 返回值
+
+(`bigint`): 返回数组的中位数。当元素个数为偶数时,返回中间两个值的平均值,并向零截断。
+
+#### 错误
+
+如果数组为空,则抛出 `RangeError`。

--- a/docs/zh_hans/reference/bigint/medianBy.md
+++ b/docs/zh_hans/reference/bigint/medianBy.md
@@ -1,0 +1,51 @@
+# medianBy (`BigInt`)
+
+返回函数从数组各元素中派生出的 `BigInt` 的中间值。
+
+```typescript
+const middle = medianBy(items, getValue);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `medianBy(items, getValue)`
+
+当您想要计算中位数的 `BigInt` 位于对象内部时,请使用 `medianBy`。传入一个从每个元素中取出该值的函数,它会计算该函数返回的所有值的中位数。
+
+```typescript
+import { medianBy } from 'es-toolkit/bigint';
+
+const accounts = [{ balance: 10n }, { balance: 30n }, { balance: 20n }];
+const middle = medianBy(accounts, account => account.balance);
+console.log(middle); // 20n
+```
+
+与 `median` 一样,当元素个数为偶数时会取中间两个值的平均值并向零截断,而空数组会抛出错误。
+
+```typescript
+import { medianBy } from 'es-toolkit/bigint';
+
+const payments = [{ amount: 1n }, { amount: 2n }, { amount: 3n }, { amount: 4n }];
+console.log(medianBy(payments, payment => payment.amount)); // 2n
+
+medianBy([], () => 0n); // RangeError: Cannot compute the median of an empty array.
+```
+
+#### 参数
+
+- `items` (`readonly T[]`): 要计算中位数的元素数组。
+- `getValue` (`(element: T) => bigint`): 为每个元素返回所用 `BigInt` 的函数。
+
+#### 返回值
+
+(`bigint`): 返回 `getValue` 返回的所有值的中位数。当元素个数为偶数时,返回中间两个值的平均值,并向零截断。
+
+#### 错误
+
+如果数组为空,则抛出 `RangeError`。

--- a/docs/zh_hans/reference/bigint/min.md
+++ b/docs/zh_hans/reference/bigint/min.md
@@ -1,0 +1,58 @@
+# min (`BigInt`)
+
+返回数组中最小的 `BigInt`。
+
+```typescript
+const smallest = min(numbers);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `min(nums)`
+
+当您想从多个 `BigInt` 中取出最小值时,请使用 `min`。`Math.min` 完全无法接受 `BigInt`,所以只能这样比较它们。
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+const smallest = min([1n, 5n, 3n]);
+console.log(smallest); // 1n
+
+// 对负数同样适用
+console.log(min([-5n, -1n, -3n])); // -5n
+```
+
+由于 `BigInt` 是精确比较的,那些用 `number` 会舍入成同一个值的数字仍然可以区分。
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+// 作为 `number`,这两个值都是 9007199254740992
+console.log(min([9007199254740993n, 9007199254740992n])); // 9007199254740992n
+```
+
+没有任何 `BigInt` 可以表示“没有最小值”,因为 `BigInt` 既没有 `NaN` 也没有 `Infinity`,所以空数组会抛出错误,而不是返回一个占位值。
+
+```typescript
+import { min } from 'es-toolkit/bigint';
+
+min([]); // RangeError: Cannot find the minimum of an empty array.
+```
+
+#### 参数
+
+- `nums` (`readonly bigint[]`): 要搜索的 `BigInt` 数组。
+
+#### 返回值
+
+(`bigint`): 返回数组中最小的 `BigInt`。
+
+#### 错误
+
+如果数组为空,则抛出 `RangeError`。

--- a/docs/zh_hans/reference/bigint/minBy.md
+++ b/docs/zh_hans/reference/bigint/minBy.md
@@ -1,0 +1,63 @@
+# minBy (`BigInt`)
+
+返回数组中派生出的 `BigInt` 值最小的元素。
+
+```typescript
+const smallest = minBy(items, getValue);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `minBy(items, getValue)`
+
+当您要比较的 `BigInt` 位于对象内部,并且想拿回整个对象而不仅仅是数字时,请使用 `minBy`。传入一个从每个元素中取出该值的函数。
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+const accounts = [
+  { owner: 'alice', balance: 10n },
+  { owner: 'bob', balance: 30n },
+  { owner: 'carol', balance: 20n },
+];
+
+const poorest = minBy(accounts, account => account.balance);
+console.log(poorest); // { owner: 'alice', balance: 10n }
+```
+
+当多个元素的最小值相同时,返回第一个。`getValue` 还会接收索引和整个数组。
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+const first = { id: 'a', score: 10n };
+const second = { id: 'b', score: 10n };
+console.log(minBy([first, second], item => item.score)); // { id: 'a', score: 10n }
+```
+
+空数组没有可返回的元素,所以会抛出错误。
+
+```typescript
+import { minBy } from 'es-toolkit/bigint';
+
+minBy([], () => 0n); // RangeError: Cannot find the minimum of an empty array.
+```
+
+#### 参数
+
+- `items` (`readonly T[]`): 要搜索的元素数组。
+- `getValue` (`(element: T, index: number, array: readonly T[]) => bigint`): 返回用于比较的 `BigInt` 的函数。
+
+#### 返回值
+
+(`T`): 返回派生出的 `BigInt` 最小的元素。如果有多个元素并列,则返回其中的第一个。
+
+#### 错误
+
+如果数组为空,则抛出 `RangeError`。

--- a/docs/zh_hans/reference/bigint/percentile.md
+++ b/docs/zh_hans/reference/bigint/percentile.md
@@ -1,0 +1,67 @@
+# percentile (`BigInt`)
+
+返回数组中位于给定百分位的 `BigInt`。
+
+```typescript
+const value = percentile(numbers, 90);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `percentile(arr, percentile)`
+
+当您想知道数据中有给定比例的值低于哪个值时(例如 p90 延迟),请使用 `percentile`。它会对数组的副本进行排序(您的数组保持不变),并取出对应排名上的值。
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+const latencies = [1n, 2n, 3n, 4n, 5n];
+
+console.log(percentile(latencies, 50)); // 3n
+console.log(percentile(latencies, 90)); // 5n
+
+// 数组不需要事先排序
+console.log(percentile([30n, 10n, 20n], 50)); // 20n
+```
+
+它使用[最近排名法](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method),所以结果始终是数组中已有的某个值。它从不在两个值之间进行插值,因此也就不需要进行舍入。
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+// 1n 和 2n 的中点是 1.5,任何 BigInt 都无法表示,
+// 因此返回的是最近排名上的值。
+console.log(percentile([1n, 2n], 50)); // 1n
+
+// 0 总是返回最小值,100 总是返回最大值
+console.log(percentile([5n, 1n, 3n], 0)); // 1n
+console.log(percentile([5n, 1n, 3n], 100)); // 5n
+```
+
+百分位本身是介于 `0` 和 `100` 之间的普通 `number`,而不是 `BigInt`,因为它是一个百分比,而不是被测量的数量。
+
+```typescript
+import { percentile } from 'es-toolkit/bigint';
+
+percentile([1n, 2n, 3n], 101); // Error: Expected percentile to be <= 100 but got "101".
+percentile([], 50); // RangeError: Cannot compute the percentile of an empty array.
+```
+
+#### 参数
+
+- `arr` (`readonly bigint[]`): 要计算百分位数的 `BigInt` 数组。
+- `percentile` (`number`): 要查询的百分位,介于 `0` 和 `100` 之间。
+
+#### 返回值
+
+(`bigint`): 返回位于给定百分位的 `BigInt`。始终是数组中已有的某个值。
+
+#### 错误
+
+如果 `percentile` 是 `NaN`、小于 `0` 或大于 `100`,则抛出错误。如果数组为空,则抛出 `RangeError`。

--- a/docs/zh_hans/reference/bigint/range.md
+++ b/docs/zh_hans/reference/bigint/range.md
@@ -1,0 +1,103 @@
+# range (`BigInt`)
+
+返回一个 `BigInt` 数组,从起始值开始计数,直到但不包括结束值。
+
+```typescript
+const numbers = range(end);
+const numbers = range(start, end);
+const numbers = range(start, end, step);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `range(end)`
+
+使用带一个参数的 `range`,从 `0n` 开始计数,直到但不包括结束值。
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(4n)); // [0n, 1n, 2n, 3n]
+console.log(range(0n)); // []
+```
+
+#### 参数
+
+- `end` (`bigint`): 范围的结束值(不包括)。
+
+#### 返回值
+
+(`bigint[]`): 返回从 `0n` 到但不包括 `end` 的 `BigInt` 数组。
+
+### `range(start, end)`
+
+使用带两个参数的 `range`,从指定的起始值而不是 `0n` 开始计数。
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(2n, 5n)); // [2n, 3n, 4n]
+console.log(range(-3n, 0n)); // [-3n, -2n, -1n]
+
+// 起始值和结束值相同时没有可计数的内容
+console.log(range(3n, 3n)); // []
+```
+
+由于 `BigInt` 在任何大小下都保持精确,您可以构建超过 `Number.MAX_SAFE_INTEGER` 的范围,而不会出现值悄悄重合的情况。
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(9007199254740993n, 9007199254740996n));
+// [9007199254740993n, 9007199254740994n, 9007199254740995n]
+```
+
+#### 参数
+
+- `start` (`bigint`): 范围的起始值(包括)。
+- `end` (`bigint`): 范围的结束值(不包括)。
+
+#### 返回值
+
+(`bigint[]`): 返回从 `start` 到但不包括 `end` 的 `BigInt` 数组。
+
+### `range(start, end, step)`
+
+使用带三个参数的 `range`,以 `1n` 以外的步长计数。负的步长表示递减计数。
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(0n, 10n, 2n)); // [0n, 2n, 4n, 6n, 8n]
+console.log(range(5n, 0n, -1n)); // [5n, 4n, 3n, 2n, 1n]
+console.log(range(5n, 0n, -2n)); // [5n, 3n, 1n]
+```
+
+如果步长的方向背离结束值,则没有可生成的内容,您会得到一个空数组。
+
+```typescript
+import { range } from 'es-toolkit/bigint';
+
+console.log(range(0n, 5n, -1n)); // []
+console.log(range(5n, 0n, 1n)); // []
+```
+
+#### 参数
+
+- `start` (`bigint`): 范围的起始值(包括)。
+- `end` (`bigint`): 范围的结束值(不包括)。
+- `step` (`bigint`, 可选): 计数的步长。默认为 `1n`。
+
+#### 返回值
+
+(`bigint[]`): 返回从 `start` 到但不包括 `end`、以 `step` 为步长计数的 `BigInt` 数组。
+
+#### 错误
+
+如果 `step` 为 `0n`,则抛出错误。

--- a/docs/zh_hans/reference/bigint/rangeRight.md
+++ b/docs/zh_hans/reference/bigint/rangeRight.md
@@ -1,0 +1,93 @@
+# rangeRight (`BigInt`)
+
+返回与 [range](./range.md) 相同的 `BigInt`,但按降序排列。
+
+```typescript
+const numbers = rangeRight(end);
+const numbers = rangeRight(start, end);
+const numbers = rangeRight(start, end, step);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `rangeRight(end)`
+
+使用带一个参数的 `rangeRight`,从刚好小于结束值的位置递减计数到 `0n`。
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(4n)); // [3n, 2n, 1n, 0n]
+console.log(rangeRight(0n)); // []
+```
+
+#### 参数
+
+- `end` (`bigint`): 范围的结束值(不包括)。
+
+#### 返回值
+
+(`bigint[]`): 返回从刚好小于 `end` 的值递减到 `0n` 的 `BigInt` 数组。
+
+### `rangeRight(start, end)`
+
+使用带两个参数的 `rangeRight`,递减计数到 `0n` 以外的起始值。
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(2n, 5n)); // [4n, 3n, 2n]
+console.log(rangeRight(-3n, 0n)); // [-1n, -2n, -3n]
+```
+
+#### 参数
+
+- `start` (`bigint`): 范围的起始值(包括)。
+- `end` (`bigint`): 范围的结束值(不包括)。
+
+#### 返回值
+
+(`bigint[]`): 返回从刚好小于 `end` 的值递减到 `start` 的 `BigInt` 数组。
+
+### `rangeRight(start, end, step)`
+
+使用带三个参数的 `rangeRight`,以 `1n` 以外的步长计数。其值与使用相同参数的 `range` 完全一致,只是顺序相反。
+
+```typescript
+import { range, rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(0n, 10n, 2n)); // [8n, 6n, 4n, 2n, 0n]
+console.log(rangeRight(5n, 0n, -1n)); // [1n, 2n, 3n, 4n, 5n]
+
+// 始终是使用相同参数的 range 的逆序
+console.log(rangeRight(0n, 10n, 3n)); // [9n, 6n, 3n, 0n]
+console.log(range(0n, 10n, 3n)); // [0n, 3n, 6n, 9n]
+```
+
+如果步长的方向背离结束值,则没有可生成的内容,您会得到一个空数组。
+
+```typescript
+import { rangeRight } from 'es-toolkit/bigint';
+
+console.log(rangeRight(0n, 5n, -1n)); // []
+```
+
+#### 参数
+
+- `start` (`bigint`): 范围的起始值(包括)。
+- `end` (`bigint`): 范围的结束值(不包括)。
+- `step` (`bigint`, 可选): 计数的步长。默认为 `1n`。
+
+#### 返回值
+
+(`bigint[]`): 按降序返回 `range(start, end, step)` 的值。
+
+#### 错误
+
+如果 `step` 为 `0n`,则抛出错误。

--- a/docs/zh_hans/reference/bigint/sum.md
+++ b/docs/zh_hans/reference/bigint/sum.md
@@ -1,0 +1,68 @@
+# sum (`BigInt`)
+
+返回 `BigInt` 数组中所有元素的总和。
+
+```typescript
+const total = sum(numbers);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `sum(nums)`
+
+当您想要计算 `BigInt` 的总和时,请使用 `sum`。它将数组中的所有元素相加并返回总和。
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+// 基本求和
+const numbers = [1n, 2n, 3n, 4n, 5n];
+const total = sum(numbers);
+console.log(total); // 15n
+
+// 负数和正数混合求和
+const values = [-10n, 5n, -3n, 8n];
+const result = sum(values);
+console.log(result); // 0n
+```
+
+空数组返回 `0n`,所以把数组拆开分别求和,结果与整体求和始终一致。
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+const empty = sum([]);
+console.log(empty); // 0n
+
+const first = [1n, 2n];
+const second = [3n, 4n];
+console.log(sum(first) + sum(second) === sum([...first, ...second])); // true
+```
+
+与 `number` 不同,无论数值多大 `BigInt` 都保持精确,因此非常适合表示以最小货币单位计的金额、代币数量或数据库标识符。
+
+```typescript
+import { sum } from 'es-toolkit/bigint';
+
+// 远远超过 Number.MAX_SAFE_INTEGER,仍然精确
+const balances = [9007199254740993n, 9007199254740993n];
+console.log(sum(balances)); // 18014398509481986n
+
+// 以最小货币单位存储的付款总额
+const paymentsInCents = [129999n, 4550n, 87500n];
+console.log(sum(paymentsInCents)); // 222049n
+```
+
+#### 参数
+
+- `nums` (`readonly bigint[]`): 要求和的 `BigInt` 数组。
+
+#### 返回值
+
+(`bigint`): 返回数组中所有 `BigInt` 的总和。对于空数组返回 `0n`。

--- a/docs/zh_hans/reference/bigint/sumBy.md
+++ b/docs/zh_hans/reference/bigint/sumBy.md
@@ -1,0 +1,52 @@
+# sumBy (`BigInt`)
+
+返回函数从数组各元素中派生出的 `BigInt` 的总和。
+
+```typescript
+const total = sumBy(items, getValue);
+```
+
+::: info
+
+此函数仅可从 `es-toolkit/bigint` 获得,以避免与其他数字类型的类似函数发生潜在冲突。
+
+:::
+
+## 用法
+
+### `sumBy(items, getValue)`
+
+当您想要相加的 `BigInt` 位于对象内部时,请使用 `sumBy`。传入一个从每个元素中取出该值的函数,它会把该函数返回的所有值相加。
+
+```typescript
+import { sumBy } from 'es-toolkit/bigint';
+
+// 对每个对象的某个字段求和
+const accounts = [{ balance: 10n }, { balance: 20n }, { balance: 30n }];
+const total = sumBy(accounts, account => account.balance);
+console.log(total); // 60n
+
+// 索引作为第二个参数传入
+const weights = sumBy(['a', 'b', 'c'], (_, index) => BigInt(index));
+console.log(weights); // 3n
+```
+
+空数组返回 `0n`,并且值可以为负数。
+
+```typescript
+import { sumBy } from 'es-toolkit/bigint';
+
+console.log(sumBy([], () => 1n)); // 0n
+
+const entries = [{ amount: -500n }, { amount: 1200n }, { amount: -200n }];
+console.log(sumBy(entries, entry => entry.amount)); // 500n
+```
+
+#### 参数
+
+- `items` (`readonly T[]`): 要求和的元素数组。
+- `getValue` (`(element: T, index: number) => bigint`): 为每个元素返回要相加的 `BigInt` 的函数。
+
+#### 返回值
+
+(`bigint`): 返回 `getValue` 返回的所有值的总和。对于空数组返回 `0n`。

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./array": "./src/array/index.ts",
+    "./bigint": "./src/bigint/index.ts",
     "./compat": "./src/compat/index.ts",
     "./error": "./src/error/index.ts",
     "./fp": "./src/fp/index.ts",
@@ -37,6 +38,7 @@
     "compat",
     "*.d.ts",
     "array.js",
+    "bigint.js",
     "compat.js",
     "error.js",
     "fp.js",
@@ -129,6 +131,16 @@
         "require": {
           "types": "./dist/array/index.d.ts",
           "default": "./dist/array/index.js"
+        }
+      },
+      "./bigint": {
+        "import": {
+          "types": "./dist/bigint/index.d.mts",
+          "default": "./dist/bigint/index.mjs"
+        },
+        "require": {
+          "types": "./dist/bigint/index.d.ts",
+          "default": "./dist/bigint/index.js"
         }
       },
       "./compat": {

--- a/src/_internal/bigIntRangeLength.ts
+++ b/src/_internal/bigIntRangeLength.ts
@@ -1,0 +1,20 @@
+/**
+ * Calculates how many elements a bigint range from `start` (inclusive) to `end` (exclusive) contains.
+ *
+ * This mirrors `Math.ceil((end - start) / step)` from the `number` implementations, but performs the
+ * ceiling division with bigint arithmetic. Returns `0` when `step` points away from `end`.
+ *
+ * @param start - The start of the range.
+ * @param end - The end of the range.
+ * @param step - A non-zero step value.
+ * @returns The number of elements in the range.
+ */
+export function bigIntRangeLength(start: bigint, end: bigint, step: bigint): number {
+  const difference = end - start;
+
+  if (step > 0n) {
+    return difference <= 0n ? 0 : Number((difference + step - 1n) / step);
+  }
+
+  return difference >= 0n ? 0 : Number((difference + step + 1n) / step);
+}

--- a/src/bigint/clamp.spec.ts
+++ b/src/bigint/clamp.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { clamp } from './clamp';
+
+describe('clamp', () => {
+  it('clamps to the maximum when called with two arguments', () => {
+    expect(clamp(10n, 5n)).toBe(5n);
+    expect(clamp(3n, 5n)).toBe(3n);
+  });
+
+  it('clamps to the minimum and maximum when called with three arguments', () => {
+    expect(clamp(10n, 0n, 5n)).toBe(5n);
+    expect(clamp(-10n, 0n, 5n)).toBe(0n);
+    expect(clamp(3n, 0n, 5n)).toBe(3n);
+  });
+
+  it('returns the bounds themselves when the value is on the edge', () => {
+    expect(clamp(0n, 0n, 5n)).toBe(0n);
+    expect(clamp(5n, 0n, 5n)).toBe(5n);
+  });
+
+  it('handles negative ranges', () => {
+    expect(clamp(-10n, -5n, -1n)).toBe(-5n);
+    expect(clamp(0n, -5n, -1n)).toBe(-1n);
+  });
+
+  it('stays exact beyond Number.MAX_SAFE_INTEGER', () => {
+    expect(clamp(9007199254740995n, 0n, 9007199254740993n)).toBe(9007199254740993n);
+  });
+});

--- a/src/bigint/clamp.ts
+++ b/src/bigint/clamp.ts
@@ -1,0 +1,53 @@
+/**
+ * Clamps a bigint within the inclusive lower and upper bounds.
+ *
+ * This function takes a bigint and returns it constrained to the given range. Unlike `Math.min` and
+ * `Math.max`, which cannot accept bigints, it compares values directly so large integers stay exact.
+ *
+ * @param value - The bigint to clamp.
+ * @param maximum - The upper bound to clamp to.
+ * @returns The clamped bigint.
+ *
+ * @example
+ * const result = clamp(10n, 5n);
+ * // result will be 5n, because 10n is greater than the maximum
+ */
+export function clamp(value: bigint, maximum: bigint): bigint;
+
+/**
+ * Clamps a bigint within the inclusive lower and upper bounds.
+ *
+ * This function takes a bigint and returns it constrained to the given range. Unlike `Math.min` and
+ * `Math.max`, which cannot accept bigints, it compares values directly so large integers stay exact.
+ *
+ * @param value - The bigint to clamp.
+ * @param minimum - The lower bound to clamp to.
+ * @param maximum - The upper bound to clamp to.
+ * @returns The clamped bigint.
+ *
+ * @example
+ * const result = clamp(10n, 0n, 5n);
+ * // result will be 5n, because 10n is greater than the maximum
+ *
+ * const result2 = clamp(-10n, 0n, 5n);
+ * // result2 will be 0n, because -10n is less than the minimum
+ */
+export function clamp(value: bigint, minimum: bigint, maximum: bigint): bigint;
+
+/**
+ * Clamps a bigint within the inclusive lower and upper bounds.
+ *
+ * @param value - The bigint to clamp.
+ * @param bound1 - The upper bound when called with two arguments, otherwise the lower bound.
+ * @param bound2 - The upper bound when called with three arguments.
+ * @returns The clamped bigint.
+ */
+export function clamp(value: bigint, bound1: bigint, bound2?: bigint): bigint {
+  if (bound2 == null) {
+    return value < bound1 ? value : bound1;
+  }
+
+  const lowerClamped = value > bound1 ? value : bound1;
+
+  return lowerClamped < bound2 ? lowerClamped : bound2;
+}

--- a/src/bigint/inRange.spec.ts
+++ b/src/bigint/inRange.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { inRange } from './inRange';
+
+describe('inRange', () => {
+  it('checks against [0n, maximum) when called with two arguments', () => {
+    expect(inRange(3n, 5n)).toBe(true);
+    expect(inRange(5n, 5n)).toBe(false);
+    expect(inRange(-1n, 5n)).toBe(false);
+  });
+
+  it('checks against [minimum, maximum) when called with three arguments', () => {
+    expect(inRange(5n, 0n, 10n)).toBe(true);
+    expect(inRange(0n, 0n, 10n)).toBe(true);
+    expect(inRange(10n, 0n, 10n)).toBe(false);
+  });
+
+  it('handles negative ranges', () => {
+    expect(inRange(-3n, -5n, -1n)).toBe(true);
+    expect(inRange(-5n, -5n, -1n)).toBe(true);
+    expect(inRange(-1n, -5n, -1n)).toBe(false);
+  });
+
+  it('stays exact beyond Number.MAX_SAFE_INTEGER', () => {
+    expect(inRange(9007199254740993n, 0n, 9007199254740994n)).toBe(true);
+    expect(inRange(9007199254740994n, 0n, 9007199254740994n)).toBe(false);
+  });
+
+  it('throws when the minimum is greater than or equal to the maximum', () => {
+    expect(() => inRange(3n, 5n, 5n)).toThrowError('The maximum value must be greater than the minimum value.');
+    expect(() => inRange(3n, 6n, 5n)).toThrowError('The maximum value must be greater than the minimum value.');
+  });
+});

--- a/src/bigint/inRange.ts
+++ b/src/bigint/inRange.ts
@@ -1,0 +1,57 @@
+/**
+ * Checks whether a bigint is within a range.
+ *
+ * The lower bound is inclusive and the upper bound is exclusive, so `inRange(5n, 0n, 5n)` is `false`.
+ *
+ * @param value - The bigint to check.
+ * @param maximum - The exclusive upper bound. The lower bound defaults to `0n`.
+ * @returns `true` if the bigint is within the range, `false` otherwise.
+ * @throws {Error} If the minimum is greater than or equal to the maximum.
+ *
+ * @example
+ * const result = inRange(3n, 5n);
+ * // result will be true, because 3n is within [0n, 5n)
+ */
+export function inRange(value: bigint, maximum: bigint): boolean;
+
+/**
+ * Checks whether a bigint is within a range.
+ *
+ * The lower bound is inclusive and the upper bound is exclusive, so `inRange(5n, 0n, 5n)` is `false`.
+ *
+ * @param value - The bigint to check.
+ * @param minimum - The inclusive lower bound.
+ * @param maximum - The exclusive upper bound.
+ * @returns `true` if the bigint is within the range, `false` otherwise.
+ * @throws {Error} If the minimum is greater than or equal to the maximum.
+ *
+ * @example
+ * const result = inRange(5n, 0n, 10n);
+ * // result will be true
+ *
+ * const result2 = inRange(10n, 0n, 10n);
+ * // result2 will be false, because the upper bound is exclusive
+ */
+export function inRange(value: bigint, minimum: bigint, maximum: bigint): boolean;
+
+/**
+ * Checks whether a bigint is within a range.
+ *
+ * @param value - The bigint to check.
+ * @param minimum - The exclusive upper bound when called with two arguments, otherwise the inclusive lower bound.
+ * @param maximum - The exclusive upper bound when called with three arguments.
+ * @returns `true` if the bigint is within the range, `false` otherwise.
+ * @throws {Error} If the minimum is greater than or equal to the maximum.
+ */
+export function inRange(value: bigint, minimum: bigint, maximum?: bigint): boolean {
+  if (maximum == null) {
+    maximum = minimum;
+    minimum = 0n;
+  }
+
+  if (minimum >= maximum) {
+    throw new Error('The maximum value must be greater than the minimum value.');
+  }
+
+  return minimum <= value && value < maximum;
+}

--- a/src/bigint/index.ts
+++ b/src/bigint/index.ts
@@ -1,0 +1,13 @@
+export { clamp } from './clamp.ts';
+export { inRange } from './inRange.ts';
+export { max } from './max.ts';
+export { maxBy } from './maxBy.ts';
+export { median } from './median.ts';
+export { medianBy } from './medianBy.ts';
+export { min } from './min.ts';
+export { minBy } from './minBy.ts';
+export { percentile } from './percentile.ts';
+export { range } from './range.ts';
+export { rangeRight } from './rangeRight.ts';
+export { sum } from './sum.ts';
+export { sumBy } from './sumBy.ts';

--- a/src/bigint/max.spec.ts
+++ b/src/bigint/max.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { max } from './max';
+
+describe('max', () => {
+  it('returns the largest bigint', () => {
+    expect(max([1n, 5n, 3n])).toBe(5n);
+  });
+
+  it('returns the only element of a single-element array', () => {
+    expect(max([42n])).toBe(42n);
+  });
+
+  it('handles negative bigints', () => {
+    expect(max([-5n, -1n, -3n])).toBe(-1n);
+  });
+
+  it('distinguishes values beyond Number.MAX_SAFE_INTEGER', () => {
+    expect(max([9007199254740992n, 9007199254740993n])).toBe(9007199254740993n);
+  });
+
+  it('throws a RangeError for an empty array', () => {
+    expect(() => max([])).toThrowError(new RangeError('Cannot find the maximum of an empty array.'));
+  });
+});

--- a/src/bigint/max.ts
+++ b/src/bigint/max.ts
@@ -1,0 +1,32 @@
+/**
+ * Finds the largest bigint in an array.
+ *
+ * This function iterates through the array and returns the largest element. Unlike `Math.max`,
+ * which cannot accept bigints, it compares values directly so arbitrarily large integers stay exact.
+ *
+ * @param nums - An array of bigints to search.
+ * @returns The largest bigint in the array.
+ * @throws {RangeError} If the array is empty, since there is no bigint that represents "no maximum".
+ *
+ * @example
+ * const result = max([1n, 5n, 3n]);
+ * // result will be 5n
+ *
+ * const huge = max([9007199254740993n, 9007199254740992n]);
+ * // huge will be 9007199254740993n, a value `Math.max` cannot distinguish
+ */
+export function max(nums: readonly bigint[]): bigint {
+  if (nums.length === 0) {
+    throw new RangeError('Cannot find the maximum of an empty array.');
+  }
+
+  let result = nums[0];
+
+  for (let i = 1; i < nums.length; i++) {
+    if (nums[i] > result) {
+      result = nums[i];
+    }
+  }
+
+  return result;
+}

--- a/src/bigint/maxBy.spec.ts
+++ b/src/bigint/maxBy.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { maxBy } from './maxBy';
+
+describe('maxBy', () => {
+  it('returns the element with the largest mapped bigint', () => {
+    const accounts = [{ balance: 10n }, { balance: 30n }, { balance: 20n }];
+
+    expect(maxBy(accounts, account => account.balance)).toEqual({ balance: 30n });
+  });
+
+  it('returns the first element when several tie', () => {
+    const first = { balance: 30n };
+    const second = { balance: 30n };
+
+    expect(maxBy([first, second], account => account.balance)).toBe(first);
+  });
+
+  it('passes the index and array to getValue', () => {
+    const items = ['a', 'b', 'c'];
+    const seen: Array<[string, number, readonly string[]]> = [];
+
+    maxBy(items, (element, index, array) => {
+      seen.push([element, index, array]);
+      return BigInt(index);
+    });
+
+    expect(seen).toEqual([
+      ['a', 0, items],
+      ['b', 1, items],
+      ['c', 2, items],
+    ]);
+  });
+
+  it('throws a RangeError for an empty array', () => {
+    expect(() => maxBy([], () => 0n)).toThrowError(new RangeError('Cannot find the maximum of an empty array.'));
+  });
+});

--- a/src/bigint/maxBy.ts
+++ b/src/bigint/maxBy.ts
@@ -1,0 +1,37 @@
+/**
+ * Finds the element in an array that has the largest bigint value returned by `getValue`.
+ *
+ * This function maps every element to a bigint and returns the element with the largest value.
+ * If several elements tie, the first one is returned.
+ *
+ * @template T - The type of elements in the array.
+ * @param items - An array of elements to search.
+ * @param getValue - A function that maps an element to the bigint to compare by.
+ * @returns The element with the largest mapped bigint.
+ * @throws {RangeError} If the array is empty, since there is no element to return.
+ *
+ * @example
+ * const accounts = [{ balance: 10n }, { balance: 30n }, { balance: 20n }];
+ * const result = maxBy(accounts, account => account.balance);
+ * // result will be { balance: 30n }
+ */
+export function maxBy<T>(items: readonly T[], getValue: (element: T, index: number, array: readonly T[]) => bigint): T {
+  if (items.length === 0) {
+    throw new RangeError('Cannot find the maximum of an empty array.');
+  }
+
+  let maxElement = items[0];
+  let max = getValue(items[0], 0, items);
+
+  for (let i = 1; i < items.length; i++) {
+    const element = items[i];
+    const value = getValue(element, i, items);
+
+    if (value > max) {
+      max = value;
+      maxElement = element;
+    }
+  }
+
+  return maxElement;
+}

--- a/src/bigint/median.spec.ts
+++ b/src/bigint/median.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { median } from './median';
+
+describe('median', () => {
+  it('returns the middle value for an odd-length array', () => {
+    expect(median([1n, 2n, 3n, 4n, 5n])).toBe(3n);
+  });
+
+  it('sorts the array before picking the middle value', () => {
+    expect(median([5n, 1n, 4n, 2n, 3n])).toBe(3n);
+  });
+
+  it('does not mutate the input array', () => {
+    const nums = [5n, 1n, 3n];
+    median(nums);
+
+    expect(nums).toEqual([5n, 1n, 3n]);
+  });
+
+  it('truncates the average toward zero for an even-length array', () => {
+    expect(median([1n, 2n, 3n, 4n])).toBe(2n);
+    expect(median([1n, 2n])).toBe(1n);
+  });
+
+  it('truncates toward zero for negative bigints', () => {
+    expect(median([-3n, -2n])).toBe(-2n);
+  });
+
+  it('returns the only element of a single-element array', () => {
+    expect(median([42n])).toBe(42n);
+  });
+
+  it('stays exact beyond Number.MAX_SAFE_INTEGER', () => {
+    expect(median([9007199254740993n, 9007199254740995n])).toBe(9007199254740994n);
+  });
+
+  it('throws a RangeError for an empty array', () => {
+    expect(() => median([])).toThrowError(new RangeError('Cannot compute the median of an empty array.'));
+  });
+});

--- a/src/bigint/median.ts
+++ b/src/bigint/median.ts
@@ -1,0 +1,32 @@
+/**
+ * Calculates the median of an array of bigints.
+ *
+ * The median is the middle value of a sorted array. When the array has an even number of elements,
+ * the two middle values are averaged. Because bigints have no fractional part, that average is
+ * truncated toward zero: `median([1n, 2n])` is `1n` and `median([-3n, -2n])` is `-2n`.
+ *
+ * @param nums - An array of bigints to calculate the median of.
+ * @returns The median of the array.
+ * @throws {RangeError} If the array is empty, since there is no bigint that represents "no median".
+ *
+ * @example
+ * const result = median([1n, 2n, 3n, 4n, 5n]);
+ * // result will be 3n
+ *
+ * const truncated = median([1n, 2n, 3n, 4n]);
+ * // truncated will be 2n, because (2n + 3n) / 2n truncates toward zero
+ */
+export function median(nums: readonly bigint[]): bigint {
+  if (nums.length === 0) {
+    throw new RangeError('Cannot compute the median of an empty array.');
+  }
+
+  const sorted = nums.slice().sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const middleIndex = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 0) {
+    return (sorted[middleIndex - 1] + sorted[middleIndex]) / 2n;
+  }
+
+  return sorted[middleIndex];
+}

--- a/src/bigint/medianBy.spec.ts
+++ b/src/bigint/medianBy.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { medianBy } from './medianBy';
+
+describe('medianBy', () => {
+  it('returns the median of the mapped bigints', () => {
+    const accounts = [{ balance: 10n }, { balance: 30n }, { balance: 20n }];
+
+    expect(medianBy(accounts, account => account.balance)).toBe(20n);
+  });
+
+  it('truncates the average toward zero for an even-length array', () => {
+    const accounts = [{ balance: 1n }, { balance: 2n }, { balance: 3n }, { balance: 4n }];
+
+    expect(medianBy(accounts, account => account.balance)).toBe(2n);
+  });
+
+  it('throws a RangeError for an empty array', () => {
+    expect(() => medianBy([], () => 0n)).toThrowError(new RangeError('Cannot compute the median of an empty array.'));
+  });
+});

--- a/src/bigint/medianBy.ts
+++ b/src/bigint/medianBy.ts
@@ -1,0 +1,22 @@
+import { median } from './median.ts';
+
+/**
+ * Calculates the median of an array by mapping each element to a bigint.
+ *
+ * This function maps every element to a bigint and returns the median of those values. Because
+ * bigints have no fractional part, the average taken for even-length arrays is truncated toward zero.
+ *
+ * @template T - The type of elements in the array.
+ * @param items - An array of elements to calculate the median of.
+ * @param getValue - A function that maps an element to the bigint to use.
+ * @returns The median of the mapped bigints.
+ * @throws {RangeError} If the array is empty, since there is no bigint that represents "no median".
+ *
+ * @example
+ * const accounts = [{ balance: 10n }, { balance: 30n }, { balance: 20n }];
+ * const result = medianBy(accounts, account => account.balance);
+ * // result will be 20n
+ */
+export function medianBy<T>(items: readonly T[], getValue: (element: T) => bigint): bigint {
+  return median(items.map(item => getValue(item)));
+}

--- a/src/bigint/min.spec.ts
+++ b/src/bigint/min.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { min } from './min';
+
+describe('min', () => {
+  it('returns the smallest bigint', () => {
+    expect(min([1n, 5n, 3n])).toBe(1n);
+  });
+
+  it('returns the only element of a single-element array', () => {
+    expect(min([42n])).toBe(42n);
+  });
+
+  it('handles negative bigints', () => {
+    expect(min([-5n, -1n, -3n])).toBe(-5n);
+  });
+
+  it('distinguishes values beyond Number.MAX_SAFE_INTEGER', () => {
+    expect(min([9007199254740993n, 9007199254740992n])).toBe(9007199254740992n);
+  });
+
+  it('throws a RangeError for an empty array', () => {
+    expect(() => min([])).toThrowError(new RangeError('Cannot find the minimum of an empty array.'));
+  });
+});

--- a/src/bigint/min.ts
+++ b/src/bigint/min.ts
@@ -1,0 +1,29 @@
+/**
+ * Finds the smallest bigint in an array.
+ *
+ * This function iterates through the array and returns the smallest element. Unlike `Math.min`,
+ * which cannot accept bigints, it compares values directly so arbitrarily large integers stay exact.
+ *
+ * @param nums - An array of bigints to search.
+ * @returns The smallest bigint in the array.
+ * @throws {RangeError} If the array is empty, since there is no bigint that represents "no minimum".
+ *
+ * @example
+ * const result = min([1n, 5n, 3n]);
+ * // result will be 1n
+ */
+export function min(nums: readonly bigint[]): bigint {
+  if (nums.length === 0) {
+    throw new RangeError('Cannot find the minimum of an empty array.');
+  }
+
+  let result = nums[0];
+
+  for (let i = 1; i < nums.length; i++) {
+    if (nums[i] < result) {
+      result = nums[i];
+    }
+  }
+
+  return result;
+}

--- a/src/bigint/minBy.spec.ts
+++ b/src/bigint/minBy.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { minBy } from './minBy';
+
+describe('minBy', () => {
+  it('returns the element with the smallest mapped bigint', () => {
+    const accounts = [{ balance: 10n }, { balance: 30n }, { balance: 20n }];
+
+    expect(minBy(accounts, account => account.balance)).toEqual({ balance: 10n });
+  });
+
+  it('returns the first element when several tie', () => {
+    const first = { balance: 10n };
+    const second = { balance: 10n };
+
+    expect(minBy([first, second], account => account.balance)).toBe(first);
+  });
+
+  it('throws a RangeError for an empty array', () => {
+    expect(() => minBy([], () => 0n)).toThrowError(new RangeError('Cannot find the minimum of an empty array.'));
+  });
+});

--- a/src/bigint/minBy.ts
+++ b/src/bigint/minBy.ts
@@ -1,0 +1,37 @@
+/**
+ * Finds the element in an array that has the smallest bigint value returned by `getValue`.
+ *
+ * This function maps every element to a bigint and returns the element with the smallest value.
+ * If several elements tie, the first one is returned.
+ *
+ * @template T - The type of elements in the array.
+ * @param items - An array of elements to search.
+ * @param getValue - A function that maps an element to the bigint to compare by.
+ * @returns The element with the smallest mapped bigint.
+ * @throws {RangeError} If the array is empty, since there is no element to return.
+ *
+ * @example
+ * const accounts = [{ balance: 10n }, { balance: 30n }, { balance: 20n }];
+ * const result = minBy(accounts, account => account.balance);
+ * // result will be { balance: 10n }
+ */
+export function minBy<T>(items: readonly T[], getValue: (element: T, index: number, array: readonly T[]) => bigint): T {
+  if (items.length === 0) {
+    throw new RangeError('Cannot find the minimum of an empty array.');
+  }
+
+  let minElement = items[0];
+  let min = getValue(items[0], 0, items);
+
+  for (let i = 1; i < items.length; i++) {
+    const element = items[i];
+    const value = getValue(element, i, items);
+
+    if (value < min) {
+      min = value;
+      minElement = element;
+    }
+  }
+
+  return minElement;
+}

--- a/src/bigint/percentile.spec.ts
+++ b/src/bigint/percentile.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { percentile } from './percentile';
+
+describe('percentile', () => {
+  it('returns the value at the given percentile', () => {
+    expect(percentile([1n, 2n, 3n, 4n, 5n], 50)).toBe(3n);
+    expect(percentile([1n, 2n, 3n, 4n, 5n], 90)).toBe(5n);
+  });
+
+  it('returns the smallest value for the 0th percentile', () => {
+    expect(percentile([5n, 1n, 3n], 0)).toBe(1n);
+  });
+
+  it('returns the largest value for the 100th percentile', () => {
+    expect(percentile([5n, 1n, 3n], 100)).toBe(5n);
+  });
+
+  it('sorts the array before looking up the rank', () => {
+    expect(percentile([30n, 10n, 20n], 50)).toBe(20n);
+  });
+
+  it('does not mutate the input array', () => {
+    const nums = [30n, 10n, 20n];
+    percentile(nums, 50);
+
+    expect(nums).toEqual([30n, 10n, 20n]);
+  });
+
+  it('never interpolates between values', () => {
+    expect(percentile([1n, 2n], 50)).toBe(1n);
+  });
+
+  it('throws for a percentile below 0', () => {
+    expect(() => percentile([1n], -1)).toThrowError('Expected percentile to be >= 0 but got "-1".');
+  });
+
+  it('throws for a percentile above 100', () => {
+    expect(() => percentile([1n], 101)).toThrowError('Expected percentile to be <= 100 but got "101".');
+  });
+
+  it('throws for a NaN percentile', () => {
+    expect(() => percentile([1n], NaN)).toThrowError('Expected percentile to be a number but got "NaN".');
+  });
+
+  it('throws a RangeError for an empty array', () => {
+    expect(() => percentile([], 50)).toThrowError(new RangeError('Cannot compute the percentile of an empty array.'));
+  });
+});

--- a/src/bigint/percentile.ts
+++ b/src/bigint/percentile.ts
@@ -1,0 +1,46 @@
+/**
+ * Calculates the value at a given percentile in an array of bigints.
+ *
+ * This function uses the [nearest-rank method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method),
+ * so it always returns one of the values that is already in the array and never interpolates between them.
+ *
+ * @param arr - An array of bigints to calculate the percentile of.
+ * @param percentile - The percentile to look up, as a number between `0` and `100`.
+ * @returns The bigint at the given percentile.
+ * @throws {Error} If `percentile` is not a number between `0` and `100`.
+ * @throws {RangeError} If the array is empty, since there is no bigint to return.
+ *
+ * @example
+ * const result = percentile([1n, 2n, 3n, 4n, 5n], 50);
+ * // result will be 3n
+ *
+ * const p90 = percentile([1n, 2n, 3n, 4n, 5n], 90);
+ * // p90 will be 5n
+ */
+export function percentile(arr: readonly bigint[], percentile: number): bigint {
+  if (Number.isNaN(Number(percentile))) {
+    throw new Error(`Expected percentile to be a number but got "${percentile}".`);
+  }
+
+  if (percentile < 0) {
+    throw new Error(`Expected percentile to be >= 0 but got "${percentile}".`);
+  }
+
+  if (percentile > 100) {
+    throw new Error(`Expected percentile to be <= 100 but got "${percentile}".`);
+  }
+
+  if (arr.length === 0) {
+    throw new RangeError('Cannot compute the percentile of an empty array.');
+  }
+
+  const sorted = arr.slice().sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+  if (percentile === 0) {
+    return sorted[0];
+  }
+
+  const index = Math.ceil(sorted.length * (percentile / 100)) - 1;
+
+  return sorted[index];
+}

--- a/src/bigint/range.spec.ts
+++ b/src/bigint/range.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { range } from './range';
+
+describe('range', () => {
+  it('counts from 0n when called with one argument', () => {
+    expect(range(4n)).toEqual([0n, 1n, 2n, 3n]);
+  });
+
+  it('counts from start to end when called with two arguments', () => {
+    expect(range(2n, 5n)).toEqual([2n, 3n, 4n]);
+  });
+
+  it('increments by step', () => {
+    expect(range(0n, 10n, 2n)).toEqual([0n, 2n, 4n, 6n, 8n]);
+    expect(range(0n, 5n, 2n)).toEqual([0n, 2n, 4n]);
+  });
+
+  it('counts down for a negative step', () => {
+    expect(range(5n, 0n, -1n)).toEqual([5n, 4n, 3n, 2n, 1n]);
+    expect(range(5n, 0n, -2n)).toEqual([5n, 3n, 1n]);
+  });
+
+  it('returns an empty array when the step points away from end', () => {
+    expect(range(0n, 5n, -1n)).toEqual([]);
+    expect(range(5n, 0n, 1n)).toEqual([]);
+  });
+
+  it('returns an empty array when start equals end', () => {
+    expect(range(3n, 3n)).toEqual([]);
+  });
+
+  it('handles negative ranges', () => {
+    expect(range(-3n, 0n)).toEqual([-3n, -2n, -1n]);
+  });
+
+  it('stays exact beyond Number.MAX_SAFE_INTEGER', () => {
+    expect(range(9007199254740993n, 9007199254740996n)).toEqual([
+      9007199254740993n,
+      9007199254740994n,
+      9007199254740995n,
+    ]);
+  });
+
+  it('throws when the step is 0n', () => {
+    expect(() => range(0n, 5n, 0n)).toThrowError('The step value must be a non-zero bigint.');
+  });
+});

--- a/src/bigint/range.ts
+++ b/src/bigint/range.ts
@@ -1,0 +1,75 @@
+import { bigIntRangeLength } from '../_internal/bigIntRangeLength.ts';
+
+/**
+ * Returns an array of bigints from `0n` up to, but not including, `end`.
+ *
+ * @param end - The exclusive end of the range.
+ * @returns An array of bigints.
+ *
+ * @example
+ * const result = range(4n);
+ * // result will be [0n, 1n, 2n, 3n]
+ */
+export function range(end: bigint): bigint[];
+
+/**
+ * Returns an array of bigints from `start` up to, but not including, `end`.
+ *
+ * @param start - The inclusive start of the range.
+ * @param end - The exclusive end of the range.
+ * @returns An array of bigints.
+ *
+ * @example
+ * const result = range(2n, 5n);
+ * // result will be [2n, 3n, 4n]
+ */
+export function range(start: bigint, end: bigint): bigint[];
+
+/**
+ * Returns an array of bigints from `start` up to, but not including, `end`, incrementing by `step`.
+ *
+ * A negative `step` counts down. If `step` points away from `end`, an empty array is returned.
+ *
+ * @param start - The inclusive start of the range.
+ * @param end - The exclusive end of the range.
+ * @param step - The amount to increment by. Must not be `0n`.
+ * @returns An array of bigints.
+ * @throws {Error} If `step` is `0n`.
+ *
+ * @example
+ * const result = range(0n, 10n, 2n);
+ * // result will be [0n, 2n, 4n, 6n, 8n]
+ *
+ * const countdown = range(5n, 0n, -1n);
+ * // countdown will be [5n, 4n, 3n, 2n, 1n]
+ */
+export function range(start: bigint, end: bigint, step: bigint): bigint[];
+
+/**
+ * Returns an array of bigints from `start` up to, but not including, `end`, incrementing by `step`.
+ *
+ * @param start - The exclusive end of the range when called with one argument, otherwise the inclusive start.
+ * @param end - The exclusive end of the range.
+ * @param step - The amount to increment by. Must not be `0n`.
+ * @returns An array of bigints.
+ * @throws {Error} If `step` is `0n`.
+ */
+export function range(start: bigint, end?: bigint, step = 1n): bigint[] {
+  if (end == null) {
+    end = start;
+    start = 0n;
+  }
+
+  if (step === 0n) {
+    throw new Error('The step value must be a non-zero bigint.');
+  }
+
+  const length = bigIntRangeLength(start, end, step);
+  const result = new Array<bigint>(length);
+
+  for (let i = 0; i < length; i++) {
+    result[i] = start + BigInt(i) * step;
+  }
+
+  return result;
+}

--- a/src/bigint/rangeRight.spec.ts
+++ b/src/bigint/rangeRight.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { rangeRight } from './rangeRight';
+
+describe('rangeRight', () => {
+  it('counts down from end when called with one argument', () => {
+    expect(rangeRight(4n)).toEqual([3n, 2n, 1n, 0n]);
+  });
+
+  it('counts down from end to start when called with two arguments', () => {
+    expect(rangeRight(2n, 5n)).toEqual([4n, 3n, 2n]);
+  });
+
+  it('increments by step', () => {
+    expect(rangeRight(0n, 10n, 2n)).toEqual([8n, 6n, 4n, 2n, 0n]);
+  });
+
+  it('handles a negative step', () => {
+    expect(rangeRight(5n, 0n, -1n)).toEqual([1n, 2n, 3n, 4n, 5n]);
+  });
+
+  it('returns an empty array when the step points away from end', () => {
+    expect(rangeRight(0n, 5n, -1n)).toEqual([]);
+  });
+
+  it('returns the reverse of range', () => {
+    expect(rangeRight(0n, 10n, 3n)).toEqual(range(0n, 10n, 3n).reverse());
+  });
+
+  it('throws when the step is 0n', () => {
+    expect(() => rangeRight(0n, 5n, 0n)).toThrowError('The step value must be a non-zero bigint.');
+  });
+});
+
+function range(start: bigint, end: bigint, step: bigint): bigint[] {
+  const result: bigint[] = [];
+
+  for (let value = start; value < end; value += step) {
+    result.push(value);
+  }
+
+  return result;
+}

--- a/src/bigint/rangeRight.ts
+++ b/src/bigint/rangeRight.ts
@@ -1,0 +1,74 @@
+import { bigIntRangeLength } from '../_internal/bigIntRangeLength.ts';
+
+/**
+ * Returns an array of bigints from `0n` up to, but not including, `end`, in descending order.
+ *
+ * @param end - The exclusive end of the range.
+ * @returns An array of bigints.
+ *
+ * @example
+ * const result = rangeRight(4n);
+ * // result will be [3n, 2n, 1n, 0n]
+ */
+export function rangeRight(end: bigint): bigint[];
+
+/**
+ * Returns an array of bigints from `start` up to, but not including, `end`, in descending order.
+ *
+ * @param start - The inclusive start of the range.
+ * @param end - The exclusive end of the range.
+ * @returns An array of bigints.
+ *
+ * @example
+ * const result = rangeRight(2n, 5n);
+ * // result will be [4n, 3n, 2n]
+ */
+export function rangeRight(start: bigint, end: bigint): bigint[];
+
+/**
+ * Returns an array of bigints from `start` up to, but not including, `end`, incrementing by `step`,
+ * in descending order.
+ *
+ * A negative `step` counts down. If `step` points away from `end`, an empty array is returned.
+ *
+ * @param start - The inclusive start of the range.
+ * @param end - The exclusive end of the range.
+ * @param step - The amount to increment by. Must not be `0n`.
+ * @returns An array of bigints.
+ * @throws {Error} If `step` is `0n`.
+ *
+ * @example
+ * const result = rangeRight(0n, 10n, 2n);
+ * // result will be [8n, 6n, 4n, 2n, 0n]
+ */
+export function rangeRight(start: bigint, end: bigint, step: bigint): bigint[];
+
+/**
+ * Returns an array of bigints from `start` up to, but not including, `end`, incrementing by `step`,
+ * in descending order.
+ *
+ * @param start - The exclusive end of the range when called with one argument, otherwise the inclusive start.
+ * @param end - The exclusive end of the range.
+ * @param step - The amount to increment by. Must not be `0n`.
+ * @returns An array of bigints.
+ * @throws {Error} If `step` is `0n`.
+ */
+export function rangeRight(start: bigint, end?: bigint, step = 1n): bigint[] {
+  if (end == null) {
+    end = start;
+    start = 0n;
+  }
+
+  if (step === 0n) {
+    throw new Error('The step value must be a non-zero bigint.');
+  }
+
+  const length = bigIntRangeLength(start, end, step);
+  const result = new Array<bigint>(length);
+
+  for (let i = 0; i < length; i++) {
+    result[i] = start + BigInt(length - i - 1) * step;
+  }
+
+  return result;
+}

--- a/src/bigint/sum.spec.ts
+++ b/src/bigint/sum.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { sum } from './sum';
+
+describe('sum', () => {
+  it('calculates the sum of an array of bigints', () => {
+    expect(sum([1n, 2n, 3n, 4n])).toBe(10n);
+  });
+
+  it('returns 0n for an empty array', () => {
+    expect(sum([])).toBe(0n);
+  });
+
+  it('handles arrays with negative bigints', () => {
+    expect(sum([-1n, -2n, -3n, 4n])).toBe(-2n);
+  });
+
+  it('stays exact beyond Number.MAX_SAFE_INTEGER', () => {
+    expect(sum([9007199254740993n, 9007199254740993n])).toBe(18014398509481986n);
+  });
+
+  it('ensures that adding the sums of two arrays equals the sum of their concatenation', () => {
+    const array1: bigint[] = [];
+    const array2 = [1n, 2n, 3n, 4n];
+
+    expect(sum(array1) + sum(array2)).toBe(sum([...array1, ...array2]));
+  });
+});

--- a/src/bigint/sum.ts
+++ b/src/bigint/sum.ts
@@ -1,0 +1,23 @@
+/**
+ * Calculates the sum of an array of bigints.
+ *
+ * This function takes an array of bigints and returns the sum of all the elements in the array.
+ * An empty array returns `0n`, so `sum(a) + sum(b)` always equals `sum([...a, ...b])`.
+ *
+ * @param nums - An array of bigints to be summed.
+ * @returns The sum of all the bigints in the array. Returns `0n` for an empty array.
+ *
+ * @example
+ * const numbers = [1n, 2n, 3n, 4n, 5n];
+ * const result = sum(numbers);
+ * // result will be 15n
+ */
+export function sum(nums: readonly bigint[]): bigint {
+  let result = 0n;
+
+  for (let i = 0; i < nums.length; i++) {
+    result += nums[i];
+  }
+
+  return result;
+}

--- a/src/bigint/sumBy.spec.ts
+++ b/src/bigint/sumBy.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { sumBy } from './sumBy';
+
+describe('sumBy', () => {
+  it('calculates the sum of the mapped bigints', () => {
+    const accounts = [{ balance: 10n }, { balance: 20n }, { balance: 30n }];
+
+    expect(sumBy(accounts, account => account.balance)).toBe(60n);
+  });
+
+  it('returns 0n for an empty array', () => {
+    expect(sumBy([], () => 1n)).toBe(0n);
+  });
+
+  it('passes the index to getValue', () => {
+    expect(sumBy(['a', 'b', 'c'], (_, index) => BigInt(index))).toBe(3n);
+  });
+
+  it('handles negative bigints', () => {
+    expect(sumBy([{ value: -5n }, { value: 3n }], item => item.value)).toBe(-2n);
+  });
+});

--- a/src/bigint/sumBy.ts
+++ b/src/bigint/sumBy.ts
@@ -1,0 +1,25 @@
+/**
+ * Calculates the sum of an array by mapping each element to a bigint.
+ *
+ * This function takes an array and a function that maps each element to a bigint,
+ * and returns the sum of the mapped values. An empty array returns `0n`.
+ *
+ * @template T - The type of elements in the array.
+ * @param items - An array of elements to be summed.
+ * @param getValue - A function that maps an element to the bigint to add.
+ * @returns The sum of the mapped bigints. Returns `0n` for an empty array.
+ *
+ * @example
+ * const items = [{ balance: 10n }, { balance: 20n }, { balance: 30n }];
+ * const result = sumBy(items, item => item.balance);
+ * // result will be 60n
+ */
+export function sumBy<T>(items: readonly T[], getValue: (element: T, index: number) => bigint): bigint {
+  let result = 0n;
+
+  for (let i = 0; i < items.length; i++) {
+    result += getValue(items[i], i);
+  }
+
+  return result;
+}

--- a/tests/check-dist.spec.ts
+++ b/tests/check-dist.spec.ts
@@ -23,6 +23,7 @@ async function getPackageJsonOfTarball(tarballPath: string) {
 const ENTRYPOINTS = [
   '.',
   './array',
+  './bigint',
   './compat',
   './compat/*',
   './server',


### PR DESCRIPTION
## Overview

Adds a new `es-toolkit/bigint` entry point.

```ts
import { sum } from 'es-toolkit/bigint';

sum([1n, 2n, 3n]); // 6n
```

Closes #1588. Refs #742.

## Motivation

Requests to make the `number`-oriented math functions accept `bigint` have come up repeatedly, and both attempts to add overloads were turned down for good reasons:

- **#766 (`sum`)** — an empty array cannot decide between `0` and `0n`, which breaks `sum(a) + sum(b) === sum([...a, ...b])`.
- **#1649 (`median`)** — a runtime `typeof` branch puts `bigint` handling on the hot path of a `number` function for a fairly niche case.

A separate entry point resolves both: the empty-array ambiguity disappears (`sum([])` is unambiguously `0n`), and no existing `number` implementation changes. This follows the direction laid out in #1588 and #1649.

## What's included

Thirteen functions, all **subpath-only** — `src/index.ts` is untouched, matching how `es-toolkit/map` and `es-toolkit/set` avoid name collisions.

| Group | Functions | Empty array |
| --- | --- | --- |
| Sum | `sum`, `sumBy` | returns `0n` |
| Extremes | `max`, `min`, `maxBy`, `minBy` | throws `RangeError` |
| Median / percentile | `median`, `medianBy`, `percentile` | throws `RangeError` |
| Range / bounds | `clamp`, `inRange`, `range`, `rangeRight` | n/a |

`max`/`min` have no `number` counterpart because `Math.max`/`Math.min` cover that case — but neither accepts a `bigint`, so they are new here. `round`, `random`, and `randomInt` are deliberately excluded (`bigint` is already an integer; `Math.random()` cannot produce a uniform distribution over a large `bigint` range), as are `mean`/`meanBy` (truncating division makes `mean([1n, 2n]) === 1n`, which is more surprising than useful).

## Design notes

**Empty input throws instead of returning a placeholder.** `bigint` can represent neither `NaN` nor `Infinity`, so there is no value that means "no maximum". `sum`/`sumBy` still return the identity `0n`.

**`median` truncates toward zero.** An even-length array averages the two middle values, and `bigint` has no fractional part:

```ts
median([1n, 2n, 3n, 4n]); // 2n, not 2.5
median([-3n, -2n]); // -2n, truncation goes toward zero
```

**Sorting uses explicit comparisons.** The usual `(a, b) => a - b` comparator returns a `bigint` and would break `Array#sort`, so `median` and `percentile` use `(a, b) => (a < b ? -1 : a > b ? 1 : 0)`.

**`percentile` keeps a `number` second argument**, since it is a percentage rather than a measured quantity. It uses the nearest-rank method, so it never interpolates and therefore never has to round.

**`range`/`rangeRight` share a ceiling-division helper.** `Math.ceil((end - start) / step)` has no `bigint` equivalent, so `src/_internal/bigIntRangeLength.ts` does that computation with `bigint` arithmetic.

## Docs

Reference pages for all 13 functions in all four languages, each carrying the subpath-only `::: info` callout used by `es-toolkit/map` and `es-toolkit/set`. `bigint` is registered as a category on the existing `esToolkit` flavor (not a new flavor), and added to the playground's `SUBPATH_ONLY` list so examples keep their `es-toolkit/bigint` import.

Prose and titles write the type as `BigInt`; code and type signatures keep TypeScript's lowercase `bigint`.

One unrelated cleanup: `docs/CLAUDE.md`'s translation table listed `异常` for "Throws", but all 17 existing `docs/zh_hans/reference` pages use `错误`. The table now matches the code.

## Test plan

- [x] 73 unit tests across the 13 functions, covering empty-array behaviour, truncation toward zero, and exactness past `Number.MAX_SAFE_INTEGER`
- [x] **Every result asserted in the English docs was verified by executing it** — all `console.log` claims were extracted into a temporary spec, run against the real implementation, and removed
- [x] All 39 translations verified to have code blocks byte-identical to the English source (comments aside), plus matching heading structure
- [x] Full suite green (659 files / 4541 tests), `tsc --noEmit` clean, lint and prettier clean on new files
- [x] `tests/check-dist.spec.ts` passes — packs a tarball, installs it, and verifies `./bigint` resolves in both CJS and ESM
- [x] `attw` reports `"es-toolkit/bigint"` OK across all module modes
- [x] Docs site builds; the sidebar renders the new category with all 13 entries in each language
