### PR TITLE
docs[usage]: document browser support

### DIFF
--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -70,6 +70,8 @@ bun add es-toolkit
 
 [jsdelivr](https://www.jsdelivr.com)や[unpkg](https://unpkg.com)などのCDNからes-toolkitを使用できます。Lodashと同様に、`_`変数にすべての関数が含まれています。
 
+es-toolkitはES2015（ES6）をサポートするブラウザで利用できます。より古いブラウザをサポートする必要がある場合は、アプリケーションのバンドルをトランスパイルし、インポートした関数が利用するJavaScript APIに必要なポリフィルを含めてください。
+
 ::: code-group
 
 ```html [jsdelivr]

--- a/docs/ko/usage.md
+++ b/docs/ko/usage.md
@@ -70,6 +70,8 @@ bun add es-toolkit
 
 [jsdelivr](https://www.jsdelivr.com) 또는 [unpkg](https://unpkg.com) 같은 CDN에서 es-toolkit을 쓸 수 있어요. Lodash와 같이 `_` 변수에 모든 함수가 포함돼요.
 
+es-toolkit은 ES2015(ES6)를 지원하는 브라우저에서 사용할 수 있어요. 더 오래된 브라우저를 지원해야 한다면 애플리케이션 번들을 트랜스파일하고, 가져와서 사용하는 함수가 필요로 하는 JavaScript API의 폴리필을 함께 포함하세요.
+
 ::: code-group
 
 ```html [jsdelivr]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,6 +70,8 @@ bun add es-toolkit
 
 You can find es-toolkit on CDNs such as [jsdelivr](https://www.jsdelivr.com), [unpkg](https://unpkg.com). We define `_` to include all functions, similar to Lodash.
 
+es-toolkit supports browsers with ES2015 (ES6) support. If you need to support older browsers, transpile your application bundle and include any required polyfills for the JavaScript APIs used by the functions you import.
+
 ::: code-group
 
 ```html [jsdelivr]

--- a/docs/zh_hans/usage.md
+++ b/docs/zh_hans/usage.md
@@ -70,6 +70,8 @@ bun add es-toolkit
 
 你可以在诸如 [jsdelivr](https://www.jsdelivr.com) 或 [unpkg](https://unpkg.com) 等CDN上找到 es-toolkit。我们将 `_` 定义为包含所有函数，类似于 Lodash。
 
+es-toolkit 支持兼容 ES2015（ES6）的浏览器。如果需要支持更旧的浏览器，请转译你的应用程序包，并为你导入的函数所使用的 JavaScript API 添加必要的 polyfill。
+
 ::: code-group
 
 ```html [jsdelivr]


### PR DESCRIPTION
## Summary
Fixes #800

Document supported browser expectations for es-toolkit usage.

## Changes
- Add an ES2015 (ES6) browser support note to the browser usage docs.
- Mention transpilation and polyfills for older browser targets.
- Keep the English, Korean, Japanese, and Simplified Chinese usage pages in sync.

## Test results
- `git diff --check`
- Not run: test suite (docs only).
