### PR TITLE
feat(string): add sentenceCase to es-toolkit/string

### DIFF
--- a/docs/ja/reference/string/sentenceCase.md
+++ b/docs/ja/reference/string/sentenceCase.md
@@ -1,0 +1,77 @@
+# sentenceCase
+
+文字列をセンテンスケースに変換します。
+
+```typescript
+const converted = sentenceCase(str);
+```
+
+## 使用法
+
+### `sentenceCase(str)`
+
+文字列をセンテンスケースに変換したい場合は `sentenceCase` を使用してください。センテンスケースは、最初の単語の最初の文字だけを大文字にし、残りの文字はすべて小文字にして、単語間を空白で連結する表記法です。
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+// 基本的な使用法
+sentenceCase('hello world'); // 'Hello world'
+sentenceCase('HELLO WORLD'); // 'Hello world'
+
+// キャメルケースやパスカルケースの変換
+sentenceCase('fooBar'); // 'Foo bar'
+sentenceCase('PascalCase'); // 'Pascal case'
+
+// ハイフンやアンダースコアで連結された単語
+sentenceCase('hello-world'); // 'Hello world'
+sentenceCase('hello_world'); // 'Hello world'
+```
+
+フィールド名や enum の値などの識別子を、人が読みやすいラベルに変換するときに便利です。
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+sentenceCase('firstName'); // 'First name'
+sentenceCase('MAX_RETRY_COUNT'); // 'Max retry count'
+sentenceCase('user-profile-settings'); // 'User profile settings'
+```
+
+さまざまな区切り文字や特殊文字を含む文字列も正しく処理します。
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+// 複数の区切り文字が含まれる場合
+sentenceCase('--foo-bar--'); // 'Foo bar'
+sentenceCase('__FOO_BAR__'); // 'Foo bar'
+
+// 連続した大文字と数字の処理
+sentenceCase('XMLHttpRequest'); // 'Xml http request'
+sentenceCase('_abc_123_def'); // 'Abc 123 def'
+
+// 空文字や意味のない区切り文字のみの場合
+sentenceCase('_-_-_-_'); // ''
+sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
+```
+
+#### パラメータ
+
+- `str` (`string`): センテンスケースに変換する文字列です。
+
+#### 戻り値
+
+(`string`): 最初の単語の最初の文字が大文字に、残りが小文字に変換され、空白で連結された新しい文字列を返します。
+
+## 使用例
+
+::: sandpack
+
+```ts index.ts
+import { sentenceCase } from 'es-toolkit/string';
+
+console.log(sentenceCase('sentenceCase'));
+```
+
+:::

--- a/docs/ja/reference/string/sentenceCase.md
+++ b/docs/ja/reference/string/sentenceCase.md
@@ -1,59 +1,49 @@
 # sentenceCase
 
-文字列をセンテンスケースに変換します。
+文字列をセンテンスケース(Sentence case)に変換します。
 
 ```typescript
-const converted = sentenceCase(str);
+const result = sentenceCase(str);
 ```
 
 ## 使用法
 
 ### `sentenceCase(str)`
 
-文字列をセンテンスケースに変換したい場合は `sentenceCase` を使用してください。センテンスケースは、最初の単語の最初の文字だけを大文字にし、残りの文字はすべて小文字にして、単語間を空白で連結する表記法です。
+文字列をセンテンスケースに変換したいときは`sentenceCase`を使用します。センテンスケースは最初の単語の最初の文字だけを大文字で書き、残りの文字はすべて小文字にして、単語間を空白で連結する命名規則です。
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-// 基本的な使用法
-sentenceCase('hello world'); // 'Hello world'
-sentenceCase('HELLO WORLD'); // 'Hello world'
-
-// キャメルケースやパスカルケースの変換
-sentenceCase('fooBar'); // 'Foo bar'
-sentenceCase('PascalCase'); // 'Pascal case'
-
-// ハイフンやアンダースコアで連結された単語
-sentenceCase('hello-world'); // 'Hello world'
-sentenceCase('hello_world'); // 'Hello world'
+// 様々な形式の文字列をセンテンスケースに変換
+sentenceCase('hello world'); // returns 'Hello world'
+sentenceCase('some-hyphen-text'); // returns 'Some hyphen text'
+sentenceCase('CONSTANT_CASE'); // returns 'Constant case'
+sentenceCase('PascalCase'); // returns 'Pascal case'
+sentenceCase('mixed   SpAcE'); // returns 'Mixed sp ac e'
 ```
 
