### PR TITLE
fix(compat/zipObject): treat null keys and values as empty arrays

### DIFF
--- a/benchmarks/bundle-size/zipObject.spec.ts
+++ b/benchmarks/bundle-size/zipObject.spec.ts
@@ -14,6 +14,6 @@ describe('zipObject bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'zipObject');
-    expect(bundleSize).toMatchInlineSnapshot(`265`);
+    expect(bundleSize).toMatchInlineSnapshot(`281`);
   });
 });

--- a/src/compat/array/zipObject.spec.ts
+++ b/src/compat/array/zipObject.spec.ts
@@ -41,4 +41,15 @@ describe('zipObject', () => {
     expect(zipObject()).toEqual({});
     expect(zipObject(undefined)).toEqual({});
   });
+
+  it('should treat null keys and values as empty arrays', () => {
+    // @ts-expect-error - invalid argument
+    expect(zipObject(null)).toEqual({});
+    // @ts-expect-error - invalid argument
+    expect(zipObject(null, null)).toEqual({});
+    // @ts-expect-error - invalid argument
+    expect(zipObject(null, [1, 2])).toEqual({});
+    // @ts-expect-error - invalid argument
+    expect(zipObject(['a', 'b'], null)).toEqual({ a: undefined, b: undefined });
+  });
 });

--- a/src/compat/array/zipObject.ts
+++ b/src/compat/array/zipObject.ts
@@ -60,6 +60,9 @@ export function zipObject(props?: ArrayLike<PropertyKey>): Record<string, undefi
  * // result2 will be { a: 1, b: 2 }
  */
 export function zipObject<K extends PropertyKey, V>(keys: ArrayLike<K> = [], values: ArrayLike<V> = []): Record<K, V> {
+  keys = keys || [];
+  values = values || [];
+
   const result = {} as Record<K, V>;
 
   for (let i = 0; i < keys.length; i++) {


### PR DESCRIPTION
current behavior:
lodash
```js
_.zipObject(null) // {}
_.zipObject(null, null) // {}
_.zipObject(null, [1,2]) // {}
_.zipObject(['a', 'b'], null) // {a: undefined, b: undefined}
```
compat
```js
esCompat.zipObject(null) // Uncaught TypeError: Cannot read properties of null (reading 'length')
esCompat.zipObject(null, null) // Uncaught TypeError: Cannot read properties of null (reading 'length')
esCompat.zipObject(null, [1,2]) // Uncaught TypeError: Cannot read properties of null (reading 'length')
esCompat.zipObject(['a', 'b'], null) // Uncaught TypeError: Cannot read properties of null (reading '0')
```