### PR TITLE
fix[without]: Narrow return type for literal exclusions

### DIFF
--- a/docs/ja/reference/array/without.md
+++ b/docs/ja/reference/array/without.md
@@ -33,6 +33,16 @@ without([1, NaN, 3, NaN, 5], NaN);
 // Returns: [1, 3, 5]
 ```
 
+入力が読み取り専用のリテラル配列の場合、TypeScript は戻り値の要素型からも指定したリテラル値を除外します。
+
+```typescript
+import { without } from 'es-toolkit/array';
+
+const letters = ['a', 'b', 'c'] as const;
+const filtered = without(letters, 'a');
+// Type: Array<'b' | 'c'>
+```
+
 #### パラメータ
 
 - `arr` (`readonly T[]`): 値を削除する配列です。

--- a/docs/ko/reference/array/without.md
+++ b/docs/ko/reference/array/without.md
@@ -33,6 +33,16 @@ without([1, NaN, 3, NaN, 5], NaN);
 // Returns: [1, 3, 5]
 ```
 
+입력이 읽기 전용 리터럴 배열이면 TypeScript는 반환되는 요소 타입에서도 지정한 리터럴 값을 제외해요.
+
+```typescript
+import { without } from 'es-toolkit/array';
+
+const letters = ['a', 'b', 'c'] as const;
+const filtered = without(letters, 'a');
+// Type: Array<'b' | 'c'>
+```
+
 #### 파라미터
 
 - `arr` (`readonly T[]`): 값들을 제거할 배열이에요.

--- a/docs/reference/array/without.md
+++ b/docs/reference/array/without.md
@@ -33,6 +33,16 @@ without([1, NaN, 3, NaN, 5], NaN);
 // Returns: [1, 3, 5]
 ```
 
+When the input is a readonly literal array, TypeScript also excludes the specified literal values from the returned element type.
+
+```typescript
+import { without } from 'es-toolkit/array';
+
+const letters = ['a', 'b', 'c'] as const;
+const filtered = without(letters, 'a');
+// Type: Array<'b' | 'c'>
+```
+
 #### Parameters
 
 - `arr` (`readonly T[]`): The array from which to remove values.

--- a/docs/zh_hans/reference/array/without.md
+++ b/docs/zh_hans/reference/array/without.md
@@ -33,6 +33,16 @@ without([1, NaN, 3, NaN, 5], NaN);
 // Returns: [1, 3, 5]
 ```
 
+当输入是只读字面量数组时，TypeScript 也会从返回数组的元素类型中排除指定的字面量值。
+
+```typescript
+import { without } from 'es-toolkit/array';
+
+const letters = ['a', 'b', 'c'] as const;
+const filtered = without(letters, 'a');
+// Type: Array<'b' | 'c'>
+```
+
 #### 参数
 
 - `arr` (`readonly T[]`): 要删除值的数组。

--- a/src/array/without.spec.ts
+++ b/src/array/without.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { without } from './without';
 
 describe('without', () => {
@@ -13,6 +13,25 @@ describe('without', () => {
   it('should return a new array excluding the specified values', () => {
     expect(without([1, 2, 3, 4, 5], 2, 4)).toEqual([1, 3, 5]);
     expect(without(['a', 'b', 'c', 'a'], 'a')).toEqual(['b', 'c']);
+  });
+
+  it('should exclude literal values from the return type', () => {
+    const result = without(['a', 'b', 'c'] as const, 'a');
+
+    expectTypeOf(result).toEqualTypeOf<Array<'b' | 'c'>>();
+  });
+
+  it('should preserve the input type when no values are excluded', () => {
+    const result = without(['a', 'b', 'c'] as const);
+
+    expectTypeOf(result).toEqualTypeOf<Array<'a' | 'b' | 'c'>>();
+  });
+
+  it('should preserve the input type for a dynamic exclusion list', () => {
+    const values: Array<'a' | 'b'> = ['a'];
+    const result = without(['a', 'b', 'c'] as const, ...values);
+
+    expectTypeOf(result).toEqualTypeOf<Array<'a' | 'b' | 'c'>>();
   });
 
   it('should handle cases where none of the specified values are in the array', () => {

--- a/src/array/without.ts
+++ b/src/array/without.ts
@@ -6,9 +6,10 @@ import { difference } from './difference.ts';
  * It correctly excludes `NaN`, as it compares values using [SameValueZero](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-samevaluezero).
  *
  * @template T The type of elements in the array.
+ * @template V The values to exclude.
  * @param array - The array to filter.
  * @param values - The values to exclude.
- * @returns A new array without the specified values.
+ * @returns A new array without the specified values. Literal values are also excluded from the return type.
  *
  * @example
  * // Removes the specified values from the array
@@ -20,6 +21,10 @@ import { difference } from './difference.ts';
  * without(['a', 'b', 'c', 'a'], 'a');
  * // Returns: ['b', 'c']
  */
+export function without<T, const V extends readonly unknown[]>(
+  array: readonly T[],
+  ...values: V
+): Array<number extends V['length'] ? T : Exclude<T, V[number]>>;
 export function without<T>(array: readonly T[], ...values: T[]): T[] {
   return difference(array, values);
 }


### PR DESCRIPTION
## Summary

Closes #1503

`without` currently returns `T[]` even when a readonly literal input and literal exclusions make a narrower element type known. This adds a const rest-tuple overload so `without(['a', 'b', 'c'] as const, 'a')` returns `Array<'b' | 'c'>`.

Calls with no exclusions keep the input element type. A spread dynamic exclusion array also keeps the input type instead of narrowing to `never[]`.

## Changes

- infer literal exclusion values in the public `without` type
- add type tests for literal, empty, and dynamic exclusion lists
- document the inferred return type in all four reference languages

## Test results

- `yarn vitest run --reporter=dot` — 660 files passed; 4,552 tests passed and 2 skipped
- `yarn typecheck`
- `yarn build`
- `yarn workspace docs docs:build`
- targeted ESLint and Prettier checks for the changed files

Full `yarn lint` still reports eight existing `curly` errors in `docs/.vitepress/components/FpLazySimulation.vue`; neither that file nor the lint configuration changes here.

_OpenAI Codex assisted with this contribution. The type behavior, generated declarations, tests, and documentation build were verified locally._
