### PR TITLE
feat[toPascalCaseKeys, toConstantCaseKeys, toKebabCaseKeys, toCamelCaseKeys]: Add new object key casing functions

### DIFF
--- a/benchmarks/performance/toKebabCaseKeys.bench.ts
+++ b/benchmarks/performance/toKebabCaseKeys.bench.ts
@@ -1,0 +1,35 @@
+import { bench, describe } from 'vitest';
+import { toKebabCaseKeys as toKebabCaseKeysToolkit } from 'es-toolkit';
+import lodashFp from 'lodash/fp';
+
+const toKebabCaseKeysLodash = <T extends Record<string, any>>(obj: T) => {
+  return lodashFp.mapKeys(lodashFp.kebabCase)(obj);
+};
+
+const testObject = {
+  userId: 1,
+  firstName: 'John',
+  lastName: 'Doe',
+  addressInfo: {
+    streetName: 'Main St',
+    zipCode: '12345',
+    contactDetails: {
+      phoneNumber: '123-456-7890',
+      emailAddress: 'john.doe@example.com',
+    },
+  },
+  orderHistory: [
+    { orderId: 1001, orderDate: '2023-01-15', totalAmount: 125.99 },
+    { orderId: 1002, orderDate: '2023-02-22', totalAmount: 89.5 },
+  ],
+};
+
+describe('toKebabCaseKeys', () => {
+  bench('es-toolkit/toKebabCaseKeys (deep nested)', () => {
+    toKebabCaseKeysToolkit(testObject);
+  });
+
+  bench('lodash/fp/toKebabCaseKeys (shallow comparison)', () => {
+    toKebabCaseKeysLodash(testObject);
+  });
+});

--- a/docs/ja/reference/object/toConstantCaseKeys.md
+++ b/docs/ja/reference/object/toConstantCaseKeys.md
@@ -1,0 +1,67 @@
+# toConstantCaseKeys
+
+オブジェクトと配列のすべてのキーを定数ケース表記に変換した新しいオブジェクトを返します。
+
+定数ケースはすべての文字を大文字で書き、単語の間をアンダースコア(`_`)で区切る命名規則です。例えば`CONSTANT_CASE`のように書きます。
+
+```typescript
+const constantCased = toConstantCaseKeys(obj);
+```
+
+## 使用法
+
+### `toConstantCaseKeys(obj)`
+
+オブジェクトのすべてのキーをCONSTANT_CASEに変換したい時に`toConstantCaseKeys`を使用してください。ネストされたオブジェクトと配列内のオブジェクトも再帰的に変換されます。
+
+例えば、オブジェクトのキーは次のように変換されます。
+
+- `camelCase` → `CONSTANT_CASE`（例: `userId` → `USER_ID`）
+- `PascalCase` → `CONSTANT_CASE`（例: `UserId` → `USER_ID`）
+- `snake_case` → `CONSTANT_CASE`（例: `first_name` → `FIRST_NAME`, `last` → `LAST`）
+
+```typescript
+import { toConstantCaseKeys } from 'es-toolkit/object';
+
+// 基本的なオブジェクト変換
+const obj = { userId: 1, firstName: 'John', lastName: 'Doe' };
+const result = toConstantCaseKeys(obj);
+// resultは{ USER_ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe' }になります
+
+// 配列内のオブジェクトも変換
+const users = [
+  { userId: 1, firstName: 'John' },
+  { userId: 2, firstName: 'Jane' },
+];
+const convertedUsers = toConstantCaseKeys(users);
+// convertedUsersは[{ USER_ID: 1, FIRST_NAME: 'John' }, { USER_ID: 2, FIRST_NAME: 'Jane' }]になります
+
+// ネストされたオブジェクトも完全に変換
+const nested = {
+  userData: {
+    userId: 1,
+    contactInfo: {
+      emailAddress: 'john@example.com',
+      phoneNumber: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toConstantCaseKeys(nested);
+// nestedResultは{
+//   USER_DATA: {
+//     USER_ID: 1,
+//     CONTACT_INFO: {
+//       EMAIL_ADDRESS: 'john@example.com',
+//       PHONE_NUMBER: '123-456-7890'
+//     }
+//   }
+// }になります
+```
+
+#### パラメータ
+
+- `obj` (`T`): キーをCONSTANT_CASEに変換するオブジェクト、配列、またはプリミティブ値です。
+
+#### 戻り値
+
+(`ToConstantCaseKeys<T>`): すべてのキーがCONSTANT_CASEに変換された新しいオブジェクトを返します。

--- a/docs/ja/reference/object/toKebabCaseKeys.md
+++ b/docs/ja/reference/object/toKebabCaseKeys.md
@@ -1,0 +1,67 @@
+# toKebabCaseKeys
+
+オブジェクトと配列のすべてのキーをケバブケース表記に変換した新しいオブジェクトを返します。
+
+ケバブケースは、各単語を小文字で書き、単語間をダッシュ（-）で繋ぐ命名規則です。例えば`kebab-case`のように書きます。
+
+```typescript
+const kebabCased = toKebabCaseKeys(obj);
+```
+
+## 使用法
+
+### `toKebabCaseKeys(obj)`
+
+オブジェクトのすべてのキーをkebab-caseに変換したい時に`toKebabCaseKeys`を使用してください。ネストされたオブジェクトと配列内のオブジェクトも再帰的に変換されます。
+
+例えば、オブジェクトのキーは次のように変換されます。
+
+- `camelCase` → `kebab-case`（例: `userId` → `user-id`）
+- `PascalCase` → `kebab-case`（例: `UserId` → `user-id`）
+- `UPPERCASE_KEYS` → `kebab-case`（例: `FIRST_NAME` → `first-name`, `LAST` → `last`）
+
+```typescript
+import { toKebabCaseKeys } from 'es-toolkit/object';
+
+// 基本的なオブジェクト変換
+const obj = { userId: 1, firstName: 'John', lastName: 'Doe' };
+const result = toKebabCaseKeys(obj);
+// resultは{ 'user-id': 1, 'first-name': 'John', 'last-name': 'Doe' }になります
+
+// 配列内のオブジェクトも変換
+const users = [
+  { userId: 1, firstName: 'John' },
+  { userId: 2, firstName: 'Jane' },
+];
+const convertedUsers = toKebabCaseKeys(users);
+// convertedUsersは[{ 'user-id': 1, 'first-name': 'John' }, { 'user-id': 2, 'first-name': 'Jane' }]になります
+
+// ネストされたオブジェクトも完全に変換
+const nested = {
+  userData: {
+    userId: 1,
+    contactInfo: {
+      emailAddress: 'john@example.com',
+      phoneNumber: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toKebabCaseKeys(nested);
+// nestedResultは{
+//   'user-data': {
+//     'user-id': 1,
+//     'contact-info': {
+//       'email-address': 'john@example.com',
+//       'phone-number': '123-456-7890'
+//     }
+//   }
+// }になります
+```
+
+#### パラメータ
+
+- `obj` (`T`): キーをkebab-caseに変換するオブジェクト、配列、またはプリミティブ値です。
+
+#### 戻り値
+
+(`ToKebabCaseKeys<T>`): すべてのキーがkebab-caseに変換された新しいオブジェクトを返します。

