### PR TITLE
fix(compat/reverse): support array-like objects and `arguments` like lodash

### DIFF
--- a/src/compat/array/reverse.spec.ts
+++ b/src/compat/array/reverse.spec.ts
@@ -84,4 +84,19 @@ describe('reverse', () => {
     expect(result).toEqual(['four', 3, 'two', 1]);
     expect(result).toBe(array);
   });
+
+  it('should work with array-like objects and `arguments`', () => {
+    const arrayLike = { 0: 'a', 1: 'b', 2: 'c', length: 3 };
+    const result = reverse(arrayLike);
+
+    expect(result).toBe(arrayLike);
+    expect(result).toEqual({ 0: 'c', 1: 'b', 2: 'a', length: 3 });
+  });
+
+  it('should return primitives unchanged', () => {
+    // @ts-expect-error - type mismatch
+    expect(Number(reverse(42))).toBe(42);
+    // @ts-expect-error - type mismatch
+    expect(Boolean(reverse(true))).toBe(true);
+  });
 });

--- a/src/compat/array/reverse.ts
+++ b/src/compat/array/reverse.ts
@@ -41,5 +41,5 @@ export function reverse<T>(array: T[] | null | undefined): T[] | null | undefine
     return array;
   }
 
-  return array.reverse();
+  return Array.prototype.reverse.call(array);
 }


### PR DESCRIPTION
lodash
```js
_.reverse({ 0: 'a', 1: 'b', 2: 'c', length: 3 }) // {0: 'c', 1: 'b', 2: 'a', length: 3}
Number(_.reverse(42)) // 42
```

compat
```js
esCompat.reverse({ 0: 'a', 1: 'b', 2: 'c', length: 3 }) // Uncaught TypeError: t.reverse is not a function
Number(esCompat.reverse(42)) // Uncaught TypeError: t.reverse is not a function
```