### PR TITLE
feat(SingleFlight, KeyedSingleFlight): share in-flight async work with duplicate callers

### DIFF
--- a/docs/ja/reference/promise/KeyedSingleFlight.md
+++ b/docs/ja/reference/promise/KeyedSingleFlight.md
@@ -1,0 +1,47 @@
+# KeyedSingleFlight
+
+キーごとに非同期タスクを1つだけ実行し、重複した呼び出しに実行中のPromiseを共有します。
+
+```typescript
+const flight = new KeyedSingleFlight<string>();
+```
+
+## 使用法
+
+### `KeyedSingleFlight<K>()`
+
+キーごとにタスクを重複排除し、異なるキーのタスクは並行して実行したい場合に`KeyedSingleFlight`を使用します。
+
+```typescript
+import { KeyedSingleFlight } from 'es-toolkit';
+
+const flight = new KeyedSingleFlight<string>();
+
+const first = flight.run('user:1', async () => {
+  const response = await fetch('/api/users/1');
+  return response.json();
+});
+
+const second = flight.run('user:1', async () => {
+  const response = await fetch('/api/users/1');
+  return response.json();
+});
+
+const other = flight.run('user:2', async () => {
+  const response = await fetch('/api/users/2');
+  return response.json();
+});
+
+console.log(first === second); // true
+console.log(first === other); // false
+```
+
+タスクが成功した場合も失敗した場合も同じPromiseを共有します。タスクが完了すると結果はキャッシュされず、同じキーの次の呼び出しでは新しいタスクを実行します。キーは`Map`と同じ規則で比較されるため、オブジェクトキーは参照が同じ場合のみ一致します。
+
+#### パラメータ
+
+- `K`（`unknown`）：タスクを識別するキーの型です。
+
+#### メソッド
+
+- `run`（`(key: K, task: () => Promise<T>) => Promise<T>`）：タスクを実行するか、そのキーで実行中のタスクのPromiseを返します。

--- a/docs/ja/reference/promise/SingleFlight.md
+++ b/docs/ja/reference/promise/SingleFlight.md
@@ -1,0 +1,37 @@
+# SingleFlight
+
+同時に実行される非同期タスクを1つに制限し、重複した呼び出しに実行中のPromiseを共有します。
+
+```typescript
+const flight = new SingleFlight();
+```
+
+## 使用法
+
+### `SingleFlight()`
+
+複数の呼び出し元が同じ処理を同時に開始する可能性があり、実際の処理は1回だけ実行したい場合に`SingleFlight`を使用します。
+
+```typescript
+import { SingleFlight } from 'es-toolkit';
+
+const flight = new SingleFlight();
+
+const first = flight.run(async () => {
+  const response = await fetch('/api/config');
+  return response.json();
+});
+
+const second = flight.run(async () => {
+  const response = await fetch('/api/config');
+  return response.json();
+});
+
+console.log(first === second); // true
+```
+
+タスクが成功した場合も失敗した場合も同じPromiseを共有します。タスクが完了すると結果はキャッシュされず、次の呼び出しでは新しいタスクを実行します。
+
+#### メソッド
+
+- `run`（`(task: () => Promise<T>) => Promise<T>`）：タスクを実行するか、すでに実行中のタスクのPromiseを返します。

