### PR TITLE
fix[attempt, attemptAsync]: default error type parameter to unknown

### DIFF
--- a/src/util/attempt.spec.ts
+++ b/src/util/attempt.spec.ts
@@ -15,6 +15,12 @@ describe('attempt', () => {
     ).toEqual([new Error('test'), null]);
   });
 
+  it('should accept a single type argument for the result type', () => {
+    const [error, names] = attempt<string[]>(() => ['Alice', 'Bob']);
+    expect(error).toBeNull();
+    expect(names).toEqual(['Alice', 'Bob']);
+  });
+
   it('should return the result of the promise', async () => {
     const [error, result] = attempt(async () => 1);
     expect(error).toBeNull();

--- a/src/util/attempt.ts
+++ b/src/util/attempt.ts
@@ -37,7 +37,7 @@
  * });
  * ```
  */
-export function attempt<T, E>(func: () => T): [null, T] | [E, null] {
+export function attempt<T, E = unknown>(func: () => T): [null, T] | [E, null] {
   try {
     return [null, func()];
   } catch (error) {

--- a/src/util/attemptAsync.spec.ts
+++ b/src/util/attemptAsync.spec.ts
@@ -38,6 +38,12 @@ describe('attemptAsync', () => {
     expect(result).toBe(30);
   });
 
+  it('should accept a single type argument for the result type', async () => {
+    const [error, result] = await attemptAsync<number[]>(async () => [1, 2, 3]);
+    expect(error).toBeNull();
+    expect(result).toEqual([1, 2, 3]);
+  });
+
   it('should work with non-Error thrown objects', async () => {
     const [error, result] = await attemptAsync(async () => {
       throw 'string error'; // Not an Error instance

--- a/src/util/attemptAsync.ts
+++ b/src/util/attemptAsync.ts
@@ -30,7 +30,7 @@
  * });
  * // users is typed as User[]
  */
-export async function attemptAsync<T, E>(func: () => Promise<T>): Promise<[null, T] | [E, null]> {
+export async function attemptAsync<T, E = unknown>(func: () => Promise<T>): Promise<[null, T] | [E, null]> {
   try {
     const result = await func();
     return [null, result];


### PR DESCRIPTION
## Summary

The documented usage `attempt<string[]>(...)` and `attemptAsync<User[]>(...)` fails to type-check with `TS2558: Expected 2 type arguments, but got 1`, because both functions declare two type parameters (`T`, `E`) and TypeScript does not support partial type argument inference.

fixes #2050

## Changes

- Add a default to the error type parameter (`E = unknown`) in `attempt` and `attemptAsync`, so supplying only the result type argument — as shown in the reference docs — compiles.
- Add tests exercising the single-type-argument usage so a regression fails the build.

`unknown` matches what `E` was already inferred as when no type arguments were given, so existing call sites are unaffected.