-フィールド名や enum の値などの識別子を、人が読みやすいラベルに変換するときに便利です。
+プロパティ名や enum の値、設定キーのような識別子を、人が読みやすいラベルやメッセージとして使用しやすい形式に変換します。
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-sentenceCase('firstName'); // 'First name'
-sentenceCase('MAX_RETRY_COUNT'); // 'Max retry count'
-sentenceCase('user-profile-settings'); // 'User profile settings'
+// プロパティ名をフォームのラベルに変換
+const fieldName = 'user_first_name';
+const label = sentenceCase(fieldName); // 'User first name'
+
+// 定数名を画面に表示するテキストに変換
+const errorCode = 'MAX_RETRY_COUNT';
+const message = sentenceCase(errorCode); // 'Max retry count'
 ```
 
-さまざまな区切り文字や特殊文字を含む文字列も正しく処理します。
+Unicode文字も保持します。
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-// 複数の区切り文字が含まれる場合
-sentenceCase('--foo-bar--'); // 'Foo bar'
-sentenceCase('__FOO_BAR__'); // 'Foo bar'
-
-// 連続した大文字と数字の処理
-sentenceCase('XMLHttpRequest'); // 'Xml http request'
-sentenceCase('_abc_123_def'); // 'Abc 123 def'
-
-// 空文字や意味のない区切り文字のみの場合
-sentenceCase('_-_-_-_'); // ''
-sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
+sentenceCase('keep unicode 😅'); // returns 'Keep unicode 😅'
+sentenceCase('한글-테스트'); // returns '한글 테스트'
 ```
 
 #### パラメータ
@@ -62,16 +52,4 @@ sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
 
 #### 戻り値
 
-(`string`): 最初の単語の最初の文字が大文字に、残りが小文字に変換され、空白で連結された新しい文字列を返します。
-
-## 使用例
-
-::: sandpack
-
-```ts index.ts
-import { sentenceCase } from 'es-toolkit/string';
-
-console.log(sentenceCase('sentenceCase'));
-```
-
-:::
+(`string`): センテンスケースに変換された新しい文字列を返します。

--- a/docs/ko/reference/string/sentenceCase.md
+++ b/docs/ko/reference/string/sentenceCase.md
@@ -1,0 +1,77 @@
+# sentenceCase
+
+문자열을 문장 케이스로 변환해요.
+
+```typescript
+const converted = sentenceCase(str);
+```
+
+## 사용법
+
+### `sentenceCase(str)`
+
+문자열을 문장 케이스로 변환하고 싶을 때 `sentenceCase`를 사용하세요. 문장 케이스는 첫 단어의 첫 글자만 대문자로 쓰고, 나머지 글자는 모두 소문자로 쓰며, 단어 사이를 공백으로 연결하는 표기법이에요.
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+// 기본 사용법
+sentenceCase('hello world'); // 'Hello world'
+sentenceCase('HELLO WORLD'); // 'Hello world'
+
+// 카멜 케이스나 파스칼 케이스 변환
+sentenceCase('fooBar'); // 'Foo bar'
+sentenceCase('PascalCase'); // 'Pascal case'
+
+// 하이픈이나 언더스코어로 연결된 단어들
+sentenceCase('hello-world'); // 'Hello world'
+sentenceCase('hello_world'); // 'Hello world'
+```
+
+필드 이름이나 enum 값 같은 식별자를 사람이 읽기 좋은 레이블로 바꿀 때 유용해요.
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+sentenceCase('firstName'); // 'First name'
+sentenceCase('MAX_RETRY_COUNT'); // 'Max retry count'
+sentenceCase('user-profile-settings'); // 'User profile settings'
+```
+
+다양한 구분자와 특수 문자가 포함된 문자열도 올바르게 처리해요.
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+// 여러 구분자가 포함된 경우
+sentenceCase('--foo-bar--'); // 'Foo bar'
+sentenceCase('__FOO_BAR__'); // 'Foo bar'
+
+// 연속된 대문자와 숫자 처리
+sentenceCase('XMLHttpRequest'); // 'Xml http request'
+sentenceCase('_abc_123_def'); // 'Abc 123 def'
+
+// 빈 문자나 의미 없는 구분자만 있는 경우
+sentenceCase('_-_-_-_'); // ''
+sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
+```
+
+#### 파라미터
+
+- `str` (`string`): 문장 케이스로 변환할 문자열이에요.
+
+#### 반환 값
+
+(`string`): 첫 단어의 첫 글자는 대문자로, 나머지는 소문자로 변환되고 공백으로 연결된 새로운 문자열을 반환해요.
+
+## 사용해보기
+
+::: sandpack
+
+```ts index.ts
+import { sentenceCase } from 'es-toolkit/string';
+
+console.log(sentenceCase('sentenceCase'));
+```
+
+:::

--- a/docs/ko/reference/string/sentenceCase.md
+++ b/docs/ko/reference/string/sentenceCase.md
@@ -1,77 +1,55 @@
 # sentenceCase
 
-문자열을 문장 케이스로 변환해요.
+문자열을 문장 표기법(Sentence case)으로 변환해요.
 
 ```typescript