--- a/docs/ko/reference/promise/KeyedSingleFlight.md
+++ b/docs/ko/reference/promise/KeyedSingleFlight.md
@@ -1,0 +1,47 @@
+# KeyedSingleFlight
+
+각 key마다 비동기 작업을 하나만 실행하고, 같은 key의 중복 요청에는 실행 중인 작업의 Promise를 공유해요.
+
+```typescript
+const flight = new KeyedSingleFlight<string>();
+```
+
+## 사용법
+
+### `KeyedSingleFlight<K>()`
+
+key별로 작업을 중복 제거하고, 서로 다른 key의 작업은 동시에 실행해야 할 때 `KeyedSingleFlight`를 사용해요.
+
+```typescript
+import { KeyedSingleFlight } from 'es-toolkit';
+
+const flight = new KeyedSingleFlight<string>();
+
+const first = flight.run('user:1', async () => {
+  const response = await fetch('/api/users/1');
+  return response.json();
+});
+
+const second = flight.run('user:1', async () => {
+  const response = await fetch('/api/users/1');
+  return response.json();
+});
+
+const other = flight.run('user:2', async () => {
+  const response = await fetch('/api/users/2');
+  return response.json();
+});
+
+console.log(first === second); // true
+console.log(first === other); // false
+```
+
+작업이 성공하거나 실패해도 같은 Promise를 공유해요. 작업이 끝나면 결과를 캐시하지 않으므로 같은 key의 다음 호출은 새로운 작업을 시작해요. key는 `Map`과 같은 방식으로 비교하므로 객체 key는 참조가 같을 때만 같은 key로 취급해요.
+
+#### 파라미터
+
+- `K` (`unknown`): 작업을 식별하는 key의 타입이에요.
+
+#### 메서드
+
+- `run` (`(key: K, task: () => Promise<T>) => Promise<T>`): 작업을 실행하거나 해당 key에서 이미 실행 중인 작업의 Promise를 반환해요.

--- a/docs/ko/reference/promise/SingleFlight.md
+++ b/docs/ko/reference/promise/SingleFlight.md
@@ -1,0 +1,37 @@
+# SingleFlight
+
+동시에 요청된 비동기 작업을 하나만 실행하고, 중복 요청에는 실행 중인 작업의 Promise를 공유해요.
+
+```typescript
+const flight = new SingleFlight();
+```
+
+## 사용법
+
+### `SingleFlight()`
+
+여러 호출자가 같은 작업을 동시에 시작할 수 있지만 실제 실행은 한 번만 해야 할 때 `SingleFlight`를 사용해요.
+
+```typescript
+import { SingleFlight } from 'es-toolkit';
+
+const flight = new SingleFlight();
+
+const first = flight.run(async () => {
+  const response = await fetch('/api/config');
+  return response.json();
+});
+
+const second = flight.run(async () => {
+  const response = await fetch('/api/config');
+  return response.json();
+});
+
+console.log(first === second); // true
+```
+
+작업이 성공하거나 실패해도 같은 Promise를 공유해요. 작업이 끝나면 결과를 캐시하지 않으므로 다음 호출은 새로운 작업을 시작해요.
+
+#### 메서드
+
+- `run` (`(task: () => Promise<T>) => Promise<T>`): 작업을 실행하거나 이미 실행 중인 작업의 Promise를 반환해요.

--- a/docs/reference/promise/KeyedSingleFlight.md
+++ b/docs/reference/promise/KeyedSingleFlight.md
@@ -1,0 +1,47 @@
+# KeyedSingleFlight
+
+Ensures that only one asynchronous task is in flight for each key and shares its Promise with duplicate callers.
+
+```typescript
+const flight = new KeyedSingleFlight<string>();
+```
+
+## Usage
+
+### `KeyedSingleFlight<K>()`
+
+Use `KeyedSingleFlight` when operations should be deduplicated independently by a key. Tasks with different keys can run concurrently.
+
+```typescript
+import { KeyedSingleFlight } from 'es-toolkit';
+
+const flight = new KeyedSingleFlight<string>();
+
+const first = flight.run('user:1', async () => {
+  const response = await fetch('/api/users/1');
+  return response.json();
+});
+
+const second = flight.run('user:1', async () => {
+  const response = await fetch('/api/users/1');
+  return response.json();
+});
+
+const other = flight.run('user:2', async () => {
+  const response = await fetch('/api/users/2');
+  return response.json();
+});
+
+console.log(first === second); // true
+console.log(first === other); // false
+```
+
+The Promise is shared for both successful and failed tasks. Once a task settles, its result is not cached and the next call for the same key starts a new task. Keys use `Map` equality, so object keys are compared by reference.
+
+#### Parameters
+
+- `K` (`unknown`): The type of keys used to identify tasks.
+
+#### Methods
+
+- `run` (`(key: K, task: () => Promise<T>) => Promise<T>`): Runs the task or returns the Promise of the task already in flight for the key.

