### PR TITLE
fix(compat/orderBy): exclude the `length` property from array-like values

### DIFF
--- a/src/compat/array/orderBy.spec.ts
+++ b/src/compat/array/orderBy.spec.ts
@@ -252,4 +252,10 @@ describe('orderBy', () => {
     expect(orderBy([3, 1, 2], 'b')).toEqual([3, 1, 2]);
     expect(orderBy(['c', 'a', 'b'], 'x')).toEqual(['c', 'a', 'b']);
   });
+
+  it('should not include the `length` property for array-like objects', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error - type mismatch
+    expect(orderBy({ 0: 3, 1: 1, 2: 2, length: 3 }, [null], ['asc'])).toEqual([1, 2, 3]);
+  });
 });

--- a/src/compat/array/orderBy.ts
+++ b/src/compat/array/orderBy.ts
@@ -5,6 +5,7 @@ import { ListIterator } from '../_internal/ListIterator.ts';
 import { Many } from '../_internal/Many.ts';
 import { ObjectIteratee } from '../_internal/ObjectIteratee.ts';
 import { ObjectIterator } from '../_internal/ObjectIterator.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { toPath } from '../util/toPath.ts';
 
 export type Criterion<T> = ((item: T) => unknown) | PropertyKey | PropertyKey[] | null | undefined;
@@ -144,7 +145,7 @@ export function orderBy<T = any>(collection: any, criteria?: any, orders?: any, 
   orders = guard ? undefined : orders;
 
   if (!Array.isArray(collection)) {
-    collection = Object.values(collection);
+    collection = isArrayLike(collection) ? Array.from(collection) : Object.values(collection);
   }
 
   if (!Array.isArray(criteria)) {

--- a/src/compat/array/sortBy.spec.ts
+++ b/src/compat/array/sortBy.spec.ts
@@ -141,6 +141,12 @@ describe('sortBy', () => {
     expect(sortBy({ a: 1, b: 2, c: 3 }, Math.sin)).toEqual([3, 1, 2]);
   });
 
+  it('should not include the `length` property for array-like objects', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(sortBy({ 0: 3, 1: 1, 2: 2, length: 3 }, [null])).toEqual([1, 2, 3]);
+  });
+
   it('should move `NaN`, nullish, and symbol values to the end', () => {
     const symbol1 = Symbol ? Symbol('a') : null;
     const symbol2 = Symbol ? Symbol('b') : null;


### PR DESCRIPTION
current behavior:
lodash
```js
_.sortBy({ 0: 3, 1: 1, 2: 2, length: 3 }, [null]) // [1, 2, 3]
_.orderBy({ 0: 3, 1: 1, 2: 2, length: 3 }, [null]) // [1, 2, 3]
```
compat
```js
esCompat.sortBy({ 0: 3, 1: 1, 2: 2, length: 3 }, [null]) // [1, 2, 3, 3]
esCompat.orderBy({ 0: 3, 1: 1, 2: 2, length: 3 }, [null]) // [1, 2, 3, 3]
```