-const converted = sentenceCase(str);
+const result = sentenceCase(str);
 ```
 
 ## 사용법
 
 ### `sentenceCase(str)`
 
-문자열을 문장 케이스로 변환하고 싶을 때 `sentenceCase`를 사용하세요. 문장 케이스는 첫 단어의 첫 글자만 대문자로 쓰고, 나머지 글자는 모두 소문자로 쓰며, 단어 사이를 공백으로 연결하는 표기법이에요.
+문자열을 문장 표기법으로 바꾸고 싶을 때 `sentenceCase`를 사용하세요. 문장 표기법은 첫 번째 단어의 첫 글자만 대문자로 쓰고, 나머지 글자는 모두 소문자로 쓰며, 단어 사이를 공백으로 연결하는 명명 규칙이에요.
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-// 기본 사용법
-sentenceCase('hello world'); // 'Hello world'
-sentenceCase('HELLO WORLD'); // 'Hello world'
-
-// 카멜 케이스나 파스칼 케이스 변환
-sentenceCase('fooBar'); // 'Foo bar'
-sentenceCase('PascalCase'); // 'Pascal case'
-
-// 하이픈이나 언더스코어로 연결된 단어들
-sentenceCase('hello-world'); // 'Hello world'
-sentenceCase('hello_world'); // 'Hello world'
+// 다양한 형태의 문자열을 문장 표기법으로 변환
+sentenceCase('hello world'); // returns 'Hello world'
+sentenceCase('some-hyphen-text'); // returns 'Some hyphen text'
+sentenceCase('CONSTANT_CASE'); // returns 'Constant case'
+sentenceCase('PascalCase'); // returns 'Pascal case'
+sentenceCase('mixed   SpAcE'); // returns 'Mixed sp ac e'
 ```
 
-필드 이름이나 enum 값 같은 식별자를 사람이 읽기 좋은 레이블로 바꿀 때 유용해요.
+프로퍼티 이름이나 enum 값, 설정 키 같은 식별자를 사람이 읽기 좋은 레이블이나 메시지로 사용하기 좋은 형태로 바꿔줘요.
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-sentenceCase('firstName'); // 'First name'
-sentenceCase('MAX_RETRY_COUNT'); // 'Max retry count'
-sentenceCase('user-profile-settings'); // 'User profile settings'
+// 프로퍼티 이름을 폼 레이블로 변환
+const fieldName = 'user_first_name';
+const label = sentenceCase(fieldName); // 'User first name'
+
+// 상수 이름을 화면에 표시할 텍스트로 변환
+const errorCode = 'MAX_RETRY_COUNT';
+const message = sentenceCase(errorCode); // 'Max retry count'
 ```
 
-다양한 구분자와 특수 문자가 포함된 문자열도 올바르게 처리해요.
+유니코드 문자도 보존해요.
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-// 여러 구분자가 포함된 경우
-sentenceCase('--foo-bar--'); // 'Foo bar'
-sentenceCase('__FOO_BAR__'); // 'Foo bar'
-
-// 연속된 대문자와 숫자 처리
-sentenceCase('XMLHttpRequest'); // 'Xml http request'
-sentenceCase('_abc_123_def'); // 'Abc 123 def'
-
-// 빈 문자나 의미 없는 구분자만 있는 경우
-sentenceCase('_-_-_-_'); // ''
-sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
+sentenceCase('keep unicode 😅'); // returns 'Keep unicode 😅'
+sentenceCase('한글-테스트'); // returns '한글 테스트'
 ```
 
 #### 파라미터
 
