### PR TITLE
ci: name release version-stamp step for readability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
           node -v
           npm -v
           yarn -v
-      - if: github.ref_type == 'branch'
+      - name: Stamp package.json and jsr.json with dev version
+        if: github.ref_type == 'branch'
         run: |
           jq \
             --arg build "$GITHUB_RUN_NUMBER" \


### PR DESCRIPTION
## Problem

In `.github/workflows/release.yml`, the branch-only version stamp `run` step is unnamed and longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when `package.json` / `jsr.json` version updates fail.

## Changes

Semantics are unchanged: same `if:` condition and the same `jq` / `mv` commands.

- Add `name: Stamp package.json and jsr.json with dev version`

## Test plan
- [ ] Confirm the step still runs only when `github.ref_type == 'branch'`
- [ ] Confirm both JSON files still get the same `-dev.<run>+<sha>` suffix
- [ ] Confirm the step shows the new name in the Actions UI
