### PR TITLE
fix(compat): convert objects with a custom valueOf in toString like lodash

### DIFF
--- a/benchmarks/bundle-size/add.spec.ts
+++ b/benchmarks/bundle-size/add.spec.ts
@@ -9,6 +9,6 @@ describe('add bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'add');
-    expect(bundleSize).toMatchInlineSnapshot(`472`);
+    expect(bundleSize).toMatchInlineSnapshot(`495`);
   });
 });

--- a/benchmarks/bundle-size/camelCase.spec.ts
+++ b/benchmarks/bundle-size/camelCase.spec.ts
@@ -14,6 +14,6 @@ describe('camelCase bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'camelCase');
-    expect(bundleSize).toMatchInlineSnapshot(`1879`);
+    expect(bundleSize).toMatchInlineSnapshot(`1963`);
   });
 });

--- a/benchmarks/bundle-size/escape.spec.ts
+++ b/benchmarks/bundle-size/escape.spec.ts
@@ -14,6 +14,6 @@ describe('escape bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'escape');
-    expect(bundleSize).toMatchInlineSnapshot(`365`);
+    expect(bundleSize).toMatchInlineSnapshot(`449`);
   });
 });

--- a/benchmarks/bundle-size/escapeRegExp.spec.ts
+++ b/benchmarks/bundle-size/escapeRegExp.spec.ts
@@ -14,6 +14,6 @@ describe('escapeRegExp bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'escapeRegExp');
-    expect(bundleSize).toMatchInlineSnapshot(`308`);
+    expect(bundleSize).toMatchInlineSnapshot(`392`);
   });
 });

--- a/benchmarks/bundle-size/find.spec.ts
+++ b/benchmarks/bundle-size/find.spec.ts
@@ -9,6 +9,6 @@ describe('find bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'find');
-    expect(bundleSize).toMatchInlineSnapshot(`9087`);
+    expect(bundleSize).toMatchInlineSnapshot(`9110`);
   });
 });

--- a/benchmarks/bundle-size/findKey.spec.ts
+++ b/benchmarks/bundle-size/findKey.spec.ts
@@ -14,6 +14,6 @@ describe('findKey bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'findKey');
-    expect(bundleSize).toMatchInlineSnapshot(`8437`);
+    expect(bundleSize).toMatchInlineSnapshot(`8523`);
   });
 });

--- a/benchmarks/bundle-size/mapKeys.spec.ts
+++ b/benchmarks/bundle-size/mapKeys.spec.ts
@@ -14,6 +14,6 @@ describe('mapKeys bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'mapKeys');
-    expect(bundleSize).toMatchInlineSnapshot(`8450`);
+    expect(bundleSize).toMatchInlineSnapshot(`8536`);
   });
 });

--- a/benchmarks/bundle-size/mapValues.spec.ts
+++ b/benchmarks/bundle-size/mapValues.spec.ts
@@ -14,6 +14,6 @@ describe('mapValues bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'mapValues');
-    expect(bundleSize).toMatchInlineSnapshot(`8450`);
+    expect(bundleSize).toMatchInlineSnapshot(`8536`);
   });
 });

--- a/benchmarks/bundle-size/omit.spec.ts
+++ b/benchmarks/bundle-size/omit.spec.ts
@@ -14,6 +14,6 @@ describe('omit bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'omit');
-    expect(bundleSize).toMatchInlineSnapshot(`8809`);
+    expect(bundleSize).toMatchInlineSnapshot(`8832`);
   });
 });

--- a/benchmarks/bundle-size/zipObjectDeep.spec.ts
+++ b/benchmarks/bundle-size/zipObjectDeep.spec.ts
@@ -9,6 +9,6 @@ describe('zipObjectDeep bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'zipObjectDeep');
-    expect(bundleSize).toMatchInlineSnapshot(`3363`);
+    expect(bundleSize).toMatchInlineSnapshot(`3386`);
   });
 });

