### PR TITLE
fix[xorBy, xorWith]: ignore the iteratee and comparator for a single array like lodash

### DIFF
--- a/src/compat/array/xorBy.spec.ts
+++ b/src/compat/array/xorBy.spec.ts
@@ -75,4 +75,17 @@ describe('xorBy', () => {
 
     expect(args).not.toEqual([1.2, 3.4]);
   });
+  it('should ignore the `iteratee` when given a single array like lodash', () => {
+    // With fewer than two arrays lodash's `baseXor` returns `baseUniq(arrays[0])`,
+    // which never sees the iteratee.
+    expect(xorBy([2.1, 2.3], Math.floor)).toEqual([2.1, 2.3]);
+    expect(xorBy([{ x: 1 }, { x: 1 }], 'x')).toEqual([{ x: 1 }, { x: 1 }]);
+    // @ts-expect-error - lodash accepts an iteratee with no arrays
+    expect(xorBy(Math.floor)).toEqual([]);
+
+    // It still de-duplicates with SameValueZero and normalizes `-0`.
+    expect(xorBy([1, 1, 2], Math.floor)).toEqual([1, 2]);
+    expect(xorBy([NaN, NaN], Math.floor)).toEqual([NaN]);
+    expect(xorBy([-0], Math.floor)).toEqual([0]);
+  });
 });

--- a/src/compat/array/xorBy.ts
+++ b/src/compat/array/xorBy.ts
@@ -2,6 +2,7 @@ import { differenceBy } from './differenceBy.ts';
 import { intersectionBy } from './intersectionBy.ts';
 import { last } from './last.ts';
 import { unionBy } from './unionBy.ts';
+import { xor } from './xor.ts';
 import { windowed } from '../../array/windowed.ts';
 import { identity } from '../../function/identity.ts';
 import { ValueIteratee } from '../_internal/ValueIteratee.ts';
@@ -100,6 +101,12 @@ export function xorBy<T>(...values: Array<ArrayLike<T> | null | undefined | Valu
   }
 
   const arrays = values.filter(isArrayLikeObject) as [any];
+
+  // With fewer than two arrays lodash's `baseXor` returns `baseUniq(arrays[0])`,
+  // dropping the iteratee. That is exactly what `xor` does.
+  if (arrays.length < 2) {
+    return xor(...arrays);
+  }
 
   const union = unionBy(...arrays, mapper);
   const intersections = windowed(arrays, 2).map(([arr1, arr2]) => intersectionBy(arr1, arr2, mapper)) as [any];

--- a/src/compat/array/xorWith.spec.ts
+++ b/src/compat/array/xorWith.spec.ts
@@ -84,4 +84,19 @@ describe('xorWith', () => {
     expect(xorWith([NaN], [NaN], eq)).toEqual([NaN, NaN]);
     expect(xorWith([-0, 1], [1], eq)).toEqual([-0]);
   });
+  it('should ignore the `comparator` when given a single array like lodash', () => {
+    const eq = (a: number, b: number) => a === b;
+
+    // With fewer than two arrays lodash's `baseXor` returns `baseUniq(arrays[0])`,
+    // which never sees the comparator.
+    expect(xorWith([{ a: 1 }, { a: 1 }], isEqual)).toEqual([{ a: 1 }, { a: 1 }]);
+    expect(xorWith([1, 2, 3], eq)).toEqual([1, 2, 3]);
+    // @ts-expect-error - lodash accepts a comparator with no arrays
+    expect(xorWith(eq)).toEqual([]);
+
+    // It still de-duplicates with SameValueZero and normalizes `-0`.
+    expect(xorWith([1, 1, 2], eq)).toEqual([1, 2]);
+    expect(xorWith([NaN, NaN], eq)).toEqual([NaN]);
+    expect(xorWith([-0], eq)).toEqual([0]);
+  });
 });

