### PR TITLE
fix(compat/mergeWith): treat a trailing non-function argument as a source

### DIFF
--- a/benchmarks/bundle-size/merge.spec.ts
+++ b/benchmarks/bundle-size/merge.spec.ts
@@ -14,6 +14,6 @@ describe('merge bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'merge');
-    expect(bundleSize).toMatchInlineSnapshot(`6381`);
+    expect(bundleSize).toMatchInlineSnapshot(`6436`);
   });
 });

--- a/benchmarks/bundle-size/mergeWith.spec.ts
+++ b/benchmarks/bundle-size/mergeWith.spec.ts
@@ -14,6 +14,6 @@ describe('mergeWith bundle size', () => {
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'mergeWith');
-    expect(bundleSize).toMatchInlineSnapshot(`6325`);
+    expect(bundleSize).toMatchInlineSnapshot(`6380`);
   });
 });

--- a/docs/compat/reference/object/mergeWith.md
+++ b/docs/compat/reference/object/mergeWith.md
@@ -11,7 +11,7 @@ Use the faster and more modern [`mergeWith`](../../../reference/object/mergeWith
 Deeply merges multiple objects while controlling the merge behavior with a custom function.
 
 ```typescript
-const result = mergeWith(target, ...sources, customizer?);
+const result = mergeWith(target, ...sources, customizer);
 ```
 
 ## Usage

--- a/docs/compat/reference/object/mergeWith.md
+++ b/docs/compat/reference/object/mergeWith.md
@@ -11,12 +11,12 @@ Use the faster and more modern [`mergeWith`](../../../reference/object/mergeWith
 Deeply merges multiple objects while controlling the merge behavior with a custom function.
 
 ```typescript
-const result = mergeWith(target, ...sources, customizer);
+const result = mergeWith(target, ...sources, customizer?);
 ```
 
 ## Usage
 
-### `mergeWith(object, ...sources, customizer)`
+### `mergeWith(object, ...sources, customizer?)`
 
 Deeply merges one or more source objects into the target object, controlling the merge behavior with a customizer function. If the customizer function returns `undefined`, the default merge logic is used. Useful for concatenating arrays or applying special merge rules.
 
@@ -83,11 +83,24 @@ const customizer = (objValue, srcValue, key, object, source, stack) => {
 };
 ```
 
+The customizer is optional. The last argument is only treated as the customizer when it is a function; otherwise it is merged as another source.
+
+```typescript
+import { mergeWith } from 'es-toolkit/compat';
+
+// Without a customizer, every argument after the target is a source
+const result = mergeWith({ a: 1 }, { b: 2 });
+// Result: { a: 1, b: 2 }
+
+const merged = mergeWith({}, { a: 1 }, { b: 2 }, { c: 3 });
+// Result: { a: 1, b: 2, c: 3 }
+```
+
 #### Parameters
 
 - `object` (`any`): The target object to merge into. This object is modified.
 - `...sources` (`any[]`): The source objects to merge from.
-- `customizer` (`MergeWithCustomizer`): The function to customize value assignment. Format: `(objValue, srcValue, key, object, source, stack) => any`.
+- `customizer` (`MergeWithCustomizer`, optional): The function to customize value assignment. Format: `(objValue, srcValue, key, object, source, stack) => any`. If the last argument is not a function, it is treated as another source object.
 
 #### Returns
 

--- a/docs/ja/compat/reference/object/mergeWith.md
+++ b/docs/ja/compat/reference/object/mergeWith.md
@@ -11,7 +11,7 @@
 カスタマイザー関数でマージ方法を制御しながら、複数のオブジェクトを深くマージします。
 
 ```typescript
-const result = mergeWith(target, ...sources, customizer?);
+const result = mergeWith(target, ...sources, customizer);
 ```
 
 ## 使用法

--- a/docs/ja/compat/reference/object/mergeWith.md
+++ b/docs/ja/compat/reference/object/mergeWith.md
@@ -11,12 +11,12 @@
 カスタマイザー関数でマージ方法を制御しながら、複数のオブジェクトを深くマージします。
 
 ```typescript
-const result = mergeWith(target, ...sources, customizer);
+const result = mergeWith(target, ...sources, customizer?);
 ```
 
 ## 使用法
 
-### `mergeWith(object, ...sources, customizer)`
+### `mergeWith(object, ...sources, customizer?)`
 
 ターゲットオブジェクトに1つ以上のソースオブジェクトを深くマージしますが、カスタマイザー関数でマージ方法を制御します。カスタマイザー関数が`undefined`を返す場合、デフォルトのマージロジックが使用されます。配列の連結や特別なマージルールが必要な場合に便利です。
 
@@ -83,11 +83,24 @@ const customizer = (objValue, srcValue, key, object, source, stack) => {
 };
 ```
 
+カスタマイザーは省略可能です。最後の引数は関数である場合にのみカスタマイザーとして扱われ、そうでない場合は別のソースオブジェクトとしてマージされます。
+
+```typescript
+import { mergeWith } from 'es-toolkit/compat';
+
+// カスタマイザーがない場合、ターゲットの後のすべての引数はソースオブジェクトです
+const result = mergeWith({ a: 1 }, { b: 2 });
+// 結果: { a: 1, b: 2 }
+
+const merged = mergeWith({}, { a: 1 }, { b: 2 }, { c: 3 });
+// 結果: { a: 1, b: 2, c: 3 }
+```
+
 #### パラメータ
 
 - `object` (`any`): マージ先となるターゲットオブジェクトです。このオブジェクトは変更されます。
 - `...sources` (`any[]`): マージするソースオブジェクトです。
-- `customizer` (`MergeWithCustomizer`): 値の割り当てをカスタマイズする関数です。形式: `(objValue, srcValue, key, object, source, stack) => any`。
+- `customizer` (`MergeWithCustomizer`, 省略可能): 値の割り当てをカスタマイズする関数です。形式: `(objValue, srcValue, key, object, source, stack) => any`。最後の引数が関数でない場合、別のソースオブジェクトとして扱われます。
 
 #### 戻り値
 

--- a/docs/ko/compat/reference/object/mergeWith.md
+++ b/docs/ko/compat/reference/object/mergeWith.md
@@ -11,12 +11,12 @@
 사용자 정의 함수로 병합 방식을 제어하면서 여러 객체를 깊게 병합해요.
 
 ```typescript
-const result = mergeWith(target, ...sources, customizer);
+const result = mergeWith(target, ...sources, customizer?);
 ```
 
 ## 사용법
 
-### `mergeWith(object, ...sources, customizer)`
+### `mergeWith(object, ...sources, customizer?)`
 
 대상 객체에 하나 이상의 소스 객체를 깊게 병합하되, 커스터마이저 함수로 병합 방식을 제어해요. 커스터마이저 함수가 `undefined`를 반환하면 기본 병합 로직이 사용돼요. 배열 합치기나 특별한 병합 규칙이 필요할 때 유용해요.
 
@@ -83,11 +83,24 @@ const customizer = (objValue, srcValue, key, object, source, stack) => {
 };
 ```
 
+커스터마이저는 선택 사항이에요. 마지막 인수는 함수일 때만 커스터마이저로 취급되고, 그렇지 않으면 또 다른 소스 객체로 병합돼요.
+
+```typescript
+import { mergeWith } from 'es-toolkit/compat';
+
+// 커스터마이저가 없으면 대상 객체 뒤의 모든 인수가 소스 객체예요
+const result = mergeWith({ a: 1 }, { b: 2 });
+// 결과: { a: 1, b: 2 }
+
+const merged = mergeWith({}, { a: 1 }, { b: 2 }, { c: 3 });
+// 결과: { a: 1, b: 2, c: 3 }
+```
+
 #### 파라미터
 
 - `object` (`any`): 병합 대상이 되는 객체예요. 이 객체가 수정돼요.
 - `...sources` (`any[]`): 병합할 소스 객체들이에요.
-- `customizer` (`MergeWithCustomizer`): 값 할당을 커스터마이즈하는 함수예요. `(objValue, srcValue, key, object, source, stack) => any` 형태예요.
+- `customizer` (`MergeWithCustomizer`, 선택): 값 할당을 커스터마이즈하는 함수예요. `(objValue, srcValue, key, object, source, stack) => any` 형태예요. 마지막 인수가 함수가 아니면 또 다른 소스 객체로 취급돼요.
 
 #### 반환 값
 

--- a/docs/ko/compat/reference/object/mergeWith.md
+++ b/docs/ko/compat/reference/object/mergeWith.md
@@ -11,7 +11,7 @@
 사용자 정의 함수로 병합 방식을 제어하면서 여러 객체를 깊게 병합해요.
 
 ```typescript
-const result = mergeWith(target, ...sources, customizer?);
+const result = mergeWith(target, ...sources, customizer);
 ```
 
 ## 사용법

--- a/docs/zh_hans/compat/reference/object/mergeWith.md
+++ b/docs/zh_hans/compat/reference/object/mergeWith.md
@@ -11,7 +11,7 @@
 使用自定义函数控制合并行为,深度合并多个对象。
 
 ```typescript
-const result = mergeWith(target, ...sources, customizer?);
+const result = mergeWith(target, ...sources, customizer);
 ```
 
 ## 用法

--- a/docs/zh_hans/compat/reference/object/mergeWith.md
+++ b/docs/zh_hans/compat/reference/object/mergeWith.md
@@ -11,12 +11,12 @@
 使用自定义函数控制合并行为,深度合并多个对象。
 
 ```typescript
-const result = mergeWith(target, ...sources, customizer);
+const result = mergeWith(target, ...sources, customizer?);
 ```
 
 ## 用法
 
-### `mergeWith(object, ...sources, customizer)`
+### `mergeWith(object, ...sources, customizer?)`
 
 将一个或多个源对象深度合并到目标对象中,使用自定义函数控制合并行为。如果自定义函数返回 `undefined`,则使用默认合并逻辑。适用于连接数组或应用特殊合并规则。
 
@@ -83,11 +83,24 @@ const customizer = (objValue, srcValue, key, object, source, stack) => {
 };
 ```
 
+自定义函数是可选的。只有当最后一个参数是函数时才会被视为自定义函数,否则会作为另一个源对象进行合并。
+
+```typescript
+import { mergeWith } from 'es-toolkit/compat';
+
+// 没有自定义函数时,目标对象之后的每个参数都是源对象
+const result = mergeWith({ a: 1 }, { b: 2 });
+// 结果: { a: 1, b: 2 }
+
+const merged = mergeWith({}, { a: 1 }, { b: 2 }, { c: 3 });
+// 结果: { a: 1, b: 2, c: 3 }
+```
+
 #### 参数
 
 - `object` (`any`): 要合并到的目标对象。此对象会被修改。
 - `...sources` (`any[]`): 要合并的源对象。
-- `customizer` (`MergeWithCustomizer`): 自定义值分配的函数。格式: `(objValue, srcValue, key, object, source, stack) => any`。
+- `customizer` (`MergeWithCustomizer`, 可选): 自定义值分配的函数。格式: `(objValue, srcValue, key, object, source, stack) => any`。如果最后一个参数不是函数,则会被视为另一个源对象。
 
 #### 返回值
 

--- a/src/compat/object/mergeWith.spec.ts
+++ b/src/compat/object/mergeWith.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { cloneDeep } from './cloneDeep';
 import { mergeWith } from './mergeWith';
 import { last } from '../../array/last';
@@ -250,5 +250,35 @@ describe('mergeWith', () => {
     expect(actual.x).toEqual(['1']);
     expect(Object.keys(actual.x)).toEqual(['0']);
     expect((actual.x as any).a).toBeUndefined();
+  });
+
+  it('should treat a trailing non-function argument as a source', () => {
+    expect(mergeWith({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+    expect(mergeWith({}, { a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+    expect(mergeWith({}, { a: 1 }, { b: 2 }, { c: 3 })).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it('should deeply merge when customizer is not given', () => {
+    const actual = mergeWith({ a: { x: 1, y: 2 }, b: [1, 2] }, { a: { y: 3, z: 4 }, b: [9] });
+
+    expect(actual).toEqual({ a: { x: 1, y: 3, z: 4 }, b: [9, 2] });
+  });
+
+  it('should still treat a trailing function as the customizer', () => {
+    const actual = mergeWith({ a: 1, b: 2 }, { b: 3, c: 4 }, (objValue: any, srcValue: any) => {
+      if (typeof objValue === 'number' && typeof srcValue === 'number') {
+        return objValue + srcValue;
+      }
+    });
+
+    expect(actual).toEqual({ a: 1, b: 5, c: 4 });
+  });
+
+  it('should treat a trailing function as the customizer across multiple sources', () => {
+    const customizer = vi.fn();
+    const actual = mergeWith({ a: 1 }, { b: 2 }, { c: 3 }, customizer);
+
+    expect(actual).toEqual({ a: 1, b: 2, c: 3 });
+    expect(customizer).toHaveBeenCalled();
   });
 });

--- a/src/compat/object/mergeWith.ts
+++ b/src/compat/object/mergeWith.ts
@@ -4,6 +4,7 @@ import { clone } from '../../object/clone.ts';
 import { isBuffer } from '../../predicate/isBuffer.ts';
 import { isPrimitive } from '../../predicate/isPrimitive.ts';
 import { getSymbols } from '../_internal/getSymbols.ts';
+import { noop } from '../function/noop.ts';
 import { isArguments } from '../predicate/isArguments.ts';
 import { isArrayLikeObject } from '../predicate/isArrayLikeObject.ts';
 import { isObjectLike } from '../predicate/isObjectLike.ts';
@@ -148,7 +149,7 @@ export function mergeWith<TObject, TSource1, TSource2, TSource3, TSource4>(
  * Merges the properties of one or more source objects into the target object.
  *
  * @param object - The target object into which the source object properties will be merged.
- * @param otherArgs - Additional source objects to merge into the target object, including the custom `merge` function.
+ * @param otherArgs - Additional source objects to merge into the target object, optionally followed by the custom `merge` function.
  * @returns The updated target object with properties from the source object(s) merged in.
  *
  * @example
@@ -158,6 +159,14 @@ export function mergeWith<TObject, TSource1, TSource2, TSource3, TSource4>(
  * const result = mergeWith(target, source, (objValue, srcValue) => {
  *   if (typeof objValue === 'number' && typeof srcValue === 'number') {
  *     return objValue + srcValue;
+ *   }
+ * });
+ * // => { a: 1, b: 5, c: 4 }
+ *
+ * @example
+ * // The last argument is only treated as the customizer when it is callable.
+ * const result = mergeWith({ a: 1 }, { b: 2 }, { c: 3 });
+ * // => { a: 1, b: 2, c: 3 }
  */
 export function mergeWith(object: any, ...otherArgs: any[]): any;
 
@@ -179,10 +188,13 @@ export function mergeWith(object: any, ...otherArgs: any[]): any;
  *
  * The `merge` function should return the value to be set in the target object. If it returns `undefined`, a default deep merge will be applied for arrays and objects.
  *
+ * The `merge` function is optional. It is only treated as a customizer when the last argument is callable;
+ * otherwise the last argument is merged as another source and the default deep merge is applied.
+ *
  * The function can handle multiple source objects and will merge them all into the target object.
  *
  * @param object - The target object into which the source object properties will be merged. This object is modified in place.
- * @param otherArgs - Additional source objects to merge into the target object, including the custom `merge` function.
+ * @param otherArgs - Additional source objects to merge into the target object, optionally followed by the custom `merge` function.
  * @returns The updated target object with properties from the source object(s) merged in.
  *
  * @example
@@ -206,10 +218,17 @@ export function mergeWith(object: any, ...otherArgs: any[]): any;
  * });
  *
  * expect(result).toEqual({ a: [1, 3], b: [2, 4] });
+ *
+ * @example
+ * // Without a customizer, every argument after the target is merged as a source.
+ * const result = mergeWith({ a: 1 }, { b: 2 }, { c: 3 });
+ * // Returns { a: 1, b: 2, c: 3 }
  */
 export function mergeWith(object: any, ...otherArgs: any[]): any {
-  const sources = otherArgs.slice(0, -1);
-  const merge = otherArgs[otherArgs.length - 1] as (
+  const last = otherArgs[otherArgs.length - 1];
+  const hasCustomizer = typeof last === 'function';
+  const sources = hasCustomizer ? otherArgs.slice(0, -1) : otherArgs;
+  const merge = (hasCustomizer ? last : noop) as (
     targetValue: any,
     sourceValue: any,
     key: string | symbol,


### PR DESCRIPTION
<!--
Thanks for contributing to es-toolkit!

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand what you submit. For this reason, **pull request descriptions from external contributors must be written by a human**.

## Title

Use the format `<type>[function names]: <description>`, for example `fix[chunk]: handle empty arrays`.
The type is one of feat, fix, docs, test, or chore. See .github/CONTRIBUTING.md#4-pull-requests

## Before you open this

Find your change below and go through its checklist. These are the only categories we accept — a rename or a rewrite that leaves the behavior unchanged is not one of them, and neither is a new function that has not been discussed yet. The reasoning behind each rule is in .github/CONTRIBUTING.md#41-what-we-accept

### Adding a new function

- [ ] A discussion proposing this function was accepted, and it is linked below. Without one we close the pull request, even when the implementation is good.
- [ ] The implementation, tests, a benchmark, and documentation in all four languages are included.

### Improving performance

- [ ] Benchmark results for `main` and for this branch are pasted under "Benchmark results". We cannot tell a real speedup from reading code, so a claim without numbers gets closed.

### Fixing behavior that differs from Lodash (es-toolkit/compat)

- [ ] The difference is written as code: the input, what Lodash returns for it, and what es-toolkit returns today.
- [ ] A test that fails without this change is included, so the behavior does not drift back later.
- [ ] Benchmark results are attached if the function runs in a hot path.

### Fixing a bug or the documentation

- [ ] Related issues are linked with `fixes #number`.
- [ ] Documentation changes are applied to all four languages: English, Korean, Japanese, and Simplified Chinese.
- [ ] Small documentation fixes are collected into this one pull request rather than split across several.

Now fill in the sections below.
-->

## Summary
<!-- What problem does this solve? Link the related issue or discussion. -->
`es-toolkit/compat/mergeWith` differs in behaviour to `lodash` with regards to the customizer.

`lodash` checks the last argument is a function, and treats it as another source if it is not, performing a standard `merge`.
`es-toolkit` does not have the function check, and does two things based on arguments:
* Two arguments - Swallows the second argument and essentially returns the target.
* Three + arguments - Throws an error as it invokes the last argument as a function.

```typescript
import { mergeWith as esToolkitMergeWith} from 'es-toolkit/compat';
import { mergeWith as lodashMergeWith } from 'lodash';

// Two Arguments
lodashMergeWith({}, { a: 1 });  // { a: 1 }
esToolkitMergeWith({}, { a: 1 }); // {}

// Three Arguments
lodashMergeWith({}, { a: 1 }, {b: 2}); // { a: 1, b: 2 } 
esToolkitMergeWith({}, { a: 1 }, {b: 2}); // TypeError: merge is not a function
```

## Changes
* Add a `typeof function` check for the last argument.
* If the last argument is not a function, it defaults the customizer to `noop`.

`compat/merge` essentially already implements this behaviour:
```typescript
export function merge(object: any, ...sources: any[]): any {
  return mergeWith(object, ...sources, noop);
}
```

<!-- What you changed, in bullet points. -->

## Benchmark results
**main**
```
✓ |benchmarks| mergeWith.bench.ts > mergeWith 5613ms
     name                                    hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · lodash/mergeWith              6,644,952.62  0.0001  0.7230  0.0002  0.0002  0.0003  0.0003  0.0005  ±0.63%  3322477
   · es-toolkit/mergeWith         16,548,747.27  0.0000  0.0454  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.07%  8274374
   · es-toolkit/compat/mergeWith   5,692,704.71  0.0001  0.1372  0.0002  0.0002  0.0003  0.0003  0.0004  ±0.31%  2846353

 BENCH  Summary

  |benchmarks| es-toolkit/mergeWith - mergeWith.bench.ts > mergeWith
    2.49x faster than lodash/mergeWith
    2.91x faster than es-toolkit/compat/mergeWith
```

**PR**
```
✓ |benchmarks| mergeWith.bench.ts > mergeWith 5742ms
     name                                    hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · lodash/mergeWith              6,796,597.99  0.0001  0.5586  0.0001  0.0002  0.0002  0.0003  0.0004  ±0.59%  3398299
   · es-toolkit/mergeWith         16,257,090.67  0.0000  0.0597  0.0001  0.0001  0.0001  0.0001  0.0002  ±0.07%  8128546
   · es-toolkit/compat/mergeWith   5,641,282.91  0.0001  0.2366  0.0002  0.0002  0.0003  0.0003  0.0004  ±0.38%  2820642

 BENCH  Summary

  |benchmarks| es-toolkit/mergeWith - mergeWith.bench.ts > mergeWith
    2.39x faster than lodash/mergeWith
    2.88x faster than es-toolkit/compat/mergeWith
```
<!--
Only for performance changes: paste the benchmark output for `main` and for this branch. Delete this section otherwise.

No need to paste test output — CI runs the test suite on every pull request. Benchmarks are the exception, since nothing in CI runs them.
-->

- [x] The difference is written as code: the input, what Lodash returns for it, and what es-toolkit returns today.
- [x] A test that fails without this change is included, so the behavior does not drift back later.
- [x] Benchmark results are attached if the function runs in a hot path.