### PR TITLE
chore[chunk]: flatten the nested conditional in compat chunk

### DIFF
--- a/src/compat/array/chunk.ts
+++ b/src/compat/array/chunk.ts
@@ -32,8 +32,12 @@ export function chunk<T>(arr: ArrayLike<T> | null | undefined, size = 1): T[][] 
 
   const array = toArray(arr);
 
+  if (array.length === 0) {
+    return [];
+  }
+
   if (!isFinite(size)) {
-    return array.length === 0 ? [] : [array];
+    return [array];
   }
 
   return chunkToolkit(array, size);


### PR DESCRIPTION
## Summary

Follow-up to #1995. That fix left `chunk` in `es-toolkit/compat` with a conditional expression nested inside an `if`, which reads worse than two flat guards. This is a readability-only change; behavior is unchanged.

## Changes

- Split the empty-collection case out of the `!isFinite(size)` branch in `src/compat/array/chunk.ts` into its own early return.

```ts
// before
if (!isFinite(size)) {
  return array.length === 0 ? [] : [array];
}

// after
if (array.length === 0) {
  return [];
}

if (!isFinite(size)) {
  return [array];
}
```

The new early return also covers finite sizes, which is equivalent: `chunk([], size)` in `es-toolkit` computes `Math.ceil(0 / size) === 0` and already returns `[]`.

The existing `chunk` tests and the bundle-size snapshot pass unchanged.