-- `str` (`string`): 문장 케이스로 변환할 문자열이에요.
+- `str` (`string`): 문장 표기법으로 변환할 문자열이에요.
 
 #### 반환 값
 
-(`string`): 첫 단어의 첫 글자는 대문자로, 나머지는 소문자로 변환되고 공백으로 연결된 새로운 문자열을 반환해요.
-
-## 사용해보기
-
-::: sandpack
-
-```ts index.ts
-import { sentenceCase } from 'es-toolkit/string';
-
-console.log(sentenceCase('sentenceCase'));
-```
-
-:::
+(`string`): 문장 표기법으로 변환된 새로운 문자열을 반환해요.

--- a/docs/reference/string/sentenceCase.md
+++ b/docs/reference/string/sentenceCase.md
@@ -1,0 +1,77 @@
+# sentenceCase
+
+Converts a string to sentence case.
+
+```typescript
+const converted = sentenceCase(str);
+```
+
+## Usage
+
+### `sentenceCase(str)`
+
+Use `sentenceCase` when you want to convert a string to sentence case. Sentence case is a naming convention where the first letter of the first word is capitalized, all other letters are lowercase, and words are separated by spaces.
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+// Basic usage
+sentenceCase('hello world'); // 'Hello world'
+sentenceCase('HELLO WORLD'); // 'Hello world'
+
+// Converting camelCase or PascalCase
+sentenceCase('fooBar'); // 'Foo bar'
+sentenceCase('PascalCase'); // 'Pascal case'
+
+// Words connected with hyphens or underscores
+sentenceCase('hello-world'); // 'Hello world'
+sentenceCase('hello_world'); // 'Hello world'
+```
+
+It's useful when turning identifiers such as field names or enum values into human-readable labels.
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+sentenceCase('firstName'); // 'First name'
+sentenceCase('MAX_RETRY_COUNT'); // 'Max retry count'
+sentenceCase('user-profile-settings'); // 'User profile settings'
+```
+
+It also correctly handles strings with various delimiters and special characters.
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+// Cases with multiple delimiters
+sentenceCase('--foo-bar--'); // 'Foo bar'
+sentenceCase('__FOO_BAR__'); // 'Foo bar'
+
+// Handling consecutive uppercase letters and numbers
+sentenceCase('XMLHttpRequest'); // 'Xml http request'
+sentenceCase('_abc_123_def'); // 'Abc 123 def'
+
+// Cases with empty strings or only meaningless delimiters
+sentenceCase('_-_-_-_'); // ''
+sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
+```
+
+#### Parameters
+
+- `str` (`string`): The string to convert to sentence case.
+
+#### Returns
+
+(`string`): Returns a new string with the first letter of the first word capitalized, the rest in lowercase, and words joined with spaces.
+
+## Try It
+
+::: sandpack
+
+```ts index.ts
+import { sentenceCase } from 'es-toolkit/string';
+
+console.log(sentenceCase('sentenceCase'));
+```
+
+:::

--- a/docs/reference/string/sentenceCase.md
+++ b/docs/reference/string/sentenceCase.md
@@ -3,7 +3,7 @@
 Converts a string to sentence case.
 
 ```typescript
