### PR TITLE
fix[omit, pick]: Allow union types

### DIFF
--- a/src/_internal/KeysOfUnion.ts
+++ b/src/_internal/KeysOfUnion.ts
@@ -1,0 +1,8 @@
+/**
+ * The keys of every member of `T`.
+ *
+ * Unlike `keyof T`, which for a union only yields the keys shared by all
+ * members, this distributes over each member, so a key that exists on some
+ * members is included.
+ */
+export type KeysOfUnion<T> = T extends unknown ? keyof T : never;

--- a/src/fp/object/omit.spec.ts
+++ b/src/fp/object/omit.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { omit } from './omit.ts';
 import { pipe } from '../pipe.ts';
 
@@ -13,5 +13,16 @@ describe('omit', () => {
 
     expect(result).toEqual({ a: 1, b: 2 });
     expect(result).not.toBe(input);
+  });
+
+  it('omits from each member of a type union separately', () => {
+    type A = { type: 'a'; a: number };
+    type B = { type: 'b'; b: string };
+    type Union = A | B;
+
+    const result = pipe({ type: 'a', a: 1 } as Union, omit(['b']));
+
+    expectTypeOf(result).toEqualTypeOf<A | Omit<B, 'b'>>();
+    expect(result).toEqual({ type: 'a', a: 1 });
   });
 });

--- a/src/fp/object/omit.ts
+++ b/src/fp/object/omit.ts
@@ -1,4 +1,5 @@
-import { omit as omitToolkit } from '../../object/omit.ts';
+import type { KeysOfUnion } from '../../_internal/KeysOfUnion.ts';
+import { type DistributedOmit, omit as omitToolkit } from '../../object/omit.ts';
 
 /**
  * Creates a function that builds a new object with the given `keys` removed from
@@ -14,8 +15,10 @@ import { omit as omitToolkit } from '../../object/omit.ts';
  *
  * pipe({ a: 1, b: 2, c: 3 }, omit(['b', 'c'])); // => { a: 1 }
  */
