### PR TITLE
fix[mean, meanBy, sum, sumBy]: Update to take `ArrayLike`

### DIFF
--- a/src/math/mean.spec.ts
+++ b/src/math/mean.spec.ts
@@ -9,4 +9,10 @@ describe('mean', () => {
   it('returns NaN for empty arrays', () => {
     expect(mean([])).toEqual(NaN);
   });
+
+  it('works with TypedArrays', () => {
+    const typedArray = new Float32Array([1.5, 2.5]);
+    const result = mean(typedArray);
+    expect(result).toBe(2.0);
+  });
 });

--- a/src/math/mean.ts
+++ b/src/math/mean.ts
@@ -5,7 +5,7 @@ import { sum } from './sum.ts';
  *
  * If the array is empty, this function returns `NaN`.
  *
- * @param nums - An array of numbers to calculate the average.
+ * @param nums - An array-like of numbers to calculate the average.
  * @returns The average of all the numbers in the array.
  *
  * @example

--- a/src/math/mean.ts
+++ b/src/math/mean.ts
@@ -13,6 +13,6 @@ import { sum } from './sum.ts';
  * const result = mean(numbers);
  * // result will be 3
  */
-export function mean(nums: readonly number[]): number {
+export function mean(nums: ArrayLike<number>): number {
   return sum(nums) / nums.length;
 }

--- a/src/math/meanBy.ts
+++ b/src/math/meanBy.ts
@@ -15,6 +15,6 @@ import { sumBy } from './sumBy';
  * meanBy([{ a: 1 }, { a: 2 }, { a: 3 }], x => x.a); // Returns: 2
  * meanBy([], x => x.a); // Returns: NaN
  */
-export function meanBy<T>(items: readonly T[], getValue: (element: T) => number): number {
+export function meanBy<T>(items: ArrayLike<T>, getValue: (element: T) => number): number {
   return sumBy(items, item => getValue(item)) / items.length;
 }

--- a/src/math/meanBy.ts
+++ b/src/math/meanBy.ts
@@ -7,8 +7,8 @@ import { sumBy } from './sumBy';
  * If the array is empty, this function returns `NaN`.
  *
  * @template T - The type of elements in the array.
- * @param items An array to calculate the average.
- * @param getValue A function that selects a numeric value from each element.
+ * @param items - An array-like to calculate the average.
+ * @param getValue - A function that selects a numeric value from each element.
  * @returns The average of all the numbers as determined by the `getValue` function.
  *
  * @example

--- a/src/math/sum.spec.ts
+++ b/src/math/sum.spec.ts
@@ -23,4 +23,10 @@ describe('sum function', () => {
 
     expect(sum(array1) + sum(array2)).toBe(sum([...array1, ...array2]));
   });
+
+  it('works with TypedArrays', () => {
+    const typedArray = new Float32Array([1.5, 2.5]);
+    const result = sum(typedArray);
+    expect(result).toBe(4.0);
+  });
 });

--- a/src/math/sum.ts
+++ b/src/math/sum.ts
@@ -3,7 +3,7 @@
  *
  * This function takes an array of numbers and returns the sum of all the elements in the array.
  *
- * @param nums - An array of numbers to be summed.
+ * @param nums - An array-like of numbers to be summed.
  * @returns The sum of all the numbers in the array.
  *
  * @example

--- a/src/math/sum.ts
+++ b/src/math/sum.ts
@@ -11,7 +11,7 @@
  * const result = sum(numbers);
  * // result will be 15
  */
-export function sum(nums: readonly number[]): number {
+export function sum(nums: ArrayLike<number>): number {
   let result = 0;
 
   for (let i = 0; i < nums.length; i++) {

--- a/src/math/sumBy.ts
+++ b/src/math/sumBy.ts
@@ -14,7 +14,7 @@
  * sumBy([{ a: 1 }, { a: 2 }, { a: 3 }], (x, i) => x.a * i); // Returns: 8
  * sumBy([], () => 1); // Returns: 0
  */
-export function sumBy<T>(items: readonly T[], getValue: (element: T, index: number) => number): number {
+export function sumBy<T>(items: ArrayLike<T>, getValue: (element: T, index: number) => number): number {
   let result = 0;
 
   for (let i = 0; i < items.length; i++) {

--- a/src/math/sumBy.ts
+++ b/src/math/sumBy.ts
@@ -5,7 +5,7 @@
  * If the array is empty, this function returns `0`.
  *
  * @template T - The type of elements in the array.
- * @param items - An array to calculate the sum.
+ * @param items - An array-like to calculate the sum.
  * @param getValue - A function that selects a numeric value from each element.
  *   It receives the element and its zero‑based index in the array.
  * @returns The sum of all the numbers as determined by the `getValue` function.


### PR DESCRIPTION
## Summary

<!-- What problem does this solve? Link the related issue or discussion. -->

Update `mean`, `meanBy`, `sum`, `sumBy` to take `ArrayLike`.

Fixes #1988

## Changes

* Broaden TypeScript types
* Add tests to verify TypedArray compatibility in particular