### PR TITLE
docs(compat/orderBy): update documentation to clarify 'orders' parameter options

### DIFF
--- a/docs/compat/reference/array/orderBy.md
+++ b/docs/compat/reference/array/orderBy.md
@@ -75,7 +75,7 @@ orderBy(undefined, 'age'); // []
 
 - `collection` (`ArrayLike<T> | object | null | undefined`): The array or object to sort.
 - `criteria` (`Criterion<T> | Array<Criterion<T>>`, optional): The sort criteria. Can use property names, property paths, functions, etc. Defaults to `[null]`.
-- `orders` (`unknown | unknown[]`, optional): The sort order for each criterion. Can use `'asc'` (ascending), `'desc'` (descending), `true` (ascending), `false` (descending). Defaults to `[]`.
+- `orders` (`unknown | unknown[]`, optional): The sort order for each criterion. Can use `'asc'` (ascending) or `'desc'` (descending). Defaults to `[]`.
 
 #### Returns
 

--- a/docs/ja/compat/reference/array/orderBy.md
+++ b/docs/ja/compat/reference/array/orderBy.md
@@ -75,7 +75,7 @@ orderBy(undefined, 'age'); // []
 
 - `collection` (`ArrayLike<T> | object | null | undefined`): ソートする配列またはオブジェクトです。
 - `criteria` (`Criterion<T> | Array<Criterion<T>>`, オプション): ソート条件です。プロパティ名、プロパティパス、関数などを使用できます。デフォルトは `[null]` です。
-- `orders` (`unknown | unknown[]`, オプション): 各条件のソート順です。`'asc'`(昇順)、`'desc'`(降順)、`true`(昇順)、`false`(降順)を使用できます。デフォルトは `[]` です。
+- `orders` (`unknown | unknown[]`, オプション): 各条件のソート順です。`'asc'`(昇順)または`'desc'`(降順)を使用できます。デフォルトは `[]` です。
 
 #### 戻り値
 

--- a/docs/ko/compat/reference/array/orderBy.md
+++ b/docs/ko/compat/reference/array/orderBy.md
@@ -75,7 +75,7 @@ orderBy(undefined, 'age'); // []
 
 - `collection` (`ArrayLike<T> | object | null | undefined`): 정렬할 배열이나 객체예요.
 - `criteria` (`Criterion<T> | Array<Criterion<T>>`, 선택): 정렬 기준이에요. 속성 이름, 속성 경로, 함수 등을 사용할 수 있어요. 기본값은 `[null]`이에요.
-- `orders` (`unknown | unknown[]`, 선택): 각 기준의 정렬 순서예요. `'asc'`(오름차순), `'desc'`(내림차순), `true`(오름차순), `false`(내림차순)를 사용할 수 있어요. 기본값은 `[]`이에요.
+- `orders` (`unknown | unknown[]`, 선택): 각 기준의 정렬 순서예요. `'asc'`(오름차순), `'desc'`(내림차순), 기본값은 `[]`이에요.
 
 #### 반환 값
 

--- a/docs/ko/compat/reference/array/orderBy.md
+++ b/docs/ko/compat/reference/array/orderBy.md
@@ -75,7 +75,7 @@ orderBy(undefined, 'age'); // []
 
 - `collection` (`ArrayLike<T> | object | null | undefined`): 정렬할 배열이나 객체예요.
 - `criteria` (`Criterion<T> | Array<Criterion<T>>`, 선택): 정렬 기준이에요. 속성 이름, 속성 경로, 함수 등을 사용할 수 있어요. 기본값은 `[null]`이에요.
-- `orders` (`unknown | unknown[]`, 선택): 각 기준의 정렬 순서예요. `'asc'`(오름차순), `'desc'`(내림차순), 기본값은 `[]`이에요.
+- `orders` (`unknown | unknown[]`, 선택): 각 기준의 정렬 순서예요. `'asc'`(오름차순) 또는 `'desc'`(내림차순)를 사용할 수 있어요. 기본값은 `[]`이에요.
 
 #### 반환 값
 

--- a/docs/zh_hans/compat/reference/array/orderBy.md
+++ b/docs/zh_hans/compat/reference/array/orderBy.md
@@ -75,7 +75,7 @@ orderBy(undefined, 'age'); // []
 
 - `collection` (`ArrayLike<T> | object | null | undefined`): 要排序的数组或对象。
 - `criteria` (`Criterion<T> | Array<Criterion<T>>`, 可选): 排序条件。可以使用属性名称、属性路径、函数等。默认为 `[null]`。
-- `orders` (`unknown | unknown[]`, 可选): 每个条件的排序顺序。可以使用 `'asc'`(升序)、`'desc'`(降序)、`true`(升序)、`false`(降序)。默认为 `[]`。
+- `orders` (`unknown | unknown[]`, 可选): 每个条件的排序顺序。可以使用 `'asc'`(升序)或`'desc'`(降序)。默认为 `[]`。
 
 #### 返回值
 


### PR DESCRIPTION
## Summary

The `orderBy` documentation incorrectly stated that `true` sorts in
ascending order and `false` sorts in descending order.

Internally, each order value is converted to a string, and `compareValues`
uses descending order only when that value is exactly `'desc'`. All other
values follow the ascending-order branch. As a result, both `true` and
`false` sort in ascending order.

Lodash also documents `orders` as a string array using `'asc'` and `'desc'`:
https://lodash.com/docs/#orderBy

## Changes

- Removed the misleading `true` and `false` sort-order descriptions.
- Kept `'asc'` and `'desc'` as the documented sort-order options.
- Updated the English, Korean, Japanese, and Simplified Chinese documentation.