### PR TITLE
fix(object): align key types with Object.keys in findKey and mapKeys

### DIFF
--- a/docs/ja/reference/object/findKey.md
+++ b/docs/ja/reference/object/findKey.md
@@ -81,8 +81,8 @@ console.log(highRamKey); // 'laptop'
 #### パラメータ
 
 - `obj` (`T extends Record<any, any>`): 検索するオブジェクトです。
-- `predicate` (`(value: T[keyof T], key: keyof T, obj: T) => boolean`): 各要素に対して実行する条件関数です。`true`を返す最初の要素のキーを見つけます。
+- `predicate` (`(value: T[keyof T], key: ObjectKeys<T>, obj: T) => boolean`): 各要素に対して実行する条件関数です。`true`を返す最初の要素のキーを見つけます([`ObjectKeys<T>`](/ja/types/reference/objects/ObjectKeys)を参照)。
 
 #### 戻り値
 
-(`keyof T | undefined`): 条件を満たす最初の要素のキーです。条件を満たす要素がない場合は`undefined`を返します。
+(`ObjectKeys<T> | undefined`): 条件を満たす最初の要素のキーです。条件を満たす要素がない場合は`undefined`を返します。

--- a/docs/ja/reference/object/mapKeys.md
+++ b/docs/ja/reference/object/mapKeys.md
@@ -32,7 +32,7 @@ const uppercased = mapKeys(obj, (value, key) => key.toString().toUpperCase());
 #### パラメータ
 
 - `object` (`T extends Record<PropertyKey, any>`): キーを変換するオブジェクトです。
-- `getNewKey` (`(value: T[keyof T], key: keyof T, object: T) => K`): 新しいキーを生成する関数です。値、キー、全体のオブジェクトをパラメータとして受け取ります。
+- `getNewKey` (`(value: T[keyof T], key: ObjectKeys<T>, object: T) => K`): 新しいキーを生成する関数です。値、キー、全体のオブジェクトをパラメータとして受け取ります([`ObjectKeys<T>`](/ja/types/reference/objects/ObjectKeys)を参照)。
 
 #### 戻り値
 

--- a/docs/ko/reference/object/findKey.md
+++ b/docs/ko/reference/object/findKey.md
@@ -81,8 +81,8 @@ console.log(highRamKey); // 'laptop'
 #### 파라미터
 
 - `obj` (`T extends Record<any, any>`): 검색할 객체예요.
-- `predicate` (`(value: T[keyof T], key: keyof T, obj: T) => boolean`): 각 요소에 대해 실행할 조건 함수예요. `true`를 반환하는 첫 번째 요소의 키를 찾아요.
+- `predicate` (`(value: T[keyof T], key: ObjectKeys<T>, obj: T) => boolean`): 각 요소에 대해 실행할 조건 함수예요. `true`를 반환하는 첫 번째 요소의 키를 찾아요 ([`ObjectKeys<T>`](/ko/types/reference/objects/ObjectKeys) 참고).
 
 #### 반환 값
 
-(`keyof T | undefined`): 조건을 만족하는 첫 번째 요소의 키예요. 조건을 만족하는 요소가 없으면 `undefined`를 반환해요.
+(`ObjectKeys<T> | undefined`): 조건을 만족하는 첫 번째 요소의 키예요. 조건을 만족하는 요소가 없으면 `undefined`를 반환해요.

--- a/docs/ko/reference/object/mapKeys.md
+++ b/docs/ko/reference/object/mapKeys.md
@@ -32,7 +32,7 @@ const uppercased = mapKeys(obj, (value, key) => key.toString().toUpperCase());
 #### 파라미터
 
 - `object` (`T extends Record<PropertyKey, any>`): 키를 변환할 객체예요.
-- `getNewKey` (`(value: T[keyof T], key: keyof T, object: T) => K`): 새로운 키를 생성하는 함수예요. 값, 키, 전체 객체를 파라미터로 받아요.
+- `getNewKey` (`(value: T[keyof T], key: ObjectKeys<T>, object: T) => K`): 새로운 키를 생성하는 함수예요. 값, 키, 전체 객체를 파라미터로 받아요 ([`ObjectKeys<T>`](/ko/types/reference/objects/ObjectKeys) 참고).
 
 #### 반환 값
 

