### PR TITLE
fix: include NOTICE file in published npm and JSR packages

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -6,6 +6,6 @@
     "./compat": "./src/compat/index.ts"
   },
   "publish": {
-    "include": ["./src/**/*.ts"]
+    "include": ["./src/**/*.ts", "./NOTICE"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "NOTICE",
     "dist",
     "compat",
     "*.d.ts",


### PR DESCRIPTION
## Summary

The [NOTICE](https://github.com/toss/es-toolkit/blob/main/NOTICE) file at the repo root carries the lodash copyright and MIT permission notice covering the lodash-derived code in `src/compat`, but it is not included in published packages:

- **npm**: `npm` auto-includes `LICENSE` but not `NOTICE`, and it is not listed in `package.json`'s `files` array — https://unpkg.com/es-toolkit@latest/NOTICE returns 404 while `LICENSE` returns 200.
- **JSR**: `jsr.json`'s publish include was only `./src/**/*.ts`; the published 1.50.0 manifest contains `/LICENSE` (auto-included by JSR) but no `/NOTICE`.

Since MIT requires the copyright/permission notice to be included in copies or substantial portions of the software, the distributed tarballs should carry the lodash notice.

## Changes

- Add `"NOTICE"` to the `"files"` array in `package.json`
- Add `"./NOTICE"` to `publish.include` in `jsr.json`

## Verification

- `npm pack --dry-run --ignore-scripts` now lists both `LICENSE` and `NOTICE` in the tarball contents
- `jsr publish --dry-run --allow-dirty` now lists both `LICENSE` and `NOTICE` in the upload set