### PR TITLE
fix[omitBy, pickBy]: type numeric callback keys as strings

### DIFF
--- a/docs/ja/reference/object/omitBy.md
+++ b/docs/ja/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### パラメータ
 
 - `obj` (`T extends Record<string, any>`): プロパティをフィルタリングするオブジェクトです。
-- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): プロパティを除外するかを決定する条件関数です。値とキーを受け取り、除外する場合は`true`、維持する場合は`false`を返します。数値キーは条件関数に文字列として渡されます。
+- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): プロパティを除外するかを決定する条件関数です。値とキーを受け取り、除外する場合は`true`、維持する場合は`false`を返します。数値キーは条件関数に文字列として渡されます([`ObjectKeys<T>`](/ja/types/reference/ObjectKeys)を参照)。
 
 #### 戻り値
 

--- a/docs/ja/reference/object/omitBy.md
+++ b/docs/ja/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### パラメータ
 
 - `obj` (`T extends Record<string, any>`): プロパティをフィルタリングするオブジェクトです。
-- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): プロパティを除外するかを決定する条件関数です。値とキーを受け取り、除外する場合は`true`、維持する場合は`false`を返します。`StringKeyOf<T>`は既知の文字列キーをそのまま保持し、数値キーを文字列に変換するため、`Object.keys`の動作と一致します。
+- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): プロパティを除外するかを決定する条件関数です。値とキーを受け取り、除外する場合は`true`、維持する場合は`false`を返します。数値キーは条件関数に文字列として渡されます。
 
 #### 戻り値
 

--- a/docs/ja/reference/object/omitBy.md
+++ b/docs/ja/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### パラメータ
 
 - `obj` (`T extends Record<string, any>`): プロパティをフィルタリングするオブジェクトです。
-- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): プロパティを除外するかを決定する条件関数です。値とキーを受け取り、除外する場合は`true`、維持する場合は`false`を返します。数値キーは条件関数に文字列として渡されます。
+- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): プロパティを除外するかを決定する条件関数です。値とキーを受け取り、除外する場合は`true`、維持する場合は`false`を返します。数値キーは条件関数に文字列として渡されます。
 
 #### 戻り値
 

--- a/docs/ja/reference/object/omitBy.md
+++ b/docs/ja/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### パラメータ
 
 - `obj` (`T extends Record<string, any>`): プロパティをフィルタリングするオブジェクトです。
-- `shouldOmit` (`(value: T[keyof T], key: keyof T) => boolean`): プロパティを除外するかを決定する条件関数です。値とキーを受け取り、除外する場合は`true`、維持する場合は`false`を返します。
+- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): プロパティを除外するかを決定する条件関数です。値とキーを受け取り、除外する場合は`true`、維持する場合は`false`を返します。`StringKeyOf<T>`は既知の文字列キーをそのまま保持し、数値キーを文字列に変換するため、`Object.keys`の動作と一致します。
 
 #### 戻り値
 

--- a/docs/ja/reference/object/pickBy.md
+++ b/docs/ja/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### パラメータ
 
 - `obj` (`T extends Record<string, any>`): プロパティをフィルタリングするオブジェクトです。
-- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): プロパティを選択するかを決定する条件関数です。値とキーを受け取り、選択する場合は`true`、除外する場合は`false`を返します。数値キーは条件関数に文字列として渡されます。
+- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): プロパティを選択するかを決定する条件関数です。値とキーを受け取り、選択する場合は`true`、除外する場合は`false`を返します。数値キーは条件関数に文字列として渡されます。
 
 #### 戻り値
 

--- a/docs/ja/reference/object/pickBy.md
+++ b/docs/ja/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### パラメータ
 
 - `obj` (`T extends Record<string, any>`): プロパティをフィルタリングするオブジェクトです。
-- `shouldPick` (`(value: T[keyof T], key: keyof T) => boolean`): プロパティを選択するかを決定する条件関数です。値とキーを受け取り、選択する場合は`true`、除外する場合は`false`を返します。
+- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): プロパティを選択するかを決定する条件関数です。値とキーを受け取り、選択する場合は`true`、除外する場合は`false`を返します。`StringKeyOf<T>`は既知の文字列キーをそのまま保持し、数値キーを文字列に変換するため、`Object.keys`の動作と一致します。
 
 #### 戻り値
 

--- a/docs/ja/reference/object/pickBy.md
+++ b/docs/ja/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### パラメータ
 
 - `obj` (`T extends Record<string, any>`): プロパティをフィルタリングするオブジェクトです。
-- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): プロパティを選択するかを決定する条件関数です。値とキーを受け取り、選択する場合は`true`、除外する場合は`false`を返します。`StringKeyOf<T>`は既知の文字列キーをそのまま保持し、数値キーを文字列に変換するため、`Object.keys`の動作と一致します。
+- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): プロパティを選択するかを決定する条件関数です。値とキーを受け取り、選択する場合は`true`、除外する場合は`false`を返します。数値キーは条件関数に文字列として渡されます。
 
 #### 戻り値
 

--- a/docs/ja/reference/object/pickBy.md
+++ b/docs/ja/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### パラメータ
 
 - `obj` (`T extends Record<string, any>`): プロパティをフィルタリングするオブジェクトです。
-- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): プロパティを選択するかを決定する条件関数です。値とキーを受け取り、選択する場合は`true`、除外する場合は`false`を返します。数値キーは条件関数に文字列として渡されます。
+- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): プロパティを選択するかを決定する条件関数です。値とキーを受け取り、選択する場合は`true`、除外する場合は`false`を返します。数値キーは条件関数に文字列として渡されます([`ObjectKeys<T>`](/ja/types/reference/ObjectKeys)を参照)。
 
 #### 戻り値
 

--- a/docs/ja/types/reference/ObjectKeys.md
+++ b/docs/ja/types/reference/ObjectKeys.md
@@ -1,0 +1,37 @@
+# ObjectKeys
+
+`Object.keys`が返す形式のまま、オブジェクトのキーをユニオンとして作成します。`keyof`とは異なり、数値キーは文字列に変換され、シンボルキーは除外されます。オブジェクトのキーが常に文字列であるJavaScriptのランタイム動作と一致します。
+
+```typescript
+type Keys = ObjectKeys<T>;
+```
+
+## 使用法
+
+### `ObjectKeys<T>`
+
+`Object.keys`、`Object.entries`、`for...in`ループがランタイムで実際に生成する値と一致するキー型が必要なときに使用してください。TypeScriptがデフォルトで`string[]`に広げてしまう`Object.keys`の結果に型を付けるときに特に便利です。
+
+```typescript
+import type { ObjectKeys } from 'es-toolkit/types';
+
+// keyofは数値キーを数値のまま保持しますが、ObjectKeysは文字列に変換します。
+type Keys = ObjectKeys<{ a: number; 1: string }>; // 'a' | '1'
+type KeyofKeys = keyof { a: number; 1: string }; // 'a' | 1
+
+// Object.keysの結果に型を付けます。
+const obj = { a: 1, b: 2 };
+const keys = Object.keys(obj) as Array<ObjectKeys<typeof obj>>; // Array<'a' | 'b'>
+
+// インデックスシグネチャは文字列形式に解決されます。
+type StringKeys = ObjectKeys<Record<string, number>>; // string
+type NumberKeys = ObjectKeys<Record<number, string>>; // `${number}`
+
+// Object.keysのランタイム動作と同様に、シンボルキーは除外されます。
+declare const sym: unique symbol;
+type NoSymbols = ObjectKeys<{ a: number; [sym]: string }>; // 'a'
+```
+
+#### 型パラメータ
+
+- `T`: キーを読み取るオブジェクト型です。

--- a/docs/ko/reference/object/omitBy.md
+++ b/docs/ko/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### 파라미터
 
 - `obj` (`T extends Record<string, any>`): 속성들을 필터링할 객체예요.
-- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 속성을 제외할지 결정하는 조건 함수예요. 값과 키를 받아서 제외하려면 `true`, 유지하려면 `false`를 반환해요. 숫자 키는 조건 함수에 문자열로 전달돼요.
+- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 속성을 제외할지 결정하는 조건 함수예요. 값과 키를 받아서 제외하려면 `true`, 유지하려면 `false`를 반환해요. 숫자 키는 조건 함수에 문자열로 전달돼요.
 
 #### 반환 값
 

--- a/docs/ko/reference/object/omitBy.md
+++ b/docs/ko/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### 파라미터
 
 - `obj` (`T extends Record<string, any>`): 속성들을 필터링할 객체예요.
-- `shouldOmit` (`(value: T[keyof T], key: keyof T) => boolean`): 속성을 제외할지 결정하는 조건 함수예요. 값과 키를 받아서 제외하려면 `true`, 유지하려면 `false`를 반환해요.
+- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 속성을 제외할지 결정하는 조건 함수예요. 값과 키를 받아서 제외하려면 `true`, 유지하려면 `false`를 반환해요. `StringKeyOf<T>`는 알려진 문자열 키를 그대로 유지하고 숫자 키를 문자열로 바꿔 `Object.keys`의 동작과 일치해요.
 
 #### 반환 값
 

--- a/docs/ko/reference/object/omitBy.md
+++ b/docs/ko/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### 파라미터
 
 - `obj` (`T extends Record<string, any>`): 속성들을 필터링할 객체예요.
-- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 속성을 제외할지 결정하는 조건 함수예요. 값과 키를 받아서 제외하려면 `true`, 유지하려면 `false`를 반환해요. 숫자 키는 조건 함수에 문자열로 전달돼요.
+- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 속성을 제외할지 결정하는 조건 함수예요. 값과 키를 받아서 제외하려면 `true`, 유지하려면 `false`를 반환해요. 숫자 키는 조건 함수에 문자열로 전달돼요 ([`ObjectKeys<T>`](/ko/types/reference/ObjectKeys) 참고).
 
 #### 반환 값
 

--- a/docs/ko/reference/object/omitBy.md
+++ b/docs/ko/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### 파라미터
 
 - `obj` (`T extends Record<string, any>`): 속성들을 필터링할 객체예요.
-- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 속성을 제외할지 결정하는 조건 함수예요. 값과 키를 받아서 제외하려면 `true`, 유지하려면 `false`를 반환해요. `StringKeyOf<T>`는 알려진 문자열 키를 그대로 유지하고 숫자 키를 문자열로 바꿔 `Object.keys`의 동작과 일치해요.
+- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 속성을 제외할지 결정하는 조건 함수예요. 값과 키를 받아서 제외하려면 `true`, 유지하려면 `false`를 반환해요. 숫자 키는 조건 함수에 문자열로 전달돼요.
 
 #### 반환 값
 