--- a/docs/ja/reference/object/toPascalCaseKeys.md
+++ b/docs/ja/reference/object/toPascalCaseKeys.md
@@ -1,0 +1,72 @@
+# toCamelCaseKeys
+
+オブジェクトと配列のすべてのキーをパスカルケース表記に変換した新しいオブジェクトを返します。
+
+パスカルケースは、各単語の最初の文字を大文字にし、単語間を区切り文字なしで連結する命名規則です。例えば`PascalCase`のように書きます。
+
+```typescript
+const pascalCased = toPascalCaseKeys(obj);
+```
+
+## 使用法
+
+### `toPascalCaseKeys(obj)`
+
+オブジェクトのすべてのキーをパスカルケースに変換したい時に `toPascalCaseKeys` を使用してください。ネストされたオブジェクトと配列内のオブジェクトも再帰的に変換されます。
+
+例えば、オブジェクトのキーは次のように変換されます。
+
+- `snake_case` → `PascalCase`（例: `user_id` → `UserId`）
+- `camelCase` → `PascalCase`（例: `UserId` → `UserId`）
+- `UPPERCASE_KEYS` → `PascalCase`（例: `FIRST_NAME` → `FirstName`, `LAST` → `Last`）
+
+```typescript
+import { toPascalCaseKeys } from 'es-toolkit/object';
+
+// 基本的なオブジェクト変換
+const obj = { user_id: 1, first_name: 'John', last_name: 'Doe' };
+const result = toPascalCaseKeys(obj);
+// resultは{ UserId: 1, FirstName: 'John', LastName: 'Doe' }になります
+
+// 配列内のオブジェクトも変換
+const users = [
+  { user_id: 1, first_name: 'John' },
+  { user_id: 2, first_name: 'Jane' },
+];
+const convertedUsers = toPascalCaseKeys(users);
+// convertedUsersは[{ UserId: 1, FirstName: 'John' }, { UserId: 2, FirstName: 'Jane' }]になります
+
+// ネストされたオブジェクトも完全に変換
+const nested = {
+  user_data: {
+    user_id: 1,
+    contact_info: {
+      email_address: 'john@example.com',
+      phone_number: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toPascalCaseKeys(nested);
+// nestedResultは{
+//   UserData: {
+//     UserId: 1,
+//     ContactInfo: {
+//       EmailAddress: 'john@example.com',
+//       PhoneNumber: '123-456-7890'
+//     }
+//   }
+// }になります
+
+// camelCase と uppercase keys のキーも変換されます
+const raw = { userId: 1, FIRST_NAME: 'JinHo', LAST: 'Yeom' };
+const converted = toPascalCaseKeys(raw);
+// converted は { UserId: 1, FirstName: 'JinHo', Last: 'Yeom' } になります
+```
+
+#### パラメータ
+
+- `obj` (`T`): キーをPascalCaseに変換するオブジェクト、配列、またはプリミティブ値です。
+
+#### 戻り値
+
+(`ToPascalCaseKeys<T>`): すべてのキーがPascalCaseeに変換された新しいオブジェクトを返します。

--- a/docs/ko/reference/object/toConstantCaseKeys.md
+++ b/docs/ko/reference/object/toConstantCaseKeys.md
@@ -1,0 +1,67 @@
+# toConstantCaseKeys
+
+객체와 배열의 모든 키를 상수 표기법으로 변환한 새로운 객체를 반환해요.
+
+상수 표기법은 모든 문자를 대문자로 쓰고 단어 사이를 밑줄(`_`)로 구분하는 명명 규칙이에요. 예를 들어서, `CONSTANT_CASE` 처럼 작성해요.
+
+```typescript
+const constantCased = toConstantCaseKeys(obj);
+```
+
+## 사용법
+
+### `toConstantCaseKeys(obj)`
+
+객체의 모든 키를 CONSTANT_CASE로 변환하고 싶을 때 `toConstantCaseKeys`를 사용하세요. 중첩된 객체와 배열 내의 객체들도 재귀적으로 변환돼요.
+
+예를 들어, 객체의 키는 다음과 같이 변환돼요.
+
+- `camelCase` → `CONSTANT_CASE` (예: `userId` → `USER_ID`)
+- `PascalCase` → `CONSTANT_CASE` (예: `UserId` → `USER_ID`)
+- `snake_case` → `CONSTANT_CASE` (예: `first_name` → `FIRST_NAME`, `last` → `LAST`)
+
+```typescript
+import { toConstantCaseKeys } from 'es-toolkit/object';
+
+// 기본 객체 변환
+const obj = { userId: 1, firstName: 'John', lastName: 'Doe' };
+const result = toConstantCaseKeys(obj);
+// result는 { USER_ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe' }가 돼요
+
+// 배열 내 객체들도 변환해요
+const users = [
+  { userId: 1, firstName: 'John' },
+  { userId: 2, firstName: 'Jane' },
+];
+const convertedUsers = toConstantCaseKeys(users);
+// convertedUsers는 [{ USER_ID: 1, FIRST_NAME: 'John' }, { USER_ID: 2, FIRST_NAME: 'Jane' }]가 돼요
+
+// 중첩된 객체도 완전히 변환돼요
+const nested = {
+  userData: {
+    userId: 1,
+    contactInfo: {
+      emailAddress: 'john@example.com',
+      phoneNumber: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toConstantCaseKeys(nested);
+// nestedResult는 {
+//   USER_DATA: {
+//     USER_ID: 1,
+//     CONTACT_INFO: {
+//       EMAIL_ADDRESS: 'john@example.com',
+//       PHONE_NUMBER: '123-456-7890'
+//     }
+//   }
+// }가 돼요
+```
+
+#### 파라미터
+
+- `obj` (`T`): 키를 CONSTANT_CASE로 변환할 객체, 배열, 또는 원시 값이에요.
+
+#### 반환 값
+
+(`ToConstantCaseKeys<T>`): 모든 키가 CONSTANT_CASE로 변환된 새로운 객체를 반환해요.

--- a/docs/ko/reference/object/toKebabCaseKeys.md
+++ b/docs/ko/reference/object/toKebabCaseKeys.md
@@ -1,0 +1,67 @@
+# toKebabCaseKeys
+
+객체와 배열의 모든 키를 케밥 표기법으로 변환한 새로운 객체를 반환해요.
+
+케밥 표기법은 각 단어를 소문자로 쓰고 단어 사이를 대시(-)로 연결하는 명명 규칙이에요. 예를 들어서, `kebab-case` 처럼 작성해요.
+
+```typescript
+const kebabCased = toKebabCaseKeys(obj);
+```
+
+## 사용법
+
+### `toKebabCaseKeys(obj)`
+
+객체의 모든 키를 kebab-case로 변환하고 싶을 때 `toKebabCaseKeys`를 사용하세요. 중첩된 객체와 배열 내의 객체들도 재귀적으로 변환돼요.
+
+예를 들어, 객체의 키는 다음과 같이 변환돼요.
+
+- `camelCase` → `kebab-case` (예: `userId` → `user-id`)
+- `PascalCase` → `kebab-case` (예: `UserId` → `user-id`)
+- `UPPERCASE_KEYS` → `kebab-case` (예: `FIRST_NAME` → `first-name`, `LAST` → `last`)
+
+```typescript
+import { toKebabCaseKeys } from 'es-toolkit/object';
+
+// 기본 객체 변환
+const obj = { userId: 1, firstName: 'John', lastName: 'Doe' };
+const result = toKebabCaseKeys(obj);
+// result는 { 'user-id': 1, 'first-name': 'John', 'last-name': 'Doe' }가 돼요
+
+// 배열 내 객체들도 변환해요
+const users = [
+  { userId: 1, firstName: 'John' },
+  { userId: 2, firstName: 'Jane' },
+];
+const convertedUsers = toKebabCaseKeys(users);
+// convertedUsers는 [{ 'user-id': 1, 'first-name': 'John' }, { 'user-id': 2, 'first-name': 'Jane' }]가 돼요
+
+// 중첩된 객체도 완전히 변환돼요
+const nested = {
+  userData: {
+    userId: 1,
+    contactInfo: {
+      emailAddress: 'john@example.com',
+      phoneNumber: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toKebabCaseKeys(nested);
+// nestedResult는 {
+//   user_data: {
+//     user_id: 1,
+//     contact_info: {
+//       email_address: 'john@example.com',
+//       phone_number: '123-456-7890'
+//     }
+//   }
+// }가 돼요
+```
+
+#### 파라미터
+
+- `obj` (`T`): 키를 kebab-case로 변환할 객체, 배열, 또는 원시 값이에요.
+
+#### 반환 값
+
+(`ToKebabCaseKeys<T>`): 모든 키가 kebab-case로 변환된 새로운 객체를 반환해요.

