### PR TITLE
fix(compat/some, compat/template): gate guard handling with isIterateeCall like lodash

### DIFF
--- a/src/compat/array/some.spec.ts
+++ b/src/compat/array/some.spec.ts
@@ -144,6 +144,13 @@ describe('some', () => {
     expect(actual).toEqual([true]);
   });
 
+  it('should not reset the predicate for a non-iteratee-call `guard`', () => {
+    // @ts-expect-error - type mismatch
+    expect(some([1, 2, 3], () => false, { n: 2 })).toBe(false);
+    // @ts-expect-error - type mismatch
+    expect(some([1, 2, 3], n => n === 2, true)).toBe(true);
+  });
+
   it('should return true for object with one value passing the predicate', () => {
     expect(some({ a: 1, b: 2, c: 3 }, value => value >= 3)).toBe(true);
   });

--- a/src/compat/array/some.ts
+++ b/src/compat/array/some.ts
@@ -1,4 +1,5 @@
 import { identity } from '../../function/identity.ts';
+import { isIterateeCall } from '../_internal/isIterateeCall.ts';
 import { ListIterateeCustom } from '../_internal/ListIterateeCustom.ts';
 import { ObjectIterateeCustom } from '../_internal/ObjectIteratee.ts';
 import { property } from '../object/property.ts';
@@ -83,7 +84,7 @@ export function some<T>(
   if (!source) {
     return false;
   }
-  if (guard != null) {
+  if (guard && isIterateeCall(source, predicate, guard)) {
     predicate = undefined;
   }
 

--- a/src/compat/string/template.spec.ts
+++ b/src/compat/string/template.spec.ts
@@ -475,4 +475,11 @@ describe('template', () => {
 
     expect(actual).toEqual(['one', '&quot;two&quot;', 'three']);
   });
+
+  it('should not reset options for a non-iteratee-call `guard`', () => {
+    // @ts-expect-error - type mismatch
+    const compiled = template('a{{x}}b', { interpolate: /\{\{([\s\S]+?)\}\}/g }, { g: 1 });
+
+    expect(compiled({ x: '?' })).toBe('a?b');
+  });
 });

--- a/src/compat/string/template.ts
+++ b/src/compat/string/template.ts
@@ -1,4 +1,5 @@
 import { escape } from './escape.ts';
+import { isIterateeCall } from '../_internal/isIterateeCall.ts';
 import { attempt } from '../function/attempt.ts';
 import { defaults } from '../object/defaults.ts';
 import { toString } from '../util/toString.ts';
@@ -122,7 +123,7 @@ export function template(string?: string, options?: TemplateOptions): TemplateEx
 export function template(string?: string, options?: TemplateOptions, guard?: object): TemplateExecutor {
   string = toString(string);
 
-  if (guard) {
+  if (guard && isIterateeCall(string, options, guard)) {
     options = templateSettings;
   }
 


### PR DESCRIPTION
lodash
```js
_.some([1, 2, 3], () => false, { n: 2 }) // false
_.template('a{{x}}b', { interpolate: /\{\{([\s\S]+?)\}\}/g }, { g: 1 })({ x: '?' }) // 'a?b'
```

compat
```js
esCompat.some([1, 2, 3], () => false, { n: 2 }) // true
esCompat.template('a{{x}}b', { interpolate: /\{\{([\s\S]+?)\}\}/g }, { g: 1 })({ x: '?' }) // 'a{{x}}b'
```