### PR TITLE
docs(unzip): `unzip` documentation clarify how to handle arguments length mismatch

### DIFF
--- a/docs/compat/reference/array/unzip.md
+++ b/docs/compat/reference/array/unzip.md
@@ -20,6 +20,8 @@ const result = unzip(array);
 
 Collects elements at the same index in nested arrays and returns them as a new array. Performs the opposite operation of the `zip` function. This is useful when transposing matrices or reorganizing structured data.
 
+The returned array's length matches the longest nested array, and missing positions from shorter arrays are filled with `undefined`.
+
 ```typescript
 import { unzip } from 'es-toolkit/compat';
 

--- a/docs/fp/reference/unzip.md
+++ b/docs/fp/reference/unzip.md
@@ -16,6 +16,8 @@ Prefer the original es-toolkit [`unzip`](../../reference/array/unzip.md) in ordi
 
 `unzip` takes an array of grouped values and returns arrays that collect the values at each position.
 
+The returned array's length matches the longest nested array, and missing positions from shorter arrays are filled with `undefined`.
+
 ```typescript
 import { pipe, unzip } from 'es-toolkit/fp';
 

--- a/docs/ja/compat/reference/array/unzip.md
+++ b/docs/ja/compat/reference/array/unzip.md
@@ -20,6 +20,8 @@ const result = unzip(array);
 
 ネストした配列の同じインデックスにある要素を集めて新しい配列として返します。`zip`関数の逆の操作を実行します。行列を転置したり構造化データを再編成するときに便利です。
 
+返される配列の長さは最も長い内部配列の長さに合わせられ、短い内部配列で足りない位置は `undefined` で埋められます。
+
 ```typescript
 import { unzip } from 'es-toolkit/compat';
 

--- a/docs/ja/fp/reference/unzip.md
+++ b/docs/ja/fp/reference/unzip.md
@@ -16,6 +16,8 @@ const result = pipe(array, unzip());
 
 `unzip` はグループ化された値の配列を受け取り、各位置の値を集めた配列を返します。
 
+返される配列の長さは最も長い内部配列の長さに合わせられ、短い内部配列で足りない位置は `undefined` で埋められます。
+
 ```typescript
 import { pipe, unzip } from 'es-toolkit/fp';
 

--- a/docs/ja/reference/array/unzip.md
+++ b/docs/ja/reference/array/unzip.md
@@ -37,7 +37,7 @@ console.log(ages); // [30, 25, 35]
 console.log(roles); // ['engineer', 'designer', 'manager']
 ```
 
-長さが異なる配列も処理できます。短い配列の場合は `undefined` で埋められます。
+返される配列の長さは最も長い内部配列の長さに合わせられ、短い内部配列で足りない位置は `undefined` で埋められます。
 
 ```typescript
 import { unzip } from 'es-toolkit/array';

--- a/docs/ko/compat/reference/array/unzip.md
+++ b/docs/ko/compat/reference/array/unzip.md
@@ -20,6 +20,8 @@ const result = unzip(array);
 
 중첩된 배열에서 같은 인덱스에 있는 요소들을 모아서 새로운 배열로 반환해요. `zip` 함수의 반대 동작을 수행해요. 행렬을 전치하거나 구조화된 데이터를 재정렬할 때 유용해요.
 
+반환되는 배열의 길이는 가장 긴 내부 배열의 길이에 맞춰지고, 더 짧은 내부 배열에서 빠진 위치는 `undefined`로 채워져요.
+
 ```typescript
 import { unzip } from 'es-toolkit/compat';
 

--- a/docs/ko/fp/reference/unzip.md
+++ b/docs/ko/fp/reference/unzip.md
@@ -16,6 +16,8 @@ const result = pipe(array, unzip());
 
 `unzip`은 묶인 값들의 배열을 받아 각 위치의 값끼리 모은 배열들을 반환해요.
 
+반환되는 배열의 길이는 가장 긴 내부 배열의 길이에 맞춰지고, 더 짧은 내부 배열에서 빠진 위치는 `undefined`로 채워져요.
+
 ```typescript
 import { pipe, unzip } from 'es-toolkit/fp';
 