--- a/docs/reference/promise/SingleFlight.md
+++ b/docs/reference/promise/SingleFlight.md
@@ -1,0 +1,37 @@
+# SingleFlight
+
+Ensures that only one asynchronous task is in flight at a time and shares its Promise with duplicate callers.
+
+```typescript
+const flight = new SingleFlight();
+```
+
+## Usage
+
+### `SingleFlight()`
+
+Use `SingleFlight` when several callers may start the same operation concurrently and only the first operation should run.
+
+```typescript
+import { SingleFlight } from 'es-toolkit';
+
+const flight = new SingleFlight();
+
+const first = flight.run(async () => {
+  const response = await fetch('/api/config');
+  return response.json();
+});
+
+const second = flight.run(async () => {
+  const response = await fetch('/api/config');
+  return response.json();
+});
+
+console.log(first === second); // true
+```
+
+The Promise is shared for both successful and failed tasks. Once the task settles, its result is not cached and the next call starts a new task.
+
+#### Methods
+
+- `run` (`(task: () => Promise<T>) => Promise<T>`): Runs the task or returns the Promise of the task that is already in flight.

--- a/docs/zh_hans/reference/promise/KeyedSingleFlight.md
+++ b/docs/zh_hans/reference/promise/KeyedSingleFlight.md
@@ -1,0 +1,47 @@
+# KeyedSingleFlight
+
+确保每个 key 同时只有一个异步任务在执行，并将该任务的 Promise 共享给相同 key 的重复调用者。
+
+```typescript
+const flight = new KeyedSingleFlight<string>();
+```
+
+## 用法
+
+### `KeyedSingleFlight<K>()`
+
+当需要按 key 消除重复任务，同时允许不同 key 的任务并行执行时，可以使用 `KeyedSingleFlight`。
+
+```typescript
+import { KeyedSingleFlight } from 'es-toolkit';
+
+const flight = new KeyedSingleFlight<string>();
+
+const first = flight.run('user:1', async () => {
+  const response = await fetch('/api/users/1');
+  return response.json();
+});
+
+const second = flight.run('user:1', async () => {
+  const response = await fetch('/api/users/1');
+  return response.json();
+});
+
+const other = flight.run('user:2', async () => {
+  const response = await fetch('/api/users/2');
+  return response.json();
+});
+
+console.log(first === second); // true
+console.log(first === other); // false
+```
+
+无论任务成功还是失败，相同 key 的调用者都会共享同一个 Promise。任务结束后不会缓存结果，相同 key 的下一次调用会启动新任务。key 使用 `Map` 的比较规则，因此对象 key 按引用进行比较。
+
+#### 参数
+
+- `K`（`unknown`）：用于标识任务的 key 类型。
+
+#### 方法
+
+- `run`（`(key: K, task: () => Promise<T>) => Promise<T>`）：执行任务，或返回该 key 当前正在执行的任务的 Promise。

--- a/docs/zh_hans/reference/promise/SingleFlight.md
+++ b/docs/zh_hans/reference/promise/SingleFlight.md
@@ -1,0 +1,37 @@
+# SingleFlight
+
+确保同一时间只有一个异步任务在执行，并将该任务的 Promise 共享给重复调用者。
+
+```typescript
+const flight = new SingleFlight();
+```
+
+## 用法
+
+### `SingleFlight()`
+
+当多个调用者可能同时启动相同操作，但实际只应执行一次时，可以使用 `SingleFlight`。
+
+```typescript
+import { SingleFlight } from 'es-toolkit';
+
+const flight = new SingleFlight();
+
+const first = flight.run(async () => {
+  const response = await fetch('/api/config');
+  return response.json();
+});
+
+const second = flight.run(async () => {
+  const response = await fetch('/api/config');
+  return response.json();
+});
+
+console.log(first === second); // true
+```
+
+无论任务成功还是失败，调用者都会共享同一个 Promise。任务结束后不会缓存结果，下一次调用会启动新任务。
+
+#### 方法
+
+- `run`（`(task: () => Promise<T>) => Promise<T>`）：执行任务，或返回当前正在执行的任务的 Promise。

