### PR TITLE
fix(compat): return an empty array for chunk of an empty collection with Infinity size

### DIFF
--- a/benchmarks/bundle-size/chunk.spec.ts
+++ b/benchmarks/bundle-size/chunk.spec.ts
@@ -14,6 +14,6 @@ describe('chunk bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'chunk');
-    expect(bundleSize).toMatchInlineSnapshot(`536`);
+    expect(bundleSize).toMatchInlineSnapshot(`552`);
   });
 });

--- a/src/compat/array/chunk.spec.ts
+++ b/src/compat/array/chunk.spec.ts
@@ -65,4 +65,9 @@ describe('chunk', () => {
   it('should return an full elements array when the size is Infinity', () => {
     expect(chunk([1, 2, 3], Infinity)).toEqual([[1, 2, 3]]);
   });
+
+  it('should return an empty array for an empty collection when the size is Infinity', () => {
+    expect(chunk([], Infinity)).toEqual([]);
+    expect(chunk({ length: 0 }, Infinity)).toEqual([]);
+  });
 });

--- a/src/compat/array/chunk.ts
+++ b/src/compat/array/chunk.ts
@@ -33,7 +33,7 @@ export function chunk<T>(arr: ArrayLike<T> | null | undefined, size = 1): T[][] 
   const array = toArray(arr);
 
   if (!isFinite(size)) {
-    return [array];
+    return array.length === 0 ? [] : [array];
   }
 
   return chunkToolkit(array, size);


### PR DESCRIPTION
## Summary

`compat/chunk` returns `[[]]` for an empty collection when `size` is `Infinity`, while lodash returns `[]`.

```ts
chunk([], Infinity)
// es-toolkit: [[]]
// lodash:     []

chunk({ length: 0 }, Infinity)
// es-toolkit: [[]]
// lodash:     []
```

lodash short-circuits empty collections before chunking (`if (!length || size < 1) return []`), so an empty input never produces a chunk. The `!isFinite(size)` branch here wraps the empty array unconditionally.

## Fix

Only wrap the array when it has elements:

```ts
if (!isFinite(size)) {
  return array.length === 0 ? [] : [array];
}
```

## Tests

Added a regression case for empty collections with an `Infinity` size. The existing `chunk([1, 2, 3], Infinity)` case still returns `[[1, 2, 3]]`. Verified against lodash 4.17.21.