### PR TITLE
fix(compat/lastIndexOf): read holes in sparse arrays as `undefined`

### DIFF
--- a/benchmarks/bundle-size/lastIndexOf.spec.ts
+++ b/benchmarks/bundle-size/lastIndexOf.spec.ts
@@ -9,6 +9,6 @@ describe('lastIndexOf bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'lastIndexOf');
-    expect(bundleSize).toMatchInlineSnapshot(`681`);
+    expect(bundleSize).toMatchInlineSnapshot(`658`);
   });
 });

--- a/src/compat/array/lastIndexOf.spec.ts
+++ b/src/compat/array/lastIndexOf.spec.ts
@@ -71,4 +71,34 @@ describe('lastIndexOf', () => {
     expect(lastIndexOf(null, 1)).toBe(-1);
     expect(lastIndexOf(undefined, 1)).toBe(-1);
   });
+
+  it(`should treat holes in a sparse array as \`undefined\``, () => {
+    const sparse = [1];
+    sparse[2] = 1;
+
+    expect(lastIndexOf(sparse, undefined, 2)).toBe(1);
+
+    const allHoles: number[] = [];
+    allHoles.length = 2;
+
+    expect(lastIndexOf(allHoles, undefined, 1)).toBe(1);
+  });
+
+  it(`should find values in a sparse array`, () => {
+    const sparse = [1];
+    sparse[2] = 1;
+
+    expect(lastIndexOf(sparse, 1)).toBe(2);
+    expect(lastIndexOf(sparse, 1, 1)).toBe(0);
+
+    const withNaN = [1];
+    withNaN[2] = NaN;
+
+    expect(lastIndexOf(withNaN, NaN)).toBe(2);
+  });
+
+  it(`should work with array-like values`, () => {
+    expect(lastIndexOf({ 0: 1, 1: 2, 2: 3, 3: 2, length: 4 }, 2)).toBe(3);
+    expect(lastIndexOf('abcb', 'b')).toBe(3);
+  });
 });

--- a/src/compat/array/lastIndexOf.ts
+++ b/src/compat/array/lastIndexOf.ts
@@ -1,4 +1,3 @@
-import { toArray } from '../_internal/toArray.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toInteger } from '../util/toInteger.ts';
 
@@ -43,14 +42,23 @@ export function lastIndexOf<T>(
     index = index < 0 ? Math.max(length + index, 0) : Math.min(index, length - 1);
   }
 
-  // `Array.prototype.lastIndexOf` doesn't find `NaN` values, so we need to handle that case separately.
+  // Not `Array.prototype.lastIndexOf`, which skips holes in sparse arrays. lodash reads a hole
+  // as `undefined`, and indexing does too.
   if (Number.isNaN(searchElement)) {
     for (let i = index; i >= 0; i--) {
       if (Number.isNaN(array[i])) {
         return i;
       }
     }
+
+    return -1;
   }
 
-  return toArray(array).lastIndexOf(searchElement, index);
+  for (let i = index; i >= 0; i--) {
+    if (array[i] === searchElement) {
+      return i;
+    }
+  }
+
+  return -1;
 }


### PR DESCRIPTION
Follow-up to #1957, which was merged before this came up in review.

## Why

#1957 replaced `Array.from(array)` with the `toArray` helper to skip a copy when the input is already an array. `toArray` returns arrays unchanged, so the search now runs `Array.prototype.lastIndexOf` on the original — and the native method **skips holes**, where `Array.from` had been filling them with `undefined`:

```js
const sparse = [1];
sparse[2] = 1;

lastIndexOf(sparse, undefined, 2);
// lodash: 1   before #1957: 1   after #1957: -1
```

lodash never converts the input at all — `baseLastIndexOf` walks backwards by index, so `array[i]` reads a hole as `undefined` and the question never arises.

## What changed

Walk backwards by index instead of delegating to the native method. This matches lodash, and still avoids the copy for array-likes, which is what #1957 was after. The `NaN` branch already looped this way — it just fell through to the native call when it found nothing, so it now returns `-1` directly.

## Results

- **Correctness**: 18/18 cases match lodash, including dense arrays, `fromIndex` edges (negative, fractional, `Infinity`, `null`, `true`), `NaN`, array-like objects, and strings
- **Performance**: 1.15x faster than lodash on the existing suite (135.80 hz vs 118.10 hz)
- **Bundle size**: 681 → **658** bytes, since the `toArray` import goes away
- compat suite: 2,884 tests pass

## Tests

Holes had no coverage, which is why the regression slipped through. Added: searching a sparse array for `undefined`, for a value (with and without `fromIndex`), and for `NaN`; plus array-like inputs (an object with `length`, and a string).

Sparse arrays are built as `const a = [1]; a[2] = 1;` rather than `[1, , 1]` so no lint suppression is needed.
