### PR TITLE
fix[differenceWith, without]: normalize `-0` to `0` like lodash

### DIFF
--- a/src/compat/array/differenceWith.spec.ts
+++ b/src/compat/array/differenceWith.spec.ts
@@ -32,7 +32,7 @@ describe('differenceWith', () => {
 
     expect(actual).toEqual([[], []]);
 
-    expect(differenceWith([-0, 1], [1])).toEqual([-0]);
+    expect(differenceWith([-0, 1], [1])).toEqual([0]);
   });
 
   it(`should match \`NaN\``, () => {
@@ -64,7 +64,7 @@ describe('differenceWith', () => {
     expect(actual).toEqual([[], []]);
 
     const largeArray = times(LARGE_ARRAY_SIZE, stubOne);
-    expect(differenceWith([-0, 1], largeArray)).toEqual([-0]);
+    expect(differenceWith([-0, 1], largeArray)).toEqual([0]);
   });
 
   it(`should work with large arrays of \`NaN\``, () => {
@@ -117,5 +117,10 @@ describe('differenceWith', () => {
     const actual = others.map(other => differenceWith(array, other, eq).map(toString));
 
     expect(actual).toEqual(expected);
+  });
+
+  it('should normalize `-0` to `0` like lodash', () => {
+    expect(differenceWith([-0, 1], [1])).toEqual([0]);
+    expect(differenceWith([-0], [])).toEqual([0]);
   });
 });

--- a/src/compat/array/differenceWith.ts
+++ b/src/compat/array/differenceWith.ts
@@ -2,6 +2,7 @@ import { last } from './last.ts';
 import { difference as differenceToolkit } from '../../array/difference.ts';
 import { differenceWith as differenceWithToolkit } from '../../array/differenceWith.ts';
 import { flattenArrayLike } from '../_internal/flattenArrayLike.ts';
+import { normalizeZero } from '../_internal/normalizeZero.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 
 /**
@@ -153,5 +154,5 @@ export function differenceWith<T>(
     return differenceWithToolkit(Array.from(array), flattenedValues, comparator);
   }
 
-  return differenceToolkit(Array.from(array), flattenedValues);
+  return differenceToolkit(Array.from(array), flattenedValues).map(normalizeZero);
 }

--- a/src/compat/array/without.spec.ts
+++ b/src/compat/array/without.spec.ts
@@ -41,4 +41,9 @@ describe('without', () => {
     expect(without('123', '1', '2')).toEqual([]);
     expect(without(args, 1, 2)).toEqual([3]);
   });
+
+  it('should normalize `-0` to `0` like lodash', () => {
+    expect(without([-0, 1], 1)).toEqual([0]);
+    expect(without([-0])).toEqual([0]);
+  });
 });

--- a/src/compat/array/without.ts
+++ b/src/compat/array/without.ts
@@ -1,4 +1,4 @@
-import { without as withoutToolkit } from '../../array/without.ts';
+import { normalizeZero } from '../_internal/normalizeZero.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 
 /**
@@ -25,5 +25,17 @@ export function without<T>(array: ArrayLike<T> | null | undefined, ...values: T[
   if (!isArrayLikeObject(array)) {
     return [];
   }
-  return withoutToolkit(Array.from(array), ...values);
+
+  const valuesSet = new Set(values);
+  const result: T[] = [];
+
+  for (let i = 0; i < array.length; i++) {
+    const value = array[i];
+
+    if (!valuesSet.has(value)) {
+      result.push(normalizeZero(value));
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary

`differenceWith` and `without` in `es-toolkit/compat` do not normalize `-0` to `0` when they are called without a comparator, while Lodash does.

```js
import lodash from 'lodash';
import * as compat from 'es-toolkit/compat';

lodash.differenceWith([-0, 1], [1]); // [0]
compat.differenceWith([-0, 1], [1]); // [-0]

lodash.without([-0, 1], 1); // [0]
compat.without([-0, 1], 1); // [-0]
```

Lodash normalizes the value inside `baseDifference`, so the sign is dropped only when no comparator is given:

```js
value = (comparator || value !== 0) ? value : 0;
```

With a comparator Lodash keeps `-0`, and compat already matched that:

```js
lodash.differenceWith([-0, 1], [1], (a, b) => a === b); // [-0]
compat.differenceWith([-0, 1], [1], (a, b) => a === b); // [-0]
```

This is the same inconsistency #2007 fixed for `difference`, `differenceBy`, `uniqBy` and `unionBy`; these two functions were not covered by it. The fix reuses the `normalizeZero` helper that PR added.

While checking the ported Lodash test, I noticed two assertions in `differenceWith.spec.ts` had been relaxed to expect the current compat output. Lodash's own `difference-methods` test asserts `'0'` for both, so they are corrected here:

```js
// before
expect(differenceWith([-0, 1], [1])).toEqual([-0]);
expect(differenceWith([-0, 1], largeArray)).toEqual([-0]);

// after
expect(differenceWith([-0, 1], [1])).toEqual([0]);
expect(differenceWith([-0, 1], largeArray)).toEqual([0]);
```

## Changes

- `differenceWith`: apply `normalizeZero` on the no-comparator branch only, the same way `difference` does. The comparator branch is untouched.

  ```js
  return differenceToolkit(Array.from(array), flattenedValues).map(normalizeZero);
  ```

- `without`: normalize while filtering, in a single pass over the input, instead of mapping over the result (see the benchmark below).

  ```js
  const valuesSet = new Set(values);
  const result: T[] = [];

  for (let i = 0; i < array.length; i++) {
    const value = array[i];

    if (!valuesSet.has(value)) {
      result.push(normalizeZero(value));
    }
  }

  return result;
  ```

- `differenceWith.spec.ts`: restore the two relaxed assertions to `[0]` and add a regression test.
- `without.spec.ts`: add a regression test.

## Benchmark results

`without` runs in a hot path, so I measured it. Appending `.map(normalizeZero)` to the existing delegation cost about 18%, so the normalization is folded into a single pass that also drops the `Array.from` copy. That ends up faster than `main`.

| benchmark | `main` | this branch | |
| --- | --- | --- | --- |
| `without`, small arrays | 7,944,478 hz | 8,948,482 hz | +12.6% |
| `without`, large arrays | 5,662 hz | 5,805 hz | +2.5% |
| `differenceWith` | 8,454,317 hz | 8,475,595 hz | within noise |
| `differenceWith/largeArray` | 15.54 hz | 15.95 hz | within noise |

**`main`**

```text
· es-toolkit/compat/without         7,944,478.46 hz  ±0.66%   (without, small arrays)
· es-toolkit/compat/without             5,662.28 hz  ±0.49%   (without, large arrays)
· es-toolkit/compat/differenceWith  8,454,317.41 hz  ±0.73%   (differenceWith)
· es-toolkit/compat/differenceWith         15.54 hz  ±3.06%   (differenceWith/largeArray)
```

**this branch**

```text
· es-toolkit/compat/without         8,948,482.57 hz  ±0.63%   (without, small arrays)
· es-toolkit/compat/without             5,804.63 hz  ±0.40%   (without, large arrays)
· es-toolkit/compat/differenceWith  8,475,595.39 hz  ±0.78%   (differenceWith)
· es-toolkit/compat/differenceWith         15.95 hz  ±0.78%   (differenceWith/largeArray)
```

Note that `differenceWith.bench.ts` always passes a comparator, so it does not exercise the branch this PR touches. I measured that branch separately and `.map(normalizeZero)` was not measurable there, since flattening the values dominates.
