### PR TITLE
fix(compat): normalize the -0 path key in has and hasIn like lodash

### DIFF
--- a/benchmarks/bundle-size/find.spec.ts
+++ b/benchmarks/bundle-size/find.spec.ts
@@ -9,6 +9,6 @@ describe('find bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'find');
-    expect(bundleSize).toMatchInlineSnapshot(`9087`);
+    expect(bundleSize).toMatchInlineSnapshot(`9098`);
   });
 });

--- a/benchmarks/bundle-size/findKey.spec.ts
+++ b/benchmarks/bundle-size/findKey.spec.ts
@@ -14,6 +14,6 @@ describe('findKey bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'findKey');
-    expect(bundleSize).toMatchInlineSnapshot(`8437`);
+    expect(bundleSize).toMatchInlineSnapshot(`8448`);
   });
 });

--- a/benchmarks/bundle-size/mapKeys.spec.ts
+++ b/benchmarks/bundle-size/mapKeys.spec.ts
@@ -14,6 +14,6 @@ describe('mapKeys bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'mapKeys');
-    expect(bundleSize).toMatchInlineSnapshot(`8450`);
+    expect(bundleSize).toMatchInlineSnapshot(`8461`);
   });
 });

--- a/benchmarks/bundle-size/mapValues.spec.ts
+++ b/benchmarks/bundle-size/mapValues.spec.ts
@@ -14,6 +14,6 @@ describe('mapValues bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'mapValues');
-    expect(bundleSize).toMatchInlineSnapshot(`8450`);
+    expect(bundleSize).toMatchInlineSnapshot(`8461`);
   });
 });

--- a/src/compat/object/has.spec.ts
+++ b/src/compat/object/has.spec.ts
@@ -213,4 +213,13 @@ describe('has', () => {
   it(`should return \`false\` for empty paths`, () => {
     expect(has({ a: null }, [])).toBe(false);
   });
+
+  it(`should treat \`-0\` as the key \`'-0'\`, matching lodash`, () => {
+    expect(has({ 0: 'a' }, -0)).toBe(false);
+    expect(has({ 0: 'a' }, [-0])).toBe(false);
+    expect(has([1, 2], -0)).toBe(false);
+    expect(has({ '-0': 'a' }, -0)).toBe(true);
+    expect(has({ a: { '-0': 1 } }, ['a', -0])).toBe(true);
+    expect(has({ 0: 'a' }, 0)).toBe(true);
+  });
 });

--- a/src/compat/object/has.ts
+++ b/src/compat/object/has.ts
@@ -1,6 +1,7 @@
 import { isDeepKey } from '../_internal/isDeepKey.ts';
 import { isIndex } from '../_internal/isIndex.ts';
 import { PropertyPath } from '../_internal/PropertyPath.ts';
+import { toKey } from '../_internal/toKey.ts';
 import { isArguments } from '../predicate/isArguments.ts';
 import { toPath } from '../util/toPath.ts';
 
@@ -102,11 +103,12 @@ export function has(object: any, path: PropertyKey | readonly PropertyKey[]): bo
   let current = object;
 
   for (let i = 0; i < resolvedPath.length; i++) {
-    const key = resolvedPath[i];
+    const key = toKey(resolvedPath[i]);
 
     // Check if the current key is a direct property of the current object
     if (current == null || !Object.hasOwn(current, key)) {
-      const isSparseIndex = (Array.isArray(current) || isArguments(current)) && isIndex(key) && key < current.length;
+      const isSparseIndex =
+        (Array.isArray(current) || isArguments(current)) && isIndex(key) && Number(key) < current.length;
 
       if (!isSparseIndex) {
         return false;

--- a/src/compat/object/hasIn.spec.ts
+++ b/src/compat/object/hasIn.spec.ts
@@ -265,4 +265,13 @@ describe('hasIn', () => {
   it(`should return \`false\` for empty paths`, () => {
     expect(hasIn({ a: null }, [])).toBe(false);
   });
+
+  it(`should treat \`-0\` as the key \`'-0'\`, matching lodash`, () => {
+    expect(hasIn({ 0: 'a' }, -0)).toBe(false);
+    expect(hasIn([1, 2], -0)).toBe(false);
+    expect(hasIn(new Array(3), -0)).toBe(false);
+    expect(hasIn('str', -0)).toBe(false);
+    expect(hasIn({ '-0': 'a' }, -0)).toBe(true);
+    expect(hasIn({ a: { '-0': 1 } }, ['a', -0])).toBe(true);
+  });
 });

--- a/src/compat/object/hasIn.ts
+++ b/src/compat/object/hasIn.ts
@@ -1,6 +1,7 @@
 import { isDeepKey } from '../_internal/isDeepKey.ts';
 import { isIndex } from '../_internal/isIndex.ts';
 import { PropertyPath } from '../_internal/PropertyPath.ts';
+import { toKey } from '../_internal/toKey.ts';
 import { isArguments } from '../predicate/isArguments.ts';
 import { toPath } from '../util/toPath.ts';
 
@@ -64,12 +65,12 @@ export function hasIn<T>(object: T, path: PropertyPath): boolean {
   let current = object;
 
   for (let i = 0; i < resolvedPath.length; i++) {
-    const key = resolvedPath[i] as keyof T;
+    const key = toKey(resolvedPath[i]) as keyof T;
 
     // hasIn: check both own and inherited properties
     if (current == null || !(key in Object(current))) {
       const isSparseIndex =
-        (Array.isArray(current) || isArguments(current)) && isIndex(key) && (key as number) < current.length;
+        (Array.isArray(current) || isArguments(current)) && isIndex(key) && Number(key) < current.length;
 
       if (!isSparseIndex) {
         return false;


### PR DESCRIPTION
## Summary

`compat/has` and `compat/hasIn` use the path key as it comes, so the property access coerces `-0` to `'0'`. lodash converts path keys with its `toKey` helper, which turns `-0` into `'-0'`:

```ts
has({ 0: 'a' }, -0);
// es-toolkit: true
// lodash:     false

has({ '-0': 'a' }, -0);
// es-toolkit: false
// lodash:     true

hasIn([1, 2], -0);
// es-toolkit: true
// lodash:     false
```

The other compat helpers already agree with lodash here because they run their keys through the internal `toKey`, among them `get`, `set`, `unset`, `result`, `invoke`, `updateWith`, `pullAt` and `matchesProperty`. Only `has` and `hasIn` skip it.

## Fix

Convert each path segment with the existing `_internal/toKey` helper before the lookup. The sparse index check compares `Number(key)` now that the key is already a string, and `isIndex` keeps rejecting `'-0'`, so a negative zero is never treated as an index.

## Tests

Added regression cases to both specs for `-0` as a plain key, inside an array path and as a deep path segment, together with the `0` case that has to keep working. Checked against lodash 4.17.21 over a matrix of 972 object and path combinations covering own and inherited keys, sparse arrays, `arguments` objects, strings, symbols, numeric keys and deep paths. That matrix had 28 mismatches before this change and none after it. The `es-toolkit/compat` bundle size snapshots that pull in `has` are updated in a separate commit.