--- a/docs/reference/object/findKey.md
+++ b/docs/reference/object/findKey.md
@@ -81,8 +81,8 @@ console.log(highRamKey); // 'laptop'
 #### Parameters
 
 - `obj` (`T extends Record<any, any>`): The object to search.
-- `predicate` (`(value: T[keyof T], key: keyof T, obj: T) => boolean`): A condition function to execute for each element. Finds the key of the first element that returns `true`.
+- `predicate` (`(value: T[keyof T], key: ObjectKeys<T>, obj: T) => boolean`): A condition function to execute for each element. Finds the key of the first element that returns `true` (see [`ObjectKeys<T>`](/types/reference/objects/ObjectKeys)).
 
 #### Returns
 
-(`keyof T | undefined`): The key of the first element that satisfies the condition. Returns `undefined` if no element satisfies the condition.
+(`ObjectKeys<T> | undefined`): The key of the first element that satisfies the condition. Returns `undefined` if no element satisfies the condition.

--- a/docs/reference/object/mapKeys.md
+++ b/docs/reference/object/mapKeys.md
@@ -32,7 +32,7 @@ const uppercased = mapKeys(obj, (value, key) => key.toString().toUpperCase());
 #### Parameters
 
 - `object` (`T extends Record<PropertyKey, any>`): The object to transform keys from.
-- `getNewKey` (`(value: T[keyof T], key: keyof T, object: T) => K`): A function that generates new keys. Receives value, key, and the entire object as parameters.
+- `getNewKey` (`(value: T[keyof T], key: ObjectKeys<T>, object: T) => K`): A function that generates new keys. Receives value, key, and the entire object as parameters (see [`ObjectKeys<T>`](/types/reference/objects/ObjectKeys)).
 
 #### Returns
 

--- a/docs/zh_hans/reference/object/findKey.md
+++ b/docs/zh_hans/reference/object/findKey.md
@@ -81,8 +81,8 @@ console.log(highRamKey); // 'laptop'
 #### 参数
 
 - `obj` (`T extends Record<any, any>`): 要搜索的对象。
-- `predicate` (`(value: T[keyof T], key: keyof T, obj: T) => boolean`): 对每个元素执行的条件函数。查找返回 `true` 的第一个元素的键。
+- `predicate` (`(value: T[keyof T], key: ObjectKeys<T>, obj: T) => boolean`): 对每个元素执行的条件函数。查找返回 `true` 的第一个元素的键(参见 [`ObjectKeys<T>`](/zh_hans/types/reference/objects/ObjectKeys))。
 
 #### 返回值
 
-(`keyof T | undefined`): 满足条件的第一个元素的键。如果没有满足条件的元素,则返回 `undefined`。
+(`ObjectKeys<T> | undefined`): 满足条件的第一个元素的键。如果没有满足条件的元素,则返回 `undefined`。

--- a/docs/zh_hans/reference/object/mapKeys.md
+++ b/docs/zh_hans/reference/object/mapKeys.md
@@ -32,7 +32,7 @@ const uppercased = mapKeys(obj, (value, key) => key.toString().toUpperCase());
 #### 参数
 
 - `object` (`T extends Record<PropertyKey, any>`): 要转换键的对象。
-- `getNewKey` (`(value: T[keyof T], key: keyof T, object: T) => K`): 生成新键的函数。接收值、键和整个对象作为参数。
+- `getNewKey` (`(value: T[keyof T], key: ObjectKeys<T>, object: T) => K`): 生成新键的函数。接收值、键和整个对象作为参数(参见 [`ObjectKeys<T>`](/zh_hans/types/reference/objects/ObjectKeys))。
 
 #### 返回值
 

--- a/src/object/findKey.spec.ts
+++ b/src/object/findKey.spec.ts
@@ -45,13 +45,4 @@ describe('findKey', () => {
 
     expect(findKey(users, (_, key, obj) => key === 'fred' && obj[key].active === false)).toBe('fred');
   });
-
-  it('should exclude symbol keys', () => {
-    const sym = Symbol('barney');
-    const usersWithSymbol = {
-      [sym]: { age: 24, active: true },
-      fred: { age: 30, active: false },
-    };
-    expect(findKey(usersWithSymbol, o => o.age < 40)).toBe('fred');
-  });
 });

