### PR TITLE
fix(mergeWith, toMerged): handle mixed array/object types consistently with merge

### DIFF
--- a/benchmarks/bundle-size/mergeWith.spec.ts
+++ b/benchmarks/bundle-size/mergeWith.spec.ts
@@ -9,7 +9,7 @@ describe('mergeWith bundle size', () => {
 
   it('es-toolkit', async () => {
     const bundleSize = await getBundleSize('es-toolkit', 'mergeWith');
-    expect(bundleSize).toMatchInlineSnapshot(`564`);
+    expect(bundleSize).toMatchInlineSnapshot(`583`);
   });
 
   it('es-toolkit/compat', async () => {

--- a/src/_internal/isMergeableValue.ts
+++ b/src/_internal/isMergeableValue.ts
@@ -1,0 +1,15 @@
+import { isPlainObject } from '../predicate/isPlainObject.ts';
+
+/**
+ * Checks if a value can be deeply merged into, i.e. it is a plain object or an array.
+ *
+ * This function is used in `merge`, `mergeWith`, and `toMerged` to decide whether
+ * the source value should be merged into the existing target value recursively,
+ * preserving the target's structure, instead of replacing it.
+ *
+ * @param value - The value to check.
+ * @returns `true` if the value is a plain object or an array, otherwise `false`.
+ */
+export function isMergeableValue(value: unknown): boolean {
+  return isPlainObject(value) || Array.isArray(value);
+}

--- a/src/object/merge.ts
+++ b/src/object/merge.ts
@@ -1,3 +1,4 @@
+import { isMergeableValue } from '../_internal/isMergeableValue.ts';
 import { isUnsafeProperty } from '../_internal/isUnsafeProperty.ts';
 import { isPlainObject } from '../predicate/isPlainObject.ts';
 
@@ -69,8 +70,4 @@ export function merge<T extends Record<PropertyKey, any>, S extends Record<Prope
   }
 
   return target;
-}
-
-function isMergeableValue(value: unknown) {
-  return isPlainObject(value) || Array.isArray(value);
 }

--- a/src/object/mergeWith.spec.ts
+++ b/src/object/mergeWith.spec.ts
@@ -125,4 +125,29 @@ describe('mergeWith', () => {
 
     expect(result).toEqual({ a: { b: { x: 1 }, c: { y: 2 }, d: { z: 3 } } });
   });
+
+  it('should behave like recursive Object.assign, applying the same logic to nested properties', () => {
+    const noop = () => undefined;
+
+    const topLevelArray = mergeWith(['1'], { a: 2 }, noop);
+    const topLevelObject = mergeWith({ a: 2 }, ['1'], noop);
+
+    const nestedArray = mergeWith({ x: ['1'] }, { x: { a: 2 } }, noop);
+    const nestedObject = mergeWith({ x: { a: 2 } }, { x: ['1'] }, noop);
+
+    expect(Array.isArray(topLevelArray)).toBe(true);
+    expect(topLevelArray[0]).toBe('1');
+    expect((topLevelArray as any).a).toBe(2);
+
+    expect(typeof topLevelObject).toBe('object');
+    expect(topLevelObject).toEqual({ a: 2, 0: '1' });
+
+    expect(typeof nestedObject.x).toBe('object');
+    expect(nestedObject.x).toEqual({ a: 2, 0: '1' });
+    expect(nestedObject.x[0]).toBe('1');
+
+    expect(Array.isArray(nestedArray.x)).toBe(true);
+    expect(nestedArray.x[0]).toBe('1');
+    expect((nestedArray.x as any).a).toBe(2);
+  });
 });

--- a/src/object/mergeWith.ts
+++ b/src/object/mergeWith.ts
@@ -1,3 +1,4 @@
+import { isMergeableValue } from '../_internal/isMergeableValue.ts';
 import { isUnsafeProperty } from '../_internal/isUnsafeProperty.ts';
 import { isPlainObject } from '../predicate/isPlainObject.ts';
 
