### PR TITLE
build(deps): bump GitHub Actions (codeql-action 4.37.9, action-gh-release 3.0.3)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,9 +19,9 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: javascript-typescript
-      - uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: '/language:javascript-typescript'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           omit-heading: true
       - run: 'cat ${{ steps.extract-changelog.outputs.output-file }}'
       - name: Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           body_path: ${{ steps.extract-changelog.outputs.output-file }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,7 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-      - uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
Combines this week's dependabot GitHub Actions updates into a single PR so they land together and `codeql.yml` keeps `init`/`analyze` on the same version.

| Action | From | To |
|---|---|---|
| `github/codeql-action/init` | 4.37.8 | 4.37.9 |
| `github/codeql-action/analyze` | 4.37.8 | 4.37.9 |
| `github/codeql-action/upload-sarif` | 4.37.8 | 4.37.9 |
| `softprops/action-gh-release` | 3.0.2 | 3.0.3 |

- codeql-action 4.37.9: updates the default CodeQL bundle to 2.26.4.
- action-gh-release 3.0.3: maintenance release; safely classifies malformed GitHub API errors to avoid secondary failures.

Pinned SHAs verified against the upstream tags.

Supersedes #2080, #2081, #2082, #2083.