### PR TITLE
fix[findLastIndex]: convert `fromIndex` to an integer in compat like lodash

### DIFF
--- a/src/compat/array/findLastIndex.spec.ts
+++ b/src/compat/array/findLastIndex.spec.ts
@@ -104,6 +104,10 @@ describe('findLastIndex', () => {
 
   it(`\`findLastIndex\` should coerce \`fromIndex\` to an integer`, () => {
     expect(findLastIndex(array, x => x === 2, 4.2)).toBe(4);
+    // `fromIndex` is truncated toward zero, so the search starts at index 5, 2, and 6.
+    expect(findLastIndex(array, x => x === 3, -1.5)).toBe(5);
+    expect(findLastIndex(array, x => x === 3, -4.5)).toBe(2);
+    expect(findLastIndex(array, x => x === 3, -0.5)).toBe(5);
   });
 
   it(`\`findLastIndex\` with \`NaN\` \`fromIndex\` should start from 0`, () => {

--- a/src/compat/array/findLastIndex.spec.ts
+++ b/src/compat/array/findLastIndex.spec.ts
@@ -110,6 +110,15 @@ describe('findLastIndex', () => {
     expect(findLastIndex(array, x => x === 3, -0.5)).toBe(5);
   });
 
+  it(`\`findLastIndex\` should coerce a non-numeric \`fromIndex\` like lodash`, () => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(findLastIndex(array, x => x === 1, '-2')).toBe(3);
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(findLastIndex(array, x => x === 1, 'abc')).toBe(0);
+  });
+
   it(`\`findLastIndex\` with \`NaN\` \`fromIndex\` should start from 0`, () => {
     // Lodash coerces `NaN` via `toInteger`, so `fromIndex` becomes `0` and the
     // search still covers the first element. The existing falsey test uses a

--- a/src/compat/array/findLastIndex.ts
+++ b/src/compat/array/findLastIndex.ts
@@ -1,6 +1,7 @@
 import { identity } from '../../function/identity.ts';
 import { ListIterateeCustom } from '../_internal/ListIterateeCustom.ts';
 import { toArray } from '../_internal/toArray.ts';
+import { toInteger } from '../compat.ts';
 import { property } from '../object/property.ts';
 import { matches } from '../predicate/matches.ts';
 import { matchesProperty } from '../predicate/matchesProperty.ts';
@@ -61,13 +62,11 @@ export function findLastIndex<T>(
   if (!arr) {
     return -1;
   }
-  if (Number.isNaN(fromIndex)) {
-    fromIndex = 0;
-  }
+  const index = toInteger(fromIndex);
   if (fromIndex < 0) {
-    fromIndex = Math.max(arr.length + fromIndex, 0);
+    fromIndex = Math.max(arr.length + index, 0);
   } else {
-    fromIndex = Math.min(fromIndex, arr.length - 1);
+    fromIndex = Math.min(index, arr.length - 1);
   }
 
   const subArray = toArray(arr).slice(0, fromIndex + 1);


### PR DESCRIPTION
## Summary

`findLastIndex()` in `es-toolkit/compat` does not run `fromIndex` through `toInteger()` the way Lodash does, so a negative fraction or a non-numeric value makes the search start from a different index.

```js
const array = [1, 2, 3, 1, 2, 3];

findLastIndex(array, x => x === 3, -1.5);
// Lodash: 5, es-toolkit/compat: 2

findLastIndex(array, x => x === 1, '-2');
// Lodash: 3, es-toolkit/compat: -1

findLastIndex(array, x => x === 1, 'abc');
// Lodash: 0, es-toolkit/compat: -1
```

The difference comes from where the truncation happens.
- `lodash.js` converts `fromIndex` with `toInteger()` before adding it to `arr.length`.
- `es-toolkit/compat` adds the raw value instead.

With `-1.5` on a six-element array, `lodash.js` starts at `6 + (-1) = 5`, while `es-toolkit/compat` gets `6 + (-1.5) = 4.5` and `slice(0, 4.5 + 1)` stops at index 4, one short.

Non-numeric values break for a different reason. `+` concatenates instead of adding, so `6 + '-2'` is `'6-2'`, which is `NaN` and leaves nothing to search.


## Changes

<!-- What you changed, in bullet points. -->

- Convert `fromIndex` with `toInteger` before using it to compute the search range.
- Add tests for negative fractional and non-numeric `fromIndex`.