### PR TITLE
v1.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # es-toolkit Changelog
 
+## Version v1.52.0
+
+Released on August 28th, 2026.
+
+- Added the `es-toolkit/iterator` entrypoint, a lazy iterator module with `chunk`,
+  `count`, `dropWhile`, `head`, `iterate`, `partition`, `range`, `scan`,
+  `takeWhile`, `uniqBy`, and `zip` ([#1815]), plus `cartesianProduct` ([#2031]).
+  The same functions are also available from `es-toolkit/fp/iterator`.
+- Added `defer` and `deferAsync` to `es-toolkit/util`. ([#2032])
+- Added `flowAsync` to `es-toolkit/fp`, a promise-aware left-to-right composition. ([#2033])
+- Added the `EmptyObject`, `IsEqual`, `JSONValue`, `Primitive`, `SetOptional`,
+  `SetRequired`, and `UnknownRecord` types. ([#2044])
+
+- Fixed `merge` to infer the deep merged return type, and exported the `Merge` type. ([#1959])
+- Fixed `omitBy` and `pickBy` to type numeric callback keys as strings, and
+  exported the `ObjectKeys` type. ([#2037])
+- Fixed `attempt` and `attemptAsync` to default their error type parameter to `unknown`. ([#2052])
+
+The following bring `es-toolkit/compat` closer to Lodash. Behavior for the affected
+edge cases now matches Lodash, so results may differ if you relied on the previous output.
+
+- Fixed `compat/debounce` to skip the `maxWait` invocation when both `leading` and
+  `trailing` are `false`. ([#1678])
+- Fixed `compat/toString` to convert objects with a custom `valueOf`. ([#2034])
+- Fixed `compat/mergeWith` to assign `null` values in array sources. ([#1929])
+- Fixed `compat/has` and `compat/hasIn` to normalize the `-0` path key. ([#2035])
+- Fixed `compat/differenceWith` and `compat/without` to normalize `-0` to `0`. ([#2049])
+- Fixed `compat/findLastIndex` to convert `fromIndex` to an integer. ([#2047])
+- Fixed `compat/xorWith` to match Lodash when no comparator is given. ([#2057])
+
+- Covered the new iterator entrypoints in the dist and browser compatibility
+  checks. ([#2030])
+- Made the agent skills portable when installed on their own. ([#2054])
+- Fixed documentation typos and the Deno install commands. ([#2062])
+
 ## Version v1.51.0
 
 Released on August 17th, 2026.

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@es-toolkit/es-toolkit",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "exports": {
     ".": "./src/index.ts",
     "./compat": "./src/compat/index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-toolkit",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "description": "A state-of-the-art, high-performance JavaScript utility library with a small bundle size and strong type annotations.",
   "homepage": "https://es-toolkit.dev",
   "bugs": "https://github.com/toss/es-toolkit/issues",


### PR DESCRIPTION
## Why

Cuts v1.52.0. Minor bump, since v1.51.0 has been followed by new entrypoints and functions.

## What changed

- `CHANGELOG.md` entry for v1.52.0
- `package.json` and `jsr.json` bumped to 1.52.0

## For reviewers

Highlights are the new `es-toolkit/iterator` and `es-toolkit/fp/iterator` entrypoints, `defer` and `deferAsync`, `flowAsync`, and seven type utilities.

Seven compat fixes move behavior closer to Lodash, so those edge cases change for anyone who relied on the old output. They are grouped under the usual warning in the changelog.

Publishing runs on the `v1.52.0` tag, not on merge, so this can land first and be tagged afterwards.