--- a/src/promise/index.ts
+++ b/src/promise/index.ts
@@ -1,6 +1,8 @@
 export { allKeyed } from './allKeyed.ts';
 export { delay } from './delay.ts';
+export { KeyedSingleFlight } from './keyedSingleFlight.ts';
 export { Mutex } from './mutex.ts';
 export { Semaphore } from './semaphore.ts';
+export { SingleFlight } from './singleFlight.ts';
 export { timeout } from './timeout.ts';
 export { withTimeout } from './withTimeout.ts';

--- a/src/promise/keyedSingleFlight.spec.ts
+++ b/src/promise/keyedSingleFlight.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { KeyedSingleFlight } from './keyedSingleFlight';
+
+describe('KeyedSingleFlight', () => {
+  it('shares work independently for each key', async () => {
+    const flight = new KeyedSingleFlight<string>();
+    const firstTask = vi.fn(() => Promise.resolve('first'));
+    const duplicateTask = vi.fn(() => Promise.resolve('duplicate'));
+    const otherTask = vi.fn(() => Promise.resolve('other'));
+
+    const first = flight.run('same', firstTask);
+    const duplicate = flight.run('same', duplicateTask);
+    const other = flight.run('other', otherTask);
+
+    expect(duplicate).toBe(first);
+    expect(firstTask).toHaveBeenCalledTimes(1);
+    expect(duplicateTask).not.toHaveBeenCalled();
+    expect(otherTask).toHaveBeenCalledTimes(1);
+    await expect(Promise.all([first, duplicate, other])).resolves.toEqual(['first', 'first', 'other']);
+  });
+
+  it('removes a key after the shared operation settles', async () => {
+    const flight = new KeyedSingleFlight<string>();
+    const first = flight.run('key', () => Promise.resolve(1));
+    await expect(first).resolves.toBe(1);
+
+    const secondTask = vi.fn(() => Promise.resolve(2));
+    await expect(flight.run('key', secondTask)).resolves.toBe(2);
+    expect(secondTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares rejection and restarts the key after rejection', async () => {
+    const flight = new KeyedSingleFlight<string>();
+    const error = new Error('failed');
+    const firstTask = vi.fn(() => Promise.reject(error));
+    const duplicateTask = vi.fn(() => Promise.resolve('duplicate'));
+
+    const first = flight.run('key', firstTask);
+    const duplicate = flight.run('key', duplicateTask);
+
+    expect(duplicate).toBe(first);
+    await expect(first).rejects.toBe(error);
+    expect(duplicateTask).not.toHaveBeenCalled();
+
+    await expect(flight.run('key', duplicateTask)).resolves.toBe('duplicate');
+    expect(duplicateTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports arbitrary Map keys', async () => {
+    const flight = new KeyedSingleFlight<object>();
+    const key = {};
+    const sameKeyTask = vi.fn(() => Promise.resolve('same'));
+    const otherKeyTask = vi.fn(() => Promise.resolve('other'));
+
+    const first = flight.run(key, sameKeyTask);
+    const duplicate = flight.run(key, otherKeyTask);
+    const other = flight.run({}, otherKeyTask);
+
+    expect(duplicate).toBe(first);
+    await expect(Promise.all([first, duplicate, other])).resolves.toEqual(['same', 'same', 'other']);
+    expect(otherKeyTask).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/promise/keyedSingleFlight.ts
+++ b/src/promise/keyedSingleFlight.ts
@@ -1,0 +1,67 @@
+import { SingleFlight } from './singleFlight.ts';
+import { isNil } from '../predicate';
+
+/**
+ * Shares in-flight asynchronous tasks independently for each key.
+ *
+ * A `KeyedSingleFlight` does not cache settled results. Once a task resolves or rejects,
+ * the next call for that key starts a new task.
+ *
+ * @template K - The type of the keys used to identify tasks.
+ *
+ * @example
+ * const flight = new KeyedSingleFlight<string>();
+ *
+ * const first = flight.run('user:1', () => fetch('/api/users/1'));
+ * const second = flight.run('user:1', () => fetch('/api/users/1'));
+ * const other = flight.run('user:2', () => fetch('/api/users/2'));
+ *
+ * console.log(first === second); // true
+ * console.log(first === other); // false
+ */
+export class KeyedSingleFlight<K> {
+  private flights = new Map<K, SingleFlight>();
+
+  /**
+   * Runs a task for a key, or returns the Promise of the task already in flight for that key.
+   *
+   * Tasks for different keys can run concurrently. If a task rejects, the rejection is shared
+   * with all callers that joined the same key's flight.
+   *
+   * @template T - The result type of the task.
+   * @param key - The key used to identify the task.
+   * @param task - An asynchronous task to run.
+   * @returns The Promise shared by all callers of the key's current flight.
+   *
+   * @example
+   * const flight = new KeyedSingleFlight<string>();
+   *
+   * const user = await flight.run('user:1', async () => {
+   *   const response = await fetch('/api/users/1');
+   *   return response.json();
+   * });
+   */
+  run<T>(key: K, task: () => Promise<T>): Promise<T> {
+    let flight = this.flights.get(key);
+
+    if (isNil(flight)) {
+      flight = new SingleFlight();
+      this.flights.set(key, flight);
+    }
+
+    const promise = flight.run(task);
+
+    promise.then(
+      () => this.deleteFlight(key, flight!),
+      () => this.deleteFlight(key, flight!)
+    );
+
+    return promise;
+  }
+
+  private deleteFlight(key: K, flight: SingleFlight): void {
+    if (this.flights.get(key) === flight) {
+      this.flights.delete(key);
+    }
+  }
+}

--- a/src/promise/singleFlight.spec.ts
+++ b/src/promise/singleFlight.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SingleFlight } from './singleFlight';
+
+describe('SingleFlight', () => {
+  it('shares the same promise for concurrent calls', async () => {
+    const flight = new SingleFlight();
+    let resolveTask!: (value: number) => void;
+    const task = vi.fn(() => new Promise<number>(resolve => (resolveTask = resolve)));
+
+    const first = flight.run(task);
+    const second = flight.run(task);
+
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+
+    resolveTask(42);
+    await expect(first).resolves.toBe(42);
+    await expect(second).resolves.toBe(42);
+  });
+
+  it('shares rejection and starts a new task after rejection', async () => {
+    const flight = new SingleFlight();
+    const error = new Error('failed');
+    const firstTask = vi.fn(() => Promise.reject(error));
+    const secondTask = vi.fn(() => Promise.resolve('recovered'));
+
+    const first = flight.run(firstTask);
+    const duplicate = flight.run(secondTask);
+
+    expect(duplicate).toBe(first);
+    await expect(first).rejects.toBe(error);
+    expect(secondTask).not.toHaveBeenCalled();
+
+    await expect(flight.run(secondTask)).resolves.toBe('recovered');
+    expect(secondTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('turns a synchronous task throw into a rejected promise', async () => {
+    const flight = new SingleFlight();
+    const error = new Error('failed synchronously');
+
+    await expect(
+      flight.run(() => {
+        throw error;
+      })
+    ).rejects.toBe(error);
+    await expect(flight.run(() => Promise.resolve('next'))).resolves.toBe('next');
+  });
+
+  it('shares the promise with a reentrant call', async () => {
+    const flight = new SingleFlight();
+    let reentrantPromise!: Promise<number>;
+
+    const first = flight.run(async () => {
+      reentrantPromise = flight.run(() => Promise.resolve(42));
+      return 42;
+    });
+
+    expect(reentrantPromise).toBe(first);
+    await expect(first).resolves.toBe(42);
+  });
+});

--- a/src/promise/singleFlight.ts
+++ b/src/promise/singleFlight.ts
@@ -1,0 +1,78 @@
+import { isNotNil } from '../predicate';
+
+/**
+ * Shares the Promise of the first in-flight asynchronous task with subsequent callers.
+ *
+ * A `SingleFlight` does not cache settled results. Once the task resolves or rejects,
+ * the next call starts a new task.
+ *
+ * @example
+ * const flight = new SingleFlight();
+ *
+ * const first = flight.run(() => fetch('/api/config'));
+ * const second = flight.run(() => fetch('/api/config'));
+ *
+ * console.log(first === second); // true
+ */
+export class SingleFlight {
+  private currentPromise: Promise<unknown> | undefined;
+
+  /**
+   * Runs a task, or returns the Promise of the task that is already in flight.
+   *
+   * If the task rejects, the rejection is shared with all callers that joined the
+   * same flight. A later call after settlement starts a new task.
+   *
+   * @template T - The result type of the task.
+   * @param task - An asynchronous task to run.
+   * @returns The Promise shared by all callers of the current flight.
+   *
+   * @example
+   * const flight = new SingleFlight();
+   *
+   * const first = flight.run(async () => {
+   *   const response = await fetch('/api/config');
+   *   return response.json();
+   * });
+   *
+   * const second = flight.run(async () => {
+   *   const response = await fetch('/api/config');
+   *   return response.json();
+   * });
+   *
+   * console.log(first === second); // true
+   */
+  run<T>(task: () => Promise<T>): Promise<T> {
+    if (isNotNil(this.currentPromise)) {
+      return this.currentPromise as Promise<T>;
+    }
+
+    let resolvePromise!: (value: T | PromiseLike<T>) => void;
+    let rejectPromise!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
+
+    this.currentPromise = promise;
+
+    try {
+      Promise.resolve(task()).then(resolvePromise, rejectPromise);
+    } catch (error) {
+      rejectPromise(error);
+    }
+
+    promise.then(
+      () => this.clearPromise(promise),
+      () => this.clearPromise(promise)
+    );
+
+    return promise;
+  }
+
+  private clearPromise(promise: Promise<unknown>): void {
+    if (this.currentPromise === promise) {
+      this.currentPromise = undefined;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `SingleFlight` and `KeyedSingleFlight` to `es-toolkit/promise`: two concurrency primitives that let duplicate callers join an operation that is already running instead of starting a second one.

Refs #1608.

When several call sites independently ask for the same thing at the same time — a config fetch on app boot, a token refresh from three parallel requests, the same user record from two components — the work runs N times. These share one Promise instead.

```ts
import { SingleFlight, KeyedSingleFlight } from 'es-toolkit';

const config = new SingleFlight();
config.run(() => fetch('/api/config')); // runs
config.run(() => fetch('/api/config')); // joins the first — same Promise

const users = new KeyedSingleFlight<string>();
users.run('user:1', fetchUser1); // runs
users.run('user:1', fetchUser1); // joins
users.run('user:2', fetchUser2); // separate key, runs concurrently
```

They join `Mutex` and `Semaphore` as class-based primitives in `es-toolkit/promise`.

## Changes

- `src/promise/singleFlight.ts` — `SingleFlight` with a single `run(task)` method.
- `src/promise/keyedSingleFlight.ts` — `KeyedSingleFlight<K>` with `run(key, task)`, backed by a `Map<K, SingleFlight>`.
- Re-exported from `src/promise/index.ts` (so also from the `es-toolkit` root and the `es-toolkit/promise` subpath).
- Tests for both, and reference docs in all four languages.

## Design notes

**Results are not cached.** Once a flight settles, the next call starts fresh. This is deduplication of concurrent work, not memoization — `memoize` already covers caching, and conflating the two would mean every user needs a TTL knob.

**The Promise is stored before the task runs.** The naive implementation calls the factory first and stores the result, which leaves a window where a reentrant call — a task that calls `run` on the same instance — sees an empty slot and starts a second flight. Here the Promise is created with an explicit resolver pair and assigned to the instance *before* `task()` is invoked, so a reentrant caller joins the flight it is already inside. #1608 raised this exact bug; `singleFlight.spec.ts` covers it.

Note that storing first makes the microtask hop unnecessary: `task()` is called synchronously, so the underlying request is dispatched on the current tick rather than one tick later.

**A synchronous throw becomes a rejection.** `run(() => { throw e })` returns a rejected Promise rather than throwing at the call site, so callers have one error channel.

**Rejections are shared, then the slot clears.** Every caller that joined a failed flight sees the same error; the next call after settlement retries. Clearing is guarded by identity (`if (this.currentPromise === promise)`), so a settling old flight cannot evict a newer one.

Cleanup uses `promise.then(onFulfilled, onRejected)` rather than `promise.finally(...)` on purpose. `finally` returns a derived Promise that re-propagates the original rejection, and nothing handles that derived Promise — which surfaces as a spurious `unhandledRejection` even when the caller correctly catches the error it received. The two-callback form returns a Promise that fulfills, so no such warning is produced.

**`KeyedSingleFlight` deletes its Map entry on settle**, also identity-guarded, so the Map does not grow without bound over the life of the instance. Keys use `Map` equality, which means object keys compare by reference.

**State is per instance, not module-scope.** A module-level registry makes the key namespace global: two unrelated features that both pick `'user'` collide, tests cannot be isolated from one another, and on a server where the module is shared across requests, two concurrent requests with the same key receive each other's result. Scoping to an instance means callers decide the sharing boundary — one instance per app for a genuinely global resource, one per request where that is what isolation requires.

## Relationship to #1921

#1921 implements the same idea from #1608 as `coalesce(key, fn)` with a module-scope `Map`. The core semantics agree with this PR — dedupe concurrent calls, no result caching, identity-guarded cleanup, reentrancy safety. I have left a comment there with the details; two behaviors are worth repeating here, since they are what motivated the shape of this API.

The module-scope registry shares state across every consumer in the process:

```ts
// two independent callers, one global Map
const a = coalesce('current-user', () => Promise.resolve({ user: 'alice' }));
const b = coalesce('current-user', () => Promise.resolve({ user: 'bob' }));
await b; // { user: 'alice' } — the second caller's own fn never runs
```

That is the intended dedupe behavior when the two calls really are the same operation, but there is no way to express that they are not. On a server rendering two requests concurrently, the second request receives the first request's data.

And `finally`-based cleanup emits an `unhandledRejection` even when the caller handles the error:

```ts
try { await coalesce('k', () => Promise.reject(new Error('boom'))); }
catch (e) { /* handled */ }
// caller caught properly: boom
// !!! UNHANDLED REJECTION: boom
```

Both reproduce on Node; `KeyedSingleFlight` returns the per-caller result in the first case and emits nothing in the second.

On naming: `coalesce` collides with SQL's `COALESCE` (first non-null argument), which is a different and more widely known operation. `SingleFlight` follows `golang.org/x/sync/singleflight`, where this pattern is named, and reads consistently next to `Mutex` and `Semaphore`. Splitting the keyed and unkeyed cases also means the common single-resource case does not have to invent a key, and the keyed case is not restricted to `string`.

Happy to fold this into #1921 instead if the maintainers prefer that path — the two PRs should not both land.

## Note on the discussion requirement

#1608 is still open and labelled `p3: discussion` rather than accepted, so per CONTRIBUTING §4.1 this may be premature. Opening it anyway because #1921 is an in-progress implementation of the same request and the two defects above seemed worth surfacing with a working alternative rather than as review comments alone. If the proposal is not wanted, feel free to close — no objection.

No benchmark section: these have no Lodash counterpart to compare against, same as `Mutex` and `Semaphore`.