-export function omit<T extends Record<string, any>, K extends keyof T>(keys: readonly K[]): (obj: T) => Omit<T, K> {
-  return function (obj: T): Omit<T, K> {
+export function omit<T extends Record<string, any>, K extends KeysOfUnion<T>>(
+  keys: readonly K[]
+): (obj: T) => DistributedOmit<T, K> {
+  return function (obj: T): DistributedOmit<T, K> {
     return omitToolkit(obj, keys);
   };
 }

--- a/src/fp/object/pick.spec.ts
+++ b/src/fp/object/pick.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { pick } from './pick.ts';
 import { pipe } from '../pipe.ts';
 
@@ -13,5 +13,16 @@ describe('pick', () => {
 
   it('returns an empty object when no keys are picked', () => {
     expect(pipe({ a: 1, b: 2 }, pick([] as Array<'a' | 'b'>))).toEqual({});
+  });
+
+  it('picks from each member of a type union separately', () => {
+    type A = { type: 'a'; a: number };
+    type B = { type: 'b'; b: string };
+    type Union = A | B;
+
+    const result = pipe({ type: 'a', a: 1 } as Union, pick(['type', 'b']));
+
+    expectTypeOf(result).toEqualTypeOf<Pick<A, 'type'> | Pick<B, 'type' | 'b'>>();
+    expect(result).toEqual({ type: 'a' });
   });
 });

--- a/src/fp/object/pick.ts
+++ b/src/fp/object/pick.ts
@@ -1,4 +1,5 @@
-import { pick as pickToolkit } from '../../object/pick.ts';
+import type { KeysOfUnion } from '../../_internal/KeysOfUnion.ts';
+import { type DistributedPick, pick as pickToolkit } from '../../object/pick.ts';
 
 /**
  * Creates a function that builds a new object containing only the given `keys`
@@ -15,8 +16,10 @@ import { pick as pickToolkit } from '../../object/pick.ts';
  *
  * pipe({ a: 1, b: 2, c: 3 }, pick(['a', 'c'])); // => { a: 1, c: 3 }
  */
-export function pick<T extends Record<string, any>, K extends keyof T>(keys: readonly K[]): (obj: T) => Pick<T, K> {
-  return function (obj: T): Pick<T, K> {
+export function pick<T extends Record<string, any>, K extends KeysOfUnion<T>>(
+  keys: readonly K[]
+): (obj: T) => DistributedPick<T, K> {
+  return function (obj: T): DistributedPick<T, K> {
     return pickToolkit(obj, keys);
   };
 }

--- a/src/object/omit.spec.ts
+++ b/src/object/omit.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { omit } from './omit';
 
 describe('omit', () => {
@@ -25,5 +25,29 @@ describe('omit', () => {
     const result = omit(obj, ['b']);
     expect(result).toEqual({ a: 1, c: 3 });
     expect(obj).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it('should work with type unions', () => {
+    type A = { type: 'a'; a: number };
+    type B = { type: 'b'; b: string };
+    type Union = A | B;
+
+    const obj = { type: 'a', a: 1 } as Union;
+    const result = omit(obj, ['b']);
+
+    expectTypeOf(result).toEqualTypeOf<A | Omit<B, 'b'>>();
+    expect(result).toEqual({ type: 'a', a: 1 });
+  });
+
+  it('should keep the discriminant of a type union', () => {
+    type A = { type: 'a'; a: number };
+    type B = { type: 'b'; b: string };
+    type Union = A | B;
+
+    const obj = { type: 'b', b: 'hello' } as Union;
+    const result = omit(obj, ['a', 'b']);
+
+    expectTypeOf(result).toEqualTypeOf<Omit<A, 'a' | 'b'> | Omit<B, 'a' | 'b'>>();
+    expect(result).toEqual({ type: 'b' });
   });
 });

--- a/src/object/omit.ts
+++ b/src/object/omit.ts
@@ -1,3 +1,10 @@
+import type { KeysOfUnion } from '../_internal/KeysOfUnion.ts';
+
+/**
+ * `Omit` applied to each member of a union separately, so that the members are preserved.
+ */
+export type DistributedOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
 /**
  * Creates a new object with specified keys omitted.
  *
@@ -15,13 +22,16 @@
  * const result = omit(obj, ['b', 'c']);
  * // result will be { a: 1 }
  */
-export function omit<T extends Record<string, any>, K extends keyof T>(obj: T, keys: readonly K[]): Omit<T, K> {
-  const result = { ...obj };
+export function omit<T extends Record<string, any>, K extends KeysOfUnion<T>>(
+  obj: T,
+  keys: readonly K[]
+): DistributedOmit<T, K> {
+  const result: Record<PropertyKey, unknown> = { ...obj };
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     delete result[key];
   }
 
-  return result as Omit<T, K>;
+  return result as DistributedOmit<T, K>;
 }

--- a/src/object/pick.spec.ts
+++ b/src/object/pick.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { pick } from './pick';
 
 describe('pick', () => {
@@ -31,5 +31,29 @@ describe('pick', () => {
     const result = pick(obj, ['a']);
 
     expect(Reflect.ownKeys(result)).toEqual([]);
+  });
+
+  it('should work with type unions', () => {
+    type A = { type: 'a'; a: number };
+    type B = { type: 'b'; b: string };
+    type Union = A | B;
+
+    const obj = { type: 'a', a: 1 } as Union;
+    const result = pick(obj, ['b']);
+
+    expectTypeOf(result).toEqualTypeOf<Pick<A, never> | Pick<B, 'b'>>();
+    expect(result).toEqual({});
+  });
+
+  it('should pick each member of a type union separately', () => {
+    type A = { type: 'a'; a: number };
+    type B = { type: 'b'; b: string };
+    type Union = A | B;
+
+    const obj = { type: 'b', b: 'hello' } as Union;
+    const result = pick(obj, ['type', 'b']);
+
+    expectTypeOf(result).toEqualTypeOf<Pick<A, 'type'> | Pick<B, 'type' | 'b'>>();
+    expect(result).toEqual({ type: 'b', b: 'hello' });
   });
 });

--- a/src/object/pick.ts
+++ b/src/object/pick.ts
@@ -1,3 +1,12 @@
+import type { KeysOfUnion } from '../_internal/KeysOfUnion.ts';
+
+/**
+ * `Pick` applied to each member of a union separately, so that the members are preserved.
+ *
+ * Keys that do not exist on a member are ignored for that member instead of being an error.
+ */
+export type DistributedPick<T, K extends PropertyKey> = T extends unknown ? Pick<T, Extract<K, keyof T>> : never;
+
 /**
  * Creates a new object composed of the picked object properties.
  *
@@ -15,16 +24,19 @@
  * const result = pick(obj, ['a', 'c']);
  * // result will be { a: 1, c: 3 }
  */
-export function pick<T extends Record<string, any>, K extends keyof T>(obj: T, keys: readonly K[]): Pick<T, K> {
-  const result = {} as Pick<T, K>;
+export function pick<T extends Record<string, any>, K extends KeysOfUnion<T>>(
+  obj: T,
+  keys: readonly K[]
+): DistributedPick<T, K> {
+  const result: Record<PropertyKey, unknown> = {};
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
 
     if (Object.hasOwn(obj, key)) {
-      result[key] = obj[key];
+      result[key] = obj[key as keyof T];
     }
   }
 
-  return result;
+  return result as DistributedPick<T, K>;
 }


### PR DESCRIPTION

<!--
Thanks for contributing to es-toolkit!

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand what you submit. For this reason, **pull request descriptions from external contributors must be written by a human**.

## Title

Use the format `<type>[function names]: <description>`, for example `fix[chunk]: handle empty arrays`.
The type is one of feat, fix, docs, test, or chore. See .github/CONTRIBUTING.md#4-pull-requests

## Before you open this

Find your change below and go through its checklist. These are the only categories we accept — a rename or a rewrite that leaves the behavior unchanged is not one of them, and neither is a new function that has not been discussed yet. The reasoning behind each rule is in .github/CONTRIBUTING.md#41-what-we-accept

### Adding a new function

- [ ] A discussion proposing this function was accepted, and it is linked below. Without one we close the pull request, even when the implementation is good.
- [ ] The implementation, tests, a benchmark, and documentation in all four languages are included.

### Improving performance

- [ ] Benchmark results for `main` and for this branch are pasted under "Benchmark results". We cannot tell a real speedup from reading code, so a claim without numbers gets closed.

### Fixing behavior that differs from Lodash (es-toolkit/compat)

- [ ] The difference is written as code: the input, what Lodash returns for it, and what es-toolkit returns today.
- [ ] A test that fails without this change is included, so the behavior does not drift back later.
- [ ] Benchmark results are attached if the function runs in a hot path.

### Fixing a bug or the documentation

- [ ] Related issues are linked with `fixes #number`.
- [ ] Documentation changes are applied to all four languages: English, Korean, Japanese, and Simplified Chinese.
- [ ] Small documentation fixes are collected into this one pull request rather than split across several.

Now fill in the sections below.
-->

## Summary

<!-- What problem does this solve? Link the related issue or discussion. -->
Revise types for omit and pick to allow union types.

Note: This changes the return type from, e.g., `Omit<A|B, K>` to a distributed union. This may technically be a breaking change but should be unlikely to cause issues in practice.

Fixes #1990

## Changes

- Change pick and omit to use new DistributedPick and DistributedOmit types so that they can support union types. Previously, they only accepted keys present on all union components; now they, accept keys of any union component.
- Introduce an internal helper type KeysOfUnion
