### PR TITLE
test(compat/toLower, compat/toUpper): align nested nullish expectations with lodash

### DIFF
--- a/src/compat/string/toLower.spec.ts
+++ b/src/compat/string/toLower.spec.ts
@@ -80,7 +80,7 @@ describe('toLower', () => {
 
   it('should handle mixed types in arrays', () => {
     const sym = Symbol('test');
-    expect((toLower as any)([1, 'b', sym, null, undefined])).toBe('1,b,symbol(test),,');
+    expect((toLower as any)([1, 'b', sym, null, undefined])).toBe('1,b,symbol(test),null,undefined');
   });
 
   it('should maintain proper TypeScript types', () => {

--- a/src/compat/string/toUpper.spec.ts
+++ b/src/compat/string/toUpper.spec.ts
@@ -83,7 +83,7 @@ describe('toUpper', () => {
 
   it('should handle mixed types in arrays', () => {
     const sym = Symbol('test');
-    expect((toUpper as any)([1, 'b', sym, null, undefined])).toBe('1,B,SYMBOL(TEST),,');
+    expect((toUpper as any)([1, 'b', sym, null, undefined])).toBe('1,B,SYMBOL(TEST),NULL,UNDEFINED');
   });
 
   it('should maintain proper TypeScript types', () => {


### PR DESCRIPTION
## Problem

CI (and Release) on `main` has been failing since #1992 (`43932e61`) landed. That PR correctly changed `compat/toString` to render nested `null`/`undefined` in arrays as `'null'`/`'undefined'`, matching lodash — but two existing specs for `toLower`/`toUpper` (which delegate to `toString`) still encoded the old `''` rendering:

- `src/compat/string/toLower.spec.ts:83`
- `src/compat/string/toUpper.spec.ts:86`

PR CI runs `vitest --changed`, which didn't pick these specs up, so the failure only surfaced on the full-suite run after merge.

## Verification

Real lodash behavior (verified at runtime with the version pinned in `benchmarks/`):

```js
_.toLower([1, 'b', null, undefined]) // => '1,b,null,undefined'
_.toUpper([1, 'b', null, undefined]) // => '1,B,NULL,UNDEFINED'
```

So the implementation from #1992 is correct and the stale test expectations are what needed updating.

`yarn vitest run src/compat/string/toLower src/compat/string/toUpper` — 32 tests pass.