### PR TITLE
fix(compat/intersectionBy): support number, object, and nullish iteratee shorthands like lodash

### DIFF
--- a/src/compat/array/intersectionBy.spec.ts
+++ b/src/compat/array/intersectionBy.spec.ts
@@ -139,12 +139,44 @@ describe('intersectionBy', () => {
     ]);
   });
 
-  it('should handle non-function, non-string, non-array iteratee', () => {
+  it('should support number iteratee shorthands', () => {
     const array1 = [1, 2, 3];
     const array2 = [2, 3, 4];
 
+    // Matches lodash: `123` is a property shorthand, so every element maps to `undefined`.
     const actual = intersectionBy(array1, array2, 123);
-    expect(actual).toEqual([1, 2, 3]);
+    expect(actual).toEqual([1]);
+
+    expect(
+      intersectionBy(
+        [
+          [1, 'a'],
+          [2, 'b'],
+          [3, 'c'],
+        ],
+        [
+          [1, 'x'],
+          [3, 'y'],
+        ],
+        0
+      )
+    ).toEqual([
+      [1, 'a'],
+      [3, 'c'],
+    ]);
+  });
+
+  it('should treat a nullish iteratee as identity', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(intersectionBy([1, 2], [2, 3], null)).toEqual([2]);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(intersectionBy([2.1, 1.2], [2.3, 3.4], undefined)).toEqual([]);
+  });
+
+  it('should support object iteratee shorthands', () => {
+    expect(intersectionBy([{ x: 1 }, { x: 2 }], [{ x: 1 }], { x: 1 })).toEqual([{ x: 1 }]);
   });
 
   it('should dedupe a single array by the iteratee', () => {

--- a/src/compat/array/intersectionBy.ts
+++ b/src/compat/array/intersectionBy.ts
@@ -5,8 +5,8 @@ import { uniqBy } from '../../array/uniqBy.ts';
 import { identity } from '../../function/identity.ts';
 import { toArray } from '../_internal/toArray.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
-import { property } from '../object/property.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
+import { iteratee as createIteratee } from '../util/iteratee.ts';
 
 /**
  * Creates an array of unique values that are included in all given arrays, using an iteratee to compute equality.
@@ -130,11 +130,14 @@ export function intersectionBy<T>(array: any, ...values: any[]): T[] {
   }
 
   const lastValue = last(values);
-  const count = isArrayLikeObject(lastValue) ? values.length : values.length - 1;
-  const iteratee = getIteratee(lastValue);
+  const hasIteratee = !isArrayLikeObject(lastValue);
+  const count = hasIteratee ? values.length - 1 : values.length;
+  const mapper = hasIteratee ? createIteratee(lastValue) : identity;
+  // Lodash invokes the iteratee with a single argument; only a user-supplied function can observe the extras.
+  const iteratee = typeof lastValue === 'function' ? (item: unknown) => mapper(item) : mapper;
 
   if (count <= 0) {
-    return uniqBy(toArray(array), iteratee ?? identity);
+    return uniqBy(toArray(array), iteratee);
   }
 
   // uniq normalizes `-0` to `0` to match Lodash; toArray alone would keep `-0`
@@ -147,23 +150,8 @@ export function intersectionBy<T>(array: any, ...values: any[]): T[] {
       return [];
     }
 
-    if (iteratee) {
-      result = intersectionByToolkit(result, toArray(value), iteratee);
-    }
+    result = intersectionByToolkit(result, toArray(value), iteratee);
   }
 
   return result;
-}
-
-function getIteratee(value: unknown) {
-  if (isArrayLikeObject(value)) {
-    return identity;
-  }
-  if (typeof value === 'function') {
-    return (item: unknown) => (value as (item: unknown) => unknown)(item);
-  }
-  if (typeof value === 'string') {
-    return property(value);
-  }
-  return null;
 }


### PR DESCRIPTION
## Summary

`intersectionBy` in `es-toolkit/compat` silently returns the first array unfiltered when the iteratee is a number, an object, or explicitly `null`/`undefined`. Lodash treats all of those as shorthands, so migrating code gets a different result with no error to point at it.

```js
import { intersectionBy } from 'es-toolkit/compat';

// property-index shorthand on tuples
intersectionBy(
  [
    [1, 'a'],
    [2, 'b'],
    [3, 'c'],
  ],
  [
    [1, 'x'],
    [3, 'y'],
  ],
  0
);
// es-toolkit/compat: [[1, 'a'], [2, 'b'], [3, 'c']]  (the first array, unfiltered)
// lodash:            [[1, 'a'], [3, 'c']]

intersectionBy([1, 2], [2, 3], null);
// es-toolkit/compat: [1, 2]
// lodash:            [2]

intersectionBy([{ x: 1 }, { x: 2 }], [{ x: 1 }], { x: 1 });
// es-toolkit/compat: [{ x: 1 }, { x: 2 }]
// lodash:            [{ x: 1 }]
```

The internal `getIteratee()` only recognized array-like, function, and string iteratees and returned `null` for everything else. The main loop then skipped the intersection step entirely (`if (iteratee) { ... }`) and returned the uniq'd first array as-is. `differenceBy`, `unionBy`, and `xorBy` already route the last argument through the shared `iteratee()` helper and handle these shorthands correctly, so `intersectionBy` was the odd one out.

## Changes

- Build the iteratee with the shared compat `iteratee()` helper, the same way `differenceBy` does. It handles nullish as identity, objects as `matches` / `matchesProperty`, and number/string/symbol/boolean as `property` (consistent with #1941). The `if (iteratee)` skip and the now-dead `getIteratee` are removed.
- Keep invoking a user-supplied function with a single argument, matching lodash's `arrayMap`, so the existing `should provide correct iteratee arguments` test still observes exactly `[2.3]`. Shorthand iteratees are passed through unwrapped, since only a user-supplied function can observe the extra arguments.
- One existing expectation asserted the divergent behavior and is updated to lodash parity: `intersectionBy([1, 2, 3], [2, 3, 4], 123)` now returns `[1]` as lodash does, instead of `[1, 2, 3]`. `123` acts as a property shorthand, so every element maps to `undefined` and the results are deduped by that mapped value. That case came from #1501, a test-only PR that predates the implementation rewrite in #1935.

The new tests cover the number, nullish, and object shorthands and fail without the implementation change. I also compared against lodash 4.17.21 directly for number, object, `[path, value]`, boolean, deep-path and nullish iteratees, single-array and multi-array calls, and the existing `-0`, `NaN`, and non-array-like argument cases.

## Benchmark results

`intersectionBy` has a benchmark under `benchmarks/performance`, so I checked the hot path rather than assuming it was unaffected. Each row is 300k calls of `intersectionBy([{ id: 1 }, { id: 2 }, { id: 3 }], [{ id: 2 }, { id: 4 }], iteratee)`, median of 5 timed runs, with each implementation measured in its own process:

| iteratee                     | main     | this branch |
| ---------------------------- | -------- | ----------- |
| function (`item => item.id`) | 92.5 ms  | 91.7 ms     |
| string (`'id'`)              | 111.0 ms | 110.7 ms    |

Worth noting for review: an earlier version of this change wrapped every iteratee in `item => mapper(item)`, and that measured about 2.5x slower on the same benchmark, since the extra closure layer blocks inlining. Passing shorthand iteratees through unwrapped and wrapping only user-supplied functions keeps the timings flat.
