### PR TITLE
fix(add,subtract,multiply,divide): match Lodash on null operands

### DIFF
--- a/benchmarks/bundle-size/add.spec.ts
+++ b/benchmarks/bundle-size/add.spec.ts
@@ -9,6 +9,6 @@ describe('add bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'add');
-    expect(bundleSize).toMatchInlineSnapshot(`495`);
+    expect(bundleSize).toMatchInlineSnapshot(`537`);
   });
 });

--- a/src/compat/math/add.spec.ts
+++ b/src/compat/math/add.spec.ts
@@ -58,6 +58,26 @@ describe('add', () => {
     expect(add(undefined, 4)).toBe(4);
   });
 
+  it(`\`add\` should treat \`null\` operands like Lodash`, () => {
+    // A `null` operand next to a string is stringified as `'null'`, not `''`.
+    // @ts-expect-error - invalid arguments
+    expect(add(null, '1')).toBe('null1');
+    // @ts-expect-error - invalid arguments
+    expect(add('1', null)).toBe('1null');
+    // @ts-expect-error - invalid arguments
+    expect(add(null, 'a')).toBe('nulla');
+    // A present `null` must win over a missing `undefined`.
+    // @ts-expect-error - invalid arguments
+    expect(add(null, undefined)).toBe(null);
+    // @ts-expect-error - invalid arguments
+    expect(add(undefined, null)).toBe(null);
+    // A `null` operand coerces to `0` in the numeric path.
+    // @ts-expect-error - invalid arguments
+    expect(add(null, 3)).toBe(3);
+    // @ts-expect-error - invalid arguments
+    expect(add(null, null)).toBe(0);
+  });
+
   it(`\`add\` should preserve the sign of \`0\``, () => {
     const values = [0, '0', -0, '-0'];
     const expected = [

--- a/src/compat/math/add.ts
+++ b/src/compat/math/add.ts
@@ -21,11 +21,15 @@ export function add(value: number, other: number): number {
     return 0;
   }
   if (value === undefined || other === undefined) {
-    return value ?? other;
+    // Only `undefined` is treated as a missing argument. A `null` operand is a
+    // real value and must be returned as-is (matches Lodash).
+    return (value === undefined ? other : value) as number;
   }
   if (typeof value === 'string' || typeof other === 'string') {
-    value = toString(value) as any;
-    other = toString(other) as any;
+    // Lodash concatenates using `baseToString`, which stringifies `null` as
+    // `'null'` (unlike `toString`, which returns `''` for nullish values).
+    value = (value === null ? 'null' : toString(value)) as any;
+    other = (other === null ? 'null' : toString(other)) as any;
   } else {
     value = toNumber(value);
     other = toNumber(other);

--- a/src/compat/math/divide.spec.ts
+++ b/src/compat/math/divide.spec.ts
@@ -37,6 +37,23 @@ describe('divide', () => {
     expect(divide(undefined, 4)).toBe(4);
   });
 
+  it(`should treat \`null\` operands like Lodash`, () => {
+    // A `null` operand next to a string is stringified as `'null'`, so the
+    // division yields `NaN` (not `0`/`Infinity` from an empty-string coercion).
+    // @ts-expect-error - invalid arguments
+    expect(divide(null, '1')).toBe(NaN);
+    // @ts-expect-error - invalid arguments
+    expect(divide('1', null)).toBe(NaN);
+    // A present `null` must win over a missing `undefined`.
+    // @ts-expect-error - invalid arguments
+    expect(divide(null, undefined)).toBe(null);
+    // @ts-expect-error - invalid arguments
+    expect(divide(undefined, null)).toBe(null);
+    // A `null` operand coerces to `0` in the numeric path.
+    // @ts-expect-error - invalid arguments
+    expect(divide(null, 3)).toBe(0);
+  });
+
   it(`should preserve the sign of \`0\``, () => {
     const values = [0, '0', -0, '-0'];
     const expected = [

--- a/src/compat/math/divide.ts
+++ b/src/compat/math/divide.ts
@@ -22,12 +22,16 @@ export function divide(value: number, other: number): number {
   }
 
   if (value === undefined || other === undefined) {
-    return value ?? other;
+    // Only `undefined` is treated as a missing argument. A `null` operand is a
+    // real value and must be returned as-is (matches Lodash).
+    return (value === undefined ? other : value) as number;
   }
 
   if (typeof value === 'string' || typeof other === 'string') {
-    value = toString(value) as any;
-    other = toString(other) as any;
+    // Lodash coerces using `baseToString`, which stringifies `null` as `'null'`
+    // (unlike `toString`, which returns `''` for nullish values).
+    value = (value === null ? 'null' : toString(value)) as any;
+    other = (other === null ? 'null' : toString(other)) as any;
   } else {
     value = toNumber(value);
     other = toNumber(other);

--- a/src/compat/math/multiply.spec.ts
+++ b/src/compat/math/multiply.spec.ts
@@ -62,6 +62,23 @@ describe('multiply', () => {
     expect(multiply(undefined, 4)).toBe(4);
   });
 
+  it(`\`multiply\` should treat \`null\` operands like Lodash`, () => {
+    // A `null` operand next to a string is stringified as `'null'`, so the
+    // product yields `NaN` (not `0` from an empty-string coercion).
+    // @ts-expect-error - invalid arguments
+    expect(multiply(null, '1')).toBe(NaN);
+    // @ts-expect-error - invalid arguments
+    expect(multiply('1', null)).toBe(NaN);
+    // A present `null` must win over a missing `undefined`.
+    // @ts-expect-error - invalid arguments
+    expect(multiply(null, undefined)).toBe(null);
+    // @ts-expect-error - invalid arguments
+    expect(multiply(undefined, null)).toBe(null);
+    // A `null` operand coerces to `0` in the numeric path.
+    // @ts-expect-error - invalid arguments
+    expect(multiply(null, 3)).toBe(0);
+  });
+
   it(`\`multiply\` should preserve the sign of \`0\``, () => {
     const values = [0, '0', -0, '-0'];
     const expected = [

--- a/src/compat/math/multiply.ts
+++ b/src/compat/math/multiply.ts
@@ -23,12 +23,16 @@ export function multiply(value: number, other: number): number {
   }
 
   if (value === undefined || other === undefined) {
-    return value ?? other;
+    // Only `undefined` is treated as a missing argument. A `null` operand is a
+    // real value and must be returned as-is (matches Lodash).
+    return (value === undefined ? other : value) as number;
   }
 
   if (typeof value === 'string' || typeof other === 'string') {
-    value = toString(value) as any;
-    other = toString(other) as any;
+    // Lodash coerces using `baseToString`, which stringifies `null` as `'null'`
+    // (unlike `toString`, which returns `''` for nullish values).
+    value = (value === null ? 'null' : toString(value)) as any;
+    other = (other === null ? 'null' : toString(other)) as any;
   } else {
     value = toNumber(value);
     other = toNumber(other);

--- a/src/compat/math/subtract.spec.ts
+++ b/src/compat/math/subtract.spec.ts
@@ -59,6 +59,23 @@ describe('subtract', () => {
     expect(subtract(undefined, 4)).toBe(4);
   });
 
+  it(`\`subtract\` should treat \`null\` operands like Lodash`, () => {
+    // A `null` operand next to a string is stringified as `'null'`, so the
+    // subtraction yields `NaN` (not `-1` from an empty-string coercion).
+    // @ts-expect-error - invalid arguments
+    expect(subtract(null, '1')).toBe(NaN);
+    // @ts-expect-error - invalid arguments
+    expect(subtract('1', null)).toBe(NaN);
+    // A present `null` must win over a missing `undefined`.
+    // @ts-expect-error - invalid arguments
+    expect(subtract(null, undefined)).toBe(null);
+    // @ts-expect-error - invalid arguments
+    expect(subtract(undefined, null)).toBe(null);
+    // A `null` operand coerces to `0` in the numeric path.
+    // @ts-expect-error - invalid arguments
+    expect(subtract(null, 3)).toBe(-3);
+  });
+
   it(`\`subtract\` should preserve the sign of \`0\``, () => {
     const values = [0, '0', -0, '-0'];
     const expected = [

--- a/src/compat/math/subtract.ts
+++ b/src/compat/math/subtract.ts
@@ -20,11 +20,15 @@ export function subtract(value: number, other: number): number {
     return 0;
   }
   if (value === undefined || other === undefined) {
-    return value ?? other;
+    // Only `undefined` is treated as a missing argument. A `null` operand is a
+    // real value and must be returned as-is (matches Lodash).
+    return (value === undefined ? other : value) as number;
   }
   if (typeof value === 'string' || typeof other === 'string') {
-    value = toString(value) as any;
-    other = toString(other) as any;
+    // Lodash coerces using `baseToString`, which stringifies `null` as `'null'`
+    // (unlike `toString`, which returns `''` for nullish values).
+    value = (value === null ? 'null' : toString(value)) as any;
+    other = (other === null ? 'null' : toString(other)) as any;
   } else {
     value = toNumber(value);
     other = toNumber(other);


### PR DESCRIPTION
## The difference (as code)

`es-toolkit/compat`'s math operations disagree with Lodash when an operand is `null`:

```js
add(null, '1')        // lodash: 'null1'  es-toolkit: '1'
add('1', null)        // lodash: '1null'  es-toolkit: '1'
add(null, undefined)  // lodash: null     es-toolkit: undefined
subtract(null, '1')   // lodash: NaN      es-toolkit: -1
multiply(null, '1')   // lodash: NaN      es-toolkit: 0
divide('1', null)     // lodash: NaN      es-toolkit: Infinity
```

## Cause

Two issues shared by all four functions:

1. `value ?? other` treated a present `null` as a missing argument; only `undefined` should be treated as missing (so `add(null, undefined)` should return `null`, not `undefined`).
2. The string branch used the public `toString` (`null` → `''`) instead of Lodash's `baseToString` (`null` → `'null'`), which is why the numeric ops silently coerced `null` to `''` and produced wrong numbers instead of `NaN`.

## Changes

- Select the defined operand with an explicit `undefined` check instead of `??`.
- Coerce a `null` operand to `'null'` in the string branch, matching Lodash's `baseToString`.
- Added regression tests covering `null` operands for all four functions (they fail on `main`).
