### PR TITLE
fix(compat/orderBy): resolve unresolved deep paths and nullish elements to `undefined` like lodash

### DIFF
--- a/src/compat/array/orderBy.spec.ts
+++ b/src/compat/array/orderBy.spec.ts
@@ -266,4 +266,22 @@ describe('orderBy', () => {
       { a: { b: 1 } },
     ]);
   });
+
+  it('should keep the order of nullish elements for empty or identity criteria', () => {
+    // empty path resolves to `undefined` like lodash's `baseGet`
+    expect(orderBy([null, { a: 1 }], [[]], ['asc'])).toEqual([null, { a: 1 }]);
+    // identity criterion keeps `null` before `undefined`
+    expect(orderBy([3, null, 1, undefined, 2])).toEqual([1, 2, 3, null, undefined]);
+  });
+
+  it('should distinguish a fully resolved `null` value from an unresolved path', () => {
+    // `{ a: { b: null } }` resolves `a.b` to `null`; the others are unresolved → `undefined`
+    expect(orderBy([{ a: { b: null } }, { a: null }, { a: {} }], ['a.b'], ['asc'])).toEqual([
+      { a: { b: null } },
+      { a: null },
+      { a: {} },
+    ]);
+    // `desc` reverses the priority order: `undefined` (higher priority) comes first
+    expect(orderBy([{ a: null }, { a: { b: null } }], ['a.b'], ['desc'])).toEqual([{ a: null }, { a: { b: null } }]);
+  });
 });

--- a/src/compat/array/orderBy.spec.ts
+++ b/src/compat/array/orderBy.spec.ts
@@ -254,8 +254,16 @@ describe('orderBy', () => {
   });
 
   it('should not include the `length` property for array-like objects', () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error - type mismatch
     expect(orderBy({ 0: 3, 1: 1, 2: 2, length: 3 }, [null], ['asc'])).toEqual([1, 2, 3]);
+  });
+
+  it('should treat unresolved deep paths and nullish elements as `undefined` like lodash', () => {
+    expect(orderBy([{ a: {} }, { a: null }, null, { a: { b: 1 } }], ['a.b.c'], ['asc'])).toEqual([
+      { a: {} },
+      { a: null },
+      null,
+      { a: { b: 1 } },
+    ]);
   });
 });

--- a/src/compat/array/orderBy.ts
+++ b/src/compat/array/orderBy.ts
@@ -164,17 +164,22 @@ export function orderBy<T = any>(collection: any, criteria?: any, orders?: any, 
 
   const getValueByNestedPath = (object: object, path: PropertyKey[]) => {
     let target: object = object;
+    let index = 0;
 
-    for (let i = 0; i < path.length && target != null; ++i) {
-      target = target[path[i] as keyof typeof target];
+    for (; index < path.length && target != null; ++index) {
+      target = target[path[index] as keyof typeof target];
     }
 
-    return target;
+    return index === path.length ? target : undefined;
   };
 
   const getValueByCriterion = (criterion: Criterion<T> | { key: PropertyKey; path: string[] }, object: T) => {
-    if (object == null || criterion == null) {
+    if (criterion == null) {
       return object;
+    }
+
+    if (object == null) {
+      return undefined;
     }
 
     if (typeof criterion === 'object' && 'key' in criterion) {

--- a/src/compat/array/orderBy.ts
+++ b/src/compat/array/orderBy.ts
@@ -170,7 +170,7 @@ export function orderBy<T = any>(collection: any, criteria?: any, orders?: any, 
       target = target[path[index] as keyof typeof target];
     }
 
-    return index === path.length ? target : undefined;
+    return index > 0 && index === path.length ? target : undefined;
   };
 
   const getValueByCriterion = (criterion: Criterion<T> | { key: PropertyKey; path: string[] }, object: T) => {


### PR DESCRIPTION
lodash
```js
_.orderBy([{ a: {} }, { a: null }, null, { a: { b: 1 } }], ['a.b.c'], ['asc'])
// [{ a: {} }, { a: null }, null, { a: { b: 1 } }]
_.orderBy([null, { a: 1 }], [[]], ['asc'])
// [null, { a: 1 }]
```

compat
```js
esCompat.orderBy([{ a: {} }, { a: null }, null, { a: { b: 1 } }], ['a.b.c'], ['asc'])
// [{ a: null }, null, { a: {} }, { a: { b: 1 } }]
esCompat.orderBy([null, { a: 1 }], [[]], ['asc'])
// [{ a: 1 }, null]
```