### PR TITLE
fix[ceil, floor, round]: coerce arguments like lodash

### DIFF
--- a/src/compat/_internal/decimalAdjust.ts
+++ b/src/compat/_internal/decimalAdjust.ts
@@ -12,7 +12,7 @@ export function decimalAdjust(
   }
   // lodash coerces the precision with `toInteger` and caps it at 292, rather
   // than parsing it as a decimal integer literal.
-  precision = precision == null ? 0 : Math.min(toInteger(precision), 292);
+  precision = Math.min(toInteger(precision), 292);
   if (precision && Number.isFinite(Number(number))) {
     const [magnitude, exponent = 0] = number.toString().split('e');
     let adjustedValue: string | number = Math[type](Number(`${magnitude}e${Number(exponent) + precision}`));

--- a/src/compat/_internal/decimalAdjust.ts
+++ b/src/compat/_internal/decimalAdjust.ts
@@ -1,13 +1,18 @@
+import { toInteger } from '../util/toInteger.ts';
+import { toNumber } from '../util/toNumber.ts';
+
 export function decimalAdjust(
   type: 'round' | 'floor' | 'ceil',
   number: number | string,
   precision: number | string = 0
 ): number {
-  number = Number(number);
+  number = toNumber(number);
   if (Object.is(number, -0)) {
     number = '-0';
   }
-  precision = Math.min(Number.parseInt(precision as string, 10), 292);
+  // lodash coerces the precision with `toInteger` and caps it at 292, rather
+  // than parsing it as a decimal integer literal.
+  precision = precision == null ? 0 : Math.min(toInteger(precision), 292);
   if (precision && Number.isFinite(Number(number))) {
     const [magnitude, exponent = 0] = number.toString().split('e');
     let adjustedValue: string | number = Math[type](Number(`${magnitude}e${Number(exponent) + precision}`));

--- a/src/compat/math/ceil.spec.ts
+++ b/src/compat/math/ceil.spec.ts
@@ -85,4 +85,36 @@ describe('ceil', () => {
     expect(ceil(5e-324, 323)).toBe(1e-292);
     expect(ceil(5e-324, -323)).toBe(0);
   });
+
+  it(`\`ceil\` should coerce \`precision\` with \`toInteger\` like lodash`, () => {
+    // Values that `toInteger` resolves to `0`, so no decimal adjustment happens.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(ceil(4.016, [1, 2, 3])).toBe(5);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(ceil(4.016, '2px')).toBe(5);
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(ceil(4.016, true)).toBe(4.1);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(ceil(4.016, '0x2')).toBe(4.02);
+
+    // Capped at `292`.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(ceil(4.016, '1e3')).toBe(4.016);
+    expect(ceil(4.016, Infinity)).toBe(4.016);
+  });
+
+  it(`\`ceil\` should coerce \`number\` with \`toNumber\` like lodash`, () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(ceil(Symbol('a'))).toBe(NaN);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(ceil(4.016, Symbol('a'))).toBe(5);
+  });
 });

--- a/src/compat/math/floor.spec.ts
+++ b/src/compat/math/floor.spec.ts
@@ -85,4 +85,36 @@ describe('floor', () => {
     expect(floor(5e-324, 323)).toBe(0);
     expect(floor(5e-324, -323)).toBe(0);
   });
+
+  it(`\`floor\` should coerce \`precision\` with \`toInteger\` like lodash`, () => {
+    // Values that `toInteger` resolves to `0`, so no decimal adjustment happens.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(floor(4.016, [1, 2, 3])).toBe(4);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(floor(4.016, '2px')).toBe(4);
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(floor(4.016, true)).toBe(4);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(floor(4.016, '0x2')).toBe(4.01);
+
+    // Capped at `292`.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(floor(4.016, '1e3')).toBe(4.016);
+    expect(floor(4.016, Infinity)).toBe(4.016);
+  });
+
+  it(`\`floor\` should coerce \`number\` with \`toNumber\` like lodash`, () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(floor(Symbol('a'))).toBe(NaN);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(floor(4.016, Symbol('a'))).toBe(4);
+  });
 });

--- a/src/compat/math/round.spec.ts
+++ b/src/compat/math/round.spec.ts
@@ -91,4 +91,36 @@ describe('round', () => {
     expect(round(5e-324, 323)).toBe(0);
     expect(round(5e-324, -323)).toBe(0);
   });
