### PR TITLE
fix(compat/difference, compat/differenceBy, compat/uniqBy, compat/unionBy): normalize `-0` to `0` like lodash

### DIFF
--- a/benchmarks/bundle-size/difference.spec.ts
+++ b/benchmarks/bundle-size/difference.spec.ts
@@ -14,6 +14,6 @@ describe('difference bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'difference');
-    expect(bundleSize).toMatchInlineSnapshot(`433`);
+    expect(bundleSize).toMatchInlineSnapshot(`471`);
   });
 });

--- a/src/compat/_internal/normalizeZero.ts
+++ b/src/compat/_internal/normalizeZero.ts
@@ -1,0 +1,10 @@
+/**
+ * Normalizes `-0` to `0` to match Lodash, which normalizes `-0` to `+0` in the
+ * results of functions like `uniq`, `union`, and `difference`.
+ *
+ * @param value - The value to normalize.
+ * @returns The value with `-0` normalized to `0`.
+ */
+export function normalizeZero<T>(value: T): T {
+  return value === 0 ? (0 as T) : value;
+}

--- a/src/compat/array/difference.spec.ts
+++ b/src/compat/array/difference.spec.ts
@@ -25,7 +25,7 @@ describe('difference', () => {
 
     expect(actual).toEqual([[], []]);
 
-    expect(difference([-0, 1], [1])).toEqual([-0]);
+    expect(difference([-0, 1], [1])).toEqual([0]);
   });
 
   it(`should match \`NaN\``, () => {
@@ -58,7 +58,7 @@ describe('difference', () => {
     expect(actual).toEqual([[], []]);
 
     const largeArray = Array.from({ length: LARGE_ARRAY_SIZE }).map(() => 1);
-    expect(difference([-0, 1], largeArray)).toEqual([-0]);
+    expect(difference([-0, 1], largeArray)).toEqual([0]);
   });
 
   it(`should work with large arrays of \`NaN\``, () => {
@@ -102,5 +102,10 @@ describe('difference', () => {
 
   it('should filter out values that are not arrays or array-like objects', () => {
     expect(difference(['2', '3'], '2', ['3'])).toEqual(['2']);
+  });
+
+  it('should normalize `-0` to `0` like lodash', () => {
+    expect(difference([-0, 1], [1])).toEqual([0]);
+    expect(difference([-0], [])).toEqual([0]);
   });
 });

--- a/src/compat/array/difference.ts
+++ b/src/compat/array/difference.ts
@@ -1,4 +1,5 @@
 import { difference as differenceToolkit } from '../../array/difference.ts';
+import { normalizeZero } from '../_internal/normalizeZero.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 
 /**
@@ -41,5 +42,5 @@ export function difference<T>(arr: ArrayLike<T> | undefined | null, ...values: A
     }
   }
 
-  return differenceToolkit(arr1, arr2);
+  return differenceToolkit(arr1, arr2).map(normalizeZero);
 }

--- a/src/compat/array/differenceBy.spec.ts
+++ b/src/compat/array/differenceBy.spec.ts
@@ -52,7 +52,7 @@ describe('differenceBy', () => {
 
     expect(actual).toEqual([[], []]);
 
-    expect(differenceBy([-0, 1], [1])).toEqual([-0]);
+    expect(differenceBy([-0, 1], [1])).toEqual([0]);
   });
 
   it(`should match \`NaN\``, () => {
@@ -85,7 +85,7 @@ describe('differenceBy', () => {
     expect(actual).toEqual([[], []]);
 
     const largeArray = Array.from({ length: LARGE_ARRAY_SIZE }).map(() => 1);
-    expect(differenceBy([-0, 1], largeArray)).toEqual([-0]);
+    expect(differenceBy([-0, 1], largeArray)).toEqual([0]);
   });
 
   it(`should work with large arrays of \`NaN\``, () => {
@@ -123,5 +123,9 @@ describe('differenceBy', () => {
   it('should filter out values that are not arrays or array-like objects', () => {
     expect(differenceBy(['2', '3'], '2', ['3'])).toEqual(['2']);
     expect(differenceBy(['2', '3'], '2', ['3'], value => value)).toEqual(['2']);
+  });
+
+  it('should normalize `-0` to `0` like lodash', () => {
+    expect(differenceBy([-0], [1], value => value)).toEqual([0]);
   });
 });

--- a/src/compat/array/differenceBy.ts
+++ b/src/compat/array/differenceBy.ts
@@ -2,6 +2,7 @@ import { last } from './last.ts';
 import { difference as differenceToolkit } from '../../array/difference.ts';
 import { differenceBy as differenceByToolkit } from '../../array/differenceBy.ts';
 import { flattenArrayLike } from '../_internal/flattenArrayLike.ts';
+import { normalizeZero } from '../_internal/normalizeZero.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 import { iteratee as createIteratee } from '../util/iteratee.ts';
@@ -172,8 +173,8 @@ export function differenceBy<T>(array: ArrayLike<T> | null | undefined, ..._valu
   const values = flattenArrayLike<T>(_values);
 
   if (isArrayLikeObject(iteratee)) {
-    return differenceToolkit(Array.from(array), values);
+    return differenceToolkit(Array.from(array), values).map(normalizeZero);
   }
 
-  return differenceByToolkit(Array.from(array), values, createIteratee(iteratee));
+  return differenceByToolkit(Array.from(array), values, createIteratee(iteratee)).map(normalizeZero);
 }

--- a/src/compat/array/unionBy.spec.ts
+++ b/src/compat/array/unionBy.spec.ts
@@ -55,4 +55,8 @@ describe('unionBy', () => {
     const actual = unionBy([{ x: 1, y: 1 }], [{ x: 1, y: 2 }], 'x');
     expect(actual).toEqual([{ x: 1, y: 1 }]);
   });
+
+  it('should normalize `-0` to `0` like lodash', () => {
+    expect(unionBy([-0], [-0], value => value)).toEqual([0]);
+  });
 });

--- a/src/compat/array/unionBy.ts
+++ b/src/compat/array/unionBy.ts
@@ -3,6 +3,7 @@ import { uniq } from '../../array/uniq.ts';
 import { uniqBy } from '../../array/uniqBy.ts';
 import { ary } from '../../function/ary.ts';
 import { flattenArrayLike } from '../_internal/flattenArrayLike.ts';
+import { normalizeZero } from '../_internal/normalizeZero.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 import { iteratee } from '../util/iteratee.ts';
@@ -155,5 +156,5 @@ export function unionBy<T>(...values: Array<ArrayLike<T> | null | undefined | It
     return uniq(flattened);
   }
 
-  return uniqBy(flattened, ary(iteratee(lastValue), 1));
+  return uniqBy(flattened, ary(iteratee(lastValue), 1)).map(normalizeZero);
 }

--- a/src/compat/array/uniqBy.spec.ts
+++ b/src/compat/array/uniqBy.spec.ts
@@ -98,4 +98,11 @@ describe('uniqBy', () => {
     // @ts-expect-error
     expect(uniqBy([1, 2, 3, 4, 1, 2, 3])).toEqual([1, 2, 3, 4]);
   });
+
+  it('should normalize `-0` to `0` like lodash', () => {
+    expect(uniqBy([-0, 0], value => value)).toEqual([0]);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(uniqBy([-0])).toEqual([0]);
+  });
 });

--- a/src/compat/array/uniqBy.ts
+++ b/src/compat/array/uniqBy.ts
@@ -1,6 +1,7 @@
 import { uniqBy as uniqByToolkit } from '../../array/uniqBy.ts';
 import { ary } from '../../function/ary.ts';
 import { identity } from '../../function/identity.ts';
+import { normalizeZero } from '../_internal/normalizeZero.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 import { iteratee as createIteratee } from '../util/iteratee.ts';
@@ -26,5 +27,5 @@ export function uniqBy<T>(
     return [];
   }
 
-  return uniqByToolkit(Array.from(array), ary(createIteratee(iteratee), 1));
+  return uniqByToolkit(Array.from(array), ary(createIteratee(iteratee), 1)).map(normalizeZero);
 }


### PR DESCRIPTION
lodash
```js
_.uniqBy([-0, 0], value => value) // [0]
_.unionBy([-0], [-0], value => value) // [0]
_.difference([-0, 1], [1]) // [0]
_.differenceBy([-0, 1], [1]) // [0]
```

compat
```js
esCompat.uniqBy([-0, 0], value => value) // [-0]
esCompat.unionBy([-0], [-0], value => value) // [-0]
esCompat.difference([-0, 1], [1]) // [-0]
esCompat.differenceBy([-0, 1], [1]) // [-0]
```