--- a/docs/ko/reference/object/pickBy.md
+++ b/docs/ko/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### 파라미터
 
 - `obj` (`T extends Record<string, any>`): 속성들을 필터링할 객체예요.
-- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 속성을 선택할지 결정하는 조건 함수예요. 값과 키를 받아서 선택하려면 `true`, 제외하려면 `false`를 반환해요. 숫자 키는 조건 함수에 문자열로 전달돼요.
+- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 속성을 선택할지 결정하는 조건 함수예요. 값과 키를 받아서 선택하려면 `true`, 제외하려면 `false`를 반환해요. 숫자 키는 조건 함수에 문자열로 전달돼요 ([`ObjectKeys<T>`](/ko/types/reference/ObjectKeys) 참고).
 
 #### 반환 값
 

--- a/docs/ko/reference/object/pickBy.md
+++ b/docs/ko/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### 파라미터
 
 - `obj` (`T extends Record<string, any>`): 속성들을 필터링할 객체예요.
-- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 속성을 선택할지 결정하는 조건 함수예요. 값과 키를 받아서 선택하려면 `true`, 제외하려면 `false`를 반환해요. `StringKeyOf<T>`는 알려진 문자열 키를 그대로 유지하고 숫자 키를 문자열로 바꿔 `Object.keys`의 동작과 일치해요.
+- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 속성을 선택할지 결정하는 조건 함수예요. 값과 키를 받아서 선택하려면 `true`, 제외하려면 `false`를 반환해요. 숫자 키는 조건 함수에 문자열로 전달돼요.
 
 #### 반환 값
 

--- a/docs/ko/reference/object/pickBy.md
+++ b/docs/ko/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### 파라미터
 
 - `obj` (`T extends Record<string, any>`): 속성들을 필터링할 객체예요.
-- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 속성을 선택할지 결정하는 조건 함수예요. 값과 키를 받아서 선택하려면 `true`, 제외하려면 `false`를 반환해요. 숫자 키는 조건 함수에 문자열로 전달돼요.
+- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 속성을 선택할지 결정하는 조건 함수예요. 값과 키를 받아서 선택하려면 `true`, 제외하려면 `false`를 반환해요. 숫자 키는 조건 함수에 문자열로 전달돼요.
 
 #### 반환 값
 

--- a/docs/ko/reference/object/pickBy.md
+++ b/docs/ko/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### 파라미터
 
 - `obj` (`T extends Record<string, any>`): 속성들을 필터링할 객체예요.
-- `shouldPick` (`(value: T[keyof T], key: keyof T) => boolean`): 속성을 선택할지 결정하는 조건 함수예요. 값과 키를 받아서 선택하려면 `true`, 제외하려면 `false`를 반환해요.
+- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 속성을 선택할지 결정하는 조건 함수예요. 값과 키를 받아서 선택하려면 `true`, 제외하려면 `false`를 반환해요. `StringKeyOf<T>`는 알려진 문자열 키를 그대로 유지하고 숫자 키를 문자열로 바꿔 `Object.keys`의 동작과 일치해요.
 
 #### 반환 값
 

--- a/docs/ko/types/reference/ObjectKeys.md
+++ b/docs/ko/types/reference/ObjectKeys.md
@@ -1,0 +1,37 @@
+# ObjectKeys
+
+`Object.keys`가 반환하는 형태 그대로 객체의 키를 유니온으로 만들어요. `keyof`와 달리 숫자 키는 문자열로 변환되고 심볼 키는 제외돼요. 객체의 키가 항상 문자열인 JavaScript의 런타임 동작과 일치해요.
+
+```typescript
+type Keys = ObjectKeys<T>;
+```
+
+## 사용법
+
+### `ObjectKeys<T>`
+
+`Object.keys`, `Object.entries`, `for...in` 루프가 런타임에 실제로 만들어내는 값과 일치하는 키 타입이 필요할 때 사용하세요. TypeScript가 기본적으로 `string[]`으로 넓혀버리는 `Object.keys`의 결과에 타입을 붙일 때 특히 유용해요.
+
+```typescript
+import type { ObjectKeys } from 'es-toolkit/types';
+
+// keyof는 숫자 키를 숫자로 유지하지만, ObjectKeys는 문자열로 변환해요.
+type Keys = ObjectKeys<{ a: number; 1: string }>; // 'a' | '1'
+type KeyofKeys = keyof { a: number; 1: string }; // 'a' | 1
+
+// Object.keys의 결과에 타입을 붙여요.
+const obj = { a: 1, b: 2 };
+const keys = Object.keys(obj) as Array<ObjectKeys<typeof obj>>; // Array<'a' | 'b'>
+
+// 인덱스 시그니처는 문자열 형태로 결정돼요.
+type StringKeys = ObjectKeys<Record<string, number>>; // string
+type NumberKeys = ObjectKeys<Record<number, string>>; // `${number}`
+
+// Object.keys의 런타임 동작처럼 심볼 키는 제외돼요.
+declare const sym: unique symbol;
+type NoSymbols = ObjectKeys<{ a: number; [sym]: string }>; // 'a'
+```
+
+#### 타입 파라미터
+
+- `T`: 키를 읽어올 객체 타입이에요.

