### PR TITLE
fix(isEqual): compare Map entries structurally instead of by reference

### DIFF
--- a/benchmarks/bundle-size/isEqual.spec.ts
+++ b/benchmarks/bundle-size/isEqual.spec.ts
@@ -9,11 +9,11 @@ describe('isEqual bundle size', () => {
 
   it('es-toolkit', async () => {
     const bundleSize = await getBundleSize('es-toolkit', 'isEqual');
-    expect(bundleSize).toMatchInlineSnapshot(`3357`);
+    expect(bundleSize).toMatchInlineSnapshot(`3441`);
   });
 
   it('es-toolkit/compat', async () => {
     const bundleSize = await getBundleSize('es-toolkit/compat', 'isEqual');
-    expect(bundleSize).toMatchInlineSnapshot(`3357`);
+    expect(bundleSize).toMatchInlineSnapshot(`3441`);
   });
 });

--- a/src/predicate/isEqual.spec.ts
+++ b/src/predicate/isEqual.spec.ts
@@ -112,4 +112,30 @@ describe('isEqual', () => {
 
     expect(isEqual(buffer3, buffer4)).toBe(false);
   });
+
+  it('should compare maps by structural keys, not by reference', () => {
+    expect(isEqual(new Map([[{ a: 1 }, 'x']]), new Map([[{ a: 1 }, 'x']]))).toBe(true);
+    expect(isEqual(new Map([[{ a: 1 }, 'x']]), new Map([[{ a: 1 }, 'y']]))).toBe(false);
+    expect(isEqual(new Map([[{ a: 1 }, 'x']]), new Map([[{ a: 2 }, 'x']]))).toBe(false);
+  });
+
+  it('should compare maps with structurally equal keys as an unordered multiset', () => {
+    const a = new Map<object, number>([
+      [{}, 1],
+      [{}, 2],
+    ]);
+    const b = new Map<object, number>([
+      [{}, 2],
+      [{}, 1],
+    ]);
+    // Both hold the entries ({} -> 1) and ({} -> 2); a greedy key match would
+    // pair the first keys and fail on the values.
+    expect(isEqual(a, b)).toBe(true);
+
+    const c = new Map<object, number>([
+      [{}, 1],
+      [{}, 1],
+    ]);
+    expect(isEqual(a, c)).toBe(false);
+  });
 });

--- a/src/predicate/isEqualWith.ts
+++ b/src/predicate/isEqualWith.ts
@@ -204,10 +204,25 @@ function areObjectsEqual(
           return false;
         }
 
-        for (const [key, value] of a.entries()) {
-          if (!b.has(key) || !isEqualWithImpl(value, b.get(key), key, a, b, stack, areValuesEqual)) {
+        // `b.has(key)` only finds a key by reference, so a map keyed by objects
+        // would never match a structurally equal key in `b`. Match entries as an
+        // unordered multiset instead, pairing each `a` entry with a `b` entry
+        // whose key and value are both equal, and removing it so duplicate-shaped
+        // keys still pair one to one. Mirrors the set branch below and lodash.
+        const bEntries = Array.from(b.entries());
+
+        for (const [aKey, aValue] of a.entries()) {
+          const index = bEntries.findIndex(
+            ([bKey, bValue]) =>
+              isEqualWithImpl(aKey, bKey, undefined, a, b, stack, areValuesEqual) &&
+              isEqualWithImpl(aValue, bValue, aKey, a, b, stack, areValuesEqual)
+          );
+
+          if (index === -1) {
             return false;
           }
+
+          bEntries.splice(index, 1);
         }
 
         return true;

--- a/src/predicate/isEqualWith.ts
+++ b/src/predicate/isEqualWith.ts
@@ -209,7 +209,7 @@ function areObjectsEqual(
         // unordered multiset instead, pairing each `a` entry with a `b` entry
         // whose key and value are both equal, and removing it so duplicate-shaped
         // keys still pair one to one. Mirrors the set branch below and lodash.
-        const bEntries = Array.from(b.entries());
+        const bEntries: Array<[any, any]> = Array.from(b.entries());
 
         for (const [aKey, aValue] of a.entries()) {
           const index = bEntries.findIndex(


### PR DESCRIPTION
Closes #1881

## Summary

`isEqual` compared Map entries with `b.has(key)`, which only finds a key by reference. A map keyed by objects never matched a structurally equal key in the other map, and greedy key pairing failed whenever two keys were structurally equal but their values were paired differently:

```ts
isEqual(new Map([[{ a: 1 }, "x"]]), new Map([[{ a: 1 }, "x"]]));
// es-toolkit: false
// lodash:     true

isEqual(new Map([[{}, 1], [{}, 2]]), new Map([[{}, 2], [{}, 1]]));
// es-toolkit: false
// lodash:     true
```

## Changes

Match the map entries as an unordered multiset: pair each entry of `a` with an entry of `b` whose key and value are both equal, and remove it so duplicate-shaped keys pair one to one. This mirrors the set branch right below it, and lodash, which also compares map entries unordered.

The comparison is O(n^2) for maps, the same approach and complexity lodash uses (it converts the map to entries and compares them unordered).

Since `es-toolkit/compat` re-exports this `isEqual`, both the strict and compat variants are fixed by the same change.

## Verification

Ran the implementation against `lodash` at runtime:

- The cases from #1881 now match lodash, including maps with object keys, duplicate-shaped keys with differing values, and sets.
- A differential fuzz of 16,000 random Map/Set/object/array comparisons against `lodash.isEqual` produced no mismatches.
- The existing map tests, including the circular-reference cases, still pass.

Added regression tests for maps compared by structural key and for the duplicate-shaped-key multiset case.