### PR TITLE
docs: fix typos and Deno install commands

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To get started:
 
 ## 1. Our Design Principles
 
-Note that we value performance, simplicity of implementation, and detailed documentations. We do not aim for supporting a variety of features and options. Our goal is to provide a small set of performant and well-functioning utilities.
+Note that we value performance, simplicity of implementation, and detailed documentation. We do not aim for supporting a variety of features and options. Our goal is to provide a small set of performant and well-functioning utilities.
 
 ### 1.1 Development Scope
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,7 +219,7 @@ We sincerely thank @SrAnthony and @umsungjun for their contributions. We appreci
 
 ## Version v1.46.0
 
-Released on April 22th, 2026.
+Released on April 22nd, 2026.
 
 - Changed `AbortError` and `TimeoutError` to extend `DOMException`. ([#1660])
 - Added `keyBy` to the `map` entrypoint exports. ([#1650])
@@ -390,7 +390,7 @@ We sincerely thank @dayongkr, @cobocho, @raon0211, and @D-Sketon for their contr
 
 ## Version v1.39.6
 
-Released on July 2th, 2025.
+Released on July 2nd, 2025.
 
 - Fixed handling of null/undefined values in `values` function.
 - Fixed type safety in `compat/get` by adding GetFieldType utility type.
@@ -1015,4 +1015,4 @@ Released on June 3rd, 2024.
 
 ## Version v1.0.2
 
-Initial release. Released on May 31th, 2024.
+Initial release. Released on May 31st, 2024.

--- a/docs/ja/usage.md
+++ b/docs/ja/usage.md
@@ -47,7 +47,7 @@ sum([1, 2, 3]);
 es-toolkitはDenoでも使用できます。[JSR](https://jsr.io/@es-toolkit/es-toolkit)から以下のコマンドでインストールしてください。
 
 ```sh
-deno add @es-toolkit/es-toolkit
+deno add jsr:@es-toolkit/es-toolkit
 ```
 
 Denoで使用する場合、JSRの制限により、NPMとは異なり追加のスコープが必要です。

--- a/docs/ko/compat/reference/predicate/isMatch.md
+++ b/docs/ko/compat/reference/predicate/isMatch.md
@@ -10,7 +10,7 @@ const result = isMatch(target, source);
 
 ### `isMatch(target, source)`
 
-객체나 배열이 다른 객체의 구조와 값에 부분적으로 일치하는지 확인할 때 `isMatch`를 사용하세요. 전체가 동일할 필요는 없고, source의 모든 프로퍼티가 target에 존재하고 같은 값을 가지면 되요.
+객체나 배열이 다른 객체의 구조와 값에 부분적으로 일치하는지 확인할 때 `isMatch`를 사용하세요. 전체가 동일할 필요는 없고, source의 모든 프로퍼티가 target에 존재하고 같은 값을 가지면 돼요.
 
 ```typescript
 import { isMatch } from 'es-toolkit/compat';

--- a/docs/ko/usage.md
+++ b/docs/ko/usage.md
@@ -47,7 +47,7 @@ sum([1, 2, 3]);
 es-toolkit을 Deno에서도 사용할 수 있어요. [JSR](https://jsr.io/@es-toolkit/es-toolkit)에서 아래 명령어로 설치하세요.
 
 ```sh
-deno add @es-toolkit/es-toolkit
+deno add jsr:@es-toolkit/es-toolkit
 ```
 
 Deno에서 사용하면, JSR에서의 제한으로 인해 NPM과 다르게 추가적인 Scope가 필요해요.

--- a/docs/zh_hans/usage.md
+++ b/docs/zh_hans/usage.md
@@ -47,7 +47,7 @@ sum([1, 2, 3]);
 es-toolkit 也可以通过 [JSR](https://jsr.io/@es-toolkit/es-toolkit) 安装到 Deno。使用以下命令安装 es-toolkit：
 
 ```sh
-deno add @es-toolkit/es-toolkit
+deno add jsr:@es-toolkit/es-toolkit
 ```
 
 请注意，根据 JSR 的限制，包名包含额外的作用域，与 npm 不同。


### PR DESCRIPTION
<!--
Thanks for contributing to es-toolkit!

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand what you submit. For this reason, **pull request descriptions from external contributors must be written by a human**.

## Title

Use the format `<type>[function names]: <description>`, for example `fix[chunk]: handle empty arrays`.
The type is one of feat, fix, docs, test, or chore. See .github/CONTRIBUTING.md#4-pull-requests

## Before you open this

Find your change below and go through its checklist. These are the only categories we accept — a rename or a rewrite that leaves the behavior unchanged is not one of them, and neither is a new function that has not been discussed yet. The reasoning behind each rule is in .github/CONTRIBUTING.md#41-what-we-accept

### Adding a new function

- [ ] A discussion proposing this function was accepted, and it is linked below. Without one we close the pull request, even when the implementation is good.
- [ ] The implementation, tests, a benchmark, and documentation in all four languages are included.

### Improving performance

- [ ] Benchmark results for `main` and for this branch are pasted under "Benchmark results". We cannot tell a real speedup from reading code, so a claim without numbers gets closed.

### Fixing behavior that differs from Lodash (es-toolkit/compat)

- [ ] The difference is written as code: the input, what Lodash returns for it, and what es-toolkit returns today.
- [ ] A test that fails without this change is included, so the behavior does not drift back later.
- [ ] Benchmark results are attached if the function runs in a hot path.

### Fixing a bug or the documentation

- [ ] Related issues are linked with `fixes #number`.
- [ ] Documentation changes are applied to all four languages: English, Korean, Japanese, and Simplified Chinese.
- [ ] Small documentation fixes are collected into this one pull request rather than split across several.

Now fill in the sections below.
-->

## Summary
Aligned the installation commands in the translated Deno usage guides with the English documentation and fixed several documentation and changelog typos found along the way.

## Changes

- Added the missing `jsr:` prefix to three translated `usage.md` files. Testing confirmed that Deno interpreted the package without the prefix as `npm:@es-toolkit/es-toolkit`, causing the installation to fail.

- Changed `documentations` to `documentation` in `CONTRIBUTING.md`.

- Fixed three incorrect date suffixes in `CHANGELOG.md`: `22th` → `22nd`, `2th` → `2nd`, and `31th` → `31st`.

- Fixed a Korean typo in `docs/ko/compat/reference/predicate/isMatch.md`: `되요` → `돼요`.


<!--
Only for performance changes: paste the benchmark output for `main` and for this branch. Delete this section otherwise.

No need to paste test output — CI runs the test suite on every pull request. Benchmarks are the exception, since nothing in CI runs them.
-->
