### PR TITLE
refactor(limitAsync): move from array to promise category

### DIFF
--- a/docs/ja/reference/promise/limitAsync.md
+++ b/docs/ja/reference/promise/limitAsync.md
@@ -13,7 +13,7 @@ const limitedFunc = limitAsync(asyncFunc, concurrency);
 複数回呼び出される非同期関数の並行実行数を制限したい場合は、`limitAsync`を使用してください。指定された数だけ同時に実行され、追加の呼び出しは実行中の操作が完了するまで待機します。
 
 ```typescript
-import { limitAsync } from 'es-toolkit/array';
+import { limitAsync } from 'es-toolkit/promise';
 
 // 最大3つのリクエストのみを同時に実行するように制限します。
 const limitedFetch = limitAsync(async url => {
@@ -28,7 +28,7 @@ await Promise.all(urls.map(url => limitedFetch(url)));
 外部API呼び出しやデータベースクエリなど、リソースを大量に使用する操作の負荷を制御するのに便利です。レート制限のあるAPIを使用する場合やサーバー負荷を管理する必要がある場合に特に効果的です。
 
 ```typescript
-import { limitAsync } from 'es-toolkit/array';
+import { limitAsync } from 'es-toolkit/promise';
 
 // 重い計算を最大2つずつ処理します。
 const processItem = async item => {

--- a/docs/ko/reference/promise/limitAsync.md
+++ b/docs/ko/reference/promise/limitAsync.md
@@ -13,7 +13,7 @@ const limitedFunc = limitAsync(asyncFunc, concurrency);
 여러 번 호출되는 비동기 함수의 동시 실행 수를 제한하고 싶을 때 `limitAsync`를 사용하세요. 지정한 수만큼만 동시에 실행되고, 추가 호출은 실행 중인 작업이 완료될 때까지 대기해요.
 
 ```typescript
-import { limitAsync } from 'es-toolkit/array';
+import { limitAsync } from 'es-toolkit/promise';
 
 // 최대 3개의 요청만 동시에 실행되도록 제한해요.
 const limitedFetch = limitAsync(async url => {
@@ -28,7 +28,7 @@ await Promise.all(urls.map(url => limitedFetch(url)));
 외부 API 호출이나 데이터베이스 쿼리처럼 리소스를 많이 사용하는 작업의 부하를 조절할 때 유용해요. 속도 제한이 있는 API를 사용하거나 서버 부하를 관리해야 할 때 특히 효과적이에요.
 
 ```typescript
-import { limitAsync } from 'es-toolkit/array';
+import { limitAsync } from 'es-toolkit/promise';
 
 // 무거운 연산을 최대 2개씩만 처리해요.
 const processItem = async item => {

--- a/docs/reference/promise/limitAsync.md
+++ b/docs/reference/promise/limitAsync.md
@@ -13,7 +13,7 @@ const limitedFunc = limitAsync(asyncFunc, concurrency);
 Use `limitAsync` when you want to limit the number of concurrent executions of an async function that gets called multiple times. Only the specified number of executions run concurrently, and additional calls wait until running operations complete.
 
 ```typescript
-import { limitAsync } from 'es-toolkit/array';
+import { limitAsync } from 'es-toolkit/promise';
 
 // Limit to at most 3 concurrent requests.
 const limitedFetch = limitAsync(async url => {
@@ -28,7 +28,7 @@ await Promise.all(urls.map(url => limitedFetch(url)));
 It's useful for controlling load on resource-intensive operations like external API calls or database queries. It's especially effective when working with rate-limited APIs or managing server load.
 
 ```typescript
-import { limitAsync } from 'es-toolkit/array';
+import { limitAsync } from 'es-toolkit/promise';
 
 // Process heavy computations at most 2 at a time.
 const processItem = async item => {

--- a/docs/zh_hans/reference/promise/limitAsync.md
+++ b/docs/zh_hans/reference/promise/limitAsync.md
@@ -13,7 +13,7 @@ const limitedFunc = limitAsync(asyncFunc, concurrency);
 当您想限制多次调用的异步函数的并发执行数时，使用 `limitAsync`。只有指定数量的执行会并发运行，额外的调用会等待正在运行的操作完成。
 
 ```typescript
-import { limitAsync } from 'es-toolkit/array';
+import { limitAsync } from 'es-toolkit/promise';
 
 // 限制最多 3 个并发请求。
 const limitedFetch = limitAsync(async url => {
@@ -28,7 +28,7 @@ await Promise.all(urls.map(url => limitedFetch(url)));
 它对控制资源密集型操作（如外部 API 调用或数据库查询）的负载很有用。当使用有速率限制的 API 或管理服务器负载时特别有效。
 
 ```typescript
-import { limitAsync } from 'es-toolkit/array';
+import { limitAsync } from 'es-toolkit/promise';
 
 // 一次最多处理 2 个重计算。
 const processItem = async item => {

--- a/src/array/filterAsync.ts
+++ b/src/array/filterAsync.ts
@@ -1,4 +1,4 @@
-import { limitAsync } from './limitAsync.ts';
+import { limitAsync } from '../promise/limitAsync.ts';
 
 interface FilterAsyncOptions {
   concurrency?: number;

--- a/src/array/flatMapAsync.ts
+++ b/src/array/flatMapAsync.ts
@@ -1,5 +1,5 @@
 import { flatten } from './flatten.ts';
-import { limitAsync } from './limitAsync.ts';
+import { limitAsync } from '../promise/limitAsync.ts';
 
 interface FlatMapAsyncOptions {
   concurrency?: number;

--- a/src/array/forEachAsync.ts
+++ b/src/array/forEachAsync.ts
@@ -1,4 +1,4 @@
-import { limitAsync } from './limitAsync.ts';
+import { limitAsync } from '../promise/limitAsync.ts';
 
 interface ForEachAsyncOptions {
   concurrency?: number;

--- a/src/array/limitAsync.ts
+++ b/src/array/limitAsync.ts
@@ -1,45 +1,8 @@
-import { Semaphore } from '../promise/semaphore';
+import { limitAsync as limitAsyncImpl } from '../promise/limitAsync.ts';
 
 /**
  * Wraps an async function to limit the number of concurrent executions.
  *
- * This function creates a wrapper around an async callback that ensures at most
- * `concurrency` number of executions can run simultaneously. Additional calls will
- * wait until a slot becomes available.
- *
- * @template F - The type of the async function to wrap.
- * @param callback The async function to wrap with concurrency control.
- * @param concurrency Maximum number of concurrent executions allowed.
- * @returns A wrapped version of the callback with concurrency limiting.
- * @example
- * const limitedFetch = limitAsync(async (url) => {
- *   return await fetch(url);
- * }, 3);
- *
- * // Only 3 fetches will run concurrently
- * const urls = ['url1', 'url2', 'url3', 'url4', 'url5'];
- * await Promise.all(urls.map(url => limitedFetch(url)));
- *
- * @example
- * const processItem = async (item) => {
- *   // Expensive async operation
- *   return await heavyComputation(item);
- * };
- *
- * const limitedProcess = limitAsync(processItem, 2);
- * const items = [1, 2, 3, 4, 5];
- * // At most 2 items will be processed concurrently
- * await Promise.all(items.map(item => limitedProcess(item)));
+ * @deprecated Use `limitAsync` from `es-toolkit/promise` instead. This export will be removed from `es-toolkit/array` in a future major version.
  */
-export function limitAsync<F extends (...args: any[]) => Promise<any>>(callback: F, concurrency: number): F {
-  const semaphore = new Semaphore(concurrency);
-
-  return async function (this: ThisType<F>, ...args: Parameters<F>): Promise<ReturnType<F>> {
-    try {
-      await semaphore.acquire();
-      return await callback.apply(this, args);
-    } finally {
-      semaphore.release();
-    }
-  } as F;
-}
+export const limitAsync = limitAsyncImpl;

--- a/src/array/mapAsync.ts
+++ b/src/array/mapAsync.ts
@@ -1,4 +1,4 @@
-import { limitAsync } from './limitAsync.ts';
+import { limitAsync } from '../promise/limitAsync.ts';
 
 interface MapAsyncOptions {
   concurrency?: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,3 +63,7 @@ export * from './predicate/index.ts';
 export * from './promise/index.ts';
 export * from './string/index.ts';
 export * from './util/index.ts';
+
+// `limitAsync` is exported from both `./array` (deprecated alias) and `./promise`;
+// an ambiguous name is dropped from star exports, so re-export the canonical one explicitly.
+export { limitAsync } from './promise/limitAsync.ts';

--- a/src/promise/index.ts
+++ b/src/promise/index.ts
@@ -1,5 +1,6 @@
 export { allKeyed } from './allKeyed.ts';
 export { delay } from './delay.ts';
+export { limitAsync } from './limitAsync.ts';
 export { Mutex } from './mutex.ts';
 export { Semaphore } from './semaphore.ts';
 export { timeout } from './timeout.ts';

--- a/src/promise/limitAsync.spec.ts
+++ b/src/promise/limitAsync.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
+import { delay } from './delay';
 import { limitAsync } from './limitAsync';
-import { delay } from '../promise/delay';
 
 describe('limitAsync', () => {
   it('limits concurrency of async callbacks', async () => {

--- a/src/promise/limitAsync.ts
+++ b/src/promise/limitAsync.ts
@@ -1,0 +1,45 @@
+import { Semaphore } from './semaphore.ts';
+
+/**
+ * Wraps an async function to limit the number of concurrent executions.
+ *
+ * This function creates a wrapper around an async callback that ensures at most
+ * `concurrency` number of executions can run simultaneously. Additional calls will
+ * wait until a slot becomes available.
+ *
+ * @template F - The type of the async function to wrap.
+ * @param callback The async function to wrap with concurrency control.
+ * @param concurrency Maximum number of concurrent executions allowed.
+ * @returns A wrapped version of the callback with concurrency limiting.
+ * @example
+ * const limitedFetch = limitAsync(async (url) => {
+ *   return await fetch(url);
+ * }, 3);
+ *
+ * // Only 3 fetches will run concurrently
+ * const urls = ['url1', 'url2', 'url3', 'url4', 'url5'];
+ * await Promise.all(urls.map(url => limitedFetch(url)));
+ *
+ * @example
+ * const processItem = async (item) => {
+ *   // Expensive async operation
+ *   return await heavyComputation(item);
+ * };
+ *
+ * const limitedProcess = limitAsync(processItem, 2);
+ * const items = [1, 2, 3, 4, 5];
+ * // At most 2 items will be processed concurrently
+ * await Promise.all(items.map(item => limitedProcess(item)));
+ */
+export function limitAsync<F extends (...args: any[]) => Promise<any>>(callback: F, concurrency: number): F {
+  const semaphore = new Semaphore(concurrency);
+
+  return async function (this: ThisType<F>, ...args: Parameters<F>): Promise<ReturnType<F>> {
+    try {
+      await semaphore.acquire();
+      return await callback.apply(this, args);
+    } finally {
+      semaphore.release();
+    }
+  } as F;
+}


### PR DESCRIPTION
## Summary

`limitAsync` wraps an async function to limit the number of concurrent executions — it is a Promise utility, not an array utility. This PR moves it to the `promise` category while keeping backward compatibility.

- Move `src/array/limitAsync.ts` (+ spec) to `src/promise/limitAsync.ts`, importing `Semaphore` locally.
- Keep a `@deprecated` alias exported from `es-toolkit/array`, pointing users to `es-toolkit/promise`.
- Explicitly re-export the canonical symbol from the root entry (`src/index.ts`); without this, `limitAsync` would be silently dropped from `es-toolkit` because both `export * from './array'` and `export * from './promise'` would provide the name (ambiguous star exports are excluded).
- Update internal consumers (`mapAsync`, `forEachAsync`, `filterAsync`, `flatMapAsync`) to import from `../promise/limitAsync.ts` so they don't go through the deprecated alias.
- Move docs in all 4 languages from `reference/array` to `reference/promise`; the sidebar is generated from the directory structure, so the page now appears under **Promise Utilities**. Import examples updated to `es-toolkit/promise`.

Note: the old docs URL (`/reference/array/limitAsync.html`) will 404; no redirect was added.

## Verification

- `yarn vitest run`: 4622 passed, 4 skipped. (The pre-existing local-only `check-dist` failure — tsdown unable to import its optional `unrun` dependency — reproduces on a clean checkout and is unrelated.)
- `tsc --noEmit`: clean.
- ESLint on all touched files: 0 errors.