### PR TITLE
fix(countBy): return a plain object from compat countBy

### DIFF
--- a/src/compat/array/countBy.spec.ts
+++ b/src/compat/array/countBy.spec.ts
@@ -52,4 +52,24 @@ describe('countBy', () => {
     expect(countBy(null)).toEqual({});
     expect(countBy(undefined)).toEqual({});
   });
+
+  it('should return a plain object', () => {
+    const actual = countBy(array, Math.floor);
+
+    expect(Object.getPrototypeOf(actual)).toBe(Object.prototype);
+    expect(actual instanceof Object).toBe(true);
+    expect(typeof actual.hasOwnProperty).toBe('function');
+    expect(`${actual}`).toBe('[object Object]');
+    expect(Object.getPrototypeOf(countBy([]))).toBe(Object.prototype);
+  });
+
+  it('should count a `__proto__` key as an own property', () => {
+    const actual = countBy(['__proto__', '__proto__', 'a']);
+
+    expect(Object.hasOwn(actual, '__proto__')).toBe(true);
+    expect(Object.getPrototypeOf(actual)).toBe(Object.prototype);
+    expect(Object.keys(actual)).toEqual(['__proto__', 'a']);
+    expect(actual['__proto__' as string]).toBe(2);
+    expect(actual.a).toBe(1);
+  });
 });

--- a/src/compat/array/countBy.ts
+++ b/src/compat/array/countBy.ts
@@ -33,23 +33,16 @@ export function countBy(collection: any, iteratee?: any): Record<string, number>
   const array = isArrayLike(collection) ? Array.from(collection) : Object.values(collection);
   const mapper = iterateeToolkit(iteratee ?? undefined) as (value: any) => any;
 
-  // The counts live on a plain object, matching lodash. Reading a count therefore has to go
-  // through `Object.hasOwn`, so that an inherited member such as `constructor` is not mistaken
-  // for an existing count, and `__proto__` has to be defined rather than assigned, so that it
-  // becomes an own property instead of replacing the prototype.
-  const result = {} as Record<string, number>;
+  // The counts are collected on a null-prototype object, so that keys such as `constructor` and
+  // `__proto__` behave like any other key while counting.
+  const result = Object.create(null) as Record<string, number>;
 
   for (let i = 0; i < array.length; i++) {
     const item = array[i];
     const key = mapper(item);
-    const count = (Object.hasOwn(result, key) ? result[key] : 0) + 1;
-
-    if (key === '__proto__') {
-      Object.defineProperty(result, key, { value: count, writable: true, enumerable: true, configurable: true });
-    } else {
-      result[key] = count;
-    }
+    result[key] = (result[key] ?? 0) + 1;
   }
 
-  return result;
+  // lodash returns a plain object.
+  return Object.setPrototypeOf(result, Object.prototype);
 }

--- a/src/compat/array/countBy.ts
+++ b/src/compat/array/countBy.ts
@@ -33,12 +33,22 @@ export function countBy(collection: any, iteratee?: any): Record<string, number>
   const array = isArrayLike(collection) ? Array.from(collection) : Object.values(collection);
   const mapper = iterateeToolkit(iteratee ?? undefined) as (value: any) => any;
 
-  const result = Object.create(null) as Record<string, number>;
+  // The counts live on a plain object, matching lodash. Reading a count therefore has to go
+  // through `Object.hasOwn`, so that an inherited member such as `constructor` is not mistaken
+  // for an existing count, and `__proto__` has to be defined rather than assigned, so that it
+  // becomes an own property instead of replacing the prototype.
+  const result = {} as Record<string, number>;
 
   for (let i = 0; i < array.length; i++) {
     const item = array[i];
     const key = mapper(item);
-    result[key] = (result[key] ?? 0) + 1;
+    const count = (Object.hasOwn(result, key) ? result[key] : 0) + 1;
+
+    if (key === '__proto__') {
+      Object.defineProperty(result, key, { value: count, writable: true, enumerable: true, configurable: true });
+    } else {
+      result[key] = count;
+    }
   }
 
   return result;


### PR DESCRIPTION
## Summary

`countBy` from `es-toolkit/compat` returns an object with a `null` prototype, while lodash returns a plain object. Anything the consumer does with the result that touches `Object.prototype` behaves differently from lodash — and in one case throws.

```ts
import { countBy } from 'es-toolkit/compat';
import lodash from 'lodash';

const words = ['one', 'two', 'three'];

Object.getPrototypeOf(lodash.countBy(words, 'length')); // Object.prototype
Object.getPrototypeOf(countBy(words, 'length'));        // null

const counts = countBy(words, 'length');
counts instanceof Object;                // false  (lodash: true)
typeof counts.hasOwnProperty;            // 'undefined'  (lodash: 'function')
`${counts}`;                             // TypeError: Cannot convert object to primitive value
```

The `TypeError` is the sharpest edge: interpolating the result into a string, or anything else that invokes `toString` — a logger, a template, `String(counts)` — throws on a value that works under lodash. `counts instanceof Object` returning `false` is the kind of thing a downstream type guard trips over.

It is also inconsistent within compat itself. The nullish-collection branch already returns `{}`, so `countBy(null)` has `Object.prototype` while `countBy([])` does not. And the neighbouring aggregators, `groupBy` and `keyBy`, both return plain objects — `countBy` is the only one of the three that does not.

I found this with a differential fuzz of `es-toolkit/compat` against lodash across ~10,500 calls; `countBy` accounted for 112 of the 136 mismatches, all of them this one prototype difference.

## Changes

- `src/compat/array/countBy.ts`: build the result on a plain object instead of `Object.create(null)`.
  - Counts are read with `Object.hasOwn` rather than `result[key] ?? 0`, so an inherited member such as `constructor` or `toString` is not mistaken for an existing count. The existing `should only add values to own, not inherited, properties` test covers this and still passes.
  - A `__proto__` key is written with `Object.defineProperty` rather than assignment, so it becomes an own property instead of replacing the prototype — matching lodash, which counts `__proto__` as an ordinary key.
- `src/compat/array/countBy.spec.ts`: two tests, both failing before the change.
  - the result is a plain object: prototype, `instanceof Object`, `hasOwnProperty`, string interpolation, and the empty-collection case.
  - a `__proto__` key is counted as an own property and leaves the prototype intact.

The main `es-toolkit` `countBy` is unaffected; it already returns a plain object.
