### PR TITLE
fix(compat/takeWhile, compat/takeRightWhile, compat/uniqBy): support string inputs

### DIFF
--- a/src/compat/array/takeRightWhile.spec.ts
+++ b/src/compat/array/takeRightWhile.spec.ts
@@ -54,4 +54,9 @@ describe('takeRightWhile', () => {
     expect(takeRightWhile({ 0: 1, 1: 2, 2: 3, length: 3 }, value => value > 1)).toEqual([2, 3]);
     expect(takeRightWhile(toArgs([1, 2, 3]), value => value > 1)).toEqual([2, 3]);
   });
+
+  it('should treat strings as arrays of characters', () => {
+    expect(takeRightWhile('hello', char => char !== 'h')).toEqual(['e', 'l', 'l', 'o']);
+    expect(takeRightWhile('hello')).toEqual(['h', 'e', 'l', 'l', 'o']);
+  });
 });

--- a/src/compat/array/takeRightWhile.ts
+++ b/src/compat/array/takeRightWhile.ts
@@ -2,7 +2,7 @@ import { identity } from '../../function/identity.ts';
 import { negate } from '../../function/negate.ts';
 import { ListIteratee } from '../_internal/ListIteratee.ts';
 import { toArray } from '../_internal/toArray.ts';
-import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { iteratee as createIteratee } from '../util/iteratee.ts';
 
 /**
@@ -91,7 +91,7 @@ export function takeRightWhile<T>(
     | [keyof T, unknown]
     | PropertyKey
 ): T[] {
-  if (!isArrayLikeObject(_array)) {
+  if (!isArrayLike(_array)) {
     return [];
   }
 

--- a/src/compat/array/takeWhile.spec.ts
+++ b/src/compat/array/takeWhile.spec.ts
@@ -54,4 +54,9 @@ describe('takeWhile', () => {
     expect(takeWhile({ 0: 3, 1: 2, 2: 1, length: 3 }, value => value > 1)).toEqual([3, 2]);
     expect(takeWhile(toArgs([3, 2, 1]), value => value > 1)).toEqual([3, 2]);
   });
+
+  it('should treat strings as arrays of characters', () => {
+    expect(takeWhile('hello', char => char !== 'o')).toEqual(['h', 'e', 'l', 'l']);
+    expect(takeWhile('hello')).toEqual(['h', 'e', 'l', 'l', 'o']);
+  });
 });

--- a/src/compat/array/takeWhile.ts
+++ b/src/compat/array/takeWhile.ts
@@ -2,7 +2,7 @@ import { ListIteratee } from '../_internal/ListIteratee.ts';
 import { toArray } from '../_internal/toArray.ts';
 import { identity } from '../function/identity.ts';
 import { negate } from '../function/negate.ts';
-import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { iteratee } from '../util/iteratee.ts';
 
 /**
@@ -91,7 +91,7 @@ export function takeWhile<T>(
     | [keyof T, unknown]
     | PropertyKey
 ): T[] {
-  if (!isArrayLikeObject(array)) {
+  if (!isArrayLike(array)) {
     return [];
   }
 

--- a/src/compat/array/uniqBy.spec.ts
+++ b/src/compat/array/uniqBy.spec.ts
@@ -98,4 +98,10 @@ describe('uniqBy', () => {
     // @ts-expect-error
     expect(uniqBy([1, 2, 3, 4, 1, 2, 3])).toEqual([1, 2, 3, 4]);
   });
+
+  it('should treat strings as arrays of characters', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(uniqBy('hello')).toEqual(['h', 'e', 'l', 'o']);
+  });
 });

--- a/src/compat/array/uniqBy.ts
+++ b/src/compat/array/uniqBy.ts
@@ -2,7 +2,7 @@ import { uniqBy as uniqByToolkit } from '../../array/uniqBy.ts';
 import { ary } from '../../function/ary.ts';
 import { identity } from '../../function/identity.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
-import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
+import { isArrayLike } from '../predicate/isArrayLike.ts';
 import { iteratee as createIteratee } from '../util/iteratee.ts';
 
 /**
@@ -22,7 +22,7 @@ export function uniqBy<T>(
   array: ArrayLike<T> | null | undefined,
   iteratee: ((value: T) => unknown) | PropertyKey | [keyof T, unknown] | Partial<T> = identity
 ): T[] {
-  if (!isArrayLikeObject(array)) {
+  if (!isArrayLike(array)) {
     return [];
   }
 


### PR DESCRIPTION
current behavior:
lodash
```js
_.takeWhile('hello', char => char !== 'o') // ['h', 'e', 'l', 'l']
_.takeRightWhile('hello', char => char !== 'h') // ['e', 'l', 'l', 'o']
_.uniqBy('hello') // ['h', 'e', 'l', 'o']
```
compat
```js
esCompat.takeWhile('hello', char => char !== 'o') // []
esCompat.takeRightWhile('hello', char => char !== 'h') // []
esCompat.uniqBy('hello') // []
```