--- a/src/compat/array/xorWith.ts
+++ b/src/compat/array/xorWith.ts
@@ -98,6 +98,12 @@ export function xorWith<T>(...values: Array<ArrayLike<T> | null | undefined | ((
   const comparator = lastValue as (a: T, b: T) => boolean;
   const arrays = values.slice(0, -1).filter(isArrayLikeObject) as T[][];
 
+  // With fewer than two arrays lodash's `baseXor` returns `baseUniq(arrays[0])`,
+  // dropping the comparator too.
+  if (arrays.length < 2) {
+    return xor(...arrays);
+  }
+
   // eslint-disable-next-line
   // @ts-ignore
   const union = unionWith(...arrays, comparator);


### PR DESCRIPTION
> [!NOTE]
> **Update after merge — the description below does not match the merged code.**
>
> This PR was merged with the maintainer's commit d4afbfc2 on top, so the final code in both functions is:
>
> ```js
> if (arrays.length < 2) {
>   return uniq(arrays[0]);
> }
> ```
>
> The following parts of this description refer to a later revision of mine that was **never pushed** (its push was rejected because d4afbfc2 had already landed): the `uniqToolkit(flattenArrayLike(arrays))` code under "Changes", the statement that the current code reads array-likes by index, the array-like regression tests, and the benchmark table.
>
> What still holds for the merged code: the differential results (0 / 1,260 mismatches against lodash for `xor`, `xorBy` and `xorWith`) and the correction about the first revision.
>
> One difference remains, and it is the same as compat's own `uniq` and `xor`: the merged code reads array-likes through `Array.from`, so an array-like whose `Symbol.iterator` disagrees with its indices still differs from lodash (`['b']` instead of `['a']` for the example below).

---

## The difference (as code)

Given a single array, `xorBy` and `xorWith` in `es-toolkit/compat` apply the iteratee / comparator, while lodash ignores it:

```js
xorBy([2.1, 2.3], Math.floor);        // lodash: [2.1, 2.3]              es-toolkit: [2.1]
xorBy([{ x: 1 }, { x: 1 }], 'x');     // lodash: [{ x: 1 }, { x: 1 }]    es-toolkit: [{ x: 1 }]
xorWith([{ a: 1 }, { a: 1 }], isEqual); // lodash: [{ a: 1 }, { a: 1 }]  es-toolkit: [{ a: 1 }]
xorWith([1, 2, 3], (a, b) => a === b);  // lodash: [1, 2, 3]             es-toolkit: [1]
```

The last one is the clearest: with `(a, b) => a === b` nothing in `[1, 2, 3]` is a duplicate, yet compat collapses the array to `[1]`.

## Cause

`baseXor` short-circuits before the iteratee and the comparator are ever used:

```js
function baseXor(arrays, iteratee, comparator) {
  var length = arrays.length;
  if (length < 2) {
    return length ? baseUniq(arrays[0]) : [];   // <- neither argument is passed on
  }
  // ...
  return baseUniq(baseFlatten(result, 1), iteratee, comparator);
}
```

Both `xorBy` and `xorWith` route through it (`baseXor(arrayFilter(arrays, isArrayLikeObject), getIteratee(iteratee, 2))` and `baseXor(..., undefined, comparator)`), so for one array lodash falls back to a plain `baseUniq`: SameValueZero de-duplication with `-0` normalized, and no iteratee.

`es-toolkit/compat` instead always builds the union / intersection / difference chain, which does apply the iteratee or comparator:

```js
const union = unionBy(...arrays, mapper);
const intersections = windowed(arrays, 2).map(([arr1, arr2]) => intersectionBy(arr1, arr2, mapper));

return differenceBy(union, unionBy(...intersections, mapper), mapper);
```

With a single array `windowed(arrays, 2)` is empty, so this reduces to `unionBy(array, mapper)` — a de-duplication *by the iteratee*, which is not what lodash does.

## Changes

Return early when fewer than two array-like arguments remain, reproducing `baseUniq(arrays[0])`:

```js
const arrays = values.filter(isArrayLikeObject) as [any];

// With fewer than two arrays lodash's `baseXor` returns `baseUniq(arrays[0])`,
// dropping the iteratee. `baseUniq` reads elements by index and de-duplicates
// with SameValueZero, normalizing `-0`, which is what a `Set` does.
if (arrays.length < 2) {
  return uniqToolkit(flattenArrayLike(arrays));
}
```

Two details matter here, both of which an earlier revision of this PR got wrong:

1. **Read by index.** `baseUniq` reads `array[i]`. `flattenArrayLike` (the helper `unionBy` / `unionWith` already use) copies by index, so an array-like whose `Symbol.iterator` disagrees with its indices is still read the lodash way.
2. **One `Set`.** The strict `uniq` is `[...new Set(arr)]`, which is SameValueZero with `-0` normalized and first-occurrence order — the same result as `baseUniq`, with a single allocation.

With no arrays at all, `flattenArrayLike([])` is `[]`, matching `length ? baseUniq(arrays[0]) : []`. The two-or-more-array path is untouched.

## Verification

Differential against `lodash@4.18.1`, every 1- and 2-argument combination of a 35-value pool (1,260 calls per function):

| | `xorBy` | `xorWith` | `xor` (untouched) |
| --- | --- | --- | --- |
| before | 102 / 1,260 | 4 / 1,260 | 0 / 1,260 |
| after | **0 / 1,260** | **0 / 1,260** | 0 / 1,260 |

A focused set of 20 calls (single array with and without an iteratee, `-0`, `NaN`, duplicates, no arrays at all, and two-array calls that must not change) goes from 9 mismatches to 0.

**Correction to the first revision.** It delegated to `xor(...arrays)` and I wrote that no previously-matching call mismatched afterwards. Copilot's review pointed out that `xor` reads through `Array.from`, i.e. the iterator, and that did regress an array-like whose iterator disagrees with its indices — a case my value pool did not contain:

```js
const arrayLike = { 0: 'a', length: 1, *[Symbol.iterator]() { yield 'b'; } };

xorBy(arrayLike, x => x);
// lodash: ['a']   main: ['a']   first revision: ['b']   now: ['a']
```

The current code reads by index, and both spec files now pin this object.

Regression tests were added to both spec files. On `main` the single-array tests fail with:

```
AssertionError: expected [ 2.1 ] to deeply equal [ 2.1, 2.3 ]
AssertionError: expected [ { a: 1 } ] to deeply equal [ { a: 1 }, { a: 1 } ]
```

and on the first revision the array-like tests fail with:

```
AssertionError: expected [ 'b' ] to deeply equal [ 'a' ]
```

Full suite: 714 files, 5041 passed / 2 skipped. `tsc --noEmit` clean, `yarn lint` 0 errors (no new warnings in the touched files), type-tests pass.

## Benchmarks

Interleaved A/B (`fix`, then `main`, five alternating rounds), median of the paired per-round deltas. The existing benchmarks only cover the two-array path, so I added a temporary local benchmark for the single-array path. Before every run the Vite dependency cache was cleared, and after every run I checked the pre-bundled `es-toolkit/compat` for which implementation had actually been measured (10/10 matched the intended side).

| benchmark | main (hz) | fix (hz) | delta |
| --- | ---: | ---: | ---: |
| *single array* `xorBy`, 10 items | 967,116 | 2,767,538 | **+184%** |
| *single array* `xorBy`, 1,000 items | 12,646 | 35,369 | **+178%** |
| *single array* `xorWith`, 10 items | 2,150,657 | 2,573,311 | **+20%** |
| *single array* `xorWith`, 1,000 items | 1,705 | 35,744 | **+1,997%** |
| `xorBy` (2 arrays) | 1,105,968 | 1,078,839 | -2.0% |
| `xorBy` — largeArray | 287 | 287 | +0.1% |
| `xorWith` (2 arrays) | 1,710,252 | 1,691,604 | +1.0% |
| `xorWith` — largeArray | 1.0 | 1.0 | +0.2% |
| *control* `lodash/xorBy` (2 arrays / largeArray) | | | -0.5% / +0.3% |
| *control* `lodash/xorWith` (2 arrays / largeArray) | | | -1.0% / -0.1% |

The single-array path is faster across the board, most of all with a comparator on larger arrays, where it no longer runs the O(n²) `unionWith` / `differenceWith` chain. The only code added to the two-array path is the `arrays.length < 2` check; small two-array `xorBy` came out 2.0% slower with all five rounds negative (-0.9% to -3.2%), slightly outside the controls' band, so I'm noting it rather than calling it noise.

**About the benchmark table in the first revision:** those numbers showed no difference on any path, and they were wrong. The runs did not clear Vite's pre-bundled dependency cache, so both sides measured the same cached build. That is also how the xor-based version's 33% slowdown for a 10-item single array with a comparator went unnoticed; the cache-cleared runs caught it, which is why the current code uses `uniq` instead of `xor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129BhQdChg7wJry7bWvRHHm