--- a/docs/reference/object/omitBy.md
+++ b/docs/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### Parameters
 
 - `obj` (`T extends Record<string, any>`): The object to filter properties from.
-- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): A condition function that determines whether to exclude a property. Receives the value and key, and returns `true` to exclude, `false` to keep. `StringKeyOf<T>` preserves known string keys and converts numeric keys to strings, matching `Object.keys`.
+- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): A condition function that determines whether to exclude a property. Receives the value and key, and returns `true` to exclude, `false` to keep. Numeric keys are passed to the condition function as strings.
 
 #### Returns
 

--- a/docs/reference/object/omitBy.md
+++ b/docs/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### Parameters
 
 - `obj` (`T extends Record<string, any>`): The object to filter properties from.
-- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): A condition function that determines whether to exclude a property. Receives the value and key, and returns `true` to exclude, `false` to keep. Numeric keys are passed to the condition function as strings.
+- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): A condition function that determines whether to exclude a property. Receives the value and key, and returns `true` to exclude, `false` to keep. Numeric keys are passed to the condition function as strings.
 
 #### Returns
 

--- a/docs/reference/object/omitBy.md
+++ b/docs/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### Parameters
 
 - `obj` (`T extends Record<string, any>`): The object to filter properties from.
-- `shouldOmit` (`(value: T[keyof T], key: keyof T) => boolean`): A condition function that determines whether to exclude a property. Receives the value and key, and returns `true` to exclude, `false` to keep.
+- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): A condition function that determines whether to exclude a property. Receives the value and key, and returns `true` to exclude, `false` to keep. `StringKeyOf<T>` preserves known string keys and converts numeric keys to strings, matching `Object.keys`.
 
 #### Returns
 

--- a/docs/reference/object/omitBy.md
+++ b/docs/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### Parameters
 
 - `obj` (`T extends Record<string, any>`): The object to filter properties from.
-- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): A condition function that determines whether to exclude a property. Receives the value and key, and returns `true` to exclude, `false` to keep. Numeric keys are passed to the condition function as strings.
+- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): A condition function that determines whether to exclude a property. Receives the value and key, and returns `true` to exclude, `false` to keep. Numeric keys are passed to the condition function as strings (see [`ObjectKeys<T>`](/types/reference/ObjectKeys)).
 
 #### Returns
 

--- a/docs/reference/object/pickBy.md
+++ b/docs/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### Parameters
 
 - `obj` (`T extends Record<string, any>`): The object to filter properties from.
-- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): A condition function that determines whether to pick a property. Receives the value and key, and returns `true` to pick, `false` to exclude. Numeric keys are passed to the condition function as strings.
+- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): A condition function that determines whether to pick a property. Receives the value and key, and returns `true` to pick, `false` to exclude. Numeric keys are passed to the condition function as strings (see [`ObjectKeys<T>`](/types/reference/ObjectKeys)).
 
 #### Returns
 

--- a/docs/reference/object/pickBy.md
+++ b/docs/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### Parameters
 
 - `obj` (`T extends Record<string, any>`): The object to filter properties from.
-- `shouldPick` (`(value: T[keyof T], key: keyof T) => boolean`): A condition function that determines whether to pick a property. Receives the value and key, and returns `true` to pick, `false` to exclude.
+- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): A condition function that determines whether to pick a property. Receives the value and key, and returns `true` to pick, `false` to exclude. `StringKeyOf<T>` preserves known string keys and converts numeric keys to strings, matching `Object.keys`.
 
 #### Returns
 

--- a/docs/reference/object/pickBy.md
+++ b/docs/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### Parameters
 
 - `obj` (`T extends Record<string, any>`): The object to filter properties from.
-- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): A condition function that determines whether to pick a property. Receives the value and key, and returns `true` to pick, `false` to exclude. Numeric keys are passed to the condition function as strings.
+- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): A condition function that determines whether to pick a property. Receives the value and key, and returns `true` to pick, `false` to exclude. Numeric keys are passed to the condition function as strings.
 
 #### Returns
 

--- a/docs/reference/object/pickBy.md
+++ b/docs/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### Parameters
 
 - `obj` (`T extends Record<string, any>`): The object to filter properties from.
-- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): A condition function that determines whether to pick a property. Receives the value and key, and returns `true` to pick, `false` to exclude. `StringKeyOf<T>` preserves known string keys and converts numeric keys to strings, matching `Object.keys`.
+- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): A condition function that determines whether to pick a property. Receives the value and key, and returns `true` to pick, `false` to exclude. Numeric keys are passed to the condition function as strings.
 
 #### Returns
 

