### PR TITLE
fix[pullAllWith]: respect the comparator for sparse arrays

### DIFF
--- a/benchmarks/performance/pullAllWith.bench.ts
+++ b/benchmarks/performance/pullAllWith.bench.ts
@@ -33,3 +33,17 @@ describe('pullAllWith/largeArray', () => {
     pullAllWithLodash([...largeArray], valuesToRemove, comparator);
   });
 });
+
+describe('pullAllWith/sparseArray', () => {
+  const array = new Array<number>(10000);
+  array[5000] = 100;
+  const valuesToRemove = Array.from({ length: 100 }, (_, i) => i);
+
+  bench('es-toolkit/pullAllWith', () => {
+    pullAllWithToolkit(array.slice(), valuesToRemove);
+  });
+
+  bench('lodash/pullAllWith', () => {
+    pullAllWithLodash(array.slice(), valuesToRemove);
+  });
+});

--- a/src/compat/array/pullAllWith.spec.ts
+++ b/src/compat/array/pullAllWith.spec.ts
@@ -76,6 +76,44 @@ describe('pullAllWith', () => {
     expect(array).toStrictEqual([1]);
   });
 
+  it.each([{ array: [2] }, { array: [3, 2] }])('should ignore appended removal values for $array', ({ array }) => {
+    const expected = array.slice();
+    const values = [1];
+
+    pullAllWith(array, values, (a, b) => {
+      if (values.length === 1) {
+        values.push(2);
+      }
+      return a === b;
+    });
+
+    expect(array).toStrictEqual(expected);
+  });
+
+  it('should visit the original removal range when the comparator shortens values', () => {
+    const array = [undefined];
+    const values: Array<number | undefined> = [1, 2];
+
+    pullAllWith(array, values, (a, b) => {
+      values.length = 1;
+      return a === b;
+    });
+
+    expect(array).toStrictEqual([]);
+  });
+
+  it.each([{ values: [undefined] }, { values: new Array<undefined>(1) }])(
+    'should remove input holes with default removal values $values',
+    ({ values }) => {
+      const array = new Array<number | undefined>(3);
+      array[1] = 1;
+
+      pullAllWith(array, values);
+
+      expect(array).toStrictEqual([1]);
+    }
+  );
+
   it(`\`_.${methodName}\` should match NaN`, () => {
     const array = [1, NaN, 3, NaN];
 

--- a/src/compat/array/pullAllWith.spec.ts
+++ b/src/compat/array/pullAllWith.spec.ts
@@ -46,6 +46,36 @@ describe('pullAllWith', () => {
     expect(array).toEqual([1, 3]);
   });
 
+  it('should preserve holes when the comparator does not match undefined', () => {
+    const array = [1, 2, 3];
+    delete array[1];
+
+    pullAllWith(array, [undefined], () => false);
+
+    expect(array).toHaveLength(3);
+    expect(1 in array).toBe(false);
+    expect(array[0]).toBe(1);
+    expect(array[2]).toBe(3);
+  });
+
+  it('should remove holes when the comparator matches them', () => {
+    const array: Array<number | null> = [1, 2, 3];
+    delete array[1];
+
+    pullAllWith(array, [null], (a, b) => a == null && b == null);
+
+    expect(array).toStrictEqual([1, 3]);
+  });
+
+  it.each([undefined, Object.is])('should treat holes in values as undefined with comparator %s', comparator => {
+    const array = [undefined, 1, undefined];
+    const values = new Array<undefined>(1);
+
+    pullAllWith(array, values, comparator);
+
+    expect(array).toStrictEqual([1]);
+  });
+
   it(`\`_.${methodName}\` should match NaN`, () => {
     const array = [1, NaN, 3, NaN];
 

--- a/src/compat/array/pullAllWith.ts
+++ b/src/compat/array/pullAllWith.ts
@@ -134,19 +134,35 @@ export function pullAllWith<T>(
   }
 
   let resultLength = 0;
+  const isDefaultComparator = comparator == null;
 
   if (comparator == null) {
     comparator = (a, b) => eq(a, b);
   }
 
   const valuesArray = Array.isArray(values) ? values : Array.from(values);
+  const valuesLength = valuesArray.length;
+  const hasUndefined = isDefaultComparator && valuesArray.includes(undefined as T);
 
   for (let i = 0; i < array.length; i++) {
+    if (isDefaultComparator && !(i in array)) {
+      if (!hasUndefined) {
+        delete (array as any)[resultLength++];
+      }
+      continue;
+    }
+
     let shouldRemove = false;
-    for (let j = 0; j < valuesArray.length; j++) {
-      if (comparator(array[i], valuesArray[j])) {
-        shouldRemove = true;
-        break;
+    if (valuesArray.length === valuesLength) {
+      // Unlike some, findIndex also visits holes and snapshots the length.
+      shouldRemove = valuesArray.findIndex(value => comparator(array[i], value)) !== -1;
+    } else {
+      // A comparator may have changed values.length while processing an earlier element.
+      for (let j = 0; j < valuesLength; j++) {
+        if (comparator(array[i], valuesArray[j])) {
+          shouldRemove = true;
+          break;
+        }
       }
     }
 

--- a/src/compat/array/pullAllWith.ts
+++ b/src/compat/array/pullAllWith.ts
@@ -140,21 +140,24 @@ export function pullAllWith<T>(
   }
 
   const valuesArray = Array.isArray(values) ? values : Array.from(values);
-  const hasUndefined = valuesArray.includes(undefined as any);
 
   for (let i = 0; i < array.length; i++) {
-    if (i in array) {
-      const shouldRemove = valuesArray.some(value => comparator(array[i], value));
-
-      if (!shouldRemove) {
-        (array as any)[resultLength++] = array[i];
+    let shouldRemove = false;
+    for (let j = 0; j < valuesArray.length; j++) {
+      if (comparator(array[i], valuesArray[j])) {
+        shouldRemove = true;
+        break;
       }
+    }
 
+    if (shouldRemove) {
       continue;
     }
 
-    // For handling sparse arrays
-    if (!hasUndefined) {
+    if (i in array) {
+      (array as any)[resultLength++] = array[i];
+    } else {
+      // Preserve unmatched holes in sparse arrays.
       delete (array as any)[resultLength++];
     }
   }


### PR DESCRIPTION
## Summary

`pullAllWith` handles holes in sparse arrays differently from Lodash in two cases.

When the input array contains a hole, it skips the comparator and removes the hole if `values` includes `undefined`. This happens even when the comparator always returns `false`.

```js
import lodash from 'lodash';
import { pullAllWith } from 'es-toolkit/compat';

lodash.pullAllWith(new Array(1), [undefined], () => false).length;
// 1

pullAllWith(new Array(1), [undefined], () => false).length;
// Before: 0
// After: 1
```

When `values` contains a hole, `.some()` skips it, so matching `undefined` elements are not removed.

```js
lodash.pullAllWith([undefined, 1], new Array(1));
// [1]

pullAllWith([undefined, 1], new Array(1));
// Before: [undefined, 1]
// After: [1]
```

## Changes

- Iterate over `values` by index so holes are compared as `undefined`.
- Apply the comparator to holes in the input array and preserve them when they do not match.
- Add regression tests for both cases, including default and custom comparators.

## Benchmark results

Measured on macOS arm64 with Node.js 24.13.0 and Lodash 4.18.1, using the repository's Vitest benchmark configuration and existing `pullAllWith` fixtures.

Results below are median throughput across three runs. Each run included the base implementation, this change, and Lodash in the same process. The order of the base implementation and this change was reversed in the second run.

Base commit: `9c6ca7dcbec5548bac4bd141b58fb231994ec12a`.

| Input | Base (ops/s) | This change (ops/s) | Lodash (ops/s) | Change vs. base |
| --- | ---: | ---: | ---: | ---: |
| 5 elements, 2 removal values | 11,968,740 | 11,020,605 | 10,661,779 | −7.9% |
| 10,000 elements, 1,000 removal values | 20.93 | 21.73 | 24.11 | +3.8% |

The small-array case was slower with this change. The large-array results varied between runs, so the measured increase should not be taken as a performance improvement.