### PR TITLE
fix(omitBy, pickBy): preserve record return types

### DIFF
--- a/src/object/omitBy.spec.ts
+++ b/src/object/omitBy.spec.ts
@@ -54,16 +54,35 @@ describe('omitBy', () => {
   it('should type number index signature keys as numeric strings', () => {
     const obj: Record<number, string> = { 1: 'keep', 2: 'omit' };
 
-    omitBy(obj, (_value, key) => {
+    const result = omitBy(obj, (_value, key) => {
       expectTypeOf(key).toEqualTypeOf<`${number}`>();
       return key === '2';
     });
+
+    expectTypeOf(result).toEqualTypeOf<Record<number, string>>();
+  });
+
+  it('should preserve string index signatures', () => {
+    const obj: Record<string, number> = { a: 1, b: 2 };
+    const result = omitBy(obj, value => value === 2);
+
+    expectTypeOf(result).toEqualTypeOf<Record<string, number>>();
+  });
+
+  it('should not preserve required properties alongside an index signature', () => {
+    const obj: Record<string, number> & { required: number } = { required: 1, other: 2 };
+    const result = omitBy(obj, (_value, key) => key === 'required');
+
+    expectTypeOf(result).toEqualTypeOf<Record<string, number>>();
+    expect(result).toEqual({ other: 2 });
   });
 
   it('should preserve string literal key types', () => {
-    omitBy({ a: 1, b: 2 }, (_value, key) => {
+    const result = omitBy({ a: 1, b: 2 }, (_value, key) => {
       expectTypeOf(key).toEqualTypeOf<'a' | 'b'>();
       return false;
     });
+
+    expectTypeOf(result).toEqualTypeOf<Partial<{ a: number; b: number }>>();
   });
 });

--- a/src/object/omitBy.ts
+++ b/src/object/omitBy.ts
@@ -1,5 +1,11 @@
 import type { ObjectKeys } from '../types/ObjectKeys.ts';
 
+type OmitByResult<T> = string extends keyof T
+  ? Record<string, T[string & keyof T]>
+  : number extends keyof T
+    ? Record<number, T[number & keyof T]>
+    : Partial<T>;
+
 /**
  * Creates a new object composed of the properties that do not satisfy the predicate function.
  *
@@ -22,7 +28,7 @@ import type { ObjectKeys } from '../types/ObjectKeys.ts';
 export function omitBy<T extends Record<string, any>>(
   obj: T,
   shouldOmit: (value: T[keyof T], key: ObjectKeys<T>) => boolean
-): Partial<T> {
+): OmitByResult<T> {
   const result: Partial<T> = {};
 
   const keys = Object.keys(obj) as Array<ObjectKeys<T>>;
@@ -37,5 +43,5 @@ export function omitBy<T extends Record<string, any>>(
     }
   }
 
-  return result;
+  return result as OmitByResult<T>;
 }

--- a/src/object/pickBy.spec.ts
+++ b/src/object/pickBy.spec.ts
@@ -54,16 +54,35 @@ describe('pickBy', () => {
   it('should type number index signature keys as numeric strings', () => {
     const obj: Record<number, string> = { 1: 'skip', 2: 'pick' };
 
-    pickBy(obj, (_value, key) => {
+    const result = pickBy(obj, (_value, key) => {
       expectTypeOf(key).toEqualTypeOf<`${number}`>();
       return key === '2';
     });
+
+    expectTypeOf(result).toEqualTypeOf<Record<number, string>>();
+  });
+
+  it('should preserve string index signatures', () => {
+    const obj: Record<string, number> = { a: 1, b: 2 };
+    const result = pickBy(obj, value => value === 2);
+
+    expectTypeOf(result).toEqualTypeOf<Record<string, number>>();
+  });
+
+  it('should not preserve required properties alongside an index signature', () => {
+    const obj: Record<string, number> & { required: number } = { required: 1, other: 2 };
+    const result = pickBy(obj, (_value, key) => key !== 'required');
+
+    expectTypeOf(result).toEqualTypeOf<Record<string, number>>();
+    expect(result).toEqual({ other: 2 });
   });
 
   it('should preserve string literal key types', () => {
-    pickBy({ a: 1, b: 2 }, (_value, key) => {
+    const result = pickBy({ a: 1, b: 2 }, (_value, key) => {
       expectTypeOf(key).toEqualTypeOf<'a' | 'b'>();
       return true;
     });
+
+    expectTypeOf(result).toEqualTypeOf<Partial<{ a: number; b: number }>>();
   });
 });

--- a/src/object/pickBy.ts
+++ b/src/object/pickBy.ts
@@ -1,5 +1,11 @@
 import type { ObjectKeys } from '../types/ObjectKeys.ts';
 
+type PickByResult<T> = string extends keyof T
+  ? Record<string, T[string & keyof T]>
+  : number extends keyof T
+    ? Record<number, T[number & keyof T]>
+    : Partial<T>;
+
 /**
  * Creates a new object composed of the properties that satisfy the predicate function.
  *
@@ -22,7 +28,7 @@ import type { ObjectKeys } from '../types/ObjectKeys.ts';
 export function pickBy<T extends Record<string, any>>(
   obj: T,
   shouldPick: (value: T[keyof T], key: ObjectKeys<T>) => boolean
-): Partial<T> {
+): PickByResult<T> {
   const result: Partial<T> = {};
 
   const keys = Object.keys(obj) as Array<ObjectKeys<T>>;
@@ -36,5 +42,5 @@ export function pickBy<T extends Record<string, any>>(
     }
   }
 
-  return result;
+  return result as PickByResult<T>;
 }


### PR DESCRIPTION
## Summary

Fixes #1987.

`omitBy` and `pickBy` currently wrap every result in `Partial<T>`. For string and number index signatures, that unnecessarily adds `undefined` to the value type and makes the result incompatible with the original record type.

## Changes

- Preserve string and number index signatures in the return type
- Keep `Partial<T>` for objects with a fixed set of keys
- Avoid preserving required properties that can be removed from types that also have an index signature
- Add type coverage for string records, number records, fixed-key objects, and mixed index-signature types

## Test results

- `yarn vitest run src/object/omitBy.spec.ts src/object/pickBy.spec.ts`: 20 tests passed
- `yarn vitest run`: passed
- `yarn typecheck`: passed
- ESLint on changed files: 0 errors