### PR TITLE
fix(compat): read sparse array holes as undefined in toString

### DIFF
--- a/src/compat/util/toString.spec.ts
+++ b/src/compat/util/toString.spec.ts
@@ -53,6 +53,13 @@ describe('toString', () => {
     ).toBe('1,null,2,undefined');
   });
 
+  it('should read holes in a sparse array as undefined, matching lodash', () => {
+    // eslint-disable-next-line no-sparse-arrays
+    expect(toString([1, , 3])).toBe('1,undefined,3');
+    // eslint-disable-next-line no-sparse-arrays
+    expect(toString([, ,])).toBe('undefined,undefined');
+  });
+
   it('should read `valueOf` before `toString`, matching lodash', () => {
     expect(toString({ valueOf: () => 7 })).toBe('7');
     expect(toString({ valueOf: () => 7, toString: () => 'from toString' })).toBe('7');

--- a/src/compat/util/toString.ts
+++ b/src/compat/util/toString.ts
@@ -30,7 +30,19 @@ function baseToString(value: any): string {
   }
 
   if (Array.isArray(value)) {
-    return value.map(baseToString).join(',');
+    // `Array.prototype.map` skips holes in a sparse array, but lodash reads
+    // each index, so a hole is rendered as `undefined` rather than dropped.
+    let result = '';
+
+    for (let i = 0; i < value.length; i++) {
+      if (i > 0) {
+        result += ',';
+      }
+
+      result += baseToString(value[i]);
+    }
+
+    return result;
   }
 
   if (isSymbol(value)) {


### PR DESCRIPTION
## Summary

`compat/toString` renders an array by mapping its elements with `Array.prototype.map`, which skips holes in a sparse array. lodash reads every index, so a hole is converted as `undefined` rather than dropped:

```ts
toString([1, , 3]);
// es-toolkit: "1,,3"
// lodash:     "1,undefined,3"

toString([, ,]);
// es-toolkit: ","
// lodash:     "undefined,undefined"
```

## Changes

Iterate the array by index instead of using `.map`, so each hole is read as `undefined` and converted through the same path as any other element. Dense arrays are unaffected, and the `-0`, symbol, and nested-array handling stay the same.

Added tests for sparse inputs.

## Verified

Ran the compat implementation against `lodash` at runtime across sparse, dense, nested, nullish, `-0`, and symbol arrays. All outputs match.