### PR TITLE
fix[pull, pullAll, pullAllBy, remove]: handle nullish inputs like lodash

### DIFF
--- a/src/compat/array/pull.spec.ts
+++ b/src/compat/array/pull.spec.ts
@@ -42,4 +42,18 @@ describe('pull', () => {
     pull(array, [NaN]);
     expect(array).toEqual([1, 3]);
   });
+  it('should return the array as is when it is `null` or `undefined`', () => {
+    // @ts-expect-error - lodash accepts a nullish array
+    expect(pullToolkit(null, 1)).toBe(null);
+    // @ts-expect-error - lodash accepts a nullish array
+    expect(pullToolkit(undefined, 1)).toBe(undefined);
+  });
+
+  it('should leave values without a `length` untouched like lodash', () => {
+    const object = { a: 1 };
+
+    // @ts-expect-error - lodash accepts values without a `length`
+    expect(pullToolkit(object, 1)).toBe(object);
+    expect(object).toEqual({ a: 1 });
+  });
 });

--- a/src/compat/array/pull.ts
+++ b/src/compat/array/pull.ts
@@ -55,5 +55,9 @@ export function pull<L extends ArrayLike<any>>(array: L extends readonly any[] ?
  * console.log(numbers); // [1, 3, 5]
  */
 export function pull<T>(arr: T[], ...valuesToRemove: readonly unknown[]): T[] {
+  if (arr?.length == null) {
+    return arr;
+  }
+
   return pullToolkit(arr, valuesToRemove);
 }

--- a/src/compat/array/pullAll.spec.ts
+++ b/src/compat/array/pullAll.spec.ts
@@ -59,4 +59,18 @@ describe('pullAll', () => {
     expect(pullAll(array, null as any)).toBe(array);
     expect(pullAll(array, undefined)).toBe(array);
   });
+  it('should return the array as is when it is `null` or `undefined`', () => {
+    // @ts-expect-error - lodash accepts a nullish array
+    expect(pullAll(null, [1])).toBe(null);
+    // @ts-expect-error - lodash accepts a nullish array
+    expect(pullAll(undefined, [1])).toBe(undefined);
+  });
+
+  it('should ignore `values` that are not array-like like lodash', () => {
+    const array = [1, 2, 3];
+
+    // @ts-expect-error - lodash accepts non-array-like values
+    expect(pullAll(array, new Set([1]))).toBe(array);
+    expect(array).toEqual([1, 2, 3]);
+  });
 });

--- a/src/compat/array/pullAll.ts
+++ b/src/compat/array/pullAll.ts
@@ -1,5 +1,4 @@
 import { pull as pullToolkit } from '../../array/pull.ts';
-import { isNil } from '../../predicate/isNil.ts';
 import type { MutableList } from '../_internal/MutableList.d.ts';
 import type { RejectReadonly } from '../_internal/RejectReadonly.d.ts';
 