@@ -82,8 +83,4 @@ export function mergeWith<T extends Record<PropertyKey, any>, S extends Record<P
   }
 
   return target;
-}
-
-function isMergeableValue(value: unknown) {
-  return isPlainObject(value) || Array.isArray(value);
 }

--- a/src/object/mergeWith.ts
+++ b/src/object/mergeWith.ts
@@ -70,22 +70,20 @@ export function mergeWith<T extends Record<PropertyKey, any>, S extends Record<P
 
     if (merged !== undefined) {
       target[key] = merged;
+    } else if (isMergeableValue(sourceValue) && isMergeableValue(targetValue)) {
+      target[key] = mergeWith<any, S[keyof T]>(targetValue, sourceValue, merge);
     } else if (Array.isArray(sourceValue)) {
-      if (Array.isArray(targetValue)) {
-        target[key] = mergeWith<any, S[keyof T]>(targetValue, sourceValue, merge);
-      } else {
-        target[key] = mergeWith<any, S[keyof T]>([], sourceValue, merge);
-      }
+      target[key] = mergeWith<any, S[keyof T]>([], sourceValue, merge);
     } else if (isPlainObject(sourceValue)) {
-      if (isPlainObject(targetValue)) {
-        target[key] = mergeWith<any, S[keyof T]>(targetValue, sourceValue, merge);
-      } else {
-        target[key] = mergeWith<any, S[keyof T]>({}, sourceValue, merge);
-      }
+      target[key] = mergeWith<any, S[keyof T]>({}, sourceValue, merge);
     } else if (targetValue === undefined || sourceValue !== undefined) {
       target[key] = sourceValue;
     }
   }
 
   return target;
+}
+
+function isMergeableValue(value: unknown) {
+  return isPlainObject(value) || Array.isArray(value);
 }

--- a/src/object/toMerged.spec.ts
+++ b/src/object/toMerged.spec.ts
@@ -219,4 +219,32 @@ describe('toMerged', () => {
     expect(result).toEqual({ a: { b: { x: 1 }, c: { y: 2 }, d: { z: 3 } } });
     expect(target).toEqual({ a: { b: null, c: undefined, d: 'text' } });
   });
+
+  it('should behave like recursive Object.assign, applying the same logic to nested properties', () => {
+    const arrayTarget = ['1'];
+    const objectTarget = { a: 2 };
+
+    const topLevelArray = toMerged(arrayTarget, { a: 2 });
+    const topLevelObject = toMerged(objectTarget, ['1']);
+
+    const nestedArray = toMerged({ x: ['1'] }, { x: { a: 2 } });
+    const nestedObject = toMerged({ x: { a: 2 } }, { x: ['1'] });
+
+    expect(Array.isArray(topLevelArray)).toBe(true);
+    expect(topLevelArray[0]).toBe('1');
+    expect((topLevelArray as any).a).toBe(2);
+    expect(arrayTarget).toEqual(['1']);
+
+    expect(typeof topLevelObject).toBe('object');
+    expect(topLevelObject).toEqual({ a: 2, 0: '1' });
+    expect(objectTarget).toEqual({ a: 2 });
+
+    expect(typeof nestedObject.x).toBe('object');
+    expect(nestedObject.x).toEqual({ a: 2, 0: '1' });
+    expect(nestedObject.x[0]).toBe('1');
+
+    expect(Array.isArray(nestedArray.x)).toBe(true);
+    expect(nestedArray.x[0]).toBe('1');
+    expect((nestedArray.x as any).a).toBe(2);
+  });
 });

--- a/src/object/toMerged.ts
+++ b/src/object/toMerged.ts
@@ -1,6 +1,7 @@
 import { clone } from './clone.ts';
 import { cloneDeep } from './cloneDeep.ts';
 import { mergeWith } from './mergeWith.ts';