+
+  it(`\`round\` should coerce \`precision\` with \`toInteger\` like lodash`, () => {
+    // Values that `toInteger` resolves to `0`, so no decimal adjustment happens.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(round(4.016, [1, 2, 3])).toBe(4);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(round(4.016, '2px')).toBe(4);
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(round(4.016, true)).toBe(4);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(round(4.016, '0x2')).toBe(4.02);
+
+    // Capped at `292`.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(round(4.016, '1e3')).toBe(4.016);
+    expect(round(4.016, Infinity)).toBe(4.016);
+  });
+
+  it(`\`round\` should coerce \`number\` with \`toNumber\` like lodash`, () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(round(Symbol('a'))).toBe(NaN);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(round(4.016, Symbol('a'))).toBe(4);
+  });
 });


### PR DESCRIPTION
## Summary

`ceil`, `floor` and `round` share `decimalAdjust`, which coerces its arguments differently from Lodash. The precision is read with `Number.parseInt(precision, 10)` where Lodash uses `toInteger(precision)` capped at `292`, and the number is read with `Number(number)` where Lodash uses `toNumber(number)`.

```js
import lodash from 'lodash';
import * as compat from 'es-toolkit/compat';

lodash.ceil(4.016, true); // 4.1
compat.ceil(4.016, true); // 5

lodash.ceil(4.016, Infinity); // 4.016
compat.ceil(4.016, Infinity); // 5

lodash.ceil(4.016, [1, 2, 3]); // 5
compat.ceil(4.016, [1, 2, 3]); // 4.1

lodash.ceil(4.016, '1e3'); // 4.016
compat.ceil(4.016, '1e3'); // 4.1

lodash.ceil(Symbol('a')); // NaN
compat.ceil(Symbol('a')); // throws TypeError
```

`parseInt` reads only the leading digits of its input, so `'1e3'` became `1`, `'2px'` became `2` and `[1, 2, 3]` became `1`. In the other direction `true` and `Infinity` parsed to `NaN`, which is falsy, so the precision was dropped entirely and the value was rounded to an integer.

The same mismatch applies to `floor` and `round`, since all three go through `decimalAdjust`.

## Changes

`decimalAdjust`: coerce both arguments the way Lodash's `createRound` does.

```js
number = toNumber(number);
// ...
precision = precision == null ? 0 : Math.min(toInteger(precision), 292);
```

Tests: add coercion cases to `ceil.spec.ts`, `floor.spec.ts` and `round.spec.ts`, covering the values `toInteger` resolves to `0`, the ones it resolves to a usable precision, the `292` cap, and `toNumber`'s handling of symbols.

```js
it('`ceil` should coerce `precision` with `toInteger` like lodash', () => {
  // Values that `toInteger` resolves to `0`, so no decimal adjustment happens.
  expect(ceil(4.016, [1, 2, 3])).toBe(5);
  expect(ceil(4.016, '2px')).toBe(5);

  expect(ceil(4.016, true)).toBe(4.1);
  expect(ceil(4.016, '0x2')).toBe(4.02);

  // Capped at `292`.
  expect(ceil(4.016, '1e3')).toBe(4.016);
  expect(ceil(4.016, Infinity)).toBe(4.016);
});

it('`ceil` should coerce `number` with `toNumber` like lodash', () => {
  expect(ceil(Symbol('a'))).toBe(NaN);
  expect(ceil(4.016, Symbol('a'))).toBe(5);
});
```

## Verification

I compared every combination of 25 numbers and 24 precisions across the three functions against Lodash at runtime. 176 of the 1800 results differed before this change and none differ after. A further 84 hand-picked edge cases — symbols, the sign of `0`, exponential notation, `valueOf`, boxed numbers — went from 12 mismatches to 0.

The existing tests continue to pass unchanged, including the ones covering the sign of `0`, infinite values, and precisions beyond the cap such as `ceil(1.797, 295)`.

## Benchmark results

`decimalAdjust` runs on every call, so I measured it. Medians of five runs of the existing benchmarks, all within noise:

| benchmark | `main` | this branch | |
| --- | --- | --- | --- |
| `ceil`, 12 calls | 541,231 hz | 549,898 hz | +1.6% |
| `floor`, 12 calls | 543,934 hz | 548,550 hz | +0.8% |
| `round`, 1 call | 3,936,717 hz | 3,950,223 hz | +0.3% |
| `round`, 9 calls | 665,385 hz | 672,704 hz | +1.1% |