@@ -58,7 +57,7 @@ export function pullAll<L extends MutableList<any>>(array: RejectReadonly<L>, va
  * console.log(numbers); // [1, 3, 5]
  */
 export function pullAll<T>(arr: T[], valuesToRemove: ArrayLike<T> = []): T[] {
-  if (isNil(valuesToRemove)) {
+  if (arr?.length == null || valuesToRemove?.length == null) {
     return arr;
   }
 

--- a/src/compat/array/pullAllBy.spec.ts
+++ b/src/compat/array/pullAllBy.spec.ts
@@ -31,4 +31,28 @@ describe('pullAllBy', () => {
     expect(Object.hasOwn(actual, '0')).toEqual(true);
     expect(Object.hasOwn(actual, '1')).toEqual(false);
   });
+  it('should return the array as is when it is `null` or `undefined`', () => {
+    // @ts-expect-error - lodash accepts a nullish array
+    expect(pullAllBy(null, [1])).toBe(null);
+    // @ts-expect-error - lodash accepts a nullish array
+    expect(pullAllBy(undefined, [1])).toBe(undefined);
+  });
+
+  it('should return the array as is when `values` is omitted, `null` or `undefined`', () => {
+    const array = [1, 2, 1];
+
+    expect(pullAllBy(array)).toBe(array);
+    // @ts-expect-error - lodash accepts nullish values
+    expect(pullAllBy(array, null, x => x)).toBe(array);
+    expect(pullAllBy(array, undefined, x => x)).toBe(array);
+    expect(array).toEqual([1, 2, 1]);
+  });
+
+  it('should ignore `values` that are not array-like like lodash', () => {
+    const array = [1, 2, 3];
+
+    // @ts-expect-error - lodash accepts non-array-like values
+    expect(pullAllBy(array, new Set([1]))).toBe(array);
+    expect(array).toEqual([1, 2, 3]);
+  });
 });

--- a/src/compat/array/pullAllBy.ts
+++ b/src/compat/array/pullAllBy.ts
@@ -119,6 +119,10 @@ export function pullAllBy<L extends ArrayLike<any>, U>(
  * console.log(result); // [{ value: 2 }]
  */
 export function pullAllBy(arr: any, valuesToRemove: any, _getValue: any): any {
+  if (arr?.length == null || valuesToRemove?.length == null) {
+    return arr;
+  }
+
   const getValue = iteratee(_getValue);
   const valuesSet = new Set(Array.from(valuesToRemove).map(x => getValue(x)));
 

--- a/src/compat/array/remove.spec.ts
+++ b/src/compat/array/remove.spec.ts
@@ -107,4 +107,10 @@ describe('remove', () => {
     expect(result).toEqual([1, true, 'hello']);
     expect(array).toEqual([0, false, '']);
   });
+  it('should return an empty array when the array is `null` or `undefined`', () => {
+    // @ts-expect-error - lodash accepts a nullish array
+    expect(remove(null, isEven)).toEqual([]);
+    // @ts-expect-error - lodash accepts a nullish array
+    expect(remove(undefined)).toEqual([]);
+  });
 });

--- a/src/compat/array/remove.ts
+++ b/src/compat/array/remove.ts
@@ -63,5 +63,9 @@ export function remove<T>(
     | [keyof T, unknown]
     | keyof T = identity as any
 ): T[] {
+  if (arr?.length == null) {
+    return [];
+  }
+
   return removeToolkit(arr as T[], iteratee(shouldRemoveElement));
 }


### PR DESCRIPTION
## The difference (as code)

`pull`, `pullAll`, `pullAllBy` and `remove` in `es-toolkit/compat` throw on a nullish array, where lodash returns it unchanged:

```js
pull(null, 1);             // lodash: null        es-toolkit: TypeError: Cannot read properties of null (reading 'length')
pull(undefined, 1);        // lodash: undefined   es-toolkit: TypeError
pullAll(null, [1]);        // lodash: null        es-toolkit: TypeError
pullAllBy(undefined, [1]); // lodash: undefined   es-toolkit: TypeError
remove(null, isEven);      // lodash: []          es-toolkit: TypeError: Cannot read properties of null (reading 'slice')
```

`pullAllBy` also throws when `values` is left out, even though its signature declares `values?` as optional:

```js
pullAllBy([1, 2, 1]);      // lodash: [1, 2, 1]   es-toolkit: TypeError: undefined is not iterable
```

This is the kind of call that shows up in real code, e.g. `pull(user.tags, 'draft')` where `tags` may be missing.

## Cause

Lodash puts one guard in front of the whole family:

```js
function pullAll(array, values) {
  return (array && array.length && values && values.length)
    ? basePullAll(array, values)
    : array;
}
// pullAllBy / pullAllWith: the same guard. pull = baseRest(pullAll).

function remove(array, predicate) {
  var result = [];
  if (!(array && array.length)) {
    return result;
  }
  // ...
}
```

In compat, only `pullAllWith` has an equivalent guard:

```js
if (array?.length == null || values?.length == null) {
  return array;
}
```

The other three do not:

- `pull` forwards straight to the strict `es-toolkit` `pull`, which reads `arr.length`.
- `pullAll` guards `values` (#1962) but not `array`.
- `pullAllBy` guards neither and starts with `Array.from(valuesToRemove)`.
- `remove` forwards straight to the strict `es-toolkit` `remove`, which calls `arr.slice()`.

## Changes

Use `pullAllWith`'s guard in `pull`, `pullAll` and `pullAllBy`, and return `[]` from `remove` for the same condition (the value lodash's `remove` returns):

```js
// pull
if (arr?.length == null) {
  return arr;
}

// pullAll, pullAllBy
if (arr?.length == null || valuesToRemove?.length == null) {
  return arr;
}

// remove
if (arr?.length == null) {
  return [];
}
```

In `pullAll` this replaces the existing `isNil(valuesToRemove)` check, which the new guard already covers.

Two side effects, both toward lodash, called out so they are not a surprise:

1. **Values without a `length` are no longer mutated.** Previously `pull({ a: 1 }, 1)` returned the object with a `length: 0` property stamped onto it. It is now returned untouched, as in lodash.
2. **A `Set` passed as `values` is now ignored.** Previously `pullAll([1, 2, 3], new Set([1]))` spread the Set with `Array.from` and returned `[2, 3]`. Lodash (and compat's own `pullAllWith`) only read array-like `values`, so it now returns `[1, 2, 3]`. A `Set` is not assignable to the declared `ArrayLike<T>`, so this is only reachable from plain JS or through a cast.

## Verification

Focused grid against `lodash@4.18.1` (nullish, empty and non-empty arrays x omitted / `undefined` / `null` / `[]` / `[1]` values, 92 calls, comparing both the return value and the mutated array):

| | mismatches |
| --- | --- |
| before | 44 / 92 (all "es-toolkit throws, lodash returns") |
| after | 0 / 92 |

Broad sweep over the five functions (`pull`, `pullAll`, `pullAllBy`, `pullAllWith`, `remove`) with every 1- and 2-argument combination of a 35-value pool (6,300 calls):

| | mismatches |
| --- | --- |
| before | 3,698 |
| after | 751 |

2,947 calls fixed, **0 calls that matched before and mismatch now**, and the remaining 751 are byte-identical before and after. They are all strings, functions or array-like objects passed as the array (e.g. `pullAll('', [])`: lodash returns early on empty `values`, while compat carries on and throws when it assigns `length` on the string primitive). `pullAllBy`'s remaining set is exactly the same as `pullAllWith`'s, the sibling that already had this guard, so those are pre-existing and out of scope here.

Regression tests were added to all four spec files. On `main` they fail with:

```
TypeError: Cannot read properties of null (reading 'length')
TypeError: Cannot read properties of null (reading 'slice')
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
AssertionError: expected { a: 1, length: +0 } to deeply equal { a: 1 }
AssertionError: expected [ 2, 3 ] to deeply equal [ 1, 2, 3 ]
```

Full suite: 714 files, 5037 passed / 2 skipped. `tsc --noEmit` clean, `yarn lint` 0 errors (no new warnings in the touched files), type-tests pass.

## Benchmarks

The guard is one optional-chained `length` check per call. Interleaved A/B (`fix`, then `main`, five alternating rounds), median of the paired per-round deltas:

| benchmark | main (hz) | fix (hz) | delta |
| --- | ---: | ---: | ---: |
| `pull` — array size 100 | 546,614 | 548,697 | +0.5% |
| `pull` — array size 1,000 | 47,913 | 47,876 | +0.9% |
| `pull` — array size 10,000 | 2,736 | 2,720 | +0.1% |
| `pullAllBy` | 3,707,047 | 3,698,570 | -0.3% |
| *control* `lodash/pull` — size 100 / 1,000 / 10,000 | | | -0.9% / -0.2% / +0.4% |
| *control* `lodash/pullAllBy` | | | -0.1% |

All within +/-1%, the same band as the untouched lodash controls, so no measurable change. (`pull.bench.ts` labels its compat benchmark `es-toolkit/pull`, but it imports from `es-toolkit/compat`.) `pullAll` and `remove` have no benchmark files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129BhQdChg7wJry7bWvRHHm