-const converted = sentenceCase(str);
+const result = sentenceCase(str);
 ```
 
 ## Usage
@@ -15,45 +15,35 @@ Use `sentenceCase` when you want to convert a string to sentence case. Sentence 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-// Basic usage
-sentenceCase('hello world'); // 'Hello world'
-sentenceCase('HELLO WORLD'); // 'Hello world'
-
-// Converting camelCase or PascalCase
-sentenceCase('fooBar'); // 'Foo bar'
-sentenceCase('PascalCase'); // 'Pascal case'
-
-// Words connected with hyphens or underscores
-sentenceCase('hello-world'); // 'Hello world'
-sentenceCase('hello_world'); // 'Hello world'
+// Convert various string formats to sentence case
+sentenceCase('hello world'); // returns 'Hello world'
+sentenceCase('some-hyphen-text'); // returns 'Some hyphen text'
+sentenceCase('CONSTANT_CASE'); // returns 'Constant case'
+sentenceCase('PascalCase'); // returns 'Pascal case'
+sentenceCase('mixed   SpAcE'); // returns 'Mixed sp ac e'
 ```
 
-It's useful when turning identifiers such as field names or enum values into human-readable labels.
+It converts identifiers such as property names, enum values, or config keys into a format suitable for human-readable labels and messages.
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-sentenceCase('firstName'); // 'First name'
-sentenceCase('MAX_RETRY_COUNT'); // 'Max retry count'
-sentenceCase('user-profile-settings'); // 'User profile settings'
+// Convert property names to form labels
+const fieldName = 'user_first_name';
+const label = sentenceCase(fieldName); // 'User first name'
+
+// Convert constant names to display text
+const errorCode = 'MAX_RETRY_COUNT';
+const message = sentenceCase(errorCode); // 'Max retry count'
 ```
 
-It also correctly handles strings with various delimiters and special characters.
+It also preserves Unicode characters.
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-// Cases with multiple delimiters
-sentenceCase('--foo-bar--'); // 'Foo bar'
-sentenceCase('__FOO_BAR__'); // 'Foo bar'
-
-// Handling consecutive uppercase letters and numbers
-sentenceCase('XMLHttpRequest'); // 'Xml http request'
-sentenceCase('_abc_123_def'); // 'Abc 123 def'
-
-// Cases with empty strings or only meaningless delimiters
-sentenceCase('_-_-_-_'); // ''
-sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
+sentenceCase('keep unicode 😅'); // returns 'Keep unicode 😅'
+sentenceCase('한글-테스트'); // returns '한글 테스트'
 ```
 
 #### Parameters
@@ -62,16 +52,4 @@ sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
 
 #### Returns
 
-(`string`): Returns a new string with the first letter of the first word capitalized, the rest in lowercase, and words joined with spaces.
-
-## Try It
-
-::: sandpack
-
-```ts index.ts
-import { sentenceCase } from 'es-toolkit/string';
-
-console.log(sentenceCase('sentenceCase'));
-```
-
-:::
+(`string`): Returns a new string converted to sentence case.

--- a/docs/zh_hans/reference/string/sentenceCase.md
+++ b/docs/zh_hans/reference/string/sentenceCase.md
@@ -1,0 +1,77 @@
+# sentenceCase
+
+将字符串转换为句子格式。
+
+```typescript
+const converted = sentenceCase(str);
+```
+
+## 用法
+
+### `sentenceCase(str)`
+
+当您想要将字符串转换为句子格式时,请使用 `sentenceCase`。句子格式是一种命名约定,只有第一个单词的首字母大写,其余字母全部小写,单词之间用空格连接。
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+// 基本用法
+sentenceCase('hello world'); // 'Hello world'
+sentenceCase('HELLO WORLD'); // 'Hello world'
+
+// 转换驼峰命名或帕斯卡命名
+sentenceCase('fooBar'); // 'Foo bar'
+sentenceCase('PascalCase'); // 'Pascal case'
+
+// 用连字符或下划线连接的单词
+sentenceCase('hello-world'); // 'Hello world'
+sentenceCase('hello_world'); // 'Hello world'
+```
+
+在将字段名或枚举值等标识符转换为易读的标签时非常有用。
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+sentenceCase('firstName'); // 'First name'
+sentenceCase('MAX_RETRY_COUNT'); // 'Max retry count'
+sentenceCase('user-profile-settings'); // 'User profile settings'
+```
+
+它还能正确处理包含各种分隔符和特殊字符的字符串。
+
+```typescript
+import { sentenceCase } from 'es-toolkit/string';
+
+// 包含多个分隔符的情况
+sentenceCase('--foo-bar--'); // 'Foo bar'
+sentenceCase('__FOO_BAR__'); // 'Foo bar'
+
+// 处理连续大写字母和数字
+sentenceCase('XMLHttpRequest'); // 'Xml http request'
+sentenceCase('_abc_123_def'); // 'Abc 123 def'
+
+// 空字符串或只有无意义分隔符的情况
+sentenceCase('_-_-_-_'); // ''
+sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
+```
+
+#### 参数
+
+- `str` (`string`): 要转换为句子格式的字符串。
+
+#### 返回值
+
+(`string`): 返回一个新字符串,第一个单词的首字母大写,其余字母小写,并用空格连接。
+
+## 试一试
+
+::: sandpack
+
+```ts index.ts
+import { sentenceCase } from 'es-toolkit/string';
+
+console.log(sentenceCase('sentenceCase'));
+```
+
+:::

