### PR TITLE
fix(compat/meanBy): skip undefined values when averaging to match lodash

### DIFF
--- a/docs/compat/reference/math/meanBy.md
+++ b/docs/compat/reference/math/meanBy.md
@@ -78,13 +78,13 @@ meanBy(users, { active: true });
 // Returns: 0.6666666 (2 out of 3 users are active)
 ```
 
-`undefined` values are ignored when summing, but they are still counted in the divisor.
+If the key is missing or the value is `undefined`, it is treated as `0`. However, if every value is `undefined`, the result is `NaN`.
 
 ```typescript
 import { meanBy } from 'es-toolkit/compat';
 
 meanBy([{ a: 1 }, {}], 'a');
-// Returns: 0.5 ((1) / 2, undefined ignored)
+// Returns: 0.5 ((1 + 0) / 2)
 
 meanBy([{}, {}], 'a');
 // Returns: NaN

--- a/docs/compat/reference/math/meanBy.md
+++ b/docs/compat/reference/math/meanBy.md
@@ -78,6 +78,18 @@ meanBy(users, { active: true });
 // Returns: 0.6666666 (2 out of 3 users are active)
 ```
 
+`undefined` values are ignored when summing, but they are still counted in the divisor.
+
+```typescript
+import { meanBy } from 'es-toolkit/compat';
+
+meanBy([{ a: 1 }, {}], 'a');
+// Returns: 0.5 ((1) / 2, undefined ignored)
+
+meanBy([{}, {}], 'a');
+// Returns: NaN
+```
+
 Empty arrays return NaN.
 
 ```typescript

--- a/docs/ja/compat/reference/math/meanBy.md
+++ b/docs/ja/compat/reference/math/meanBy.md
@@ -78,13 +78,13 @@ meanBy(users, { active: true });
 // Returns: 0.6666666 (active が true の人の割合)
 ```
 
-`undefined` の値は合計では無視されますが、割る個数にはそのまま含まれます。
+キーがない場合や値が `undefined` の場合は、0として扱われます。ただし、すべての値が `undefined` の場合は `NaN` を返します。
 
 ```typescript
 import { meanBy } from 'es-toolkit/compat';
 
 meanBy([{ a: 1 }, {}], 'a');
-// Returns: 0.5 ((1) / 2, undefinedを無視)
+// Returns: 0.5 ((1 + 0) / 2)
 
 meanBy([{}, {}], 'a');
 // Returns: NaN

--- a/docs/ja/compat/reference/math/meanBy.md
+++ b/docs/ja/compat/reference/math/meanBy.md
@@ -78,6 +78,18 @@ meanBy(users, { active: true });
 // Returns: 0.6666666 (active が true の人の割合)
 ```
 
+`undefined` の値は合計では無視されますが、割る個数にはそのまま含まれます。
+
+```typescript
+import { meanBy } from 'es-toolkit/compat';
+
+meanBy([{ a: 1 }, {}], 'a');
+// Returns: 0.5 ((1) / 2, undefinedを無視)
+
+meanBy([{}, {}], 'a');
+// Returns: NaN
+```
+
 空の配列はNaNを返します。
 
 ```typescript

--- a/docs/ko/compat/reference/math/meanBy.md
+++ b/docs/ko/compat/reference/math/meanBy.md
@@ -78,13 +78,13 @@ meanBy(users, { active: true });
 // Returns: 0.6666666 (active 가 true 인 사람의 비율)
 ```
 
-`undefined` 값은 합에서 무시되지만, 나누는 개수에는 그대로 포함돼요.
+키가 없거나 값이 `undefined`이면 0으로 취급해요. 다만 모든 값이 `undefined`이면 `NaN`을 반환해요.
 
 ```typescript
 import { meanBy } from 'es-toolkit/compat';
 
 meanBy([{ a: 1 }, {}], 'a');
-// Returns: 0.5 ((1) / 2, undefined 무시)
+// Returns: 0.5 ((1 + 0) / 2)
 
 meanBy([{}, {}], 'a');
 // Returns: NaN

