### PR TITLE
fix(compat/sampleSize): clamp the default size to the collection length

### DIFF
--- a/src/compat/array/sampleSize.spec.ts
+++ b/src/compat/array/sampleSize.spec.ts
@@ -59,6 +59,16 @@ describe('sampleSize', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should return an empty array for nullish collections when `size` is not provided', () => {
+    expect(sampleSize(null)).toEqual([]);
+    expect(sampleSize(undefined)).toEqual([]);
+    expect(sampleSize([])).toEqual([]);
+    // @ts-expect-error - type mismatch
+    expect(sampleSize(1)).toEqual([]);
+    // @ts-expect-error - type mismatch
+    expect(sampleSize(true)).toEqual([]);
+  });
+
   it('should sample an object', () => {
     const object = { a: 1, b: 2, c: 3 };
     const actual = sampleSize(object, 2);

--- a/src/compat/array/sampleSize.ts
+++ b/src/compat/array/sampleSize.ts
@@ -59,8 +59,10 @@ export function sampleSize<T>(
   if (guard ? isIterateeCall(collection, size, guard) : size === undefined) {
     size = 1;
   } else {
-    size = clamp(toInteger(size), 0, arrayCollection.length);
+    size = toInteger(size);
   }
+
+  size = clamp(size, 0, arrayCollection.length);
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error


### PR DESCRIPTION
current behavior:
lodash
```js
_.sampleSize(null) // []
```
compat
```js
esCompat.sampleSize(null) //Uncaught Error: Size must be less than or equal to the length of array.
```