--- a/docs/zh_hans/reference/string/sentenceCase.md
+++ b/docs/zh_hans/reference/string/sentenceCase.md
@@ -1,59 +1,49 @@
 # sentenceCase
 
-将字符串转换为句子格式。
+将字符串转换为句子格式(Sentence case)。
 
 ```typescript
-const converted = sentenceCase(str);
+const result = sentenceCase(str);
 ```
 
 ## 用法
 
 ### `sentenceCase(str)`
 
-当您想要将字符串转换为句子格式时,请使用 `sentenceCase`。句子格式是一种命名约定,只有第一个单词的首字母大写,其余字母全部小写,单词之间用空格连接。
+当您想将字符串转换为句子格式时,请使用 `sentenceCase`。句子格式是一种命名规则,只有第一个单词的首字母大写,其余字母全部小写,单词之间用空格连接。
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-// 基本用法
-sentenceCase('hello world'); // 'Hello world'
-sentenceCase('HELLO WORLD'); // 'Hello world'
-
-// 转换驼峰命名或帕斯卡命名
-sentenceCase('fooBar'); // 'Foo bar'
-sentenceCase('PascalCase'); // 'Pascal case'
-
-// 用连字符或下划线连接的单词
-sentenceCase('hello-world'); // 'Hello world'
-sentenceCase('hello_world'); // 'Hello world'
+// 将各种形式的字符串转换为句子格式
+sentenceCase('hello world'); // returns 'Hello world'
+sentenceCase('some-hyphen-text'); // returns 'Some hyphen text'
+sentenceCase('CONSTANT_CASE'); // returns 'Constant case'
+sentenceCase('PascalCase'); // returns 'Pascal case'
+sentenceCase('mixed   SpAcE'); // returns 'Mixed sp ac e'
 ```
 
-在将字段名或枚举值等标识符转换为易读的标签时非常有用。
+将属性名、枚举值、配置键等标识符转换为适合用作易读标签或消息的形式。
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-sentenceCase('firstName'); // 'First name'
-sentenceCase('MAX_RETRY_COUNT'); // 'Max retry count'
-sentenceCase('user-profile-settings'); // 'User profile settings'
+// 将属性名转换为表单标签
+const fieldName = 'user_first_name';
+const label = sentenceCase(fieldName); // 'User first name'
+
+// 将常量名转换为显示文本
+const errorCode = 'MAX_RETRY_COUNT';
+const message = sentenceCase(errorCode); // 'Max retry count'
 ```
 
-它还能正确处理包含各种分隔符和特殊字符的字符串。
+也会保留Unicode字符。
 
 ```typescript
 import { sentenceCase } from 'es-toolkit/string';
 
-// 包含多个分隔符的情况
-sentenceCase('--foo-bar--'); // 'Foo bar'
-sentenceCase('__FOO_BAR__'); // 'Foo bar'
-
-// 处理连续大写字母和数字
-sentenceCase('XMLHttpRequest'); // 'Xml http request'
-sentenceCase('_abc_123_def'); // 'Abc 123 def'
-
-// 空字符串或只有无意义分隔符的情况
-sentenceCase('_-_-_-_'); // ''
-sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
+sentenceCase('keep unicode 😅'); // returns 'Keep unicode 😅'
+sentenceCase('한글-테스트'); // returns '한글 테스트'
 ```
 
 #### 参数