--- a/docs/ko/reference/array/unzip.md
+++ b/docs/ko/reference/array/unzip.md
@@ -37,7 +37,7 @@ console.log(ages); // [30, 25, 35]
 console.log(roles); // ['engineer', 'designer', 'manager']
 ```
 
-길이가 다른 배열들도 처리할 수 있어요. 짧은 배열의 경우 `undefined`로 채워져요.
+반환되는 배열의 길이는 가장 긴 내부 배열의 길이에 맞춰지고, 더 짧은 내부 배열에서 빠진 위치는 `undefined`로 채워져요.
 
 ```typescript
 import { unzip } from 'es-toolkit/array';

--- a/docs/reference/array/unzip.md
+++ b/docs/reference/array/unzip.md
@@ -37,7 +37,7 @@ console.log(ages); // [30, 25, 35]
 console.log(roles); // ['engineer', 'designer', 'manager']
 ```
 
-It can also handle arrays of different lengths. For shorter arrays, empty positions are filled with `undefined`.
+The returned array's length matches the longest nested array, and missing positions from shorter arrays are filled with `undefined`.
 
 ```typescript
 import { unzip } from 'es-toolkit/array';

--- a/docs/zh_hans/compat/reference/array/unzip.md
+++ b/docs/zh_hans/compat/reference/array/unzip.md
@@ -20,6 +20,8 @@ const result = unzip(array);
 
 收集嵌套数组中相同索引处的元素并将它们作为新数组返回。执行与 `zip` 函数相反的操作。这在转置矩阵或重组结构化数据时很有用。
 
+返回数组的长度与最长的内部数组一致，较短内部数组中缺少的位置会用 `undefined` 填充。
+
 ```typescript
 import { unzip } from 'es-toolkit/compat';
 

--- a/docs/zh_hans/fp/reference/unzip.md
+++ b/docs/zh_hans/fp/reference/unzip.md
@@ -16,6 +16,8 @@ const result = pipe(array, unzip());
 
 `unzip` 接收由分组值组成的数组,并返回按每个位置收集值的数组。
 
+返回数组的长度与最长的内部数组一致，较短内部数组中缺少的位置会用 `undefined` 填充。
+
 ```typescript
 import { pipe, unzip } from 'es-toolkit/fp';
 

--- a/docs/zh_hans/reference/array/unzip.md
+++ b/docs/zh_hans/reference/array/unzip.md
@@ -37,7 +37,7 @@ console.log(ages); // [30, 25, 35]
 console.log(roles); // ['engineer', 'designer', 'manager']
 ```
 
-也可以处理长度不同的数组。较短数组的空位会用 `undefined` 填充。
+返回数组的长度与最长的内部数组一致，较短内部数组中缺少的位置会用 `undefined` 填充。
 
 ```typescript
 import { unzip } from 'es-toolkit/array';

--- a/src/array/unzip.ts
+++ b/src/array/unzip.ts
@@ -2,6 +2,9 @@
  * Gathers elements in the same position in an internal array
  * from a grouped array of elements and returns them as a new array.
  *
+ * The returned array's length matches the longest nested array.
+ * Missing positions in shorter arrays are filled with `undefined`.
+ *
  * @template T - The type of elements in the nested array.
  * @param zipped - The nested array to unzip.
  * @returns A new array of unzipped elements.

--- a/src/compat/array/unzip.ts
+++ b/src/compat/array/unzip.ts
@@ -6,6 +6,9 @@ import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
  * Gathers elements in the same position in an internal array
  * from a grouped array of elements and returns them as a new array.
  *
+ * The returned array's length matches the longest nested array.
+ * Missing positions in shorter arrays are filled with `undefined`.
+ *
  * @template T - The type of elements in the nested array.
  * @param array - The nested array to unzip.
  * @returns A new array of unzipped elements.

--- a/src/fp/array/unzip.ts
+++ b/src/fp/array/unzip.ts
@@ -8,6 +8,9 @@ type Unzip<K extends unknown[]> = { [I in keyof K]: Array<K[I]> };
  * The returned function is the data-last form of the main {@link unzip} utility.
  * Use it with {@link pipe}.
  *
+ * When the returned function is invoked, the result's length matches the longest nested array.
+ * Missing positions in shorter arrays are filled with `undefined`.
+ *
  * @template T - The tuple type inside the zipped array.
  * @returns A function that maps zipped tuples to arrays grouped by tuple position.
  *


### PR DESCRIPTION
I've aligned the level of docs detail for result array format of `unzip` with that of `zip`.

It clarified what happens when the input arrays have different lengths(filled with `undefined`).

* localizations are generated by AI