### PR TITLE
fix(compat): render nested nullish values in toString like lodash

### DIFF
--- a/benchmarks/bundle-size/add.spec.ts
+++ b/benchmarks/bundle-size/add.spec.ts
@@ -9,6 +9,6 @@ describe('add bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'add');
-    expect(bundleSize).toMatchInlineSnapshot(`455`);
+    expect(bundleSize).toMatchInlineSnapshot(`472`);
   });
 });

--- a/benchmarks/bundle-size/camelCase.spec.ts
+++ b/benchmarks/bundle-size/camelCase.spec.ts
@@ -14,6 +14,6 @@ describe('camelCase bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'camelCase');
-    expect(bundleSize).toMatchInlineSnapshot(`1814`);
+    expect(bundleSize).toMatchInlineSnapshot(`1831`);
   });
 });

--- a/benchmarks/bundle-size/escape.spec.ts
+++ b/benchmarks/bundle-size/escape.spec.ts
@@ -14,6 +14,6 @@ describe('escape bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'escape');
-    expect(bundleSize).toMatchInlineSnapshot(`348`);
+    expect(bundleSize).toMatchInlineSnapshot(`365`);
   });
 });

--- a/benchmarks/bundle-size/escapeRegExp.spec.ts
+++ b/benchmarks/bundle-size/escapeRegExp.spec.ts
@@ -14,6 +14,6 @@ describe('escapeRegExp bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'escapeRegExp');
-    expect(bundleSize).toMatchInlineSnapshot(`291`);
+    expect(bundleSize).toMatchInlineSnapshot(`308`);
   });
 });

--- a/benchmarks/bundle-size/find.spec.ts
+++ b/benchmarks/bundle-size/find.spec.ts
@@ -9,6 +9,6 @@ describe('find bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'find');
-    expect(bundleSize).toMatchInlineSnapshot(`8524`);
+    expect(bundleSize).toMatchInlineSnapshot(`8543`);
   });
 });

--- a/benchmarks/bundle-size/findKey.spec.ts
+++ b/benchmarks/bundle-size/findKey.spec.ts
@@ -14,6 +14,6 @@ describe('findKey bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'findKey');
-    expect(bundleSize).toMatchInlineSnapshot(`8189`);
+    expect(bundleSize).toMatchInlineSnapshot(`8208`);
   });
 });

--- a/benchmarks/bundle-size/mapKeys.spec.ts
+++ b/benchmarks/bundle-size/mapKeys.spec.ts
@@ -14,6 +14,6 @@ describe('mapKeys bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'mapKeys');
-    expect(bundleSize).toMatchInlineSnapshot(`8202`);
+    expect(bundleSize).toMatchInlineSnapshot(`8221`);
   });
 });

--- a/benchmarks/bundle-size/mapValues.spec.ts
+++ b/benchmarks/bundle-size/mapValues.spec.ts
@@ -14,6 +14,6 @@ describe('mapValues bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'mapValues');
-    expect(bundleSize).toMatchInlineSnapshot(`8202`);
+    expect(bundleSize).toMatchInlineSnapshot(`8221`);
   });
 });

--- a/benchmarks/bundle-size/omit.spec.ts
+++ b/benchmarks/bundle-size/omit.spec.ts
@@ -14,6 +14,6 @@ describe('omit bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'omit');
-    expect(bundleSize).toMatchInlineSnapshot(`8614`);
+    expect(bundleSize).toMatchInlineSnapshot(`8633`);
   });
 });

--- a/benchmarks/bundle-size/zipObjectDeep.spec.ts
+++ b/benchmarks/bundle-size/zipObjectDeep.spec.ts
@@ -9,6 +9,6 @@ describe('zipObjectDeep bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'zipObjectDeep');
-    expect(bundleSize).toMatchInlineSnapshot(`3110`);
+    expect(bundleSize).toMatchInlineSnapshot(`3127`);
   });
 });

--- a/src/compat/util/toString.spec.ts
+++ b/src/compat/util/toString.spec.ts
@@ -36,4 +36,15 @@ describe('toString', () => {
   it('should handle an array of symbols', () => {
     expect(toString([symbol])).toBe('Symbol(a)');
   });
+
+  it('should render nested nullish array values, matching lodash', () => {
+    expect(toString([1, null, 3])).toBe('1,null,3');
+    expect(toString([null, undefined])).toBe('null,undefined');
+    expect(
+      toString([
+        [1, null],
+        [2, undefined],
+      ])
+    ).toBe('1,null,2,undefined');
+  });
 });

--- a/src/compat/util/toString.ts
+++ b/src/compat/util/toString.ts
@@ -19,12 +19,16 @@ export function toString(value: any): string {
     return '';
   }
 
+  return baseToString(value);
+}
+
+function baseToString(value: any): string {
   if (typeof value === 'string') {
     return value;
   }
 
   if (Array.isArray(value)) {
-    return value.map(toString).join(',');
+    return value.map(baseToString).join(',');
   }
 
   const result = String(value);


### PR DESCRIPTION
## Summary

`compat/toString` renders nested nullish array values differently from lodash.

The array branch maps over the elements using the public `toString`, whose top guard turns `null` and `undefined` into `''`. lodash only applies that nullish guard at the top level; internally its `baseToString` renders nested `null` as `"null"` and `undefined` as `"undefined"`.

```ts
toString([1, null, 3])
// es-toolkit: "1,,3"
// lodash:     "1,null,3"

toString([null, undefined])
// es-toolkit: ","
// lodash:     "null,undefined"
```

## Fix

Split the public nullish guard from the recursive conversion by adding a private `baseToString`, so the top level still returns `''` for `null`/`undefined` while nested values are stringified. This mirrors lodash's `toString`/`baseToString` split.

## Tests

Added regression cases for nested nullish values in arrays and nested arrays. All existing cases (nullish top level, sign of `-0`, symbols) still pass. Verified against lodash 4.17.21.

## Bundle size snapshots

Adding the private `baseToString` helper slightly increases the compiled size of `toString`, so the bundle-size snapshots of the compat functions that import it (`add`, `camelCase`, `escape`, `escapeRegExp`, `find`, `findKey`, `mapKeys`, `mapValues`, `omit`, `zipObjectDeep`) were regenerated to match.