@@ -62,16 +52,4 @@ sentenceCase('12abc 12ABC'); // '12 abc 12 abc'
 
 #### 返回值
 
-(`string`): 返回一个新字符串,第一个单词的首字母大写,其余字母小写,并用空格连接。
-
-## 试一试
-
-::: sandpack
-
-```ts index.ts
-import { sentenceCase } from 'es-toolkit/string';
-
-console.log(sentenceCase('sentenceCase'));
-```
-
-:::
+(`string`): 返回转换为句子格式的新字符串。

--- a/src/string/index.ts
+++ b/src/string/index.ts
@@ -11,6 +11,7 @@ export { lowerFirst } from './lowerFirst.ts';
 export { pad } from './pad.ts';
 export { pascalCase } from './pascalCase.ts';
 export { reverseString } from './reverseString.ts';
+export { sentenceCase } from './sentenceCase.ts';
 export { snakeCase } from './snakeCase.ts';
 export { startCase } from './startCase.ts';
 export { trim } from './trim.ts';

--- a/src/string/sentenceCase.spec.ts
+++ b/src/string/sentenceCase.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { sentenceCase } from './sentenceCase';
+
+describe('sentenceCase', () => {
+  it('should capitalize the first word and lowercase the rest', () => {
+    expect(sentenceCase('hello world')).toBe('Hello world');
+    expect(sentenceCase('HELLO WORLD')).toBe('Hello world');
+    expect(sentenceCase('Hello World')).toBe('Hello world');
+  });
+
+  it('should convert camelCase and PascalCase', () => {
+    expect(sentenceCase('fooBar')).toBe('Foo bar');
+    expect(sentenceCase('createElement')).toBe('Create element');
+    expect(sentenceCase('PascalCase')).toBe('Pascal case');
+    expect(sentenceCase('XMLHttpRequest')).toBe('Xml http request');
+    expect(sentenceCase('iPhone')).toBe('I phone');
+  });
+
+  it('should handle various delimiters', () => {
+    expect(sentenceCase('hello-world')).toBe('Hello world');
+    expect(sentenceCase('hello_world')).toBe('Hello world');
+    expect(sentenceCase('--foo-bar--')).toBe('Foo bar');
+    expect(sentenceCase('__FOO_BAR__')).toBe('Foo bar');
+    expect(sentenceCase('ABC-DEF')).toBe('Abc def');
+    expect(sentenceCase('_abc_123_def')).toBe('Abc 123 def');
+  });
+
+  it('should handle empty strings', () => {
+    expect(sentenceCase('')).toBe('');
+  });
+
+  it('should handle strings with only delimiters', () => {
+    expect(sentenceCase('_-_-_-_')).toBe('');
+  });
+
+  it('should handle single words', () => {
+    expect(sentenceCase('hello')).toBe('Hello');
+    expect(sentenceCase('HELLO')).toBe('Hello');
+  });
+
+  it('should work with numbers', () => {
+    expect(sentenceCase('12abc 12ABC')).toBe('12 abc 12 abc');
+    expect(sentenceCase('123ABC')).toBe('123 abc');
+    expect(sentenceCase('a1B2c3')).toBe('A 1 b 2 c 3');
+  });
+
+  it('should handle consecutive uppercase letters', () => {
+    expect(sentenceCase('ABC')).toBe('Abc');
+    expect(sentenceCase('ABCdef')).toBe('Ab cdef');
+  });
+
+  it('should handle special characters', () => {
+    expect(sentenceCase('foo@bar')).toBe('Foo bar');
+    expect(sentenceCase('test*case')).toBe('Test case');
+  });
+
+  it('should handle whitespace characters', () => {
+    expect(sentenceCase('  foo  bar  ')).toBe('Foo bar');
+    expect(sentenceCase('\tfoo\nbar')).toBe('Foo bar');
+  });
+
+  it('should handle long strings', () => {
+    expect(sentenceCase('thisIsAVeryLongStringWithManyWordsAndNumbers123')).toBe(
+      'This is a very long string with many words and numbers 123'
+    );
+  });
+
+  it('should correctly handle accented letters', () => {
+    expect(sentenceCase('lunedì 18 SET')).toBe('Lunedì 18 set');
+    expect(sentenceCase('héllo wörld')).toBe('Héllo wörld');
+  });
+});