--- a/src/object/findKey.spec.ts
+++ b/src/object/findKey.spec.ts
@@ -43,6 +43,15 @@ describe('findKey', () => {
       fred: { age: 40, active: false },
     };
 
-    expect(findKey(users, (value, key, obj) => key === 'fred' && obj[key].active === false)).toBe('fred');
+    expect(findKey(users, (_, key, obj) => key === 'fred' && obj[key].active === false)).toBe('fred');
+  });
+
+  it('should exclude symbol keys', () => {
+    const sym = Symbol('barney');
+    const usersWithSymbol = {
+      [sym]: { age: 24, active: true },
+      fred: { age: 30, active: false },
+    };
+    expect(findKey(usersWithSymbol, o => o.age < 40)).toBe('fred');
   });
 });

--- a/src/object/findKey.ts
+++ b/src/object/findKey.ts
@@ -1,3 +1,5 @@
+import type { ObjectKeys } from '../types/ObjectKeys.ts';
+
 /**
  * Finds the key of the first element in the object that satisfies the provided testing function.
  *
@@ -18,9 +20,9 @@
  */
 export function findKey<T extends Record<any, any>>(
   obj: T,
-  predicate: (value: T[keyof T], key: keyof T, obj: T) => boolean
-): keyof T | undefined {
-  const keys = Object.keys(obj) as Array<keyof T>;
+  predicate: (value: T[keyof T], key: ObjectKeys<T>, obj: T) => boolean
+): ObjectKeys<T> | undefined {
+  const keys = Object.keys(obj) as Array<ObjectKeys<T>>;
 
   return keys.find(key => predicate(obj[key], key, obj));
 }

--- a/src/object/mapKeys.spec.ts
+++ b/src/object/mapKeys.spec.ts
@@ -7,7 +7,7 @@ describe('mapKeys', () => {
   });
 
   it('should iterate over and map the object using its own number keys', () => {
-    expect(mapKeys({ 1: 'a', 2: 'b', 3: 'c' }, (_, key) => key * 2)).toEqual({ 2: 'a', 4: 'b', 6: 'c' });
+    expect(mapKeys({ 1: 'a', 2: 'b', 3: 'c' }, (_, key) => Number(key) * 2)).toEqual({ 2: 'a', 4: 'b', 6: 'c' });
   });
 
   it('should pass the value corresponding to the current key into the iteratee', () => {

--- a/src/object/mapKeys.ts
+++ b/src/object/mapKeys.ts
@@ -1,3 +1,5 @@
+import type { ObjectKeys } from '../types/ObjectKeys.ts';
+
 /**
  * Creates a new object with the same values as the given object, but with keys generated
  * by running each own enumerable property of the object through the iteratee function.
@@ -17,10 +19,10 @@
  */
 export function mapKeys<T extends Record<PropertyKey, any>, K extends PropertyKey>(
   object: T,
-  getNewKey: (value: T[keyof T], key: keyof T, object: T) => K
+  getNewKey: (value: T[keyof T], key: ObjectKeys<T>, object: T) => K
 ): Record<K, T[keyof T]> {
   const result = {} as Record<K, T[keyof T]>;
-  const keys = Object.keys(object) as Array<keyof T>;
+  const keys = Object.keys(object) as Array<ObjectKeys<T>>;
 
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];


### PR DESCRIPTION
[86f8937](https://github.com/toss/es-toolkit/commit/86f8937ef3b61bd8f567833a1a4782c7edeada65) introduced `ObjectKeys<T>` as a public type in `es-toolkit/types` and applied it to `omitBy` and `pickBy`.

`findKey` and `mapKeys` have the same shape — they iterate with `Object.keys` but type the callback key as `keyof T` 
```ts
const obj = { 1: 'a', 2: 'b' };

// key is 1 | 2, so a comparison that is true at runtime does not compile
// TS2367: This comparison appears to be unintentional because the types 'number' and 'string' have no overlap.
findKey(obj, (_, key) => key === '1');

const sym = Symbol('sym');

// key is 'a' | unique symbol, even though only 'a' is ever passed
// TS2339: Property 'toUpperCase' does not exist on type '"a" | unique symbol'.
mapKeys({ a: 1, [sym]: 2 }, (_, key) => key.toUpperCase());
```

Both functions now use ObjectKeys<T>, so the key the callback receives — and the key findKey returns — matches what Object.keys produces.