### PR TITLE
fix[xorWith]: match lodash when no comparator is given

### DIFF
--- a/src/compat/array/xorWith.spec.ts
+++ b/src/compat/array/xorWith.spec.ts
@@ -66,4 +66,22 @@ describe('xorWith', () => {
 
     expect(actual).toEqual([objects[1], others[0]]);
   });
+
+  it('should match `NaN` like lodash when no `comparator` is given', () => {
+    expect(xorWith([NaN], [NaN])).toEqual([]);
+    expect(xorWith([1, NaN], [2, NaN])).toEqual([1, 2]);
+    expect(xorWith([NaN, NaN], [1])).toEqual([NaN, 1]);
+  });
+
+  it('should normalize `-0` to `0` like lodash when no `comparator` is given', () => {
+    expect(xorWith([-0, 1], [1])).toEqual([0]);
+    expect(xorWith([-0])).toEqual([0]);
+  });
+
+  it('should keep the `comparator` semantics when one is given', () => {
+    const eq = (a: number, b: number) => a === b;
+
+    expect(xorWith([NaN], [NaN], eq)).toEqual([NaN, NaN]);
+    expect(xorWith([-0, 1], [1], eq)).toEqual([-0]);
+  });
 });

--- a/src/compat/array/xorWith.ts
+++ b/src/compat/array/xorWith.ts
@@ -2,6 +2,7 @@ import { differenceWith } from './differenceWith.ts';
 import { intersectionWith } from './intersectionWith.ts';
 import { last } from './last.ts';
 import { unionWith } from './unionWith.ts';
+import { xor } from './xor.ts';
 import { windowed } from '../../array/windowed.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 
@@ -88,14 +89,14 @@ export function xorWith<T>(
 export function xorWith<T>(...values: Array<ArrayLike<T> | null | undefined | ((a: T, b: T) => boolean)>): T[] {
   const lastValue = last(values);
 
-  let comparator = (a: T, b: T) => a === b;
-
-  if (typeof lastValue === 'function') {
-    comparator = lastValue as (a: T, b: T) => boolean;
-    values = values.slice(0, -1);
+  // Without a comparator lodash runs plain `baseXor`, which compares with
+  // SameValueZero and normalizes `-0`. That is exactly what `xor` does.
+  if (typeof lastValue !== 'function') {
+    return xor(...(values as Array<ArrayLike<T> | null | undefined>));
   }
 
-  const arrays = values.filter(isArrayLikeObject) as T[][];
+  const comparator = lastValue as (a: T, b: T) => boolean;
+  const arrays = values.slice(0, -1).filter(isArrayLikeObject) as T[][];
 
   // eslint-disable-next-line
   // @ts-ignore


### PR DESCRIPTION
## Summary

`xorWith` in `es-toolkit/compat` defaults its comparator to `(a, b) => a === b` when none is given. Lodash does not use a comparator at all in that case — it runs plain `baseXor`, which compares with SameValueZero and normalizes `-0`. So `NaN` never matches itself in compat, and the sign of `0` survives:

```js
import lodash from 'lodash';
import * as compat from 'es-toolkit/compat';

lodash.xorWith([NaN], [NaN]); // []
compat.xorWith([NaN], [NaN]); // [NaN, NaN]

lodash.xorWith([1, NaN], [2, NaN]); // [1, 2]
compat.xorWith([1, NaN], [2, NaN]); // [1, NaN, 2, NaN]

lodash.xorWith([-0, 1], [1]); // [0]
compat.xorWith([-0, 1], [1]); // [-0]
```

I compared 30 no-comparator cases at runtime. Lodash's `xorWith` returned exactly what lodash's `xor` returned in all 30, and compat's `xor` already matched lodash in all 30 as well. compat's `xorWith` differed in 11 of them.

The comparator branch is unaffected — lodash deliberately keeps `-0` and treats `NaN` as distinct there, and compat already matched:

```js
lodash.xorWith([NaN], [NaN], (a, b) => a === b); // [NaN, NaN]
compat.xorWith([NaN], [NaN], (a, b) => a === b); // [NaN, NaN]

lodash.xorWith([-0, 1], [1], (a, b) => a === b); // [-0]
compat.xorWith([-0, 1], [1], (a, b) => a === b); // [-0]
```

## Changes

`xorWith`: delegate to `xor` when the last argument is not a function.

```js
export function xorWith(...values) {
  const lastValue = last(values);

  // Without a comparator lodash runs plain `baseXor`, which compares with
  // SameValueZero and normalizes `-0`. That is exactly what `xor` does.
  if (typeof lastValue !== 'function') {
    return xor(...values);
  }

  const comparator = lastValue;
  const arrays = values.slice(0, -1).filter(isArrayLikeObject);

  // ... unchanged comparator path
}
```

`xorWith.spec.ts`: add regression tests for `NaN` and `-0` without a comparator, and one asserting the comparator branch keeps its current semantics.

```js
it('should match `NaN` like lodash when no `comparator` is given', () => {
  expect(xorWith([NaN], [NaN])).toEqual([]);
  expect(xorWith([1, NaN], [2, NaN])).toEqual([1, 2]);
  expect(xorWith([NaN, NaN], [1])).toEqual([NaN, 1]);
});

it('should normalize `-0` to `0` like lodash when no `comparator` is given', () => {
  expect(xorWith([-0, 1], [1])).toEqual([0]);
  expect(xorWith([-0])).toEqual([0]);
});

it('should keep the `comparator` semantics when one is given', () => {
  const eq = (a: number, b: number) => a === b;

  expect(xorWith([NaN], [NaN], eq)).toEqual([NaN, NaN]);
  expect(xorWith([-0, 1], [1], eq)).toEqual([-0]);
});
```

## Benchmark results

Delegating also removes the `unionWith` / `intersectionWith` / `differenceWith` chain from this path, which compared every pair through the comparator. `xor` is Set/Map based:

| benchmark | `main` | this branch | |
| --- | --- | --- | --- |
| no comparator, 10,000 × 2 | 3.61 hz | 631.35 hz | ~175× |
| no comparator, small | 1,721,150 hz | 1,859,538 hz | +8% |
| comparator, small | 2,063,366 hz | 2,057,688 hz | unchanged |
| comparator, large | 0.4805 hz | 0.4725 hz | unchanged |

`xorWith.bench.ts` always passes a comparator, so it does not exercise the branch this PR changes. The no-comparator rows come from this benchmark, which I ran locally rather than adding to the repo:

```js
describe('xorWith no-comparator, large', () => {
  const a = Array.from({ length: 10000 }, (_, i) => i);
  const b = Array.from({ length: 10000 }, (_, i) => i + 5000);

  bench('es-toolkit/compat/xorWith', () => {
    xorWithCompat(a, b);
  });

  bench('lodash/xorWith', () => {
    xorWithLodash(a, b);
  });
});
```

The comparator rows are medians of three runs of the existing benchmark.