--- a/src/string/sentenceCase.ts
+++ b/src/string/sentenceCase.ts
@@ -1,0 +1,33 @@
+import { words as getWords } from './words.ts';
+
+/**
+ * Converts a string to sentence case.
+ *
+ * Sentence case is the naming convention in which the first character of the first word is capitalized,
+ * all other characters are lowercase, and words are separated by spaces.
+ *
+ * @param {string} str - The string to convert.
+ * @returns {string} The converted string.
+ *
+ * @example
+ * const result1 = sentenceCase('hello world');  // result will be 'Hello world'
+ * const result2 = sentenceCase('HELLO WORLD');  // result will be 'Hello world'
+ * const result3 = sentenceCase('hello-world');  // result will be 'Hello world'
+ * const result4 = sentenceCase('helloWorld');   // result will be 'Hello world'
+ */
+export function sentenceCase(str: string): string {
+  const words = getWords(str.trim());
+  let result = '';
+
+  for (let i = 0; i < words.length; i++) {
+    const word = words[i];
+
+    if (i === 0) {
+      result += word[0].toUpperCase() + word.slice(1).toLowerCase();
+    } else {
+      result += ' ' + word.toLowerCase();
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Adds `sentenceCase` to `es-toolkit/string`.

Sentence case capitalizes the first letter of the first word, lowercases everything else, and joins words with spaces. It complements the existing `camelCase` / `pascalCase` / `kebabCase` / `snakeCase` / `constantCase` / `startCase` family and is built on the same `words()` splitting, so it behaves consistently with them.

```ts
import { sentenceCase } from 'es-toolkit/string';

sentenceCase('hello world'); // 'Hello world'
sentenceCase('HELLO WORLD'); // 'Hello world'
sentenceCase('fooBar'); // 'Foo bar'
sentenceCase('MAX_RETRY_COUNT'); // 'Max retry count'
sentenceCase('XMLHttpRequest'); // 'Xml http request'
```

Typical use is turning identifiers (field names, enum values, config keys) into human-readable labels.

## Motivation

Requested in #1285. To check how much demand there actually is, I ran GitHub code search for files that import the case-conversion library referenced in that issue together with each of its function names (files on default branches, same method for every function):

| Function | Files | es-toolkit equivalent |
| --- | ---: | --- |
| capitalCase | 4,591 | `startCase` |
| pascalCase | 4,058 | `pascalCase` |
| camelCase | 3,523 | `camelCase` |
| **sentenceCase** | **3,259** | **none** |
| snakeCase | 3,039 | `snakeCase` |
| kebabCase | 1,556 | `kebabCase` |
| constantCase | 978 | `constantCase` |
| dotCase | 434 | none |
| pathCase | 379 | none |
| trainCase / headerCase | 404 | none |

`sentenceCase` is used about as often as `camelCase` and more often than `snakeCase`, and it is the only function at that level of usage with no es-toolkit counterpart. The other missing ones (`dotCase`, `pathCase`, `trainCase`) are an order of magnitude less common and can be composed from `words()` in one line, so this PR adds only `sentenceCase`.

## Changes

- `src/string/sentenceCase.ts`: implementation (uses `words()`, same structure as `startCase`)
- `src/string/sentenceCase.spec.ts`: tests mirroring the `startCase` suite (delimiters, camel/Pascal input, numbers, consecutive uppercase, special characters, whitespace, accented letters)
- `src/string/index.ts`: export
- Docs in en / ko / ja / zh_hans

## Test plan

- [x] `yarn vitest run src/string` (23 files, 217 tests passed)
- [x] `yarn eslint` on changed files
- [x] `tsc --noEmit`
- [x] `prettier --check` on new files