--- a/docs/types/reference/ObjectKeys.md
+++ b/docs/types/reference/ObjectKeys.md
@@ -1,0 +1,37 @@
+# ObjectKeys
+
+Creates a union of the keys of an object as they are returned by `Object.keys`. Unlike `keyof`, numeric keys are converted to strings and symbol keys are excluded, matching the runtime behavior of JavaScript, where object keys are always strings.
+
+```typescript
+type Keys = ObjectKeys<T>;
+```
+
+## Usage
+
+### `ObjectKeys<T>`
+
+Use it when you want key types that match what `Object.keys`, `Object.entries`, or a `for...in` loop actually produce at runtime. It's especially handy for typing the result of `Object.keys`, which TypeScript widens to `string[]` by default.
+
+```typescript
+import type { ObjectKeys } from 'es-toolkit/types';
+
+// keyof keeps numeric keys as numbers, ObjectKeys converts them to strings.
+type Keys = ObjectKeys<{ a: number; 1: string }>; // 'a' | '1'
+type KeyofKeys = keyof { a: number; 1: string }; // 'a' | 1
+
+// Type the result of Object.keys.
+const obj = { a: 1, b: 2 };
+const keys = Object.keys(obj) as Array<ObjectKeys<typeof obj>>; // Array<'a' | 'b'>
+
+// Index signatures resolve to their string forms.
+type StringKeys = ObjectKeys<Record<string, number>>; // string
+type NumberKeys = ObjectKeys<Record<number, string>>; // `${number}`
+
+// Symbol keys are excluded, like Object.keys does at runtime.
+declare const sym: unique symbol;
+type NoSymbols = ObjectKeys<{ a: number; [sym]: string }>; // 'a'
+```
+
+#### Type Parameters
+
+- `T`: The object type to read keys from.

--- a/docs/zh_hans/reference/object/omitBy.md
+++ b/docs/zh_hans/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### 参数
 
 - `obj` (`T extends Record<string, any>`): 要过滤属性的对象。
-- `shouldOmit` (`(value: T[keyof T], key: keyof T) => boolean`): 决定是否排除属性的条件函数。接收值和键,返回 `true` 表示排除,返回 `false` 表示保留。
+- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 决定是否排除属性的条件函数。接收值和键,返回 `true` 表示排除,返回 `false` 表示保留。`StringKeyOf<T>` 会保留已知的字符串键，并将数字键转换为字符串，与 `Object.keys` 的行为一致。
 
 #### 返回值
 

--- a/docs/zh_hans/reference/object/omitBy.md
+++ b/docs/zh_hans/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### 参数
 
 - `obj` (`T extends Record<string, any>`): 要过滤属性的对象。
-- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 决定是否排除属性的条件函数。接收值和键,返回 `true` 表示排除,返回 `false` 表示保留。数字键会以字符串形式传递给条件函数。
+- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 决定是否排除属性的条件函数。接收值和键,返回 `true` 表示排除,返回 `false` 表示保留。数字键会以字符串形式传递给条件函数(参见 [`ObjectKeys<T>`](/zh_hans/types/reference/ObjectKeys))。
 
 #### 返回值
 

--- a/docs/zh_hans/reference/object/omitBy.md
+++ b/docs/zh_hans/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### 参数
 
 - `obj` (`T extends Record<string, any>`): 要过滤属性的对象。
-- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 决定是否排除属性的条件函数。接收值和键,返回 `true` 表示排除,返回 `false` 表示保留。`StringKeyOf<T>` 会保留已知的字符串键，并将数字键转换为字符串，与 `Object.keys` 的行为一致。
+- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 决定是否排除属性的条件函数。接收值和键,返回 `true` 表示排除,返回 `false` 表示保留。数字键会以字符串形式传递给条件函数。
 
 #### 返回值
 

--- a/docs/zh_hans/reference/object/omitBy.md
+++ b/docs/zh_hans/reference/object/omitBy.md
@@ -34,7 +34,7 @@ const nonAdmins = omitBy(data, (value, key) => key.startsWith('admin'));
 #### 参数
 
 - `obj` (`T extends Record<string, any>`): 要过滤属性的对象。
-- `shouldOmit` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 决定是否排除属性的条件函数。接收值和键,返回 `true` 表示排除,返回 `false` 表示保留。数字键会以字符串形式传递给条件函数。
+- `shouldOmit` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 决定是否排除属性的条件函数。接收值和键,返回 `true` 表示排除,返回 `false` 表示保留。数字键会以字符串形式传递给条件函数。
 
 #### 返回值
 

--- a/docs/zh_hans/reference/object/pickBy.md
+++ b/docs/zh_hans/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### 参数
 
 - `obj` (`T extends Record<string, any>`): 要过滤属性的对象。
-- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 决定是否选择属性的条件函数。接收值和键,返回 `true` 表示选择,返回 `false` 表示排除。`StringKeyOf<T>` 会保留已知的字符串键，并将数字键转换为字符串，与 `Object.keys` 的行为一致。
+- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 决定是否选择属性的条件函数。接收值和键,返回 `true` 表示选择,返回 `false` 表示排除。数字键会以字符串形式传递给条件函数。
 
 #### 返回值
 

--- a/docs/zh_hans/reference/object/pickBy.md
+++ b/docs/zh_hans/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### 参数
 
 - `obj` (`T extends Record<string, any>`): 要过滤属性的对象。
-- `shouldPick` (`(value: T[keyof T], key: keyof T) => boolean`): 决定是否选择属性的条件函数。接收值和键,返回 `true` 表示选择,返回 `false` 表示排除。
+- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 决定是否选择属性的条件函数。接收值和键,返回 `true` 表示选择,返回 `false` 表示排除。`StringKeyOf<T>` 会保留已知的字符串键，并将数字键转换为字符串，与 `Object.keys` 的行为一致。
 
 #### 返回值
 

--- a/docs/zh_hans/reference/object/pickBy.md
+++ b/docs/zh_hans/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### 参数
 
 - `obj` (`T extends Record<string, any>`): 要过滤属性的对象。
-- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 决定是否选择属性的条件函数。接收值和键,返回 `true` 表示选择,返回 `false` 表示排除。数字键会以字符串形式传递给条件函数。
+- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 决定是否选择属性的条件函数。接收值和键,返回 `true` 表示选择,返回 `false` 表示排除。数字键会以字符串形式传递给条件函数(参见 [`ObjectKeys<T>`](/zh_hans/types/reference/ObjectKeys))。
 
 #### 返回值
 

--- a/docs/zh_hans/reference/object/pickBy.md
+++ b/docs/zh_hans/reference/object/pickBy.md
@@ -34,7 +34,7 @@ const admins = pickBy(data, (value, key) => key.startsWith('admin') && value > 2
 #### 参数
 
 - `obj` (`T extends Record<string, any>`): 要过滤属性的对象。
-- `shouldPick` (`(value: T[keyof T], key: StringKeyOf<T>) => boolean`): 决定是否选择属性的条件函数。接收值和键,返回 `true` 表示选择,返回 `false` 表示排除。数字键会以字符串形式传递给条件函数。
+- `shouldPick` (`(value: T[keyof T], key: ObjectKeys<T>) => boolean`): 决定是否选择属性的条件函数。接收值和键,返回 `true` 表示选择,返回 `false` 表示排除。数字键会以字符串形式传递给条件函数。
 
 #### 返回值
 

--- a/docs/zh_hans/types/reference/ObjectKeys.md
+++ b/docs/zh_hans/types/reference/ObjectKeys.md
@@ -1,0 +1,37 @@
+# ObjectKeys
+
+按照 `Object.keys` 返回的形式,将对象的键创建为联合类型。与 `keyof` 不同,数字键会被转换为字符串,符号键会被排除,与 JavaScript 中对象键始终为字符串的运行时行为一致。
+
+```typescript
+type Keys = ObjectKeys<T>;
+```
+
+## 用法
+
+### `ObjectKeys<T>`
+
+当你需要与 `Object.keys`、`Object.entries` 或 `for...in` 循环在运行时实际产生的值一致的键类型时使用。在为 `Object.keys` 的结果添加类型时特别有用,因为 TypeScript 默认会将其扩宽为 `string[]`。
+
+```typescript
+import type { ObjectKeys } from 'es-toolkit/types';
+
+// keyof 将数字键保留为数字,而 ObjectKeys 将其转换为字符串。
+type Keys = ObjectKeys<{ a: number; 1: string }>; // 'a' | '1'
+type KeyofKeys = keyof { a: number; 1: string }; // 'a' | 1
+
+// 为 Object.keys 的结果添加类型。
+const obj = { a: 1, b: 2 };
+const keys = Object.keys(obj) as Array<ObjectKeys<typeof obj>>; // Array<'a' | 'b'>
+
+// 索引签名会解析为其字符串形式。
+type StringKeys = ObjectKeys<Record<string, number>>; // string
+type NumberKeys = ObjectKeys<Record<number, string>>; // `${number}`
+
+// 与 Object.keys 的运行时行为一样,符号键会被排除。
+declare const sym: unique symbol;
+type NoSymbols = ObjectKeys<{ a: number; [sym]: string }>; // 'a'
+```
+
+#### 类型参数
+
+- `T`: 要读取键的对象类型。

--- a/src/_internal/StringKeyOf.ts
+++ b/src/_internal/StringKeyOf.ts
@@ -1,3 +1,0 @@
-export type StringKeyOf<T> =
-  | Extract<keyof T, string>
-  | (number extends keyof T ? string : `${Extract<keyof T, number>}`);

--- a/src/_internal/StringKeyOf.ts
+++ b/src/_internal/StringKeyOf.ts
@@ -1,0 +1,3 @@
+export type StringKeyOf<T> =
+  | Extract<keyof T, string>
+  | (number extends keyof T ? string : `${Extract<keyof T, number>}`);

--- a/src/object/omitBy.spec.ts
+++ b/src/object/omitBy.spec.ts
@@ -51,11 +51,11 @@ describe('omitBy', () => {
     expect(result).toEqual({ 1: 'keep' });
   });
 
-  it('should type number index signature keys as strings', () => {
+  it('should type number index signature keys as numeric strings', () => {
     const obj: Record<number, string> = { 1: 'keep', 2: 'omit' };
 
     omitBy(obj, (_value, key) => {
-      expectTypeOf(key).toEqualTypeOf<string>();
+      expectTypeOf(key).toEqualTypeOf<`${number}`>();
       return key === '2';
     });
   });

--- a/src/object/omitBy.spec.ts
+++ b/src/object/omitBy.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { omitBy } from './omitBy';
 
 describe('omitBy', () => {
@@ -35,5 +35,35 @@ describe('omitBy', () => {
     const shouldOmit = (_: number | { nested: string }, key: string) => key === 'b';
     const result = omitBy(obj, shouldOmit);
     expect(result).toEqual({ a: 1, c: 3 });
+  });
+
+  it('should pass numeric keys as strings', () => {
+    const obj = { 1: 'keep', 2: 'omit' };
+    const keys: string[] = [];
+
+    const result = omitBy(obj, (value, key) => {
+      expectTypeOf(key).toEqualTypeOf<'1' | '2'>();
+      keys.push(key);
+      return value === 'omit';
+    });
+
+    expect(keys).toEqual(['1', '2']);
+    expect(result).toEqual({ 1: 'keep' });
+  });
+
+  it('should type number index signature keys as strings', () => {
+    const obj: Record<number, string> = { 1: 'keep', 2: 'omit' };
+
+    omitBy(obj, (_value, key) => {
+      expectTypeOf(key).toEqualTypeOf<string>();
+      return key === '2';
+    });
+  });
+
+  it('should preserve string literal key types', () => {
+    omitBy({ a: 1, b: 2 }, (_value, key) => {
+      expectTypeOf(key).toEqualTypeOf<'a' | 'b'>();
+      return false;
+    });
   });
 });

--- a/src/object/omitBy.ts
+++ b/src/object/omitBy.ts
@@ -1,4 +1,4 @@
-import type { StringKeyOf } from '../_internal/StringKeyOf.ts';
+import type { ObjectKeys } from '../types/ObjectKeys.ts';
 
 /**
  * Creates a new object composed of the properties that do not satisfy the predicate function.
@@ -21,11 +21,11 @@ import type { StringKeyOf } from '../_internal/StringKeyOf.ts';
  */
 export function omitBy<T extends Record<string, any>>(
   obj: T,
-  shouldOmit: (value: T[keyof T], key: StringKeyOf<T>) => boolean
+  shouldOmit: (value: T[keyof T], key: ObjectKeys<T>) => boolean
 ): Partial<T> {
   const result: Partial<T> = {};
 
-  const keys = Object.keys(obj) as Array<StringKeyOf<T>>;
+  const keys = Object.keys(obj) as Array<ObjectKeys<T>>;
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];

--- a/src/object/omitBy.ts
+++ b/src/object/omitBy.ts
@@ -1,3 +1,5 @@
+import type { StringKeyOf } from '../_internal/StringKeyOf.ts';
+
 /**
  * Creates a new object composed of the properties that do not satisfy the predicate function.
  *
@@ -8,7 +10,7 @@
  * @param obj - The object to omit properties from.
  * @param shouldOmit - A predicate function that determines
  * whether a property should be omitted. It takes the property's key and value as arguments and returns `true`
- * if the property should be omitted, and `false` otherwise.
+ * if the property should be omitted, and `false` otherwise. Numeric keys are passed as strings.
  * @returns A new object with the properties that do not satisfy the predicate function.
  *
  * @example
@@ -19,18 +21,19 @@
  */
 export function omitBy<T extends Record<string, any>>(
   obj: T,
-  shouldOmit: (value: T[keyof T], key: keyof T) => boolean
+  shouldOmit: (value: T[keyof T], key: StringKeyOf<T>) => boolean
 ): Partial<T> {
   const result: Partial<T> = {};
 
-  const keys = Object.keys(obj) as Array<keyof T>;
+  const keys = Object.keys(obj) as Array<StringKeyOf<T>>;
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
-    const value = obj[key];
+    const objectKey = key as keyof T;
+    const value = obj[objectKey];
 
     if (!shouldOmit(value, key)) {
-      result[key] = value;
+      result[objectKey] = value;
     }
   }
 

--- a/src/object/pickBy.spec.ts
+++ b/src/object/pickBy.spec.ts
@@ -51,11 +51,11 @@ describe('pickBy', () => {
     expect(result).toEqual({ 2: 'pick' });
   });
 
-  it('should type number index signature keys as strings', () => {
+  it('should type number index signature keys as numeric strings', () => {
     const obj: Record<number, string> = { 1: 'skip', 2: 'pick' };
 
     pickBy(obj, (_value, key) => {
-      expectTypeOf(key).toEqualTypeOf<string>();
+      expectTypeOf(key).toEqualTypeOf<`${number}`>();
       return key === '2';
     });
   });

--- a/src/object/pickBy.spec.ts
+++ b/src/object/pickBy.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { pickBy } from './pickBy';
 
 describe('pickBy', () => {
@@ -35,5 +35,35 @@ describe('pickBy', () => {
     const shouldPick = (value: number | { nested: string }, key: string) => key === 'b';
     const result = pickBy(obj, shouldPick);
     expect(result).toEqual({ b: { nested: 'pick' } });
+  });
+
+  it('should pass numeric keys as strings', () => {
+    const obj = { 1: 'skip', 2: 'pick' };
+    const keys: string[] = [];
+
+    const result = pickBy(obj, (value, key) => {
+      expectTypeOf(key).toEqualTypeOf<'1' | '2'>();
+      keys.push(key);
+      return value === 'pick';
+    });
+
+    expect(keys).toEqual(['1', '2']);
+    expect(result).toEqual({ 2: 'pick' });
+  });
+
+  it('should type number index signature keys as strings', () => {
+    const obj: Record<number, string> = { 1: 'skip', 2: 'pick' };
+
+    pickBy(obj, (_value, key) => {
+      expectTypeOf(key).toEqualTypeOf<string>();
+      return key === '2';
+    });
+  });
+
+  it('should preserve string literal key types', () => {
+    pickBy({ a: 1, b: 2 }, (_value, key) => {
+      expectTypeOf(key).toEqualTypeOf<'a' | 'b'>();
+      return true;
+    });
   });
 });

--- a/src/object/pickBy.ts
+++ b/src/object/pickBy.ts
@@ -1,4 +1,4 @@
-import type { StringKeyOf } from '../_internal/StringKeyOf.ts';
+import type { ObjectKeys } from '../types/ObjectKeys.ts';
 
 /**
  * Creates a new object composed of the properties that satisfy the predicate function.
@@ -21,11 +21,11 @@ import type { StringKeyOf } from '../_internal/StringKeyOf.ts';
  */
 export function pickBy<T extends Record<string, any>>(
   obj: T,
-  shouldPick: (value: T[keyof T], key: StringKeyOf<T>) => boolean
+  shouldPick: (value: T[keyof T], key: ObjectKeys<T>) => boolean
 ): Partial<T> {
   const result: Partial<T> = {};
 
-  const keys = Object.keys(obj) as Array<StringKeyOf<T>>;
+  const keys = Object.keys(obj) as Array<ObjectKeys<T>>;
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     const objectKey = key as keyof T;

--- a/src/object/pickBy.ts
+++ b/src/object/pickBy.ts
@@ -1,3 +1,5 @@
+import type { StringKeyOf } from '../_internal/StringKeyOf.ts';
+
 /**
  * Creates a new object composed of the properties that satisfy the predicate function.
  *
@@ -8,7 +10,7 @@
  * @param obj - The object to pick properties from.
  * @param shouldPick - A predicate function that determines
  * whether a property should be picked. It takes the property's key and value as arguments and returns `true`
- * if the property should be picked, and `false` otherwise.
+ * if the property should be picked, and `false` otherwise. Numeric keys are passed as strings.
  * @returns A new object with the properties that satisfy the predicate function.
  *
  * @example
@@ -19,17 +21,18 @@
  */
 export function pickBy<T extends Record<string, any>>(
   obj: T,
-  shouldPick: (value: T[keyof T], key: keyof T) => boolean
+  shouldPick: (value: T[keyof T], key: StringKeyOf<T>) => boolean
 ): Partial<T> {
   const result: Partial<T> = {};
 
-  const keys = Object.keys(obj) as Array<keyof T>;
+  const keys = Object.keys(obj) as Array<StringKeyOf<T>>;
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
-    const value = obj[key];
+    const objectKey = key as keyof T;
+    const value = obj[objectKey];
 
     if (shouldPick(value, key)) {
-      result[key] = value;
+      result[objectKey] = value;
     }
   }
 

--- a/src/types/ObjectKeys.spec.ts
+++ b/src/types/ObjectKeys.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { ObjectKeys } from './ObjectKeys';
+
+describe('ObjectKeys', () => {
+  it('preserves string literal keys', () => {
+    expectTypeOf<ObjectKeys<{ a: number; b: string }>>().toEqualTypeOf<'a' | 'b'>();
+  });
+
+  it('converts numeric keys to string literals', () => {
+    expectTypeOf<ObjectKeys<{ 1: string; 2: string }>>().toEqualTypeOf<'1' | '2'>();
+    expectTypeOf<ObjectKeys<{ a: number; 1: string }>>().toEqualTypeOf<'a' | '1'>();
+  });
+
+  it('resolves index signatures to their string forms', () => {
+    expectTypeOf<ObjectKeys<Record<string, number>>>().toEqualTypeOf<string>();
+    expectTypeOf<ObjectKeys<Record<number, string>>>().toEqualTypeOf<`${number}`>();
+  });
+
+  it('excludes symbol keys', () => {
+    const sym = Symbol('sym');
+    type WithSymbol = { a: number; [sym]: string };
+    expectTypeOf<ObjectKeys<WithSymbol>>().toEqualTypeOf<'a'>();
+  });
+});

--- a/src/types/ObjectKeys.ts
+++ b/src/types/ObjectKeys.ts
@@ -1,0 +1,16 @@
+/**
+ * Creates a union of the keys of `T` as they are returned by `Object.keys`:
+ * numeric keys are converted to strings and symbol keys are excluded. The key-side
+ * counterpart to `ValueOf`.
+ *
+ * @template T - The object type to read keys from.
+ *
+ * @example
+ * type Keys = ObjectKeys<{ a: number; 1: string }>;
+ * // => 'a' | '1'
+ *
+ * const obj = { a: 1, b: 2 };
+ * const keys = Object.keys(obj) as Array<ObjectKeys<typeof obj>>;
+ * // => Array<'a' | 'b'>
+ */
+export type ObjectKeys<T> = `${Exclude<keyof T, symbol>}`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export type { DeepPartial } from './DeepPartial.ts';
 export type { DeepReadonly } from './DeepReadonly.ts';
 export type { NonEmptyArray } from './NonEmptyArray.ts';
+export type { ObjectKeys } from './ObjectKeys.ts';
 export type { Simplify } from './Simplify.ts';
 export type { ToCamelCaseKeys } from './ToCamelCaseKeys.ts';
 export type { ToConstantCaseKeys } from './ToConstantCaseKeys.ts';


### PR DESCRIPTION
## Summary

Fixes #2036.

`omitBy` and `pickBy` use `Object.keys`, so numeric object keys are passed to predicates as strings at runtime. For number-keyed objects, their types currently expose those keys as numbers. This change aligns the callback key type with the runtime behavior.

## Changes

- Use `StringKeyOf<T>` for predicate keys, preserving string literal keys and converting numeric keys to strings.
- Add runtime and type-level regression tests.
- Update documentation in all four supported languages.