--- a/docs/ko/compat/reference/math/meanBy.md
+++ b/docs/ko/compat/reference/math/meanBy.md
@@ -78,6 +78,18 @@ meanBy(users, { active: true });
 // Returns: 0.6666666 (active 가 true 인 사람의 비율)
 ```
 
+`undefined` 값은 합에서 무시되지만, 나누는 개수에는 그대로 포함돼요.
+
+```typescript
+import { meanBy } from 'es-toolkit/compat';
+
+meanBy([{ a: 1 }, {}], 'a');
+// Returns: 0.5 ((1) / 2, undefined 무시)
+
+meanBy([{}, {}], 'a');
+// Returns: NaN
+```
+
 빈 배열은 NaN을 반환해요.
 
 ```typescript

--- a/docs/zh_hans/compat/reference/math/meanBy.md
+++ b/docs/zh_hans/compat/reference/math/meanBy.md
@@ -78,6 +78,18 @@ meanBy(users, { active: true });
 // Returns: 0.6666666 (active 为 true 的人占总人数的比例)
 ```
 
+求和时会忽略 `undefined` 值，但它们仍会计入除数。
+
+```typescript
+import { meanBy } from 'es-toolkit/compat';
+
+meanBy([{ a: 1 }, {}], 'a');
+// Returns: 0.5 ((1) / 2，忽略 undefined)
+
+meanBy([{}, {}], 'a');
+// Returns: NaN
+```
+
 空数组返回 NaN。
 
 ```typescript

--- a/docs/zh_hans/compat/reference/math/meanBy.md
+++ b/docs/zh_hans/compat/reference/math/meanBy.md
@@ -78,13 +78,13 @@ meanBy(users, { active: true });
 // Returns: 0.6666666 (active 为 true 的人占总人数的比例)
 ```
 
-求和时会忽略 `undefined` 值，但它们仍会计入除数。
+如果键不存在或值为 `undefined`，会被当作 0 处理。但如果所有值都是 `undefined`，则返回 `NaN`。
 
 ```typescript
 import { meanBy } from 'es-toolkit/compat';
 
 meanBy([{ a: 1 }, {}], 'a');
-// Returns: 0.5 ((1) / 2，忽略 undefined)
+// Returns: 0.5 ((1 + 0) / 2)
 
 meanBy([{}, {}], 'a');
 // Returns: NaN

--- a/src/compat/math/meanBy.spec.ts
+++ b/src/compat/math/meanBy.spec.ts
@@ -38,4 +38,19 @@ describe('meanBy', () => {
 
     expect(meanBy(numbers)).toBe(2);
   });
+
+  it('should skip `undefined` values when summing, but still count them in the divisor', () => {
+    expect(meanBy([{ a: 1 }, {}], 'a')).toBe(0.5);
+    expect(meanBy([{ a: 1 }, { a: undefined }, { a: 3 }], 'a')).toBe(4 / 3);
+    expect(meanBy([1, undefined, 2])).toBe(1);
+    expect(meanBy([{ a: { b: 1 } }, {}], 'a.b')).toBe(0.5);
+  });
+
+  it('should return `NaN` when every value is `undefined`', () => {
+    expect(meanBy([{}, {}], 'a')).toBe(NaN);
+  });
+
+  it('should work with array-like objects', () => {
+    expect(meanBy({ 0: { a: 1 }, 1: {}, length: 2 }, 'a')).toBe(0.5);
+  });
 });

--- a/src/compat/math/meanBy.ts
+++ b/src/compat/math/meanBy.ts
@@ -9,8 +9,8 @@ import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
  *
  * If the array is empty, this function returns `NaN`.
  *
- * Values of `undefined` are skipped when summing, but they are still counted
- * in the divisor, which is the length of `items`.
+ * If the key is missing or the value is `undefined`, it is treated as `0`.
+ * However, if every value is `undefined`, the result is `NaN`.
  *
  * @template T - The type of elements in the array.
  * @param items An array to calculate the average.

--- a/src/compat/math/meanBy.ts
+++ b/src/compat/math/meanBy.ts
@@ -1,5 +1,5 @@
+import { sumBy } from './sumBy.ts';
 import { identity } from '../../function/identity.ts';