--- a/docs/ko/reference/object/toPascalCaseKeys.md
+++ b/docs/ko/reference/object/toPascalCaseKeys.md
@@ -1,0 +1,72 @@
+# toPascalCaseKeys
+
+객체와 배열의 모든 키를 파스칼 표기법으로 변환한 새로운 객체를 반환해요.
+
+파스칼 표기법은 각 단어의 첫 글자를 대문자로 하고 단어 사이를 구분자 없이 연결하는 명명 규칙이에요. 예를 들어 `PascalCase`와 같이 작성해요.
+
+```typescript
+const pascalCased = toPascalCaseKeys(obj);
+```
+
+## 사용법
+
+### `toPascalCaseKeys(obj)`
+
+객체의 모든 키를 파스칼 케이스로 변환하고 싶을 때 `toPascalCaseKeys`를 사용하세요. 중첩된 객체와 배열 내의 객체들도 재귀적으로 변환돼요.
+
+예를 들어, 객체의 키는 다음과 같이 변환돼요.
+
+- `snake_case` → `PascalCase` (예: `user_id` → `UserId`)
+- `camelCase` → `PascalCase` (예: `UserId` → `UserId`)
+- `UPPERCASE_KEYS` → `PascalCase` (예: `FIRST_NAME` → `FirstName`, `LAST` → `Last`)
+
+```typescript
+import { toPascalCaseKeys } from 'es-toolkit/object';
+
+// 기본 객체 변환
+const obj = { user_id: 1, first_name: 'John', last_name: 'Doe' };
+const result = toPascalCaseKeys(obj);
+// result는 { UserId: 1, FirstName: 'John', LastName: 'Doe' }가 돼요
+
+// 배열 내 객체들도 변환해요
+const users = [
+  { user_id: 1, first_name: 'John' },
+  { user_id: 2, first_name: 'Jane' },
+];
+const convertedUsers = toPascalCaseKeys(users);
+// convertedUsers는 [{ UserId: 1, FirstName: 'John' }, { UserId: 2, FirstName: 'Jane' }]가 돼요
+
+// 중첩된 객체도 완전히 변환돼요
+const nested = {
+  user_data: {
+    user_id: 1,
+    contact_info: {
+      email_address: 'john@example.com',
+      phone_number: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toPascalCaseKeys(nested);
+// nestedResult는 {
+//   UserData: {
+//     UserId: 1,
+//     ContactInfo: {
+//       EmailAddress: 'john@example.com',
+//       PhoneNumber: '123-456-7890'
+//     }
+//   }
+// }가 돼요
+
+// PascalCase와 uppercase keys 키도 변환돼요
+const raw = { UserId: 1, FIRST_NAME: 'JinHo', LAST: 'Yeom' };
+const converted = toPascalCaseKeys(raw);
+// converted는 { UserId: 1, FirstName: 'JinHo', Last: 'Yeom' }가 돼요
+```
+
+#### 파라미터
+
+- `obj` (`T`): 키를 PascalCase로 변환할 객체, 배열, 또는 원시 값이에요.
+
+#### 반환 값
+
+(`ToPascalCaseKeys<T>`): 모든 키가 PascalCase로 변환된 새로운 객체를 반환해요.

--- a/docs/reference/object/toCamelCaseKeys.md
+++ b/docs/reference/object/toCamelCaseKeys.md
@@ -18,7 +18,7 @@ For example, object keys are converted as follows:
 
 - `snake_case` → `camelCase` (e.g. `user_id` → `userId`)
 - `PascalCase` → `camelCase` (e.g. `UserId` → `userId`)
