### PR TITLE
feat(defer, deferAsync): add defer and deferAsync to es-toolkit/util

### DIFF
--- a/docs/ja/reference/util/defer.md
+++ b/docs/ja/reference/util/defer.md
@@ -1,0 +1,56 @@
+# defer
+
+スコープを抜けるときにコールバックを実行する `Disposable` オブジェクトを作成します。
+
+```typescript
+using cleanup = defer(callback);
+```
+
+## 使用法
+
+### `defer(callback)`
+
+スコープの終わりにクリーンアップコードを自動で実行したいときに `defer` を使います。返されたオブジェクトを [`using` 宣言](https://github.com/tc39/proposal-explicit-resource-management)で宣言すると、エラーでスコープを抜ける場合でも、ブロックの終了時にコールバックが実行されます。
+
+```typescript
+import { defer } from 'es-toolkit/util';
+
+function processFile() {
+  const file = openFile('data.txt');
+  using cleanup = defer(() => file.close());
+
+  // この関数が戻るかエラーを投げると、ファイルは自動的に閉じられます。
+  return file.read();
+}
+```
+
+同じスコープに複数の `using` 宣言がある場合、コールバックはスタックのように宣言の逆順で実行されます。
+
+```typescript
+import { defer } from 'es-toolkit/util';
+
+function run() {
+  using first = defer(() => console.log('first'));
+  using second = defer(() => console.log('second'));
+  console.log('body');
+}
+
+run();
+// 'body'、'second'、'first' の順に出力されます。
+```
+
+`using` 宣言を使うには、TypeScript 5.2 以上と、Explicit Resource Management をサポートするランタイム(Node.js 24 以上、最新のブラウザ)が必要です。古い環境では、構文をトランスパイルして `Symbol.dispose` のポリフィルを追加すると使用できます。
+
+::: info 非同期のクリーンアップには deferAsync を使ってください
+
+この関数はコールバックを同期的に実行します。クリーンアップコードが非同期で、完了を待つ必要がある場合は、[`deferAsync`](./deferAsync.md) 関数を `await using` と一緒に使ってください。
+
+:::
+
+#### パラメータ
+
+- `callback` (`() => void`): オブジェクトが破棄されるときに実行するクリーンアップ関数です。
+
+#### 戻り値
+
+(`Disposable`): 破棄されるときに `callback` を実行するオブジェクトを返します。

--- a/docs/ja/reference/util/deferAsync.md
+++ b/docs/ja/reference/util/deferAsync.md
@@ -1,0 +1,43 @@
+# deferAsync
+
+スコープを抜けるときに非同期コールバックを実行する `AsyncDisposable` オブジェクトを作成します。
+
+```typescript
+await using cleanup = deferAsync(callback);
+```
+
+## 使用法
+
+### `deferAsync(callback)`
+
+スコープの終わりに非同期のクリーンアップコードを自動で実行したいときに `deferAsync` を使います。返されたオブジェクトを [`await using` 宣言](https://github.com/tc39/proposal-explicit-resource-management)で宣言すると、エラーでスコープを抜ける場合でも、ブロックの終了時にコールバックが実行され、完了まで待機します。
+
+```typescript
+import { deferAsync } from 'es-toolkit/util';
+
+async function main() {
+  const connection = await connect();
+  await using cleanup = deferAsync(async () => {
+    await connection.close();
+  });
+
+  // この関数が戻るかエラーを投げると、接続は自動的に閉じられます。
+  await connection.query('SELECT 1');
+}
+```
+
+`await using` 宣言を使うには、TypeScript 5.2 以上と、Explicit Resource Management をサポートするランタイム(Node.js 24 以上、最新のブラウザ)が必要です。古い環境では、構文をトランスパイルして `Symbol.asyncDispose` のポリフィルを追加すると使用できます。
+
+::: info 同期のクリーンアップには defer を使ってください
+
+この関数はコールバックの完了を待つため、async 関数の中でのみ使えます。クリーンアップコードが同期的な場合は、[`defer`](./defer.md) 関数を `using` と一緒に使ってください。
+
+:::
+
+#### パラメータ
+
+- `callback` (`() => void | PromiseLike<void>`): オブジェクトが破棄されるときに実行するクリーンアップ関数です。返された値の完了まで待機します。
+
+#### 戻り値
+
+(`AsyncDisposable`): 破棄されるときに `callback` を実行して完了を待つオブジェクトを返します。

--- a/docs/ko/reference/util/defer.md
+++ b/docs/ko/reference/util/defer.md
@@ -1,0 +1,56 @@
+# defer
+
+스코프를 벗어날 때 콜백을 실행하는 `Disposable` 객체를 만들어요.
+
+```typescript
+using cleanup = defer(callback);
+```
+
+## 사용법
+
+### `defer(callback)`
+
+스코프가 끝날 때 정리 코드를 자동으로 실행하고 싶을 때 `defer`를 사용하세요. 반환된 객체를 [`using` 선언](https://github.com/tc39/proposal-explicit-resource-management)으로 선언하면, 에러로 스코프를 벗어나는 경우에도 블록이 끝날 때 콜백이 실행돼요.
+
+```typescript
+import { defer } from 'es-toolkit/util';
+
+function processFile() {
+  const file = openFile('data.txt');
+  using cleanup = defer(() => file.close());
+
+  // 이 함수가 반환되거나 에러를 던지면 파일이 자동으로 닫혀요.
+  return file.read();
+}
+```
+
+같은 스코프에 여러 개의 `using` 선언이 있으면, 콜백은 스택처럼 선언의 역순으로 실행돼요.
+
+```typescript
+import { defer } from 'es-toolkit/util';
+
+function run() {
+  using first = defer(() => console.log('first'));
+  using second = defer(() => console.log('second'));
+  console.log('body');
+}
+
+run();
+// 'body', 'second', 'first' 순서로 출력돼요.
+```
+
+`using` 선언을 사용하려면 TypeScript 5.2 이상과 Explicit Resource Management를 지원하는 런타임(Node.js 24 이상, 최신 브라우저)이 필요해요. 오래된 환경에서는 문법을 트랜스파일하고 `Symbol.dispose` 폴리필을 추가하면 사용할 수 있어요.
+
+::: info 비동기 정리에는 deferAsync를 사용하세요
+
+이 함수는 콜백을 동기적으로 실행해요. 정리 코드가 비동기이고 기다려야 한다면, [`deferAsync`](./deferAsync.md) 함수를 `await using`과 함께 사용하세요.
+
+:::
+
+#### 파라미터
+
+- `callback` (`() => void`): 객체가 정리될 때 실행할 정리 함수예요.
+
+#### 반환 값
+
+(`Disposable`): 정리될 때 `callback`을 실행하는 객체를 반환해요.

--- a/docs/ko/reference/util/deferAsync.md
+++ b/docs/ko/reference/util/deferAsync.md
@@ -1,0 +1,43 @@
+# deferAsync
+
+스코프를 벗어날 때 비동기 콜백을 실행하는 `AsyncDisposable` 객체를 만들어요.
+
+```typescript
+await using cleanup = deferAsync(callback);
+```
+
+## 사용법
+
+### `deferAsync(callback)`
+
+스코프가 끝날 때 비동기 정리 코드를 자동으로 실행하고 싶을 때 `deferAsync`를 사용하세요. 반환된 객체를 [`await using` 선언](https://github.com/tc39/proposal-explicit-resource-management)으로 선언하면, 에러로 스코프를 벗어나는 경우에도 블록이 끝날 때 콜백이 실행되고 완료될 때까지 기다려요.
+
+```typescript
+import { deferAsync } from 'es-toolkit/util';
+
+async function main() {
+  const connection = await connect();
+  await using cleanup = deferAsync(async () => {
+    await connection.close();
+  });
+
+  // 이 함수가 반환되거나 에러를 던지면 연결이 자동으로 닫혀요.
+  await connection.query('SELECT 1');
+}
+```
+
+`await using` 선언을 사용하려면 TypeScript 5.2 이상과 Explicit Resource Management를 지원하는 런타임(Node.js 24 이상, 최신 브라우저)이 필요해요. 오래된 환경에서는 문법을 트랜스파일하고 `Symbol.asyncDispose` 폴리필을 추가하면 사용할 수 있어요.
+
+::: info 동기 정리에는 defer를 사용하세요
+
+이 함수는 콜백을 기다리기 때문에 async 함수 안에서만 사용할 수 있어요. 정리 코드가 동기라면, [`defer`](./defer.md) 함수를 `using`과 함께 사용하세요.
+
+:::
+
+#### 파라미터
+
+- `callback` (`() => void | PromiseLike<void>`): 객체가 정리될 때 실행할 정리 함수예요. 반환한 값이 완료될 때까지 기다려요.
+
+#### 반환 값
+
+(`AsyncDisposable`): 정리될 때 `callback`을 실행하고 완료를 기다리는 객체를 반환해요.

--- a/docs/reference/util/defer.md
+++ b/docs/reference/util/defer.md
@@ -1,0 +1,56 @@
+# defer
+
+Creates a `Disposable` object that runs a callback when its scope exits.
+
+```typescript
+using cleanup = defer(callback);
+```
+
+## Usage
+
+### `defer(callback)`
+
+Use `defer` when you want cleanup code to run automatically at the end of a scope. Declare the returned object with a [`using` declaration](https://github.com/tc39/proposal-explicit-resource-management), and the callback runs when the enclosing block exits — even if it exits with an error.
+
+```typescript
+import { defer } from 'es-toolkit/util';
+
+function processFile() {
+  const file = openFile('data.txt');
+  using cleanup = defer(() => file.close());
+
+  // The file is closed automatically when this function returns or throws.
+  return file.read();
+}
+```
+
+When several `using` declarations appear in the same scope, their callbacks run in reverse declaration order, like a stack.
+
+```typescript
+import { defer } from 'es-toolkit/util';
+
+function run() {
+  using first = defer(() => console.log('first'));
+  using second = defer(() => console.log('second'));
+  console.log('body');
+}
+
+run();
+// Logs 'body', 'second', then 'first'.
+```
+
+`using` declarations require TypeScript 5.2 or later, and a runtime that supports Explicit Resource Management, such as Node.js 24 or the latest browsers. In older environments, you can transpile the syntax and polyfill `Symbol.dispose`.
+
+::: info Use deferAsync for asynchronous cleanup
+
+This function runs the callback synchronously. If your cleanup code is asynchronous and should be awaited, use the [`deferAsync`](./deferAsync.md) function with `await using` instead.
+
+:::
+
+#### Parameters
+
+- `callback` (`() => void`): The cleanup function to run when the object is disposed.
+
+#### Returns
+
+(`Disposable`): An object that runs `callback` when it is disposed.

--- a/docs/reference/util/deferAsync.md
+++ b/docs/reference/util/deferAsync.md
@@ -1,0 +1,43 @@
+# deferAsync
+
+Creates an `AsyncDisposable` object that runs an asynchronous callback when its scope exits.
+
+```typescript
+await using cleanup = deferAsync(callback);
+```
+
+## Usage
+
+### `deferAsync(callback)`
+
+Use `deferAsync` when you want asynchronous cleanup code to run automatically at the end of a scope. Declare the returned object with an [`await using` declaration](https://github.com/tc39/proposal-explicit-resource-management), and the callback runs and is awaited when the enclosing block exits — even if it exits with an error.
+
+```typescript
+import { deferAsync } from 'es-toolkit/util';
+
+async function main() {
+  const connection = await connect();
+  await using cleanup = deferAsync(async () => {
+    await connection.close();
+  });
+
+  // The connection is closed automatically when this function returns or throws.
+  await connection.query('SELECT 1');
+}
+```
+
+`await using` declarations require TypeScript 5.2 or later, and a runtime that supports Explicit Resource Management, such as Node.js 24 or the latest browsers. In older environments, you can transpile the syntax and polyfill `Symbol.asyncDispose`.
+
+::: info Use defer for synchronous cleanup
+
+This function awaits the callback, so it can only be used in async functions. If your cleanup code is synchronous, use the [`defer`](./defer.md) function with `using` instead.
+
+:::
+
+#### Parameters
+
+- `callback` (`() => void | PromiseLike<void>`): The cleanup function to run when the object is disposed. Its result is awaited.
+
+#### Returns
+
+(`AsyncDisposable`): An object that runs and awaits `callback` when it is disposed.

--- a/docs/zh_hans/reference/util/defer.md
+++ b/docs/zh_hans/reference/util/defer.md
@@ -1,0 +1,56 @@
+# defer
+
+创建一个 `Disposable` 对象,在离开作用域时执行回调函数。
+
+```typescript
+using cleanup = defer(callback);
+```
+
+## 用法
+
+### `defer(callback)`
+
+当你希望在作用域结束时自动执行清理代码时,请使用 `defer`。用 [`using` 声明](https://github.com/tc39/proposal-explicit-resource-management)声明返回的对象后,即使因为错误离开作用域,回调也会在代码块结束时执行。
+
+```typescript
+import { defer } from 'es-toolkit/util';
+
+function processFile() {
+  const file = openFile('data.txt');
+  using cleanup = defer(() => file.close());
+
+  // 当此函数返回或抛出错误时,文件会自动关闭。
+  return file.read();
+}
+```
+
+如果同一个作用域中有多个 `using` 声明,回调会像栈一样按声明的相反顺序执行。
+
+```typescript
+import { defer } from 'es-toolkit/util';
+
+function run() {
+  using first = defer(() => console.log('first'));
+  using second = defer(() => console.log('second'));
+  console.log('body');
+}
+
+run();
+// 依次输出 'body'、'second'、'first'。
+```
+
+使用 `using` 声明需要 TypeScript 5.2 或更高版本,以及支持 Explicit Resource Management 的运行时(Node.js 24 或更高版本、最新的浏览器)。在较旧的环境中,可以转译该语法并添加 `Symbol.dispose` 的 polyfill。
+
+::: info 异步清理请使用 deferAsync
+
+此函数会同步执行回调。如果清理代码是异步的并且需要等待完成,请将 [`deferAsync`](./deferAsync.md) 函数与 `await using` 一起使用。
+
+:::
+
+#### 参数
+
+- `callback` (`() => void`): 对象被释放时执行的清理函数。
+
+#### 返回值
+
+(`Disposable`): 返回一个在被释放时执行 `callback` 的对象。

--- a/docs/zh_hans/reference/util/deferAsync.md
+++ b/docs/zh_hans/reference/util/deferAsync.md
@@ -1,0 +1,43 @@
+# deferAsync
+
+创建一个 `AsyncDisposable` 对象,在离开作用域时执行异步回调函数。
+
+```typescript
+await using cleanup = deferAsync(callback);
+```
+
+## 用法
+
+### `deferAsync(callback)`
+
+当你希望在作用域结束时自动执行异步清理代码时,请使用 `deferAsync`。用 [`await using` 声明](https://github.com/tc39/proposal-explicit-resource-management)声明返回的对象后,即使因为错误离开作用域,回调也会在代码块结束时执行并等待完成。
+
+```typescript
+import { deferAsync } from 'es-toolkit/util';
+
+async function main() {
+  const connection = await connect();
+  await using cleanup = deferAsync(async () => {
+    await connection.close();
+  });
+
+  // 当此函数返回或抛出错误时,连接会自动关闭。
+  await connection.query('SELECT 1');
+}
+```
+
+使用 `await using` 声明需要 TypeScript 5.2 或更高版本,以及支持 Explicit Resource Management 的运行时(Node.js 24 或更高版本、最新的浏览器)。在较旧的环境中,可以转译该语法并添加 `Symbol.asyncDispose` 的 polyfill。
+
+::: info 同步清理请使用 defer
+
+此函数会等待回调完成,因此只能在 async 函数中使用。如果清理代码是同步的,请将 [`defer`](./defer.md) 函数与 `using` 一起使用。
+
+:::
+
+#### 参数
+
+- `callback` (`() => void | PromiseLike<void>`): 对象被释放时执行的清理函数。会等待其返回值完成。
+
+#### 返回值
+
+(`AsyncDisposable`): 返回一个在被释放时执行 `callback` 并等待其完成的对象。

--- a/src/util/defer.spec.ts
+++ b/src/util/defer.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { defer } from './defer';
+
+// Prettier (3.2.5) cannot parse `using` declarations yet, so these tests
+// invoke `[Symbol.dispose]()` directly, exactly as the `using` machinery does.
+describe('defer', () => {
+  it('should not run the callback until disposed', () => {
+    const callback = vi.fn();
+
+    defer(callback);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should run the callback when disposed', () => {
+    const callback = vi.fn();
+
+    const disposable = defer(callback);
+    disposable[Symbol.dispose]();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should run the callback without arguments', () => {
+    const callback = vi.fn();
+
+    defer(callback)[Symbol.dispose]();
+
+    expect(callback).toHaveBeenCalledWith();
+  });
+
+  it('should propagate errors thrown by the callback', () => {
+    const disposable = defer(() => {
+      throw new Error('boom');
+    });
+
+    expect(() => disposable[Symbol.dispose]()).toThrowError('boom');
+  });
+});

--- a/src/util/defer.ts
+++ b/src/util/defer.ts
@@ -1,0 +1,30 @@
+/**
+ * Creates a `Disposable` object that runs the given callback when it is disposed.
+ *
+ * Use it with `using` declarations from
+ * [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management)
+ * to ensure cleanup code runs when the enclosing scope exits, even if an error is thrown.
+ *
+ * For asynchronous cleanup, use {@link deferAsync} with `await using` instead.
+ *
+ * @param callback - The cleanup function to run on dispose.
+ * @returns A `Disposable` object that invokes `callback` when disposed.
+ *
+ * @example
+ * const logs: string[] = [];
+ *
+ * function run() {
+ *   using cleanup = defer(() => logs.push('cleanup'));
+ *   logs.push('body');
+ * }
+ *
+ * run();
+ * console.log(logs); // ['body', 'cleanup']
+ */
+export function defer(callback: () => void): Disposable {
+  return {
+    [Symbol.dispose]: () => {
+      callback();
+    },
+  };
+}

--- a/src/util/deferAsync.spec.ts
+++ b/src/util/deferAsync.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { deferAsync } from './deferAsync';
+import { delay } from '../promise';
+
+// Prettier (3.2.5) cannot parse `await using` declarations yet, so these tests
+// invoke `[Symbol.asyncDispose]()` directly, exactly as the `await using`
+// machinery does.
+describe('deferAsync', () => {
+  it('should not run the callback until disposed', () => {
+    const callback = vi.fn();
+
+    deferAsync(callback);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should await the callback when disposed', async () => {
+    const order: string[] = [];
+
+    const disposable = deferAsync(async () => {
+      await delay(10);
+      order.push('cleanup');
+    });
+
+    await disposable[Symbol.asyncDispose]();
+
+    expect(order).toEqual(['cleanup']);
+  });
+
+  it('should accept a synchronous callback', async () => {
+    const callback = vi.fn();
+
+    const disposable = deferAsync(callback);
+    await disposable[Symbol.asyncDispose]();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return a promise from dispose', () => {
+    const disposable = deferAsync(() => {});
+
+    expect(disposable[Symbol.asyncDispose]()).toBeInstanceOf(Promise);
+  });
+
+  it('should propagate errors thrown by the callback', async () => {
+    const disposable = deferAsync(async () => {
+      throw new Error('boom');
+    });
+
+    await expect(disposable[Symbol.asyncDispose]()).rejects.toThrowError('boom');
+  });
+});

--- a/src/util/deferAsync.ts
+++ b/src/util/deferAsync.ts
@@ -1,0 +1,33 @@
+/**
+ * Creates an `AsyncDisposable` object that runs the given callback when it is disposed.
+ *
+ * Use it with `await using` declarations from
+ * [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management)
+ * to ensure asynchronous cleanup code runs and is awaited when the enclosing scope exits,
+ * even if an error is thrown.
+ *
+ * For synchronous cleanup, use {@link defer} with `using` instead.
+ *
+ * @param callback - The cleanup function to run on dispose. Its result is awaited.
+ * @returns An `AsyncDisposable` object that invokes and awaits `callback` when disposed.
+ *
+ * @example
+ * const connection = await connect();
+ *
+ * async function run() {
+ *   await using cleanup = deferAsync(async () => {
+ *     await connection.close();
+ *   });
+ *
+ *   await connection.query('SELECT 1');
+ * }
+ *
+ * await run(); // The connection is closed after `run` finishes.
+ */
+export function deferAsync(callback: () => void | PromiseLike<void>): AsyncDisposable {
+  return {
+    [Symbol.asyncDispose]: async () => {
+      await callback();
+    },
+  };
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,4 +1,6 @@
 export { attempt } from './attempt.ts';
 export { attemptAsync } from './attemptAsync.ts';
+export { defer } from './defer.ts';
+export { deferAsync } from './deferAsync.ts';
 export { invariant } from './invariant.ts';
 export { invariant as assert } from './invariant.ts';

--- a/tests/browser-compat/skip-list.json
+++ b/tests/browser-compat/skip-list.json
@@ -46,8 +46,10 @@
   "nodeSkip": {
     "compat:compat/predicate/isElement#0": "uses DOM (document); still runs in browsers"
   },
-  "browserSkipNote": "predicate:predicate/isPlainObject#0 is overridden below to drop its node:vm cross-realm line, which cannot run in browsers.",
+  "browserSkipNote": "predicate:predicate/isPlainObject#0 is overridden below to drop its node:vm cross-realm line, which cannot run in browsers. util/defer#0 and util/deferAsync#0 are overridden to dispose manually, because no browser in the matrix parses `using` declarations.",
   "overrides": {
+    "util:util/defer#0": "const logs = [];\nconst disposable = defer(() => logs.push('cleanup'));\n__assertEq(logs, []);\ndisposable[Symbol.dispose]();\n__assertEq(logs, ['cleanup']);",
+    "util:util/deferAsync#0": "const logs = [];\nconst disposable = deferAsync(async () => {\n  logs.push('cleanup');\n});\n__assertEq(logs, []);\nawait disposable[Symbol.asyncDispose]();\n__assertEq(logs, ['cleanup']);",
     "predicate:predicate/isNode#0": "__assertEq(typeof isNode(), 'boolean');",
     "predicate:predicate/isBrowser#0": "__assertEq(typeof isBrowser(), 'boolean');",
     "compat:compat/predicate/isNative#0": "if (typeof globalThis === 'undefined' || !globalThis['__core-js_shared__']) {\n  __assertEq(isNative(Array.prototype.push), true);\n  __assertEq(isNative(function () {}), false);\n} else {\n  // Like lodash, isNative refuses to run when core-js shims are detected.\n  __assertEq(true, true);\n}",


### PR DESCRIPTION
Closes #2011

## Summary

Implements `defer` and `deferAsync` proposed in #2011. They wrap a cleanup callback in a `Disposable` / `AsyncDisposable` object, so cleanup code registered with `using` / `await using` declarations ([Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management)) runs when the enclosing scope exits, even on errors.

```ts
import { defer, deferAsync } from 'es-toolkit/util';

function processFile() {
  const file = openFile('data.txt');
  using cleanup = defer(() => file.close());
  return file.read(); // file is closed on return or throw
}

async function main() {
  const connection = await connect();
  await using cleanup = deferAsync(() => connection.close());
  await connection.query('SELECT 1');
}
```

They live in `es-toolkit/util`, next to `attempt` / `attemptAsync`: language-level control-flow helpers that come as a sync/async pair and fit no data-type category. `function` transforms functions into functions, and `promise` coordinates promises, so neither fits — `defer` returns a `Disposable`, not a function or a promise.

On the "replaceable by TC39 Stage 3+" principle: the proposal's own `DisposableStack#defer` covers this, but `using cleanup = defer(fn)` is far more ergonomic than allocating a stack for a single callback, and `DisposableStack` is still missing from most runtimes, while these helpers only need the `Symbol.dispose` well-known symbols that transpiled `using` requires anyway.

## Changes

- Add `src/util/defer.ts` and `src/util/deferAsync.ts` with specs; re-export from `src/util/index.ts` (the root barrel picks them up via `export *`).
- Docs in all four languages under `reference/util/`.
- `tests/browser-compat/skip-list.json`: override the two JSDoc examples to dispose via `Symbol.dispose` / `Symbol.asyncDispose` directly, since no browser in the matrix (Chrome 51/80/98, WebKit 14.1/15.4) parses `using` declarations. The node-check completeness gate passes with the overrides (1386/1386 locally).

## Notes

- The spec files also call `[Symbol.dispose]()` directly instead of using `using` declarations: Prettier 3.2.5 (current devDependency) cannot parse the syntax, which breaks `yarn lint` on those files. Once Prettier is bumped to ≥ 3.3, the tests can be rewritten with literal `using` blocks.
- No benchmark is included: lodash has no counterpart, same as `mutex` / `semaphore`.