-import { meanBy as meanByToolkit } from '../../math/meanBy.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
 import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
 
@@ -8,6 +8,9 @@ import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
  * the `iteratee` function to each element.
  *
  * If the array is empty, this function returns `NaN`.
+ *
+ * Values of `undefined` are skipped when summing, but they are still counted
+ * in the divisor, which is the length of `items`.
  *
  * @template T - The type of elements in the array.
  * @param items An array to calculate the average.
@@ -24,11 +27,14 @@ import { iteratee as iterateeToolkit } from '../util/iteratee.ts';
  * meanBy([], x => x.a); // Returns: NaN
  * meanBy([[2], [3], [1]], 0); // Returns: 2
  * meanBy([{ a: 2 }, { a: 3 }, { a: 1 }], 'a'); // Returns: 2
+ * meanBy([{ a: 1 }, {}], 'a'); // Returns: 0.5
  */
 export function meanBy<T>(items: ArrayLike<T> | null | undefined, iteratee?: ValueIteratee<T>): number {
-  if (items == null) {
+  const length = items == null ? 0 : items.length;
+
+  if (!length) {
     return NaN;
   }
 
-  return meanByToolkit(Array.from(items), iterateeToolkit(iteratee ?? identity));
+  return sumBy(items, iterateeToolkit(iteratee ?? identity)) / length;
 }


### PR DESCRIPTION
## Summary

`es-toolkit/compat`'s `meanBy` returns `NaN` whenever the iteratee produces `undefined` for any element, while lodash skips those values and still divides by the full length.

```ts
import { meanBy } from 'es-toolkit/compat';
import lodashMeanBy from 'lodash/meanBy';

meanBy([{ a: 1 }, {}], 'a'); // NaN (before this PR)
lodashMeanBy([{ a: 1 }, {}], 'a'); // 0.5
```

More cases measured against `lodash@4.18.1` on `main` (81af489):

| call | compat (before) | lodash |
| --- | --- | --- |
| `meanBy([{ a: 1 }, {}], 'a')` | `NaN` | `0.5` |
| `meanBy([{ a: 1 }, { a: undefined }, { a: 3 }], 'a')` | `NaN` | `1.333...` |
| `meanBy([1, undefined, 2])` | `NaN` | `1` |
| `meanBy({ 0: { a: 1 }, 1: {}, length: 2 }, 'a')` | `NaN` | `0.5` |
| `meanBy([{ a: { b: 1 } }, {}], 'a.b')` | `NaN` | `0.5` |

This is also inconsistent inside `compat` itself: `mean([1, undefined, 2])` already returns `1` like lodash, because `compat/mean` builds on `compat/sum`, which skips `undefined`.

## Cause

`src/compat/math/meanBy.ts` delegated to the main library's `meanBy`, which sums with the main library's `sumBy`. That one adds every value as-is, so one `undefined` turns the whole sum into `NaN`. lodash's `baseMean` divides `baseSum` — which ignores `undefined` — by `array.length`.

## Changes

- Compute the sum with `compat`'s own `sumBy`, which already implements lodash's undefined-skipping behavior, and divide by the length of `items`. When every value is `undefined` the result stays `NaN`, matching lodash.
- Drop the intermediate `Array.from` copy, since `compat/sumBy` accepts array-likes directly.
- Add regression tests for missing keys, explicit `undefined`, deep paths, array-likes, and the all-`undefined` case.
- Document the behavior in the `compat` reference docs for all four languages.

Only `es-toolkit/compat` is changed; `es-toolkit`'s own `meanBy` keeps its stricter `getValue: (element: T) => number` contract.

## Test results

- `yarn vitest run src/compat/math src/math` — 35 files, 288 tests pass
- `yarn vitest run` — 659 files pass (`tests/check-dist.spec.ts` fails to build locally on Node 24.10 with an unrelated tsdown/PnP loader error; it also fails on unmodified `main` here)
- `yarn typecheck`, `yarn workspace type-tests test` — no errors
- `yarn eslint` on the changed files — no errors
- Differential run of the table above against `lodash@4.18.1` in the `benchmarks` workspace: all cases match after the change