-- `uppercase keys` → `camelCase` (e.g. `FIRST_NAME` → `firstName`, `LAST` → `last`)
+- `UPPERCASE_KEYS` → `camelCase` (e.g. `FIRST_NAME` → `firstName`, `LAST` → `last`)
 
 ```typescript
 import { toCamelCaseKeys } from 'es-toolkit/object';

--- a/docs/reference/object/toConstantCaseKeys.md
+++ b/docs/reference/object/toConstantCaseKeys.md
@@ -1,0 +1,67 @@
+# toConstantCaseKeys
+
+Returns a new object with all keys in objects and arrays converted to CONSTANT_CASE.
+
+Constant case is a naming convention where each word in an identifier is written in uppercase and connected with underscores (`_`). For example, it's written as `CONSTANT_CASE`.
+
+```typescript
+const constantCased = toConstantCaseKeys(obj);
+```
+
+## Usage
+
+### `toConstantCaseKeys(obj)`
+
+Use `toConstantCaseKeys` when you want to convert all keys of an object to CONSTANT_CASE. Nested objects and objects within arrays are also converted recursively.
+
+For example, object keys are converted as follows:
+
+- `camelCase` → `CONSTANT_CASE` (e.g. `userId` → `USER_ID`)
+- `PascalCase` → `CONSTANT_CASE` (e.g. `UserId` → `USER_ID`)
+- `snake_case` → `CONSTANT_CASE` (e.g. `first_name` → `FIRST_NAME`, `last` → `LAST`)
+
+```typescript
+import { toConstantCaseKeys } from 'es-toolkit/object';
+
+// Basic object conversion
+const obj = { userId: 1, firstName: 'John', lastName: 'Doe' };
+const result = toConstantCaseKeys(obj);
+// result is { USER_ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe' }
+
+// Objects within arrays are also converted
+const users = [
+  { userId: 1, firstName: 'John' },
+  { userId: 2, firstName: 'Jane' },
+];
+const convertedUsers = toConstantCaseKeys(users);
+// convertedUsers is [{ USER_ID: 1, FIRST_NAME: 'John' }, { USER_ID: 2, FIRST_NAME: 'Jane' }]
+
+// Nested objects are fully converted
+const nested = {
+  userData: {
+    userId: 1,
+    contactInfo: {
+      emailAddress: 'john@example.com',
+      phoneNumber: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toConstantCaseKeys(nested);
+// nestedResult is {
+//   USER_DATA: {
+//     USER_ID: 1,
+//     CONTACT_INFO: {
+//       EMAIL_ADDRESS: 'john@example.com',
+//       PHONE_NUMBER: '123-456-7890'
+//     }
+//   }
+// }
+```
+
+#### Parameters
+
+- `obj` (`T`): The object, array, or primitive value to convert keys to CONSTANT_CASE.
+
+#### Returns
+
+(`ToConstantCaseKeys<T>`): Returns a new object with all keys converted to CONSTANT_CASE.

--- a/docs/reference/object/toKebabCaseKeys.md
+++ b/docs/reference/object/toKebabCaseKeys.md
@@ -1,0 +1,67 @@
+# toKebabCaseKeys
+
+Returns a new object with all keys in objects and arrays converted to kebab-case.
+
+Kebab case is a naming convention where each word is written in lowercase and connected with dashes (-). For example, it's written as `kebab-case`.
+
+```typescript
+const kebabCased = toKebabCaseKeys(obj);
+```
+
+## Usage
+
+### `toKebabCaseKeys(obj)`
+
+Use `toKebabCaseKeys` when you want to convert all keys of an object to kebab-case. Nested objects and objects within arrays are also converted recursively.
+
+For example, object keys are converted as follows:
+
+- `camelCase` → `kebab-case` (e.g. `userId` → `user-id`)
+- `PascalCase` → `kebab-case` (e.g. `UserId` → `user-id`)
+- `UPPERCASE_KEYS` → `kebab-case` (e.g. `FIRST_NAME` → `first-name`, `LAST` → `last`)
+
+```typescript
+import { toKebabCaseKeys } from 'es-toolkit/object';
+
+// Basic object conversion
+const obj = { userId: 1, firstName: 'John', lastName: 'Doe' };
+const result = toKebabCaseKeys(obj);
+// result is { 'user-id': 1, 'first-name': 'John', 'last-name': 'Doe' }
+
+// Objects within arrays are also converted
+const users = [
+  { userId: 1, firstName: 'John' },
+  { userId: 2, firstName: 'Jane' },
+];
+const convertedUsers = toKebabCaseKeys(users);
+// convertedUsers is [{ 'user-id': 1, 'first-name': 'John' }, { 'user-id': 2, 'first-name': 'Jane' }]
+
+// Nested objects are fully converted
+const nested = {
+  userData: {
+    userId: 1,
+    contactInfo: {
+      emailAddress: 'john@example.com',
+      phoneNumber: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toKebabCaseKeys(nested);
+// nestedResult is {
+//   'user-data': {
+//     'user-id': 1,
+//     'contact-info': {
+//       'email-address': 'john@example.com',
+//       'phone-number': '123-456-7890'
+//     }
+//   }
+// }
+```
+
+#### Parameters
+
+- `obj` (`T`): The object, array, or primitive value to convert keys to kebab-case.
+
+#### Returns
+
+(`ToKebabCaseKeys<T>`): Returns a new object with all keys converted to kebab-case.

--- a/docs/reference/object/toPascalCaseKeys.md
+++ b/docs/reference/object/toPascalCaseKeys.md
@@ -1,0 +1,72 @@
+# toPascalCaseKeys
+
+Returns a new object with all keys in objects and arrays converted to PascalCase.
+
+Pascal case is a naming convention where each word in an identifier is capitalized and concatenated. For example, it's written as `PascalCase`.
+
+```typescript
+const pascalCased = toPascalCaseKeys(obj);
+```
+
+## Usage
+
+### `toPascalCaseKeys(obj)`
+
+Use `toPascalCaseKeys` when you want to convert all keys of an object to pascal case. Nested objects and objects within arrays are also converted recursively.
+
+For example, object keys are converted as follows:
+
+- `snake_case` → `PascalCase` (e.g. `user_id` → `UserId`)
+- `camelCase` → `PascalCase` (e.g. `UserId` → `UserId`)
+- `UPPERCASE_KEYS` → `PascalCase` (e.g. `FIRST_NAME` → `FirstName`, `LAST` → `Last`)
+
+```typescript
+import { toPascalCaseKeys } from 'es-toolkit/object';
+
+// Basic object conversion
+const obj = { user_id: 1, first_name: 'John', last_name: 'Doe' };
+const result = toPascalCaseKeys(obj);
+// result is { UserId: 1, FirstName: 'John', LastName: 'Doe' }
+
+// Objects within arrays are also converted
+const users = [
+  { user_id: 1, first_name: 'John' },
+  { user_id: 2, first_name: 'Jane' },
+];
+const convertedUsers = toPascalCaseKeys(users);
+// convertedUsers is [{ UserId: 1, FirstName: 'John' }, { UserId: 2, FirstName: 'Jane' }]
+
+// Nested objects are fully converted
+const nested = {
+  user_data: {
+    user_id: 1,
+    contact_info: {
+      email_address: 'john@example.com',
+      phone_number: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toPascalCaseKeys(nested);
+// nestedResult is {
+//   UserData: {
+//     UserId: 1,
+//     ContactInfo: {
+//       EmailAddress: 'john@example.com',
+//       PhoneNumber: '123-456-7890'
+//     }
+//   }
+// }
+
+// camelCase and uppercase keys are also converted
+const raw = { userId: 1, FIRST_NAME: 'JinHo', LAST: 'Yeom' };
+const converted = toPascalCaseKeys(raw);
+// converted is { UserId: 1, FirstName: 'JinHo', Last: 'Yeom' }
+```
+
+#### Parameters
+
+- `obj` (`T`): The object, array, or primitive value to convert keys to PascalCase.
+
+#### Returns
+
+(`ToPascalCaseKeys<T>`): Returns a new object with all keys converted to PascalCase.

--- a/docs/zh_hans/reference/object/toConstantCaseKeys.md
+++ b/docs/zh_hans/reference/object/toConstantCaseKeys.md
@@ -1,0 +1,67 @@
+# toConstantCaseKeys
+
+返回一个将对象和数组的所有键转换为常量命名法的新对象。
+
+常量命名法是一种命名规则,所有字符都大写,单词之间用下划线(`_`)分隔。。例如 `CONSTANT_CASE`。
+
+```typescript
+const constantCased = toConstantCaseKeys(obj);
+```
+
+## 用法
+
+### `toConstantCaseKeys(obj)`
+
+当您想要将对象的所有键转换为 CONSTANT_CASE 时,请使用 `toConstantCaseKeys`。嵌套对象和数组中的对象也会递归转换。
+
+例如，对象的键会按如下方式转换：
+
+- `camelCase` → `CONSTANT_CASE`（例如 `userId` → `USER_ID`）
+- `PascalCase` → `CONSTANT_CASE`（例如 `UserId` → `USER_ID`）
+- `snake_case` → `CONSTANT_CASE`（例如 `first_name` → `FIRST_NAME`, `last` → `LAST`）
+
+```typescript
+import { toConstantCaseKeys } from 'es-toolkit/object';
+
+// 基本对象转换
+const obj = { userId: 1, firstName: 'John', lastName: 'Doe' };
+const result = toConstantCaseKeys(obj);
+// result 是 { USER_ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe' }
+
+// 数组中的对象也会转换
+const users = [
+  { userId: 1, firstName: 'John' },
+  { userId: 2, firstName: 'Jane' },
+];
+const convertedUsers = toConstantCaseKeys(users);
+// convertedUsers 是 [{ USER_ID: 1, FIRST_NAME: 'John' }, { USER_ID: 2, FIRST_NAME: 'Jane' }]
+
+// 嵌套对象也会完全转换
+const nested = {
+  userData: {
+    userId: 1,
+    contactInfo: {
+      emailAddress: 'john@example.com',
+      phoneNumber: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toConstantCaseKeys(nested);
+// nestedResult 是 {
+//   USER_DATA: {
+//     USER_ID: 1,
+//     CONTACT_INFO: {
+//       EMAIL_ADDRESS: 'john@example.com',
+//       PHONE_NUMBER: '123-456-7890'
+//     }
+//   }
+// }
+```
+
+#### 参数
+
+- `obj` (`T`): 要将键转换为 CONSTANT_CASE 的对象、数组或原始值。
+
+#### 返回值
+
+(`ToConstantCaseKeys<T>`): 返回所有键都已转换为 CONSTANT_CASE 的新对象。

--- a/docs/zh_hans/reference/object/toKebabCaseKeys.md
+++ b/docs/zh_hans/reference/object/toKebabCaseKeys.md
@@ -1,0 +1,67 @@
+# toKebabCaseKeys
+
+返回一个将对象和数组的所有键转换为短横线命名法的新对象。
+
+短横线命名法是一种命名约定，其中每个单词都以小写字母书写，并用短横线（-）连接。例如 `kebab-case`。
+
+```typescript
+const snakeCased = toKebabCaseKeys(obj);
+```
+
+## 用法
+
+### `toKebabCaseKeys(obj)`
+
+当您想要将对象的所有键转换为 kebab-case 时,请使用 `toKebabCaseKeys`。嵌套对象和数组中的对象也会递归转换。
+
+例如，对象的键会按如下方式转换：
+
+- `camelCase` → `kebab-case`（例如 `userId` → `user-id`）
+- `PascalCase` → `kebab-case`（例如 `UserId` → `user-id`）
+- `UPPERCASE_KEYS` → `kebab-case`（例如 `FIRST_NAME` → `first-name`, `LAST` → `last`）
+
+```typescript
+import { toKebabCaseKeys } from 'es-toolkit/object';
+
+// 基本对象转换
+const obj = { userId: 1, firstName: 'John', lastName: 'Doe' };
+const result = toKebabCaseKeys(obj);
+// result 是 { 'user-id': 1, 'first-name': 'John', 'last-name': 'Doe' }
+
+// 数组中的对象也会转换
+const users = [
+  { userId: 1, firstName: 'John' },
+  { userId: 2, firstName: 'Jane' },
+];
+const convertedUsers = toKebabCaseKeys(users);
+// convertedUsers 是 [{ 'user-id': 1, 'first-name': 'John' }, { 'user-id': 2, 'first-name': 'Jane' }]
+
+// 嵌套对象也会完全转换
+const nested = {
+  userData: {
+    userId: 1,
+    contactInfo: {
+      emailAddress: 'john@example.com',
+      phoneNumber: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toKebabCaseKeys(nested);
+// nestedResult 是 {
+//   'user-data': {
+//     'user-id': 1,
+//     'contact-info': {
+//       'email-address': 'john@example.com',
+//       'phone-number': '123-456-7890'
+//     }
+//   }
+// }
+```
+
+#### 参数
+
+- `obj` (`T`): 要将键转换为 kebab-case 的对象、数组或原始值。
+
+#### 返回值
+
+(`ToKebabCaseKeys<T>`): 返回所有键都已转换为 kebab-case 的新对象。

--- a/docs/zh_hans/reference/object/toPascalCaseKeys.md
+++ b/docs/zh_hans/reference/object/toPascalCaseKeys.md
@@ -1,0 +1,72 @@
+# toPascalCaseKeys
+
+返回一个将对象和数组的所有键转换为帕斯卡命名法的新对象。
+
+帕斯卡命名法是一种命名规范，每个单词的首字母大写，单词之间不使用分隔符连接。例如 `PascalCase`。
+
+```typescript
+const pascalCased = toPascalCaseKeys(obj);
+```
+
+## 用法
+
+### `toPascalCaseKeys(obj)`
+
+当您想要将对象的所有键转换为帕斯卡命名法时,请使用 `toPascalCaseKeys`。嵌套对象和数组中的对象也会递归转换。
+
+例如，对象的键会按如下方式转换：
+
+- `snake_case` → `PascalCase`（例如 `user_id` → `UserId`）
+- `camelCase` → `PascalCase`（例如 `UserId` → `UserId`）
+- `UPPERCASE_KEYS` → `PascalCase`（例如 `FIRST_NAME` → `FirstName`, `LAST` → `Last`）
+
+```typescript
+import { toPascalCaseKeys } from 'es-toolkit/object';
+
+// 基本对象转换
+const obj = { user_id: 1, first_name: 'John', last_name: 'Doe' };
+const result = toPascalCaseKeys(obj);
+// result 是 { UserId: 1, FirstName: 'John', LastName: 'Doe' }
+
+// 数组中的对象也会转换
+const users = [
+  { user_id: 1, first_name: 'John' },
+  { user_id: 2, first_name: 'Jane' },
+];
+const convertedUsers = toPascalCaseKeys(users);
+// convertedUsers 是 [{ UserId: 1, FirstName: 'John' }, { UserId: 2, FirstName: 'Jane' }]
+
+// 嵌套对象也会完全转换
+const nested = {
+  user_data: {
+    user_id: 1,
+    contact_info: {
+      email_address: 'john@example.com',
+      phone_number: '123-456-7890',
+    },
+  },
+};
+const nestedResult = toPascalCaseKeys(nested);
+// nestedResult 是 {
+//   UserData: {
+//     UserId: 1,
+//     ContactInfo: {
+//       EmailAddress: 'john@example.com',
+//       PhoneNumber: '123-456-7890'
+//     }
+//   }
+// }
+
+// PascalCase 和 uppercase keys 的键也会被转换
+const raw = { UserId: 1, FIRST_NAME: 'JinHo', LAST: 'Yeom' };
+const converted = toPascalCaseKeys(raw);
+// converted 是 { UserId: 1, FirstName: 'JinHo', Last: 'Yeom' }
+```
+
+#### 参数
+
+- `obj` (`T`): 要将键转换为 PascalCase 的对象、数组或原始值。
+
+#### 返回值
+
+(`ToPascalCaseKeys<T>`): 返回所有键都已转换为 PascalCase 的新对象。

--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -16,4 +16,5 @@ export { sortKeys } from './sortKeys.ts';
 export { toCamelCaseKeys } from './toCamelCaseKeys.ts';
 export { toConstantCaseKeys } from './toConstantCaseKeys.ts';
 export { toMerged } from './toMerged.ts';
+export { toPascalCaseKeys } from './toPascalCaseKeys.ts';
 export { toSnakeCaseKeys } from './toSnakeCaseKeys.ts';

--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -14,5 +14,6 @@ export { pick } from './pick.ts';
 export { pickBy } from './pickBy.ts';
 export { sortKeys } from './sortKeys.ts';
 export { toCamelCaseKeys } from './toCamelCaseKeys.ts';
+export { toConstantCaseKeys } from './toConstantCaseKeys.ts';
 export { toMerged } from './toMerged.ts';
 export { toSnakeCaseKeys } from './toSnakeCaseKeys.ts';

--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -15,6 +15,7 @@ export { pickBy } from './pickBy.ts';
 export { sortKeys } from './sortKeys.ts';
 export { toCamelCaseKeys } from './toCamelCaseKeys.ts';
 export { toConstantCaseKeys } from './toConstantCaseKeys.ts';
+export { toKebabCaseKeys } from './toKebabCaseKeys.ts';
 export { toMerged } from './toMerged.ts';
 export { toPascalCaseKeys } from './toPascalCaseKeys.ts';
 export { toSnakeCaseKeys } from './toSnakeCaseKeys.ts';

--- a/src/object/toCamelCaseKeys.ts
+++ b/src/object/toCamelCaseKeys.ts
@@ -40,7 +40,7 @@ type NonPlainObject =
   | ((...args: any[]) => any)
   | typeof globalThis;
 
-type ToCamelCaseKeys<T> = T extends NonPlainObject
+export type ToCamelCaseKeys<T> = T extends NonPlainObject
   ? T
   : T extends any[]
     ? Array<ToCamelCaseKeys<T[number]>>

--- a/src/object/toConstantCaseKeys.spec.ts
+++ b/src/object/toConstantCaseKeys.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { toConstantCaseKeys } from './toConstantCaseKeys';
+
+describe('constantizeKeys', () => {
+  it('should convert camelCase keys to CONSTANT_CASE in a flat object', () => {
+    const input = { userId: 1, firstName: 'John', lastName: 'Doe' };
+    const expected = { USER_ID: 1, FIRST_NAME: 'John', LAST_NAME: 'Doe' };
+    expect(toConstantCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should convert keys recursively in nested objects', () => {
+    const input = {
+      userData: {
+        userId: 1,
+        userAddress: {
+          streetName: 'Main St',
+          zipCode: '12345',
+        },
+      },
+    };
+    const expected = {
+      USER_DATA: {
+        USER_ID: 1,
+        USER_ADDRESS: {
+          STREET_NAME: 'Main St',
+          ZIP_CODE: '12345',
+        },
+      },
+    };
+    expect(toConstantCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should handle arrays of objects', () => {
+    const input = [
+      { userId: 1, firstName: 'John' },
+      { userId: 2, firstName: 'Jane' },
+    ];
+    const expected = [
+      { USER_ID: 1, FIRST_NAME: 'John' },
+      { USER_ID: 2, FIRST_NAME: 'Jane' },
+    ];
+    expect(toConstantCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should handle arrays inside objects', () => {
+    const input = {
+      userList: [
+        { userId: 1, firstName: 'John' },
+        { userId: 2, firstName: 'Jane' },
+      ],
+    };
+    const expected = {
+      USER_LIST: [
+        { USER_ID: 1, FIRST_NAME: 'John' },
+        { USER_ID: 2, FIRST_NAME: 'Jane' },
+      ],
+    };
+    expect(toConstantCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should not modify primitive values', () => {
+    expect(toConstantCaseKeys(123)).toBe(123);
+    expect(toConstantCaseKeys('string')).toBe('string');
+    expect(toConstantCaseKeys(null)).toBe(null);
+    expect(toConstantCaseKeys(undefined)).toBe(undefined);
+    expect(toConstantCaseKeys(true)).toBe(true);
+  });
+
+  it('should handle empty objects and arrays', () => {
+    expect(toConstantCaseKeys({})).toEqual({});
+    expect(toConstantCaseKeys([])).toEqual([]);
+  });
+
+  it('should preserve object prototype methods', () => {
+    const input = { userId: 1, toString: Object.prototype.toString };
+    const result = toConstantCaseKeys(input);
+    expect(result).toHaveProperty('USER_ID', 1);
+    expect(result).toHaveProperty('TO_STRING');
+    expect(result.TO_STRING).toBe(Object.prototype.toString);
+  });
+
+  it('should properly type nested objects', () => {
+    const input = {
+      userData: {
+        personalInfo: {
+          firstName: 'John',
+        },
+      },
+    };
+    const result = toConstantCaseKeys(input);
+
+    expectTypeOf(result).toMatchTypeOf<{
+      USER_DATA: {
+        PERSONAL_INFO: {
+          FIRST_NAME: string;
+        };
+      };
+    }>();
+  });
+
+  it('should properly type arrays', () => {
+    const input = [{ userId: 1 }, { userId: 2 }];
+    const result = toConstantCaseKeys(input);
+
+    expectTypeOf(result).toMatchTypeOf<Array<{ USER_ID: number }>>();
+  });
+
+  it('should properly type mixed complex structures', () => {
+    const input = {
+      users: [
+        { userId: 1, settings: { isActive: true } },
+        { userId: 2, settings: { isActive: false } },
+      ],
+    };
+    const result = toConstantCaseKeys(input);
+
+    expectTypeOf(result).toMatchTypeOf<{
+      USERS: Array<{
+        USER_ID: number;
+        SETTINGS: {
+          IS_ACTIVE: boolean;
+        };
+      }>;
+    }>();
+  });
+
+  it('should have correct TypeScript types for non-plain objects', () => {
+    const input = { a: new Date(), b: /test/, c: new Map() };
+    const result = toConstantCaseKeys(input);
+
+    expectTypeOf(result.A).toEqualTypeOf<Date>();
+    expectTypeOf(result.B).toEqualTypeOf<RegExp>();
+    expectTypeOf(result.C).toEqualTypeOf<Map<any, any>>();
+  });
+
+  it('should convert snake_case keys to CONSTANT_CASE at both runtime and type level', () => {
+    const input = {
+      first_name: 'JinHo',
+      last: 'Yeom',
+    } as const;
+
+    const result = toConstantCaseKeys(input);
+
+    expect(result).toEqual({
+      FIRST_NAME: 'JinHo',
+      LAST: 'Yeom',
+    });
+
+    expectTypeOf(result).toMatchTypeOf<{
+      FIRST_NAME: 'JinHo';
+      LAST: 'Yeom';
+    }>();
+  });
+});

--- a/src/object/toConstantCaseKeys.ts
+++ b/src/object/toConstantCaseKeys.ts
@@ -1,0 +1,114 @@
+import { isArray } from '../compat/predicate/isArray.ts';
+import { isPlainObject } from '../compat/predicate/isPlainObject.ts';
+import { constantCase } from '../string/constantCase.ts';
+
+type ConstantCase<S extends string> =
+  S extends Lowercase<S>
+    ? Uppercase<S>
+    : S extends `${infer P1}${infer P2}`
+      ? P2 extends Uncapitalize<P2>
+        ? `${Uppercase<P1>}${ConstantCase<P2>}`
+        : `${Uppercase<P1>}_${ConstantCase<Uncapitalize<P2>>}`
+      : Uppercase<S>;
+
+type NonPlainObject =
+  | Date
+  | RegExp
+  | Map<any, any>
+  | Set<any>
+  | WeakMap<any, any>
+  | WeakSet<any>
+  | Promise<any>
+  | Error
+  | ArrayBuffer
+  | DataView
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array
+  | ((...args: any[]) => any)
+  | typeof globalThis;
+
+export type ToConstantCaseKeys<T> = T extends NonPlainObject
+  ? T
+  : T extends any[]
+    ? Array<ToConstantCaseKeys<T[number]>>
+    : T extends Record<string, any>
+      ? { [K in keyof T as ConstantCase<string & K>]: ToConstantCaseKeys<T[K]> }
+      : T;
+
+/**
+ * Creates a new object composed of the properties with keys converted to CONSTANT_CASE.
+ *
+ * This function takes an object and returns a new object that includes the same properties,
+ * but with all keys converted to CONSTANT_CASE format.
+ *
+ * @template T - The type of object.
+ * @param obj - The object to convert keys from.
+ * @returns A new object with all keys converted to CONSTANT_CASE.
+ *
+ * @example
+ * // Example with objects
+ * const obj = { userId: 1, firstName: 'John' };
+ * const result = toConstantCaseKeys(obj);
+ * // result will be { USER_ID: 1, FIRST_NAME: 'John' }
+ *
+ * // Example with arrays of objects
+ * const arr = [
+ *   { userId: 1, firstName: 'John' },
+ *   { userId: 2, firstName: 'Jane' }
+ * ];
+ * const arrResult = toConstantCaseKeys(arr);
+ * // arrResult will be [{ USER_ID: 1, FIRST_NAME: 'John' }, { USER_ID: 2, FIRST_NAME: 'Jane' }]
+ *
+ * // Example with nested objects
+ * const nested = {
+ *   userData: {
+ *     userId: 1,
+ *     userAddress: {
+ *       streetName: 'Main St',
+ *       zipCode: '12345'
+ *     }
+ *   }
+ * };
+ * const nestedResult = toConstantCaseKeys(nested);
+ * // nestedResult will be:
+ * // {
+ * //   USER_DATA: {
+ * //     USER_ID: 1,
+ * //     USER_ADDRESS: {
+ * //       STREET_NAME: 'Main St',
+ * //       ZIP_CODE: '12345'
+ * //     }
+ * //   }
+ * // }
+ */
+export function toConstantCaseKeys<T>(obj: T): ToConstantCaseKeys<T> {
+  if (isArray(obj)) {
+    return obj.map(item => toConstantCaseKeys(item)) as unknown as ToConstantCaseKeys<T>;
+  }
+
+  if (isPlainObject(obj)) {
+    const result = {} as ToConstantCaseKeys<T>;
+    const keys = Object.keys(obj as Record<PropertyKey, any>);
+
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+
+      const constantKey = constantCase(key) as keyof typeof result;
+      const convertedValue = toConstantCaseKeys((obj as Record<PropertyKey, any>)[key]);
+      result[constantKey] = convertedValue as ToConstantCaseKeys<T>[keyof ToConstantCaseKeys<T>];
+    }
+
+    return result;
+  }
+
+  return obj as ToConstantCaseKeys<T>;
+}

--- a/src/object/toKebabCaseKeys.spec.ts
+++ b/src/object/toKebabCaseKeys.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { toKebabCaseKeys } from './toKebabCaseKeys';
+
+describe('kebabizeKeys', () => {
+  it('should convert camelCase keys to kebab-case in a flat object', () => {
+    const input = { userId: 1, firstName: 'John', lastName: 'Doe' };
+    const expected = { 'user-id': 1, 'first-name': 'John', 'last-name': 'Doe' };
+    expect(toKebabCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should convert keys recursively in nested objects', () => {
+    const input = {
+      userData: {
+        userId: 1,
+        userAddress: {
+          streetName: 'Main St',
+          zipCode: '12345',
+        },
+      },
+    };
+    const expected = {
+      'user-data': {
+        'user-id': 1,
+        'user-address': {
+          'street-name': 'Main St',
+          'zip-code': '12345',
+        },
+      },
+    };
+    expect(toKebabCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should handle arrays of objects', () => {
+    const input = [
+      { userId: 1, firstName: 'John' },
+      { userId: 2, firstName: 'Jane' },
+    ];
+    const expected = [
+      { 'user-id': 1, 'first-name': 'John' },
+      { 'user-id': 2, 'first-name': 'Jane' },
+    ];
+    expect(toKebabCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should handle arrays inside objects', () => {
+    const input = {
+      userList: [
+        { userId: 1, firstName: 'John' },
+        { userId: 2, firstName: 'Jane' },
+      ],
+    };
+    const expected = {
+      'user-list': [
+        { 'user-id': 1, 'first-name': 'John' },
+        { 'user-id': 2, 'first-name': 'Jane' },
+      ],
+    };
+    expect(toKebabCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should not modify primitive values', () => {
+    expect(toKebabCaseKeys(123)).toBe(123);
+    expect(toKebabCaseKeys('string')).toBe('string');
+    expect(toKebabCaseKeys(null)).toBe(null);
+    expect(toKebabCaseKeys(undefined)).toBe(undefined);
+    expect(toKebabCaseKeys(true)).toBe(true);
+  });
+
+  it('should handle empty objects and arrays', () => {
+    expect(toKebabCaseKeys({})).toEqual({});
+    expect(toKebabCaseKeys([])).toEqual([]);
+  });
+
+  it('should preserve object prototype methods', () => {
+    const input = { userId: 1, toString: Object.prototype.toString };
+    const result = toKebabCaseKeys(input);
+    expect(result).toHaveProperty('user-id', 1);
+    expect(result).toHaveProperty('toString');
+    expect(result.toString).toBe(Object.prototype.toString);
+  });
+
+  it('should properly type nested objects', () => {
+    const input = {
+      userData: {
+        personalInfo: {
+          firstName: 'John',
+        },
+      },
+    };
+    const result = toKebabCaseKeys(input);
+
+    expectTypeOf(result).toMatchTypeOf<{
+      'user-data': {
+        'personal-info': {
+          'first-name': string;
+        };
+      };
+    }>();
+  });
+
+  it('should properly type arrays', () => {
+    const input = [{ userId: 1 }, { userId: 2 }];
+    const result = toKebabCaseKeys(input);
+
+    expectTypeOf(result).toMatchTypeOf<Array<{ 'user-id': number }>>();
+  });
+
+  it('should properly type mixed complex structures', () => {
+    const input = {
+      users: [
+        { userId: 1, settings: { isActive: true } },
+        { userId: 2, settings: { isActive: false } },
+      ],
+    };
+    const result = toKebabCaseKeys(input);
+
+    expectTypeOf(result).toMatchTypeOf<{
+      users: Array<{
+        'user-id': number;
+        settings: {
+          'is-active': boolean;
+        };
+      }>;
+    }>();
+  });
+
+  it('should have correct TypeScript types for non-plain objects', () => {
+    const input = { a: new Date(), b: /test/, c: new Map() };
+    const result = toKebabCaseKeys(input);
+
+    expectTypeOf(result.a).toEqualTypeOf<Date>();
+    expectTypeOf(result.b).toEqualTypeOf<RegExp>();
+    expectTypeOf(result.c).toEqualTypeOf<Map<any, any>>();
+  });
+
+  it('should convert uppercase keys to kebab-case at both runtime and type level', () => {
+    const input = {
+      FIRST_NAME: 'JinHo',
+      LAST: 'Yeom',
+    } as const;
+
+    const result = toKebabCaseKeys(input);
+
+    expect(result).toEqual({
+      'first-name': 'JinHo',
+      last: 'Yeom',
+    });
+
+    expectTypeOf(result).toMatchTypeOf<{
+      'first-name': 'JinHo';
+      last: 'Yeom';
+    }>();
+  });
+});

--- a/src/object/toKebabCaseKeys.ts
+++ b/src/object/toKebabCaseKeys.ts
@@ -1,0 +1,120 @@
+import { isArray } from '../compat/predicate/isArray.ts';
+import { isPlainObject } from '../compat/predicate/isPlainObject.ts';
+import { kebabCase } from '../string/kebabCase.ts';
+
+type SnakeToKebab<S extends string> = S extends `${infer P1}_${infer P2}`
+  ? Lowercase<`${P1}-${SnakeToKebab<P2>}`>
+  : Lowercase<S>;
+type CamelToKebab<S extends string> = S extends `${infer P1}${infer P2}`
+  ? P2 extends Uncapitalize<P2>
+    ? `${Lowercase<P1>}${CamelToKebab<P2>}`
+    : `${Lowercase<P1>}-${CamelToKebab<Uncapitalize<P2>>}`
+  : S;
+
+type KebabCase<S extends string> = S extends `${string}_${string}`
+  ? SnakeToKebab<S>
+  : S extends Uppercase<S>
+    ? Lowercase<S>
+    : CamelToKebab<S>;
+
+type NonPlainObject =
+  | Date
+  | RegExp
+  | Map<any, any>
+  | Set<any>
+  | WeakMap<any, any>
+  | WeakSet<any>
+  | Promise<any>
+  | Error
+  | ArrayBuffer
+  | DataView
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array
+  | ((...args: any[]) => any)
+  | typeof globalThis;
+
+export type ToKebabCaseKeys<T> = T extends NonPlainObject
+  ? T
+  : T extends any[]
+    ? Array<ToKebabCaseKeys<T[number]>>
+    : T extends Record<string, any>
+      ? { [K in keyof T as KebabCase<string & K>]: ToKebabCaseKeys<T[K]> }
+      : T;
+
+/**
+ * Creates a new object composed of the properties with keys converted to kebab-case.
+ *
+ * This function takes an object and returns a new object that includes the same properties,
+ * but with all keys converted to kebab-case format.
+ *
+ * @template T - The type of object.
+ * @param obj - The object to convert keys from.
+ * @returns A new object with all keys converted to kebab-case.
+ *
+ * @example
+ * // Example with objects
+ * const obj = { userId: 1, firstName: 'John' };
+ * const result = toKebabCaseKeys(obj);
+ * // result will be { 'user-id': 1, 'first-name': 'John' }
+ *
+ * // Example with arrays of objects
+ * const arr = [
+ *   { userId: 1, firstName: 'John' },
+ *   { userId: 2, firstName: 'Jane' }
+ * ];
+ * const arrResult = toKebabCaseKeys(arr);
+ * // arrResult will be [{ 'user-id': 1, 'first-name': 'John' }, { 'user-id': 2, 'first-name': 'Jane' }]
+ *
+ * // Example with nested objects
+ * const nested = {
+ *   userData: {
+ *     userId: 1,
+ *     userAddress: {
+ *       streetName: 'Main St',
+ *       zipCode: '12345'
+ *     }
+ *   }
+ * };
+ * const nestedResult = toKebabCaseKeys(nested);
+ * // nestedResult will be:
+ * // {
+ * //   'user-data': {
+ * //     'user-id': 1,
+ * //     'user-address': {
+ * //       'street-name': 'Main St',
+ * //       'zip-code': '12345'
+ * //     }
+ * //   }
+ * // }
+ */
+export function toKebabCaseKeys<T>(obj: T): ToKebabCaseKeys<T> {
+  if (isArray(obj)) {
+    return obj.map(item => toKebabCaseKeys(item)) as unknown as ToKebabCaseKeys<T>;
+  }
+
+  if (isPlainObject(obj)) {
+    const result = {} as ToKebabCaseKeys<T>;
+    const keys = Object.keys(obj as Record<PropertyKey, any>);
+
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+
+      const kebabKey = kebabCase(key) as keyof typeof result;
+      const convertedValue = toKebabCaseKeys((obj as Record<PropertyKey, any>)[key]);
+      result[kebabKey] = convertedValue as ToKebabCaseKeys<T>[keyof ToKebabCaseKeys<T>];
+    }
+
+    return result;
+  }
+
+  return obj as ToKebabCaseKeys<T>;
+}

--- a/src/object/toPascalCaseKeys.spec.ts
+++ b/src/object/toPascalCaseKeys.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { toPascalCaseKeys } from './toPascalCaseKeys';
+
+describe('pascalizeKeys', () => {
+  it('should convert camelCase keys to PascalCase in a flat object', () => {
+    const input = { userId: 1, firstName: 'John', lastName: 'Doe' };
+    const expected = { UserId: 1, FirstName: 'John', LastName: 'Doe' };
+    expect(toPascalCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should convert keys recursively in nested objects', () => {
+    const input = {
+      userData: {
+        userId: 1,
+        userAddress: {
+          streetName: 'Main St',
+          zipCode: '12345',
+        },
+      },
+    };
+    const expected = {
+      UserData: {
+        UserId: 1,
+        UserAddress: {
+          StreetName: 'Main St',
+          ZipCode: '12345',
+        },
+      },
+    };
+    expect(toPascalCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should handle arrays of objects', () => {
+    const input = [
+      { userId: 1, firstName: 'John' },
+      { userId: 2, firstName: 'Jane' },
+    ];
+    const expected = [
+      { UserId: 1, FirstName: 'John' },
+      { UserId: 2, FirstName: 'Jane' },
+    ];
+    expect(toPascalCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should handle arrays inside objects', () => {
+    const input = {
+      userList: [
+        { userId: 1, firstName: 'John' },
+        { userId: 2, firstName: 'Jane' },
+      ],
+    };
+    const expected = {
+      UserList: [
+        { UserId: 1, FirstName: 'John' },
+        { UserId: 2, FirstName: 'Jane' },
+      ],
+    };
+    expect(toPascalCaseKeys(input)).toEqual(expected);
+  });
+
+  it('should not modify primitive values', () => {
+    expect(toPascalCaseKeys(123)).toBe(123);
+    expect(toPascalCaseKeys('string')).toBe('string');
+    expect(toPascalCaseKeys(null)).toBe(null);
+    expect(toPascalCaseKeys(undefined)).toBe(undefined);
+    expect(toPascalCaseKeys(true)).toBe(true);
+  });
+
+  it('should handle empty objects and arrays', () => {
+    expect(toPascalCaseKeys({})).toEqual({});
+    expect(toPascalCaseKeys([])).toEqual([]);
+  });
+
+  it('should preserve object prototype methods', () => {
+    const input = { userId: 1, toString: Object.prototype.toString };
+    const result = toPascalCaseKeys(input);
+    expect(result).toHaveProperty('UserId', 1);
+    expect(result).toHaveProperty('ToString');
+    expect(result.toString).toBe(Object.prototype.toString);
+  });
+
+  it('should properly type nested objects', () => {
+    const input = {
+      userData: {
+        personalInfo: {
+          firstName: 'John',
+        },
+      },
+    };
+    const result = toPascalCaseKeys(input);
+
+    expectTypeOf(result).toMatchTypeOf<{
+      UserData: {
+        PersonalInfo: {
+          FirstName: string;
+        };
+      };
+    }>();
+  });
+
+  it('should properly type arrays', () => {
+    const input = [{ userId: 1 }, { userId: 2 }];
+    const result = toPascalCaseKeys(input);
+
+    expectTypeOf(result).toMatchTypeOf<Array<{ UserId: number }>>();
+  });
+
+  it('should properly type mixed complex structures', () => {
+    const input = {
+      users: [
+        { userId: 1, settings: { isActive: true } },
+        { userId: 2, settings: { isActive: false } },
+      ],
+    };
+    const result = toPascalCaseKeys(input);
+
+    expectTypeOf(result).toMatchTypeOf<{
+      Users: Array<{
+        UserId: number;
+        Settings: {
+          IsActive: boolean;
+        };
+      }>;
+    }>();
+  });
+
+  it('should have correct TypeScript types for non-plain objects', () => {
+    const input = { a: new Date(), b: /test/, c: new Map() };
+    const result = toPascalCaseKeys(input);
+
+    expectTypeOf(result.A).toEqualTypeOf<Date>();
+    expectTypeOf(result.B).toEqualTypeOf<RegExp>();
+    expectTypeOf(result.C).toEqualTypeOf<Map<any, any>>();
+  });
+
+  it('should convert uppercase keys to PascalCase at both runtime and type level', () => {
+    const input = {
+      FIRST_NAME: 'JinHo',
+      LAST: 'Yeom',
+    } as const;
+
+    const result = toPascalCaseKeys(input);
+
+    expect(result).toEqual({
+      FirstName: 'JinHo',
+      Last: 'Yeom',
+    });
+
+    expectTypeOf(result).toMatchTypeOf<{
+      FirstName: 'JinHo';
+      Last: 'Yeom';
+    }>();
+  });
+});

--- a/src/object/toPascalCaseKeys.ts
+++ b/src/object/toPascalCaseKeys.ts
@@ -1,0 +1,118 @@
+import { isArray } from '../compat/predicate/isArray.ts';
+import { isPlainObject } from '../compat/predicate/isPlainObject.ts';
+import { pascalCase } from '../string/pascalCase.ts';
+
+type SnakeToPascal<S extends string> = S extends `${infer H}_${infer T}`
+  ? `${Capitalize<Lowercase<H>>}${Capitalize<SnakeToPascal<T>>}`
+  : Capitalize<Lowercase<S>>;
+
+type CamelToPascal<S extends string> = S extends `${infer F}${infer R}` ? `${Uppercase<F>}${R}` : S;
+
+/** If it's snake_case, apply the snake_case rule; for uppercase keys, lowercase and capitalize the entire string; otherwise, just uppercase the first letter (including camelCase → PascalCase). */
+type AnyToPascal<S extends string> = S extends `${string}_${string}`
+  ? SnakeToPascal<S>
+  : S extends Uppercase<S>
+    ? Capitalize<Lowercase<S>>
+    : CamelToPascal<S>;
+
+type NonPlainObject =
+  | Date
+  | RegExp
+  | Map<any, any>
+  | Set<any>
+  | WeakMap<any, any>
+  | WeakSet<any>
+  | Promise<any>
+  | Error
+  | ArrayBuffer
+  | DataView
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array
+  | ((...args: any[]) => any)
+  | typeof globalThis;
+
+export type ToPascalCaseKeys<T> = T extends NonPlainObject
+  ? T
+  : T extends any[]
+    ? Array<ToPascalCaseKeys<T[number]>>
+    : T extends Record<string, any>
+      ? { [K in keyof T as AnyToPascal<Extract<K, string>>]: ToPascalCaseKeys<T[K]> }
+      : T;
+
+/**
+ * Creates a new object composed of the properties with keys converted to PascalCase.
+ *
+ * This function takes an object and returns a new object that includes the same properties,
+ * but with all keys converted to PascalCase format.
+ *
+ * @template T - The type of object.
+ * @param obj - The object to convert keys from.
+ * @returns A new object with all keys converted to PascalCase.
+ *
+ * @example
+ * // Example with objects
+ * const obj = { userId: 1, firstName: 'John' };
+ * const result = toPascalCaseKeys(obj);
+ * // result will be { UserId: 1, FirstName: 'John' }
+ *
+ * // Example with arrays of objects
+ * const arr = [
+ *   { userId: 1, firstName: 'John' },
+ *   { userId: 2, firstName: 'Jane' }
+ * ];
+ * const arrResult = toPascalCaseKeys(arr);
+ * // arrResult will be [{ UserId: 1, FirstName: 'John' }, { UserId: 2, FirstName: 'Jane' }]
+ *
+ * // Example with nested objects
+ * const nested = {
+ *   userData: {
+ *     userId: 1,
+ *     userAddress: {
+ *       streetName: 'Main St',
+ *       zipCode: '12345'
+ *     }
+ *   }
+ * };
+ * const nestedResult = toPascalCaseKeys(nested);
+ * // nestedResult will be:
+ * // {
+ * //   UserData: {
+ * //     UserId: 1,
+ * //     UserAddress: {
+ * //       StreetName: 'Main St',
+ * //       ZipCode: '12345'
+ * //     }
+ * //   }
+ * // }
+ */
+export function toPascalCaseKeys<T>(obj: T): ToPascalCaseKeys<T> {
+  if (isArray(obj)) {
+    return obj.map(item => toPascalCaseKeys(item)) as unknown as ToPascalCaseKeys<T>;
+  }
+
+  if (isPlainObject(obj)) {
+    const result = {} as ToPascalCaseKeys<T>;
+    const keys = Object.keys(obj as Record<PropertyKey, any>);
+
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+
+      const pascalKey = pascalCase(key) as keyof typeof result;
+      const convertedValue = toPascalCaseKeys((obj as Record<PropertyKey, any>)[key]);
+      result[pascalKey] = convertedValue as ToPascalCaseKeys<T>[keyof ToPascalCaseKeys<T>];
+    }
+
+    return result;
+  }
+
+  return obj as ToPascalCaseKeys<T>;
+}


### PR DESCRIPTION
Fixes #1982.

Adds `toPascalCaseKeys`, `toConstantCaseKeys`, and `toKebabCaseKeys`, the equivalent object key casing functions for the equivalent string functions.

## Changes
- Add `toPascalCaseKeys`, `toConstantCaseKeys`, and `toKebabCaseKeys` functions
- Add documentation for each function in all languages
- Aligned English documentation for `toCamelCaseKeys` with other languages ("`uppercase keys` -> `UPPERCASE_KEYS`)
- Exported `ToCamelCaseKeys<T>` type to align with `ToSnakeCaseKeys<T>` being exported (and the new functions as well)