+import { isMergeableValue } from '../_internal/isMergeableValue.ts';
 import { isPlainObject } from '../predicate/isPlainObject.ts';
 
 /**
@@ -58,8 +59,4 @@ export function toMerged<T extends Record<PropertyKey, any>, S extends Record<Pr
       return mergeWith({}, sourceValue, mergeRecursively);
     }
   });
-}
-
-function isMergeableValue(value: unknown) {
-  return isPlainObject(value) || Array.isArray(value);
 }

--- a/src/object/toMerged.ts
+++ b/src/object/toMerged.ts
@@ -50,18 +50,16 @@ export function toMerged<T extends Record<PropertyKey, any>, S extends Record<Pr
   source: S
 ): T & S {
   return mergeWith(cloneDeep(target), source, function mergeRecursively(targetValue, sourceValue) {
-    if (Array.isArray(sourceValue)) {
-      if (Array.isArray(targetValue)) {
-        return mergeWith(clone(targetValue), sourceValue, mergeRecursively);
-      } else {
-        return mergeWith([], sourceValue, mergeRecursively);
-      }
+    if (isMergeableValue(sourceValue) && isMergeableValue(targetValue)) {
+      return mergeWith(clone(targetValue), sourceValue, mergeRecursively);
+    } else if (Array.isArray(sourceValue)) {
+      return mergeWith([], sourceValue, mergeRecursively);
     } else if (isPlainObject(sourceValue)) {
-      if (isPlainObject(targetValue)) {
-        return mergeWith(clone(targetValue), sourceValue, mergeRecursively);
-      } else {
-        return mergeWith({}, sourceValue, mergeRecursively);
-      }
+      return mergeWith({}, sourceValue, mergeRecursively);
     }
   });
+}
+
+function isMergeableValue(value: unknown) {
+  return isPlainObject(value) || Array.isArray(value);
 }


### PR DESCRIPTION
## Summary

Completes the fix for #1394. Related to #1530.

#1553 fixed `merge` to behave like a recursive `Object.assign` — when the target and source values are both mergeable (plain object or array) but of different kinds, the target's structure is preserved and the source's properties are merged into it. However, `mergeWith` and `toMerged` were not updated, so they still treat top-level arguments differently from nested properties:

### Before

```typescript
const noop = () => undefined;

mergeWith(['1'], { a: 2 }, noop)             // ['1'] with .a = 2 (target preserved)
mergeWith({ x: ['1'] }, { x: { a: 2 } }, noop).x  // { a: 2 } — element '1' is lost!

toMerged(['1'], { a: 2 })                    // ['1'] with .a = 2 (target preserved)
toMerged({ x: ['1'] }, { x: { a: 2 } }).x    // { a: 2 } — element '1' is lost!
```

### After

```typescript
mergeWith(['1'], { a: 2 }, noop)                  // ['1'] with .a = 2
mergeWith({ x: ['1'] }, { x: { a: 2 } }, noop).x  // ['1'] with .a = 2 — consistent

toMerged(['1'], { a: 2 })                    // ['1'] with .a = 2
toMerged({ x: ['1'] }, { x: { a: 2 } }).x    // ['1'] with .a = 2 — consistent
```

This matches both the behavior of `merge` after #1553 and lodash's behavior (lodash preserves the target array in all four cases above).

## Changes

- `mergeWith`: when the customizer returns `undefined` and both values are mergeable (plain object or array), recurse into the existing target value instead of replacing it with a fresh `{}` or `[]` — same logic as `merge` in #1553.
- `toMerged`: apply the same logic in its internal customizer (it replicates the old branching, so fixing `mergeWith` alone was not enough).
- Added the same top-level/nested consistency tests that #1553 added for `merge`, plus non-mutation assertions for `toMerged`.

## Test results

- `yarn vitest run src/object/mergeWith src/object/toMerged src/object/merge.spec.ts` — 33 passed
- Full suite: 4625 passed (the only failing file, `tests/check-dist.spec.ts`, also fails on a clean tree in my environment due to a local tsdown/PnP issue and is unrelated)
- `tsc --noEmit` and ESLint pass