### PR TITLE
fix(compat): convert non-array-like iterables in toArray like lodash

### DIFF
--- a/src/compat/util/toArray.spec.ts
+++ b/src/compat/util/toArray.spec.ts
@@ -13,6 +13,18 @@ describe('toArray', () => {
     }
   });
 
+  it('should convert non-array-like iterables to arrays', () => {
+    const iterable = {
+      *[Symbol.iterator]() {
+        yield 1;
+        yield 2;
+      },
+    };
+    expect(toArray(iterable)).toEqual([1, 2]);
+    expect(toArray(new Map([['a', 1]]).entries())).toEqual([['a', 1]]);
+    expect(toArray(new Set([1, 2]).values())).toEqual([1, 2]);
+  });
+
   it('should convert maps to arrays', () => {
     if (Map) {
       const map = new Map();

--- a/src/compat/util/toArray.ts
+++ b/src/compat/util/toArray.ts
@@ -60,6 +60,10 @@ export function toArray(value?: unknown): any[] {
   }
 
   if (typeof value === 'object') {
+    if (typeof (value as Record<symbol, unknown>)[Symbol.iterator] === 'function') {
+      return Array.from(value as Iterable<unknown>);
+    }
+
     return Object.values(value);
   }
 

--- a/src/compat/util/toArray.ts
+++ b/src/compat/util/toArray.ts
@@ -1,3 +1,4 @@
+import { isIterable } from '../../predicate/isIterable.ts';
 import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { isMap } from '../predicate/isMap.ts';
 import { isSet } from '../predicate/isSet.ts';
@@ -60,8 +61,8 @@ export function toArray(value?: unknown): any[] {
   }
 
   if (typeof value === 'object') {
-    if (typeof (value as Record<symbol, unknown>)[Symbol.iterator] === 'function') {
-      return Array.from(value as Iterable<unknown>);
+    if (isIterable(value)) {
+      return Array.from(value);
     }
 
     return Object.values(value);


### PR DESCRIPTION
## Summary

`compat/toArray` ignores a non-array-like object's `Symbol.iterator` and falls straight through to `Object.values`, so iterables are not converted the way lodash converts them.

```ts
toArray(new Map([['a', 1]]).entries())
// es-toolkit: []
// lodash:     [['a', 1]]

toArray(new Set([1, 2]).values())
// es-toolkit: []
// lodash:     [1, 2]

const iterable = { *[Symbol.iterator]() { yield 1; yield 2; } };
toArray(iterable)
// es-toolkit: []
// lodash:     [1, 2]
```

lodash's `toArray` handles the iterator (`symIterator && value[symIterator]`) before falling back to `values`.

## Fix

Convert iterables with `Array.from` before the `Object.values` fallback, mirroring lodash's ordering. Array-likes, `Map` and `Set` are still handled first, and plain non-iterable objects still use `Object.values`.

## Tests

Added a regression case for non-array-like iterables (a generator object, `Map` entries and `Set` values). All existing cases still pass. Verified against lodash 4.17.21.