### PR TITLE
build(deps): group GitHub Actions dependabot updates into one monthly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,8 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Actions in this repo are pinned to commit SHAs, so every upstream patch release currently produces its own dependabot PR. This week's codeql-action 4.37.9 release alone arrived as three PRs (init / analyze / upload-sarif), which then had to be combined by hand in #2088.

This change:

- adds a `groups` entry that matches every `github-actions` dependency, so all action bumps land in a single PR;
- switches the schedule from `weekly` to `monthly` (dependabot runs on the first day of each month).

Security updates are not affected by `schedule`; dependabot still opens those as soon as an advisory is published.