--- a/src/compat/util/toString.spec.ts
+++ b/src/compat/util/toString.spec.ts
@@ -37,6 +37,11 @@ describe('toString', () => {
     expect(toString([symbol])).toBe('Symbol(a)');
   });
 
+  it('should handle wrapped symbols', () => {
+    expect(toString(Object(symbol))).toBe('Symbol(a)');
+    expect(toString([Object(symbol)])).toBe('Symbol(a)');
+  });
+
   it('should render nested nullish array values, matching lodash', () => {
     expect(toString([1, null, 3])).toBe('1,null,3');
     expect(toString([null, undefined])).toBe('null,undefined');
@@ -46,5 +51,17 @@ describe('toString', () => {
         [2, undefined],
       ])
     ).toBe('1,null,2,undefined');
+  });
+
+  it('should read `valueOf` before `toString`, matching lodash', () => {
+    expect(toString({ valueOf: () => 7 })).toBe('7');
+    expect(toString({ valueOf: () => 7, toString: () => 'from toString' })).toBe('7');
+    expect(toString([{ valueOf: () => 1 }, { valueOf: () => 2 }])).toBe('1,2');
+  });
+
+  it('should keep the string representation of values without a custom `valueOf`', () => {
+    expect(toString({})).toBe('[object Object]');
+    expect(toString(new Date(0))).toBe(new Date(0).toString());
+    expect(toString(/re/g)).toBe('/re/g');
   });
 });

--- a/src/compat/util/toString.ts
+++ b/src/compat/util/toString.ts
@@ -1,3 +1,5 @@
+import { isSymbol } from '../predicate/isSymbol.ts';
+
 /**
  * Converts `value` to a string.
  *
@@ -31,7 +33,14 @@ function baseToString(value: any): string {
     return value.map(baseToString).join(',');
   }
 
-  const result = String(value);
+  if (isSymbol(value)) {
+    return value.toString();
+  }
+
+  // Concatenation converts the value with the default hint, which reads `valueOf()` before
+  // `toString()`. `String(value)` uses the string hint instead and never reads `valueOf()`.
+  // eslint-disable-next-line no-implicit-coercion
+  const result = value + '';
 
   if (result === '0' && Object.is(Number(value), -0)) {
     return '-0';


### PR DESCRIPTION
## Summary

`compat/toString` converts values with `String(value)`, which asks an object for its string representation and never reads `valueOf()`. lodash coerces with `value + ''`, so the default hint applies and `valueOf()` is read first. Objects that carry their value in `valueOf` come out as `[object Object]`:

```ts
toString({ valueOf: () => 7 });
// es-toolkit: '[object Object]'
// lodash:     '7'

escape({ valueOf: () => '<a>' });
// es-toolkit: '[object Object]'
// lodash:     '&lt;a&gt;'

camelCase({ valueOf: () => 'a b' });
// es-toolkit: 'objectObject'
// lodash:     'aB'
```

Every compat function that renders its input through `toString` inherits the gap: `camelCase`, `capitalize`, `deburr`, `escape`, `escapeRegExp`, `kebabCase`, `lowerCase`, `lowerFirst`, `snakeCase`, `startCase`, `toLower`, `toUpper`, `upperCase`, `upperFirst`, `words`, `pad`, `padStart`, `padEnd`, `split`, `replace` and `repeat`.

## Fix

Coerce with concatenation so the conversion uses the default hint, mirroring lodash's `baseToString`. Symbols return before that point because they throw when concatenated, which is also why lodash checks for symbols first. Reusing the existing `isSymbol` predicate keeps wrapped symbols such as `Object(Symbol('a'))` working.

`trim` and `truncate` build their string from the value's own `toString()` method instead of this helper, so they are not covered by this change.

## Tests

Added regression cases for objects with a custom `valueOf`, for values that must keep their string representation (plain objects, dates and regular expressions), and for wrapped symbols. Verified against lodash 4.17.21. The `es-toolkit/compat` bundle size snapshots that pull in `toString` are updated in a separate commit.
