### PR TITLE
fix[once]: preserve this context

### DIFF
--- a/src/compat/function/once.spec.ts
+++ b/src/compat/function/once.spec.ts
@@ -30,4 +30,15 @@ describe('once', () => {
     expect(resultFunc).toThrow();
     expect(resultFunc).not.toThrow();
   });
+
+  it('should preserve this context', () => {
+    const object = {
+      value: 42,
+      getValue: once(function (this: { value: number }) {
+        return this.value;
+      }),
+    };
+
+    expect(object.getValue()).toBe(42);
+  });
 });

--- a/src/function/once.spec.ts
+++ b/src/function/once.spec.ts
@@ -32,4 +32,15 @@ describe('once', () => {
     expect(onceFunc()).toBeUndefined();
     expect(func).toHaveBeenCalledTimes(1);
   });
+
+  it('should preserve this context', () => {
+    const object = {
+      value: 42,
+      getValue: once(function (this: { value: number }) {
+        return this.value;
+      }),
+    };
+
+    expect(object.getValue()).toBe(42);
+  });
 });

--- a/src/function/once.ts
+++ b/src/function/once.ts
@@ -35,10 +35,10 @@ export function once<F extends (() => any) | ((...args: any[]) => void)>(func: F
   let called = false;
   let cache: ReturnType<F>;
 
-  return function (...args: Parameters<F>): ReturnType<F> {
+  return function (this: unknown, ...args: Parameters<F>): ReturnType<F> {
     if (!called) {
       called = true;
-      cache = func(...args);
+      cache = func.apply(this, args);
     }
 
     return cache;


### PR DESCRIPTION
## Summary
Fixes #2068 

Fixes the `once` function to preserve the `this` context of the wrapped function, matching Lodash's behavior.

## Changes
The following case returns `42` in Lodash, while `es-toolkit/compat` returned `undefined` before this change because the wrapped function lost its `this` context.

```ts
import { once } from 'es-toolkit/compat';

const object = {
  value: 42,
  getValue: once(function () {
    return this?.value;
  }),
};

object.getValue();

// Lodash: 42
// es-toolkit/compat before this change: undefined
```

- Updated the shared `once` implementation to forward the wrapper's `this` context to the original function using `func.apply(this, args)`.
- Added regression tests for both `es-toolkit` and `es-toolkit/compat`.

Since `es-toolkit/compat` reuses the main `once` implementation, both `es-toolkit` and `es-toolkit/compat` now return `42`.